### PR TITLE
Add Location

### DIFF
--- a/src/main/java/org/spongepowered/api/Location.java
+++ b/src/main/java/org/spongepowered/api/Location.java
@@ -1,0 +1,63 @@
+/**
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2014 SpongePowered <http://spongepowered.org/>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api;
+
+import java.io.Serializable;
+
+public class Location implements Serializable {
+    private static final long serialVersionUID = -3111002372579366172L;
+    private double x;
+    private double y;
+    private double z;
+    
+    public Location(double x, double y, double z) {
+        this.setX(x);
+        this.setY(y);
+        this.setZ(z);
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public void setX(double x) {
+        this.x = x;
+    }
+
+    public double getY() {
+        return y;
+    }
+
+    public void setY(double y) {
+        this.y = y;
+    }
+
+    public double getZ() {
+        return z;
+    }
+
+    public void setZ(double z) {
+        this.z = z;
+    }
+}


### PR DESCRIPTION
So that adds simple double based Location object. Bukkit had it and I needed it with every my plugin. And if we use this instead of Vector3, we can add our new methods, when it is necessary.

I use doubles because they're needed by entity locations, but we still can round them to ints for blocks. Plugin developer can then easily store all kinds of locations with same object. And its of course serializable.
