### PR TITLE
Proposal for Location<T extends Extent>

### DIFF
--- a/src/main/java/org/spongepowered/api/block/Block.java
+++ b/src/main/java/org/spongepowered/api/block/Block.java
@@ -57,7 +57,7 @@ public interface Block {
      *
      * @return The location
      */
-    Location getLocation();
+    Location<Extent> getLocation();
 
     /**
      * Get the X component of this block instance's position.

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -30,6 +30,8 @@ import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.math.EulerDirection;
 import org.spongepowered.api.math.Vector3d;
 import org.spongepowered.api.math.Vector3f;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.extent.Extent;
 
 /**
  * An entity is a Minecraft entity.
@@ -70,6 +72,28 @@ public interface Entity extends EntityState {
      * @param interactionType The type of interaction performed on this entity
      */
     void interactWith(ItemStack itemStack, EntityInteractionType interactionType);
+
+    /**
+     * Get the location of this entity.
+     *
+     * @return The location
+     */
+    Location<Extent> getLocation();
+
+    /**
+     * Teleport the entity to a location.
+     *
+     * @param location The location
+     */
+    void teleport(Location<Extent> location);
+
+    /**
+     * Teleport the entity to a location.
+     *
+     * @param extent The new extent
+     * @param position The new position
+     */
+    void teleport(Extent extent, Vector3d position);
 
     /**
      * Gets the position.

--- a/src/main/java/org/spongepowered/api/event/entity/EntityMoveEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityMoveEvent.java
@@ -28,6 +28,7 @@ package org.spongepowered.api.event.entity;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.util.event.Cancellable;
 import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.extent.Extent;
 
 /**
  * Called when an {@link Entity} moves.
@@ -39,12 +40,12 @@ public interface EntityMoveEvent extends EntityEvent, Cancellable {
      * 
      * @return The old location
      */
-    Location getOldLocation();
+    Location<Extent> getOldLocation();
 
     /**
      * Gets the new {@link Location} that the entity is in.
      * 
      * @return The new location
      */
-    Location getNewLocation();
+    Location<Extent> getNewLocation();
 }

--- a/src/main/java/org/spongepowered/api/world/Location.java
+++ b/src/main/java/org/spongepowered/api/world/Location.java
@@ -30,86 +30,85 @@ import org.spongepowered.api.math.Vector3d;
 import org.spongepowered.api.math.Vector3f;
 import org.spongepowered.api.math.Vector3i;
 import org.spongepowered.api.math.Vectors;
+import org.spongepowered.api.world.extent.Extent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * A position within a particular {@link World}.
+ * A position within a particular {@link Extent}.
  *
  * <p>Locations are immutable. Methods that change the properties of the
  * location create a new instance.</p>
  */
-public class Location {
+public class Location<T extends Extent> {
 
-    private final World world;
+    private final T extent;
     private final Vector3d position;
 
     /**
      * Create a new instance.
      *
-     * @param world The world
+     * @param extent The extent
      * @param position The position
      */
-    public Location(World world, Vector3d position) {
-        checkNotNull(world);
+    public Location(T extent, Vector3d position) {
+        checkNotNull(extent);
         checkNotNull(position);
-        this.world = world;
+        this.extent = extent;
         this.position = position;
     }
 
     /**
      * Create a new instance.
      *
-     * @param world The world
+     * @param extent The extent
      * @param position The position
      */
-    public Location(World world, Vector3f position) {
-        this(world, position.toDouble());
+    public Location(T extent, Vector3f position) {
+        this(extent, position.toDouble());
     }
 
     /**
      * Create a new instance.
      *
-     * @param world The world
+     * @param extent The extent
      * @param position The position
      */
-    public Location(World world, Vector3i position) {
-        this(world, position.toDouble());
+    public Location(T extent, Vector3i position) {
+        this(extent, position.toDouble());
     }
 
     /**
      * Create a new instance.
      *
-     * @param world The world
+     * @param extent The extent
      * @param x The x position
      * @param y The y position
      * @param z The z position
      */
-    public Location(World world, double x, double y, double z) {
-        this(world, Vectors.create3d(x, y, z));
+    public Location(T extent, double x, double y, double z) {
+        this(extent, Vectors.create3d(x, y, z));
     }
 
     /**
-     * Get the underlying world.
+     * Get the underlying extent.
      *
-     * @return The world
+     * @return The extent
      */
-    public World getWorld() {
-        return world;
+    public T getExtent() {
+        return extent;
     }
 
     /**
-     * Create a new instance with a new world.
+     * Create a new instance with a new extent.
      *
-     * @param world The new world
+     * @param <V> The Type of Extent
+     * @param extent The new extent
      * @return A new instance
      */
-    public Location setWorld(World world) {
-        checkNotNull(world);
-        if (world == getWorld()) {
-            return this;
-        }
-        return new Location(world, getPosition());
+    public <V extends Extent> Location<V> setExtent(V extent) {
+        checkNotNull(extent);
+        return new Location<V>(extent, getPosition());
     }
 
     /**
@@ -127,12 +126,12 @@ public class Location {
      * @param position The new position
      * @return A new instance
      */
-    public Location setPosition(Vector3d position) {
+    public Location<T> setPosition(Vector3d position) {
         checkNotNull(position);
         if (position == getPosition()) {
             return this;
         }
-        return new Location(getWorld(), position);
+        return new Location<T>(getExtent(), position);
     }
 
     /**
@@ -142,7 +141,7 @@ public class Location {
      * @param v The vector to add
      * @return A new instance
      */
-    public Location add(Vector3d v) {
+    public Location<T> add(Vector3d v) {
         return setPosition(getPosition().add(v));
     }
 
@@ -155,7 +154,7 @@ public class Location {
      * @param z The z component
      * @return A new instance
      */
-    public Location add(double x, double y, double z) {
+    public Location<T> add(double x, double y, double z) {
         return setPosition(getPosition().add(x, y, z));
     }
 
@@ -165,22 +164,18 @@ public class Location {
      * @return The block
      */
     public Block getBlock() {
-        return getWorld().getBlock(getPosition());
+        return getExtent().getBlock(getPosition());
     }
 
     /**
      * Create a new location instance from a {@link Block} residing
-     * inside a {@link World}.
+     * inside a {@link Extent}.
      *
      * @param block The block
      * @return The location
      */
-    public static Location fromBlock(Block block) {
-        if (block.getExtent() instanceof World) {
-            return new Location((World) block.getExtent(), block.getPosition());
-        } else {
-            throw new IllegalArgumentException("The given block is not in an instance of a World");
-        }
+    public static Location<Extent> fromBlock(Block block) {
+        return new Location<Extent>(block.getExtent(), block.getPosition());
     }
 
 }


### PR DESCRIPTION
This is a proposal for `Location` to be `Location<T extends Extent>`.

`Location` is `Extent/World` + `Vector3d`

It also adds some methods to get/set `Locations`.

Example usage:

``` java
Location<Extent> location = entity.getLocation();
entity.teleport(location.setExtent(otherWorld));
```

Alternatives:
- `Location` only handles `Extent` (`Location` is not generic)
- `Location` only handles `World`
- We have no `Location`
