### PR TITLE
Double instead of Int?

### DIFF
--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -62,5 +62,5 @@ public interface World {
      * @param z Z block coordinate
      * @return The block
      */
-    Block getBlock(int x, int y, int z);
+    Block getBlock(double x, double y, double z);
 }


### PR DESCRIPTION
If I were you I would do use Double instead of Int, because the most times when you make a plugin and will use the getBlock(); method. You  will love it to add 0.5 to it. Otherwise players will teleport in to the ground (and setting that 1 block higher also doesn't look very nice).
