### PR TITLE
Added valueOf() method to Arts.

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/hanging/art/ArtFactory.java
+++ b/src/main/java/org/spongepowered/api/entity/hanging/art/ArtFactory.java
@@ -28,6 +28,21 @@ import java.util.List;
 
 interface ArtFactory {
 
+    /**
+     * Gets a list of all possible {@link Art}s, that are supported by this
+     * implementation.
+     * 
+     * @return An immutable list containing all available arts
+     */
     List<Art> getArtPieces();
 
+    /**
+     * Gets the {@link Art} by it's name.
+     * 
+     * @param name The name of the art that should be returned
+     * @return An {@link Art} with the given name, or null if there is no
+     *         {@link Art} with the given name.
+     * @see Art#getName()
+     */
+    Art getFromName(String name);
 }

--- a/src/main/java/org/spongepowered/api/entity/hanging/art/Arts.java
+++ b/src/main/java/org/spongepowered/api/entity/hanging/art/Arts.java
@@ -26,7 +26,12 @@ package org.spongepowered.api.entity.hanging.art;
 
 import java.util.List;
 
-public class Arts {
+import com.google.common.base.Optional;
+
+/**
+ * A utility class for easy access to all available {@link Art}s.
+ */
+public final class Arts {
 
     private static final ArtFactory factory = new NullArtFactory();
 
@@ -60,7 +65,25 @@ public class Arts {
     public static final Art PIGSCENE = null;
     public static final Art BURNING_SKULL = null;
 
+    /**
+     * Gets a list of all possible {@link Art}s, that are supported by this
+     * implementation.
+     * 
+     * @return An immutable list containing all available arts
+     */
     public static List<Art> getValues() {
         return factory.getArtPieces();
+    }
+
+    /**
+     * Gets the {@link Art} by it's name.
+     * 
+     * @param name The name of the art
+     * @return An {@link Optional} containing the {@link Art} with the given
+     *         name, if any
+     * @see Art#getName()
+     */
+    public static Optional<Art> valueOf(String name) {
+        return Optional.fromNullable(factory.getFromName(name));
     }
 }

--- a/src/main/java/org/spongepowered/api/entity/hanging/art/NullArtFactory.java
+++ b/src/main/java/org/spongepowered/api/entity/hanging/art/NullArtFactory.java
@@ -26,10 +26,15 @@ package org.spongepowered.api.entity.hanging.art;
 
 import java.util.List;
 
-class NullArtFactory implements ArtFactory {
+final class NullArtFactory implements ArtFactory {
 
     @Override
     public List<Art> getArtPieces() {
+        return null;
+    }
+
+    @Override
+    public Art getFromName(String name) {
         return null;
     }
 }


### PR DESCRIPTION
**The issue**
Currently there is a `getName()` method in `Art`, but for a given name you cannot get the   associated `Art`. So i added the `Arts.valueOf()` method along with some javadocs. Silimar to `DyeColors.valueOf(String)`

**PR Breakdown:**
Added the `Arts.valueOf()` and `ArtFactory.getFromName(String)` method
Added some missing javadocs (`Art___` only).
Made classes final that cannot be extended. (I can remove that if this is not disired)
