### PR TITLE
Add getWorld() to Entity

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -25,6 +25,8 @@
 
 package org.spongepowered.api.entity;
 
+import org.spongepowered.api.world.World;
+
 import java.util.UUID;
 
 public interface Entity {
@@ -35,4 +37,11 @@ public interface Entity {
      * @return The entity's {@link UUID}
      */
     UUID getUniqueID();
+
+    /**
+     * Gets the world this entity is in
+     *
+     * @return The entity's {@link World}
+     */
+    World getWorld();
 }


### PR DESCRIPTION
I feel like it's safe to assume that every Entity will have an associated World. (Please correct me if I'm wrong.)
