### PR TITLE
Implement Cancellable in the example plugin

### DIFF
--- a/src/main/example/main/java/org/spongepowered/example/ExamplePlugin.java
+++ b/src/main/example/main/java/org/spongepowered/example/ExamplePlugin.java
@@ -48,14 +48,23 @@ public class ExamplePlugin {
     public class MyEvent extends BaseEvent implements Cancellable {
         
         private final String message;
+        private final boolean cancelled;
         
         public MyEvent(String message) {
             this.message = message;
+            cancelled = false;
         }
         
         public String getMessage() {
             return message;
         }
         
+        public boolean isCancelled() {
+            return cancelled;
+        }
+        
+        public boolean setCancelled(boolean cancelled) {
+            this.cancelled = cancelled;
+        }
     }
 }


### PR DESCRIPTION
The example plugin did not implement cancelled properly, it just said `implements Cancelled` without an implementation - now it has an implementation.
I assume this is straight-forward enough to not require pre-discussion.
