### PR TITLE
Added a getVoxel() method to Entity.java

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -42,5 +42,6 @@ public interface Entity {
      * 
      * @return The entity's {@link Voxel}
      */
-     Voxel getVoxel(); 
+     Voxel getVoxel();
+     
 }


### PR DESCRIPTION
You should be able to get the Voxel of an Entity. Voxel is preferred over Vector3i since you can get the block that the Entity is at without unnecessary function calls. 
