### PR TITLE
World/chunk interface

### DIFF
--- a/src/main/java/org/spongepowered/api/Game.java
+++ b/src/main/java/org/spongepowered/api/Game.java
@@ -26,6 +26,10 @@ package org.spongepowered.api;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.api.event.EventManager;
 import org.spongepowered.api.plugin.PluginManager;
+import org.spongepowered.api.world.World;
+
+import java.util.Collection;
+import java.util.UUID;
 
 /**
  * The core accessor of the API. The implementation uses this to pass constructed objects.
@@ -58,4 +62,34 @@ public interface Game {
      * @return The event manager
      */
     public EventManager getEventManager();
+
+    /**
+     * Gets all currently loaded worlds
+     *
+     * @return list of loaded worlds
+     */
+    public Collection<World> getWorlds();
+
+    /**
+     * Gets a loaded {@link World} by UUID
+     *
+     * @param uniqueId
+     * @return a world
+     */
+    public World getWorld(UUID uniqueId);
+
+    /**
+     * Gets a loaded {@link World} by name
+     *
+     * @param worldName
+     * @return a world
+     */
+    public World getWorld(String worldName);
+
+    /**
+     * Sends the given message to all online players
+     *
+     * @param message
+     */
+    public void broadcastMessage(String message);
 }

--- a/src/main/java/org/spongepowered/api/world/Chunk.java
+++ b/src/main/java/org/spongepowered/api/world/Chunk.java
@@ -1,0 +1,48 @@
+/**
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2014 SpongePowered <http://spongepowered.org/>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.world;
+
+/**
+ * Chunks are 16x256x16 (x/y/z) containers of {@link Block}s
+ * in a specific {@link World}.
+ */
+public interface Chunk {
+
+    /**
+     * Gets the x coordinate of this chunk as it appears in the
+     * {@link World}.
+     *
+     * @return x coordinate
+     */
+    public int getX();
+
+    /**
+     * Gets the z coordinate of this chunk as it appears in the
+     * {@link World}.
+     *
+     * @return z coordinate
+     */
+    public int getZ();
+
+}

--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -1,0 +1,55 @@
+/**
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2014 SpongePowered <http://spongepowered.org/>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.world;
+
+import java.util.UUID;
+
+/**
+ * A loaded Minecraft world
+ */
+public interface World {
+
+    /**
+     * Gets the unique id for this world
+     *
+     * @return a unique id
+     */
+    public UUID getUniqueID();
+
+    /**
+     * Gets the name of the world
+     *
+     * @return the world name
+     */
+    public String getName();
+
+    /**
+     * Gets a specific {@link Chunk} by the x/z coordinate in the world
+     * @param x
+     * @param z
+     * @return a chunk
+     */
+    public Chunk getChunk(int x, int z);
+
+}


### PR DESCRIPTION
Adding core world/chunk interface.

_Note_ `World` will need a way to return all loaded chunks, but we'll need some discussion as to which containing object structure should be used.
