### PR TITLE
Added getName() method to entities/living/meta

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/living/meta/DyeColor.java
+++ b/src/main/java/org/spongepowered/api/entity/living/meta/DyeColor.java
@@ -26,4 +26,12 @@ package org.spongepowered.api.entity.living.meta;
 
 public interface DyeColor {
 
+    /**
+     * The unique name of this dye color.
+     * 
+     * @return The name of this dye color
+     * @see DyeColors#valueOf(String)
+     */
+    String getName();
+
 }

--- a/src/main/java/org/spongepowered/api/entity/living/meta/HorseColor.java
+++ b/src/main/java/org/spongepowered/api/entity/living/meta/HorseColor.java
@@ -31,4 +31,12 @@ package org.spongepowered.api.entity.living.meta;
  */
 public interface HorseColor {
 
+    /**
+     * The unique name of this horse color.
+     * 
+     * @return The name of this horse color
+     * @see HorseColors#valueOf(String)
+     */
+    String getName();
+
 }

--- a/src/main/java/org/spongepowered/api/entity/living/meta/HorseStyle.java
+++ b/src/main/java/org/spongepowered/api/entity/living/meta/HorseStyle.java
@@ -31,4 +31,12 @@ package org.spongepowered.api.entity.living.meta;
  */
 public interface HorseStyle {
 
+    /**
+     * The unique name of this horse style.
+     * 
+     * @return The name of this horse style
+     * @see HorseStyles#valueOf(String)
+     */
+    String getName();
+
 }

--- a/src/main/java/org/spongepowered/api/entity/living/meta/HorseVariant.java
+++ b/src/main/java/org/spongepowered/api/entity/living/meta/HorseVariant.java
@@ -32,4 +32,12 @@ package org.spongepowered.api.entity.living.meta;
  */
 public interface HorseVariant {
 
+    /**
+     * The unique name of this horse variant.
+     * 
+     * @return The name of this horse variant
+     * @see HorseVariants#valueOf(String)
+     */
+    String getName();
+
 }

--- a/src/main/java/org/spongepowered/api/entity/living/meta/OcelotType.java
+++ b/src/main/java/org/spongepowered/api/entity/living/meta/OcelotType.java
@@ -29,4 +29,12 @@ package org.spongepowered.api.entity.living.meta;
  */
 public interface OcelotType {
 
+    /**
+     * The unique name of this horse variant.
+     * 
+     * @return The name of this horse variant
+     * @see HorseVariants#valueOf(String)
+     */
+    String getName();
+
 }

--- a/src/main/java/org/spongepowered/api/entity/living/meta/RabbitType.java
+++ b/src/main/java/org/spongepowered/api/entity/living/meta/RabbitType.java
@@ -26,4 +26,12 @@ package org.spongepowered.api.entity.living.meta;
 
 public interface RabbitType {
 
+    /**
+     * The unique name of this rabbit type.
+     * 
+     * @return The name of this rabbit type
+     * @see RabbitTypes#valueOf(String)
+     */
+    String getName();
+
 }

--- a/src/main/java/org/spongepowered/api/entity/living/meta/SkeletonType.java
+++ b/src/main/java/org/spongepowered/api/entity/living/meta/SkeletonType.java
@@ -31,4 +31,12 @@ package org.spongepowered.api.entity.living.meta;
  */
 public interface SkeletonType {
 
+    /**
+     * The unique name of this skeleton type.
+     * 
+     * @return The name of this skeleton type
+     * @see SkeletonTypes#valueOf(String)
+     */
+    String getName();
+
 }


### PR DESCRIPTION
**The issue**
Currently there is now way to use the interface to display infos about an entity.
This PR adds a `getName()` to the meta interfaces, so you could do things like this.

``` java
player.sendMessage("The horse you are looking at is " + horse.getHorseColor().getName() + "!");
```

**PR Breakdown:**
Added a `getName()` method to all entity/living/meta interfaces.
