### PR TITLE
Removing markdown ticks from javadoc

### DIFF
--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -60,7 +60,7 @@ public interface World extends EntityUniverse, VoxelVolume {
 
     /**
      * Loads and returns a {@link Chunk}. If the chunk does not exist, it will
-     * be generated unless `shouldGenerate` is false.
+     * be generated unless {@code shouldGenerate} is false.
      *
      * @param cx X chunk coordinate
      * @param cz Z chunk coordinate


### PR DESCRIPTION
I've written too much markdown lately, sorry. Replaced backticks with @code. 
