### PR TITLE
Add Vector3i getters to Chunk and World

### DIFF
--- a/src/main/java/org/spongepowered/api/world/VoxelVolume.java
+++ b/src/main/java/org/spongepowered/api/world/VoxelVolume.java
@@ -24,6 +24,7 @@
 package org.spongepowered.api.world;
 
 import org.spongepowered.api.block.Block;
+import org.spongepowered.api.math.Vector3i;
 
 /**
  * For Objects that contain volumes of {@link org.spongepowered.api.world.Voxel}s.
@@ -49,4 +50,21 @@ public interface VoxelVolume {
      * @return The voxel
      */
     Voxel getVoxel(int x, int y, int z);
+    
+    /**
+     * Gets the {@link org.spongepowered.api.block.Block} at the block coordinate x/y/z.
+     *
+     * @param location location of block in Vector3i format
+     * @return The block
+     */
+    Block getBlock(Vector3i location);
+
+    
+    /**
+     * Gets the {@link org.spongepowered.api.world.Voxel} at the block coordinate x/y/z.
+     *
+     * @param location of voxel in Vector3i format
+     * @return The voxel
+     */
+    Voxel getVoxel(Vector3i location);
 }


### PR DESCRIPTION
Vector3i Voxel/Block getters for Chunk and World. I guess they're simply forgotten when Vector3i was added. They'll be definitely needed in my opinion.
