### PR TITLE
Various doc & formatting fixes in API classes

### DIFF
--- a/src/main/java/org/spongepowered/api/Game.java
+++ b/src/main/java/org/spongepowered/api/Game.java
@@ -72,21 +72,21 @@ public interface Game {
     GameRegistry getRegistry();
 
     /**
-     * Gets the {@link Player}s currently online
+     * Gets the {@link Player}s currently online.
      *
      * @return a {@link Collection} of online players
      */
     Collection<Player> getOnlinePlayers();
 
     /**
-     * Gets the max players allowed on this server
+     * Gets the max players allowed on this server.
      *
      * @return Maximum number of connected players
      */
     int getMaxPlayers();
 
     /**
-     * Gets a {@link Player} by their unique id
+     * Gets a {@link Player} by their unique id.
      *
      * @param uniqueId The UUID to get the player from
      * @return {@link Player} or null if none found
@@ -110,7 +110,7 @@ public interface Game {
     World getWorld(UUID uniqueId);
 
     /**
-     * Gets a loaded {@link World} by name
+     * Gets a loaded {@link World} by name.
      *
      * @param worldName Name to lookup
      * @return The world or null if not found
@@ -118,7 +118,7 @@ public interface Game {
     World getWorld(String worldName);
 
     /**
-     * Sends the given message to all online players
+     * Sends the given message to all online players.
      *
      * @param message The message to send
      */

--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -30,7 +30,8 @@ import org.spongepowered.api.item.Item;
 import javax.annotation.Nullable;
 
 /**
- * Provides an easy way to retrieve objects from the {@link Game} based on their ids.
+ * Provides an easy way to retrieve objects from the {@link Game} based on
+ * their ids.
  */
 public interface GameRegistry {
 

--- a/src/main/java/org/spongepowered/api/GameState.java
+++ b/src/main/java/org/spongepowered/api/GameState.java
@@ -28,6 +28,7 @@ package org.spongepowered.api;
  * Top to bottom order of the lifecycle.
  */
 public enum GameState {
+
     CONSTRUCTION,
     LOAD_COMPLETE,
     PRE_INITIALIZATION,
@@ -38,4 +39,5 @@ public enum GameState {
     SERVER_STARTED,
     SERVER_STOPPING,
     SERVER_STOPPED
+
 }

--- a/src/main/java/org/spongepowered/api/Platform.java
+++ b/src/main/java/org/spongepowered/api/Platform.java
@@ -26,7 +26,7 @@
 package org.spongepowered.api;
 
 /**
- * Effective side platforms
+ * Effective side platforms.
  *
  * <p>A side is what part of minecraft this is being run on. The client, or the
  * server. The internal server is also treated like a dedicated server.</p>

--- a/src/main/java/org/spongepowered/api/command/CommandCallable.java
+++ b/src/main/java/org/spongepowered/api/command/CommandCallable.java
@@ -62,8 +62,8 @@ public interface CommandCallable extends CommandCompleter {
     /**
      * Test whether this command can probably be executed by the given source.
      *
-     * <p>If implementations are unsure if the command can be executed by
-     * the source, {@code true} should be returned. Return values of this method
+     * <p>If implementations are unsure if the command can be executed by the
+     * source, {@code true} should be returned. Return values of this method
      * may be used to determine whether this command is listed in command
      * listings.</p>
      *

--- a/src/main/java/org/spongepowered/api/command/CommandException.java
+++ b/src/main/java/org/spongepowered/api/command/CommandException.java
@@ -28,8 +28,8 @@ package org.spongepowered.api.command;
 import javax.annotation.Nullable;
 
 /**
- * Thrown when an executed command raises an error or when execution of
- * the command failed.
+ * Thrown when an executed command raises an error or when execution of the
+ * command failed.
  */
 public class CommandException extends Exception {
 

--- a/src/main/java/org/spongepowered/api/command/CommandMapping.java
+++ b/src/main/java/org/spongepowered/api/command/CommandMapping.java
@@ -57,7 +57,7 @@ public interface CommandMapping {
     Set<String> getAllAliases();
 
     /**
-     * Get the callable
+     * Get the callable.
      *
      * @return The callable
      */

--- a/src/main/java/org/spongepowered/api/command/InvalidUsageException.java
+++ b/src/main/java/org/spongepowered/api/command/InvalidUsageException.java
@@ -37,8 +37,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * is true, which, in that case, the full help of the command should be
  * shown.</p>
  *
- * <p>If no error message is set and full help is not to be shown, then a generic
- * "you used this command incorrectly" message should be shown.</p>
+ * <p>If no error message is set and full help is not to be shown, then a
+ * generic "you used this command incorrectly" message should be shown.</p>
  */
 public class InvalidUsageException extends CommandException {
 
@@ -47,9 +47,9 @@ public class InvalidUsageException extends CommandException {
     private final boolean fullHelpSuggested;
 
     /**
-     * Create a new instance with no error message and with no suggestion
-     * that full and complete help for the command should be shown. This will
-     * result in a generic error message.
+     * Create a new instance with no error message and with no suggestion that
+     * full and complete help for the command should be shown. This will result
+     * in a generic error message.
      *
      * @param command The command
      */
@@ -58,8 +58,8 @@ public class InvalidUsageException extends CommandException {
     }
 
     /**
-     * Create a new instance with a message and with no suggestion
-     * that full and complete help for the command should be shown.
+     * Create a new instance with a message and with no suggestion that full and
+     * complete help for the command should be shown.
      *
      * @param message The message
      * @param command The command
@@ -73,7 +73,8 @@ public class InvalidUsageException extends CommandException {
      *
      * @param message The message
      * @param command The command
-     * @param fullHelpSuggested True if the full help for the command should be shown
+     * @param fullHelpSuggested True if the full help for the command should be
+     *                          shown
      */
     public InvalidUsageException(@Nullable String message, CommandCallable command, boolean fullHelpSuggested) {
         super(message);
@@ -94,7 +95,7 @@ public class InvalidUsageException extends CommandException {
     /**
      * Return whether the full usage of the command should be shown.
      *
-     * @return show full usage
+     * @return Show full usage
      */
     public boolean isFullHelpSuggested() {
         return fullHelpSuggested;

--- a/src/main/java/org/spongepowered/api/command/dispatcher/Dispatcher.java
+++ b/src/main/java/org/spongepowered/api/command/dispatcher/Dispatcher.java
@@ -46,8 +46,8 @@ public interface Dispatcher extends CommandCallable {
     void registerCommand(CommandCallable callable, String... alias);
     
     /**
-     * Get a list of commands. Each command, regardless of how many aliases
-     * it may have, will only appear once in the returned set.
+     * Get a list of commands. Each command, regardless of how many aliases it
+     * may have, will only appear once in the returned set.
      *
      * <p>The returned collection cannot be modified.</p>
      * 
@@ -75,8 +75,8 @@ public interface Dispatcher extends CommandCallable {
     Collection<String> getAliases();
 
     /**
-     * Get the {@link CommandCallable} associated with an alias. Returns
-     * null if no command is named by the given alias.
+     * Get the {@link CommandCallable} associated with an alias. Returns null if
+     * no command is named by the given alias.
      * 
      * @param alias The alias
      * @return The command mapping (null if not found)

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -51,7 +51,7 @@ import java.util.UUID;
 public interface Entity extends Flammable, Movable, Positionable, Rotatable {
 
     /**
-     * Gets the unique ID for this entity
+     * Gets the unique ID for this entity.
      *
      * @return The entity's {@link UUID}
      */

--- a/src/main/java/org/spongepowered/api/entity/EntityUniverse.java
+++ b/src/main/java/org/spongepowered/api/entity/EntityUniverse.java
@@ -57,9 +57,11 @@ public interface EntityUniverse {
     <T extends Entity> Collection<T> getEntitiesByClass(Class<T> entityClass);
 
     /**
-     * Gets a {@link Collection} of Entities, in this universe, with the given classes/interfaces.
+     * Gets a {@link Collection} of Entities, in this universe, with
+     * the given classes/interfaces.
      *
-     * @param entityClasses The classes for the types of Entities which are trying to be matched.
+     * @param entityClasses The classes for the types of Entities which are
+     *                      trying to be matched.
      * @return A {@link Collection} of Entities based upon the given classes.
      */
     Collection<Entity> getEntitiesByClasses(Class<? extends Entity>... entityClasses);

--- a/src/main/java/org/spongepowered/api/entity/Player.java
+++ b/src/main/java/org/spongepowered/api/entity/Player.java
@@ -35,7 +35,8 @@ public interface Player extends HumanEntity {
     String getName();
 
     /**
-     * Gets the player's display name. If none set, returns their current username.
+     * Gets the player's display name. If none set, returns their
+     * current username.
      *
      * @return The player's display name
      */

--- a/src/main/java/org/spongepowered/api/event/BaseEvent.java
+++ b/src/main/java/org/spongepowered/api/event/BaseEvent.java
@@ -27,9 +27,8 @@ package org.spongepowered.api.event;
 import org.spongepowered.api.Game;
 
 /**
- * This class should be used as the base class for all plugin
- * created custom events.  Handlers may not listen for this event 
- * directly.
+ * This class should be used as the base class for all plugin created
+ * custom events. Handlers may not listen for this event directly.
  */
 public abstract class BaseEvent implements Event {
 

--- a/src/main/java/org/spongepowered/api/event/Event.java
+++ b/src/main/java/org/spongepowered/api/event/Event.java
@@ -28,7 +28,8 @@ package org.spongepowered.api.event;
 import org.spongepowered.api.Game;
 
 /**
- * A game event. A game event can be any sort of event from anywhere, and can be anything.
+ * A game event. A game event can be any sort of event from anywhere, and can
+ * be anything.
  */
 public interface Event {
 

--- a/src/main/java/org/spongepowered/api/event/Order.java
+++ b/src/main/java/org/spongepowered/api/event/Order.java
@@ -58,48 +58,48 @@ public enum Order {
     /**
      * The order point of PRE handles setting up things that need to be done
      * before other things are handled PRE is read only and cannot cancel the
-     * events
+     * events.
      */
     PRE,
     /**
      * The order point of AFTER_PRE handles things that need to be done after
-     * PRE AFTER_PRE is read only and cannot cancel the events
+     * PRE AFTER_PRE is read only and cannot cancel the events.
      */
     AFTER_PRE,
     /**
      * The order point of FIRST handles cancellation by protection plugins for
-     * informational responses FIRST is read only but can cancel events
+     * informational responses FIRST is read only but can cancel events.
      */
     FIRST,
     /**
      * The order point of EARLY handles standard actions that need to be done
-     * before other plugins EARLY is not read only and can cancel events
+     * before other plugins EARLY is not read only and can cancel events.
      */
     EARLY,
     /**
      * The order point of DEFAULT handles just standard event handlings, you
      * should use this unless you know you need otherwise DEFAULT is not read
-     * only and can cancel events
+     * only and can cancel events.
      */
     DEFAULT,
     /**
      * The order point of LATE handles standard actions that need to be done
-     * after other plugins LATE is not read only and can cancel the event
+     * after other plugins LATE is not read only and can cancel the event.
      */
     LATE,
     /**
      * The order point of LAST handles last minute cancellations by protection
-     * plugins LAST is read only but can cancel events
+     * plugins LAST is read only but can cancel events.
      */
     LAST,
     /**
      * The order point of BEFORE_POST handles preparation for things needing
-     * to be done in post BEFORE_POST is read only but can cancel events
+     * to be done in post BEFORE_POST is read only but can cancel events.
      */
     BEFORE_POST,
     /**
      * The order point of POST handles last minute things and monitoring of
-     * events for rollback or logging POST is read only but can cancel events
+     * events for rollback or logging POST is read only but can cancel events.
      */
     POST
 

--- a/src/main/java/org/spongepowered/api/event/Result.java
+++ b/src/main/java/org/spongepowered/api/event/Result.java
@@ -26,25 +26,26 @@
 package org.spongepowered.api.event;
 
 /**
- * The result of an action such as an event
+ * The result of an action such as an event.
  */
 public enum Result {
 
     /**
-     * The result of a request such as an event has been denied continuation
+     * The result of a request such as an event has been denied continuation.
      */
     DENY,
     /**
      * The result of a request such as an event has not been modified, and will
-     * progress based on the default expectation
+     * progress based on the default expectation.
      */
     DEFAULT,
     /**
-     * The result of a request such as an event has been allowed continuation
+     * The result of a request such as an event has been allowed continuation.
      */
     ALLOW,
     /**
-     * There is no result from a request such as an event, or a result is not applicable
+     * There is no result from a request such as an event, or a result is
+     * not applicable.
      */
     NO_RESULT
 

--- a/src/main/java/org/spongepowered/api/event/entity/EntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityEvent.java
@@ -29,12 +29,12 @@ import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.Event;
 
 /**
- * Describes events which contain an {@link Entity}
+ * Describes events which contain an {@link Entity}.
  */
 public interface EntityEvent extends Event {
 
     /**
-     * Gets the {@link Entity} involved
+     * Gets the {@link Entity} involved.
      *
      * @return {@link Entity} involved
      */

--- a/src/main/java/org/spongepowered/api/event/player/AsyncPlayerChatEvent.java
+++ b/src/main/java/org/spongepowered/api/event/player/AsyncPlayerChatEvent.java
@@ -28,12 +28,12 @@ package org.spongepowered.api.event.player;
 import org.spongepowered.api.entity.Player;
 
 /**
- * Called when a {@link Player} sends a chat message
+ * Called when a {@link Player} sends a chat message.
  */
 public interface AsyncPlayerChatEvent extends PlayerEvent {
 
     /**
-     * Get the message sent in this event
+     * Get the message sent in this event.
      *
      * @return The message sent
      */

--- a/src/main/java/org/spongepowered/api/event/player/PlayerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/player/PlayerEvent.java
@@ -29,12 +29,12 @@ import org.spongepowered.api.entity.Player;
 import org.spongepowered.api.event.Event;
 
 /**
- * Describes events which contain a {@link Player}
+ * Describes events which contain a {@link Player}.
  */
 public interface PlayerEvent extends Event {
 
     /**
-     * Gets the {@link Player} involved
+     * Gets the {@link Player} involved.
      *
      * @return {@link Player} involved
      */

--- a/src/main/java/org/spongepowered/api/event/state/ConstructionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/state/ConstructionEvent.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.event.state;
 import org.spongepowered.api.GameState;
 
 /**
- * Represents the {@link GameState#CONSTRUCTION} event
+ * Represents the {@link GameState#CONSTRUCTION} event.
  */
 public interface ConstructionEvent extends StateEvent {
 

--- a/src/main/java/org/spongepowered/api/event/state/InitializationEvent.java
+++ b/src/main/java/org/spongepowered/api/event/state/InitializationEvent.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.event.state;
 import org.spongepowered.api.GameState;
 
 /**
- * Represents the {@link GameState#INITIALIZATION} event
+ * Represents the {@link GameState#INITIALIZATION} event.
  */
 public interface InitializationEvent extends StateEvent {
 

--- a/src/main/java/org/spongepowered/api/event/state/LoadCompleteEvent.java
+++ b/src/main/java/org/spongepowered/api/event/state/LoadCompleteEvent.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.event.state;
 import org.spongepowered.api.GameState;
 
 /**
- * Represents {@link GameState#LOAD_COMPLETE} event
+ * Represents {@link GameState#LOAD_COMPLETE} event.
  */
 public interface LoadCompleteEvent extends StateEvent {
 

--- a/src/main/java/org/spongepowered/api/event/state/PostInitializationEvent.java
+++ b/src/main/java/org/spongepowered/api/event/state/PostInitializationEvent.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.event.state;
 import org.spongepowered.api.GameState;
 
 /**
- * Represents {@link GameState#POST_INITIALIZATION} event
+ * Represents {@link GameState#POST_INITIALIZATION} event.
  */
 public interface PostInitializationEvent extends StateEvent {
 

--- a/src/main/java/org/spongepowered/api/event/state/PreInitializationEvent.java
+++ b/src/main/java/org/spongepowered/api/event/state/PreInitializationEvent.java
@@ -31,26 +31,28 @@ import org.spongepowered.api.GameState;
 import java.io.File;
 
 /**
- * Represents {@link GameState#PRE_INITIALIZATION} event
+ * Represents {@link GameState#PRE_INITIALIZATION} event.
  */
 public interface PreInitializationEvent extends StateEvent {
 
     /**
-     * gets a logger pre-configured to use the Plugin's ID
-     * Use this.
+     * Gets a logger pre-configured to use the Plugin's ID.
+     *
      * @return A Logger for the plugin
      */
     public Logger getPluginLog();
 
     /**
      *
-     * @return Plugin Specific Configuration file for smaller plugins that do not need an entire directory
+     * @return Plugin Specific Configuration file for smaller plugins that do
+     *         not need an entire directory
      */
     public File getSuggestedConfigurationFile();
 
     /**
      *
-     * @return Plugin specific Configuration directory for plugins that need more than a single config file
+     * @return Plugin specific Configuration directory for plugins that need
+     *         more than a single config file
      */
     public File getSuggestedConfigurationDirectory();
 

--- a/src/main/java/org/spongepowered/api/event/state/ServerAboutToStartEvent.java
+++ b/src/main/java/org/spongepowered/api/event/state/ServerAboutToStartEvent.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.event.state;
 import org.spongepowered.api.GameState;
 
 /**
- * Represents {@link GameState#SERVER_ABOUT_TO_START} event
+ * Represents {@link GameState#SERVER_ABOUT_TO_START} event.
  */
 public interface ServerAboutToStartEvent extends StateEvent {
 

--- a/src/main/java/org/spongepowered/api/event/state/ServerStartedEvent.java
+++ b/src/main/java/org/spongepowered/api/event/state/ServerStartedEvent.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.event.state;
 import org.spongepowered.api.GameState;
 
 /**
- * Represents {@link GameState#SERVER_STARTED} event
+ * Represents {@link GameState#SERVER_STARTED} event.
  */
 public interface ServerStartedEvent extends StateEvent {
 

--- a/src/main/java/org/spongepowered/api/event/state/ServerStartingEvent.java
+++ b/src/main/java/org/spongepowered/api/event/state/ServerStartingEvent.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.event.state;
 import org.spongepowered.api.GameState;
 
 /**
- * Represents {@link GameState#SERVER_STARTING} event
+ * Represents {@link GameState#SERVER_STARTING} event.
  */
 public interface ServerStartingEvent extends StateEvent {
 

--- a/src/main/java/org/spongepowered/api/event/state/ServerStoppedEvent.java
+++ b/src/main/java/org/spongepowered/api/event/state/ServerStoppedEvent.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.event.state;
 import org.spongepowered.api.GameState;
 
 /**
- * Represents {@link GameState#SERVER_STOPPED} event
+ * Represents {@link GameState#SERVER_STOPPED} event.
  */
 public interface ServerStoppedEvent extends StateEvent {
 

--- a/src/main/java/org/spongepowered/api/event/state/ServerStoppingEvent.java
+++ b/src/main/java/org/spongepowered/api/event/state/ServerStoppingEvent.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.event.state;
 import org.spongepowered.api.GameState;
 
 /**
- * Represents {@link GameState#SERVER_STOPPING} event
+ * Represents {@link GameState#SERVER_STOPPING} event.
  */
 public interface ServerStoppingEvent extends StateEvent {
 

--- a/src/main/java/org/spongepowered/api/event/state/StateEvent.java
+++ b/src/main/java/org/spongepowered/api/event/state/StateEvent.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.event.state;
 import org.spongepowered.api.event.Event;
 
 /**
- * Parent interface for all state events
+ * Parent interface for all state events.
  */
 public interface StateEvent extends Event {
 

--- a/src/main/java/org/spongepowered/api/event/voxel/VoxelEvent.java
+++ b/src/main/java/org/spongepowered/api/event/voxel/VoxelEvent.java
@@ -30,12 +30,12 @@ import org.spongepowered.api.event.Event;
 import org.spongepowered.api.world.Voxel;
 
 /**
- * Describes events which contain a {@link Block} wrapped by a {@link Voxel}
+ * Describes events which contain a {@link Block} wrapped by a {@link Voxel}.
  */
 public interface VoxelEvent extends Event {
 
     /**
-     * Get {@link Voxel} included in the event
+     * Get {@link Voxel} included in the event.
      *
      * @return Event {@link Voxel}
      */

--- a/src/main/java/org/spongepowered/api/event/world/ChunkEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/ChunkEvent.java
@@ -28,12 +28,12 @@ package org.spongepowered.api.event.world;
 import org.spongepowered.api.world.Chunk;
 
 /**
- * Describes events which involve a {@link Chunk}
+ * Describes events which involve a {@link Chunk}.
  */
 public interface ChunkEvent {
 
     /**
-     * Gets the {@link Chunk} included in the event
+     * Gets the {@link Chunk} included in the event.
      *
      * @return Event {@link Chunk}
      */

--- a/src/main/java/org/spongepowered/api/event/world/ChunkLoadEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/ChunkLoadEvent.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.event.world;
 import org.spongepowered.api.world.Chunk;
 
 /**
- * Called when a {@link Chunk} is loaded in an existing {@link World} map
+ * Called when a {@link Chunk} is loaded in an existing {@link World} map.
  */
 public interface ChunkLoadEvent extends ChunkEvent {
 

--- a/src/main/java/org/spongepowered/api/event/world/ChunkUnloadEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/ChunkUnloadEvent.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.event.world;
 import org.spongepowered.api.world.Chunk;
 
 /**
- * Called when a {@link Chunk} is unloaded
+ * Called when a {@link Chunk} is unloaded.
  */
 public interface ChunkUnloadEvent extends ChunkEvent {
 

--- a/src/main/java/org/spongepowered/api/event/world/WorldEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/WorldEvent.java
@@ -28,12 +28,12 @@ package org.spongepowered.api.event.world;
 import org.spongepowered.api.world.World;
 
 /**
- * Describes {@link World} events
+ * Describes {@link World} events.
  */
 public interface WorldEvent {
 
     /**
-     * Gets the {@link World} involved in the event
+     * Gets the {@link World} involved in the event.
      *
      * @return The world that this event is involved in
      */

--- a/src/main/java/org/spongepowered/api/event/world/WorldLoadEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/WorldLoadEvent.java
@@ -29,7 +29,7 @@ import org.spongepowered.api.Game;
 import org.spongepowered.api.world.World;
 
 /**
- * Called when the {@link Game} loads a {@link World} map
+ * Called when the {@link Game} loads a {@link World} map.
  */
 public interface WorldLoadEvent extends WorldEvent {
 

--- a/src/main/java/org/spongepowered/api/event/world/WorldUnloadEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/WorldUnloadEvent.java
@@ -29,7 +29,7 @@ import org.spongepowered.api.Game;
 import org.spongepowered.api.world.World;
 
 /**
- * Called when the {@link Game} unloads a {@link World} map
+ * Called when the {@link Game} unloads a {@link World} map.
  */
 public interface WorldUnloadEvent extends WorldEvent {
 

--- a/src/main/java/org/spongepowered/api/item/Item.java
+++ b/src/main/java/org/spongepowered/api/item/Item.java
@@ -38,8 +38,7 @@ public interface Item {
     String getID();
 
     /**
-     * Get the default maximum quantity for {@link ItemStack}s
-     * of this item.
+     * Get the default maximum quantity for {@link ItemStack}s of this item.
      *
      * @return Max stack quantity
      */

--- a/src/main/java/org/spongepowered/api/item/ItemBlock.java
+++ b/src/main/java/org/spongepowered/api/item/ItemBlock.java
@@ -28,12 +28,12 @@ package org.spongepowered.api.item;
 import org.spongepowered.api.block.Block;
 
 /**
- * Represents a {@link Block} as an {@link Item}
+ * Represents a {@link Block} as an {@link Item}.
  */
 public interface ItemBlock extends Item {
 
     /**
-     * Gets the {@link Block} this item places on interaction
+     * Gets the {@link Block} this item places on interaction.
      *
      * @return The block
      */

--- a/src/main/java/org/spongepowered/api/math/EulerDirection.java
+++ b/src/main/java/org/spongepowered/api/math/EulerDirection.java
@@ -30,7 +30,8 @@ import java.io.Serializable;
 /**
  * Represents a euler direction, made up of both a pitch and yaw component.
  *
- * Euler directions are most commonly used by entities to represent the direction they are looking in.
+ * Euler directions are most commonly used by entities to represent the
+ * direction they are looking in.
  */
 public interface EulerDirection extends Cloneable, Comparable<EulerDirection>, Serializable {
 
@@ -51,7 +52,8 @@ public interface EulerDirection extends Cloneable, Comparable<EulerDirection>, S
     /**
      * Converts this Euler Direction into a {@link Vector2d}.
      *
-     * The vector will represent the directions that this direction is facing in x, y, z coordinates, with a length of 1.
+     * The vector will represent the directions that this direction is facing in
+     * x, y, z coordinates, with a length of 1.
      *
      * @return the vector representation of this direction
      */
@@ -71,7 +73,8 @@ public interface EulerDirection extends Cloneable, Comparable<EulerDirection>, S
     EulerDirection clone();
 
     /**
-     * Returns a string representation of this direction in the form "(pitch, yaw)".
+     * Returns a string representation of this direction in the form
+     * "(pitch, yaw)".
      *
      * @return This direction as a string
      */

--- a/src/main/java/org/spongepowered/api/plugin/Plugin.java
+++ b/src/main/java/org/spongepowered/api/plugin/Plugin.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * An annotation used to describe and mark a Sponge plugin
+ * An annotation used to describe and mark a Sponge plugin.
  */
 @Target(TYPE)
 @Retention(RUNTIME)
@@ -60,10 +60,14 @@ public @interface Plugin {
     String version() default "unknown";
 
     /**
-     * A simple dependency string for this mod separated by a ";"
-     * example:
+     * A simple dependency string for this mod separated by a ";".
+     *
+     * Example:
+     *
      * <pre>"required-after:Sponge@[1.2.3.2222,);required-after:myLibraryPlugin;after:towny;before:worldguard"</pre>
-     * supported options:
+     *
+     * Supported options:
+     *
      * <dl>
      *   <dt>after</dt>
      *   <dd>when present this plugin will run after plugin x</dd>
@@ -74,9 +78,9 @@ public @interface Plugin {
      *   <dt>required-before</dt>
      *   <dd>plugin x must be present, load before plugin x</dd>
      * </dl>
-     * supports maven version ranges after @ in any field
+     *
+     * Supports maven version ranges after @ in any field.
      */
     String dependencies() default "";
-
 
 }

--- a/src/main/java/org/spongepowered/api/plugin/PluginManager.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginManager.java
@@ -51,7 +51,7 @@ public interface PluginManager {
     Logger getLogger(PluginContainer plugin);
 
     /**
-     * Gets a {@link Collection} of all {@link PluginContainer}s
+     * Gets a {@link Collection} of all {@link PluginContainer}s.
      *
      * @return The plugins
      */

--- a/src/main/java/org/spongepowered/api/world/Chunk.java
+++ b/src/main/java/org/spongepowered/api/world/Chunk.java
@@ -35,14 +35,16 @@ import org.spongepowered.api.entity.EntityUniverse;
 public interface Chunk extends EntityUniverse, VoxelVolume {
 
     /**
-     * Gets the x chunk coordinate of this chunk as it appears in the {@link World}.
+     * Gets the x chunk coordinate of this chunk as it appears in the
+     * {@link World}.
      *
      * @return X chunk coordinate
      */
     int getX();
 
     /**
-     * Gets the z chunk coordinate of this chunk as it appears in the {@link World}.
+     * Gets the z chunk coordinate of this chunk as it appears in the
+     * {@link World}.
      *
      * @return Z chunk coordinate
      */

--- a/src/main/java/org/spongepowered/api/world/VoxelVolume.java
+++ b/src/main/java/org/spongepowered/api/world/VoxelVolume.java
@@ -34,8 +34,7 @@ import org.spongepowered.api.math.Vector3i;
 public interface VoxelVolume {
 
     /**
-     * Gets a specific {@link Block} by its x/y/z
-     * block coordinate.
+     * Gets a specific {@link Block} by its x/y/z block coordinate.
      *
      * @param x X block coordinate
      * @param y Y block coordinate
@@ -45,8 +44,7 @@ public interface VoxelVolume {
     Block getBlock(int x, int y, int z);
 
     /**
-     * Gets a specific {@link Voxel} by its x/y/z
-     * block coordinate.
+     * Gets a specific {@link Voxel} by its x/y/z block coordinate.
      *
      * @param x X block coordinate
      * @param y Y block coordinate
@@ -56,8 +54,7 @@ public interface VoxelVolume {
     Voxel getVoxel(int x, int y, int z);
 
     /**
-     * Gets the {@link Block} at the block
-     * coordinate x/y/z.
+     * Gets the {@link Block} at the block coordinate x/y/z.
      *
      * @param location location of block in Vector3i format
      * @return The block
@@ -66,8 +63,7 @@ public interface VoxelVolume {
 
 
     /**
-     * Gets the {@link Voxel} at the block
-     * coordinate x/y/z.
+     * Gets the {@link Voxel} at the block coordinate x/y/z.
      *
      * @param location of voxel in Vector3i format
      * @return The voxel

--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -50,7 +50,7 @@ public interface World extends EntityUniverse, VoxelVolume {
 
     /**
      * Gets an already-loaded {@link Chunk} by its x/z chunk coordinate, or
-     * null if it's not available
+     * null if it's not available.
      *
      * @param cx X chunk coordinate
      * @param cz Z chunk coordinate


### PR DESCRIPTION
I made some changes to ensure the JavaDocs were mainly compliant with the contribution guidelines.

**Readability:**  
- When adjusting wrapping of lines, I made sure to leave (at least) 2 words on the next line

**Consistency:**  
- Added some missing 'periods' (full stops for those among us who hail from the UK)
- Wrapped some lines if they exceeded 80 characters
- Correctly spaced some doc tags (`@return`, `@param`, etc.)
- Also did some spacing in the code where there should be some

**Exceptions:**  
- I had some trouble with the `Order.java` class. The table formatting admittedly threw me off a tad.

Also, in `Plugin.java`, I'd like to ask whether lines 62-83 are correct. I tried to space it out a little but it looks a bit weird.

---

If you want someone to maintain the documentation in the way that I did here, I'd be glad to do it. [I did a major reformat of nearly all the classes in the Bukkit API JavaDocs](https://github.com/Bukkit/Bukkit-JavaDoc/commits?author=aerouk), so I feel I've got the gist of how a role like this works.

Cheers!
