### PR TITLE
Add locale getter for Player

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/Player.java
+++ b/src/main/java/org/spongepowered/api/entity/Player.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.entity;
 
 import org.spongepowered.api.title.Title;
 import org.spongepowered.api.util.command.CommandSource;
+import java.util.Locale;
 
 public interface Player extends HumanEntity, CommandSource {
 
@@ -76,5 +77,12 @@ public interface Player extends HumanEntity, CommandSource {
      * Removes the currently displayed {@link Title} from the player's screen.
      */
     void clearTitle();
+
+    /**
+     * Gets the Locale that best represents the player's chosen locale.
+     *
+     * @return The player's locale
+     */
+    Locale getLocale();
 
 }


### PR DESCRIPTION
Adds a getLocale method to the player interface. 

NMS keeps track of which locale the player has selected in EntityPlayer field 'locale' as a String (default "en_US") and updates it when packet 0x15 Client Settings is sent (on connect + when settings are changed). 

Will need to store the parsed Locale and update on packet to avoid having to lookup with LocaleUtils on each potential call
