### PR TITLE
Add method to prevent a null return of World#loadChunk

### DIFF
--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -71,10 +71,7 @@ public interface World extends EntityUniverse, VoxelVolume {
 
     /**
      * Loads and returns a {@link Chunk}. If the chunk does not
-     * exist, it will be automatically generated. Should never
-     * return null like {@link World#loadChunk(int, int, boolean)}
-     * may in the case that the chunk does not exist and
-     * <code>shouldGenerate</code> is false.
+     * exist, it will be automatically generated.
      * 
      * @param cx X chunk coordinate
      * @param cz Z chunk coordinate


### PR DESCRIPTION
Added a method as suggested by @sk89q that automatically generates the chunk if it is loaded and does not exist rather than only generating if shouldGenerate is true. If should generate is false the method would normally return null. This method should never return null. The missing Nullable annotations are added in a seperate PR shown here: https://github.com/SpongePowered/SpongeAPI/pull/155. This also fixes a markdown tick
