### PR TITLE
Add method to get nearby entities

### DIFF
--- a/src/main/java/org/spongepowered/api/world/VoxelVolume.java
+++ b/src/main/java/org/spongepowered/api/world/VoxelVolume.java
@@ -59,7 +59,6 @@ public interface VoxelVolume {
      */
     Block getBlock(Vector3i location);
 
-    
     /**
      * Gets the {@link org.spongepowered.api.world.Voxel} at the block coordinate x/y/z.
      *
@@ -67,4 +66,16 @@ public interface VoxelVolume {
      * @return The voxel
      */
     Voxel getVoxel(Vector3i location);
+
+    /**
+     * Gets the {@link org.spongepowered.api.world.Voxel} at the block coordinate x/y/z.
+     *
+     * @param x X block coordinate
+     * @param y Y block coordinate
+     * @param z Z block coordinate
+     * @param radius area to look for entities
+     * @return A collection of all {@link org.spongepowered.api.entity.Entity}s within the given radius
+     */
+    Collection<Entity> getNearbyEntities(int x, int y, int z, double radius);
+
 }


### PR DESCRIPTION
Added method in VoxelVolume so that a collection of entities can be
accessed in any given area without having to already have a given
entity in memory.
