### PR TITLE
Get player by username

### DIFF
--- a/src/main/java/org/spongepowered/api/Game.java
+++ b/src/main/java/org/spongepowered/api/Game.java
@@ -96,6 +96,15 @@ public interface Game {
      */
     @Nullable
     Player getPlayer(UUID uniqueId);
+    
+    /**
+     * Gets a {@link Player} by their recent username
+     *
+     * @param username
+     * @return {@link Player} or null if none found
+     */
+    @Nullable
+    Player getPlayer(String username);
 
     /**
      * Gets all currently loaded {@link org.spongepowered.api.world.World}s.


### PR DESCRIPTION
Despite usernames being deprecated players still need a way to get the player by their name.
Players won't type UUID's in commands.

On implementation this could be done using the mojang API to fetch the most recent UUID based on their username

Sponge PR: https://github.com/SpongePowered/Sponge/pull/30
