### PR TITLE
Renamed event methods to match these methods with forge ones.

### DIFF
--- a/src/main/java/org/spongepowered/api/event/BaseEvent.java
+++ b/src/main/java/org/spongepowered/api/event/BaseEvent.java
@@ -44,17 +44,17 @@ public abstract class BaseEvent implements Event {
     }
 
     @Override
-    public final boolean isCancellable() {
+    public final boolean isCancelable() {
         return false;
     }
 
     @Override
-    public final boolean isCancelled() {
+    public final boolean isCanceled() {
         return false;
     }
 
     @Override
-    public final void setCancelled(boolean cancel) {
+    public final void setCanceled(boolean cancel) {
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/event/Event.java
+++ b/src/main/java/org/spongepowered/api/event/Event.java
@@ -51,21 +51,21 @@ public interface Event {
      *
      * @return Can this event be cancelled
      */
-    boolean isCancellable();
+    boolean isCancelable();
 
     /**
      * Gets if the {@link Event} has been cancelled.
      *
      * @return Is this event cancelled
      */
-    boolean isCancelled();
+    boolean isCanceled();
 
     /**
      * Sets the cancelled state of the {@link Event}.
      *
      * @param cancel the new cancelled state
      */
-    void setCancelled(boolean cancel);
+    void setCanceled(boolean cancel);
 
     /**
      * Gets the {@link Result} of the {@link Event}.


### PR DESCRIPTION
When you try to make the events cancel in the real implementation you will see that its not working. And the ASM code (that i have ready for it) is way to much work. Wouldn't it be simpler if we take over forge event method names?

resource files:
-https://github.com/MinecraftForge/FML/blob/master/src/main/java/cpw/mods/fml/common/eventhandler/Event.java#L107
-https://github.com/SpongePowered/Sponge/blob/master/src/main/java/org/spongepowered/mod/asm/transformers/EventTransformer.java
