### PR TITLE
`HumanEntity` properly extendeds `LivingEntity`

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/HumanEntity.java
+++ b/src/main/java/org/spongepowered/api/entity/HumanEntity.java
@@ -23,5 +23,5 @@
  */
 package org.spongepowered.api.entity;
 
-public interface HumanEntity {
+public interface HumanEntity extends LivingEntity {
 }


### PR DESCRIPTION
We somehow missed this in the last PR.
