### PR TITLE
Convert all events types to concrete classes

### DIFF
--- a/src/main/java/org/spongepowered/api/event/entity/EntityDismountEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityDismountEvent.java
@@ -24,18 +24,50 @@
  */
 package org.spongepowered.api.event.entity;
 
+import org.spongepowered.api.Game;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.util.event.Cancellable;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Raised when an entity dismounts another entity.
  */
-public interface EntityDismountEvent extends EntityEvent, Cancellable {
+public class EntityDismountEvent extends AbstractEventEntity implements Cancellable {
+
+    private boolean cancelled;
+    private final Entity dismounted;
+
+    public EntityDismountEvent(Game game, List<Entity> entities, Entity dismounted) {
+        super(game, entities);
+        checkNotNull(dismounted, "dismounted");
+        this.dismounted = dismounted;
+    }
 
     /**
-     * Gets the entity that is being dismounted from.
+     * Get the entity that was dismounted.
      *
-     * @return The entity that is being dismounted from
+     * @return The entity dismounted
      */
-    Entity getDismounted();
+    public Entity getDismounted() {
+        return dismounted;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public boolean isCancellable() {
+        return true;
+    }
+
 }

--- a/src/main/java/org/spongepowered/api/event/entity/EntitySpawnEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntitySpawnEvent.java
@@ -25,15 +25,15 @@
 
 package org.spongepowered.api.event.entity;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.spongepowered.api.Game;
 import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.util.event.Result;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.CauseTracked;
+import org.spongepowered.api.util.event.Result;
 
 import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Raised when entities are spawned.

--- a/src/main/java/org/spongepowered/api/util/event/AbstractEvent.java
+++ b/src/main/java/org/spongepowered/api/util/event/AbstractEvent.java
@@ -23,59 +23,23 @@
  * THE SOFTWARE.
  */
 
-package org.spongepowered.api.event.entity;
-
-import com.google.common.base.Predicate;
-import org.spongepowered.api.Game;
-import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.util.event.AbstractEvent;
-
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
+package org.spongepowered.api.util.event;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-/**
- * An abstract implementation of entity events.
- */
-public abstract class AbstractEventEntity extends AbstractEvent implements EntityEvent {
+public abstract class AbstractEvent implements Event {
 
-    private final Game game;
-    private final List<Entity> entities;
+    private Result result = Result.DEFAULT;
 
-    /**
-     * Create a new instance.
-     *
-     * @param game The game
-     * @param entities A list of entities
-     */
-    public AbstractEventEntity(Game game, List<Entity> entities) {
-        checkNotNull(game);
-        checkNotNull(entities);
-        this.game = game;
-        this.entities = entities;
+    @Override
+    public Result getResult() {
+        return result;
     }
 
     @Override
-    public Game getGame() {
-        return game;
-    }
-
-    @Override
-    public List<Entity> getEntities() {
-        return isCancellable() ? entities : Collections.unmodifiableList(entities);
-    }
-
-    @Override
-    public void filter(Predicate<Entity> predicate) {
-        Iterator<Entity> it = entities.iterator();
-        boolean canRemove = isCancellable();
-        while (it.hasNext()) {
-            if (!predicate.apply(it.next()) && canRemove) {
-                it.remove();
-            }
-        }
+    public void setResult(Result result) {
+        checkNotNull(result, "result");
+        this.result = result;
     }
 
 }


### PR DESCRIPTION
**This branch is primarily for discussion, but the current likelihood that it will be implemented is HIGH (though not necessarily in the form of this branch's commits).**

Right now, events in the API are interfaces. The plan is to convert them all to concrete classes. This comes with some advantages and disadvantages.

## If we keep them as interfaces

The advantage:

* Mapping our events to Forge events is very easy. For example, since our block events are interfaces, we can just have Forge's events implement our interfaces (by rewriting the Forge classes at runtime).

The disadvantage:

* Constructing events becomes quite messy because you need factories (`EventFactory.createBlockChangeEvent(...)`). It gets pretty inconsistent especially when all plugin-provided events would likely be concrete classes (`new MyPluginEvent(...)`).

## What makes this difficult

The main difficulty is that we want to maintain correct event handler ordering between the Forge events and Sponge events.

This is what SHOULD happen:

* Handler for Sponge event handler at FIRST priority
* Handler for Forge event handler at FIRST priority
* Handler for Sponge event handler at LOW priority
* Handler for Forge event handler at LOW priority

This is what should NOT happen:

* Handler for Sponge event handler at FIRST priority
* Handler for Sponge event handler at LOW priority
* Handler for Forge event handler at FIRST priority
* Handler for Forge event handler at LOW priority

(or the inverse)

If someone fires a Forge event, it should trigger the equivalent Sponge event, and vice versa.

## Fixing the problem

Unfortunately, we do not yet have a sane way to fix the problem.

Here is one crazy proposal:

* Change FML's event bus to handle paired events (both sponge's block events and Forge's block events fire interweaved). This will make the event bus code extremely messy.

## Ignoring the problem

On the other hand, we may choose to ignore the problem for the following reasons:

* Forge events are not as well developed and are a lot more inconsistent than ours.
* This is a lot of work to solve a problem that may not really matter in the grand scheme of things.
* Figuring out a solution may delay the first release.
* A solution can still be implemented in the future without breaking API.

## My opinion

I am currently of the opinion that:

* We should use concrete event classes.
* We should ignore Forge events for now.