### PR TITLE
JavaDocs served via GitHub pages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,11 @@
 buildscript {
     repositories {
         jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0'
+        classpath 'org.ajoberstar:gradle-git:0.10.0'
     }
 }
 
@@ -15,6 +17,7 @@ apply plugin: 'checkstyle'
 apply plugin: 'maven'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
+apply plugin: 'github-pages'
 
 // Default tasks
 defaultTasks 'licenseFormat', 'check', 'build'
@@ -97,3 +100,13 @@ jar.manifest.mainAttributes(
         "Implementation-Version": version + "+" + ciSystem + "-b" + buildNumber + ".git-" + commit,
         "Implementation-Vendor": url)
 
+githubPages {
+  repoUri = 'https://github.com/SpongePowered/SpongeAPI/'
+  pages {
+    from javadoc.outputs.files
+  }
+  credentials {
+    username = System.getenv('GH_TOKEN')
+    password = ''
+  }
+}


### PR DESCRIPTION
Gradle plugin to automatically publish JavaDocs to GitHub pages when `githubPages` goal is run.

See https://github.com/ajoberstar/gradle-git#travis-ci-authentication-notes for setting the GH_TOKEN variable, I can't do that bit.

@sk89q, I believe you setup the .travis file so it makes sense for you to do that bit I guess.

SpongePowered/Meta#5
