### PR TITLE
Change Block to Voxel

### DIFF
--- a/src/main/java/org/spongepowered/api/block/Voxel.java
+++ b/src/main/java/org/spongepowered/api/block/Voxel.java
@@ -36,7 +36,7 @@ import java.util.Collection;
 /**
  * Represents a block at a specific location in an {@link Extent}.
  */
-public interface Block {
+public interface Voxel {
 
     /**
      * Get the extent.

--- a/src/main/java/org/spongepowered/api/event/player/PlayerInteractEvent.java
+++ b/src/main/java/org/spongepowered/api/event/player/PlayerInteractEvent.java
@@ -25,7 +25,7 @@
 
 package org.spongepowered.api.event.player;
 
-import org.spongepowered.api.block.Block;
+import org.spongepowered.api.block.Voxel;
 import org.spongepowered.api.entity.EntityInteractionType;
 import org.spongepowered.api.entity.Player;
 import org.spongepowered.api.util.event.Cancellable;
@@ -38,11 +38,11 @@ import com.google.common.base.Optional;
 public interface PlayerInteractEvent extends PlayerEvent, Cancellable {
 
     /**
-     * Gets the {@link Block} that the player has clicked, if available.
+     * Gets the {@link Voxel} that the player has clicked, if available.
      * 
      * @return The block
      */
-    Optional<Block> getBlock();
+    Optional<Voxel> getBlock();
 
     /**
      * Gets the {@link EntityInteractionType} that the player used.

--- a/src/main/java/org/spongepowered/api/world/Location.java
+++ b/src/main/java/org/spongepowered/api/world/Location.java
@@ -25,7 +25,7 @@
 
 package org.spongepowered.api.world;
 
-import org.spongepowered.api.block.Block;
+import org.spongepowered.api.block.Voxel;
 import org.spongepowered.api.math.Vector3d;
 import org.spongepowered.api.math.Vector3f;
 import org.spongepowered.api.math.Vector3i;
@@ -164,20 +164,20 @@ public class Location {
      *
      * @return The block
      */
-    public Block getBlock() {
-        return getWorld().getBlock(getPosition());
+    public Voxel getVoxel() {
+        return getWorld().getVoxel(getPosition());
     }
 
     /**
-     * Create a new location instance from a {@link Block} residing
+     * Create a new location instance from a {@link Voxel} residing
      * inside a {@link World}.
      *
-     * @param block The block
+     * @param voxel The block
      * @return The location
      */
-    public static Location fromBlock(Block block) {
-        if (block.getExtent() instanceof World) {
-            return new Location((World) block.getExtent(), block.getPosition());
+    public static Location fromVoxel(Voxel voxel) {
+        if (voxel.getExtent() instanceof World) {
+            return new Location((World) voxel.getExtent(), voxel.getPosition());
         } else {
             throw new IllegalArgumentException("The given block is not in an instance of a World");
         }

--- a/src/main/java/org/spongepowered/api/world/extent/Extent.java
+++ b/src/main/java/org/spongepowered/api/world/extent/Extent.java
@@ -28,6 +28,6 @@ package org.spongepowered.api.world.extent;
 /**
  * Contains blocks, entities, and possibly other game objects.
  */
-public interface Extent extends BlockVolume, EntityUniverse, BiomeVolume {
+public interface Extent extends VoxelVolume, EntityUniverse, BiomeVolume {
 
 }

--- a/src/main/java/org/spongepowered/api/world/extent/VoxelVolume.java
+++ b/src/main/java/org/spongepowered/api/world/extent/VoxelVolume.java
@@ -25,13 +25,13 @@
 
 package org.spongepowered.api.world.extent;
 
-import org.spongepowered.api.block.Block;
+import org.spongepowered.api.block.Voxel;
 import org.spongepowered.api.math.Vector3d;
 
 /**
  * A volume containing blocks.
  */
-public interface BlockVolume {
+public interface VoxelVolume {
 
     /**
      * Get a representation of the block at the given position.
@@ -39,7 +39,7 @@ public interface BlockVolume {
      * @param position The position
      * @return The block
      */
-    Block getBlock(Vector3d position);
+    Voxel getVoxel(Vector3d position);
 
     /**
      * Get a representation of the block at the given position.
@@ -49,6 +49,6 @@ public interface BlockVolume {
      * @param z The Z position
      * @return The block
      */
-    Block getBlock(int x, int y, int z);
+    Voxel getVoxel(int x, int y, int z);
 
 }


### PR DESCRIPTION
**This branch is primarily for discussion.**

There was some disagreement as to what `Block` should be called.

The problem stems from the fact that the MCP and Bukkit diverged on what to name things.
## Block from Bukkit's PoV

`Block` in Bukkit (and currently in Sponge) is essentially a value type containing `World` (actually `Extent`) + `Vector3i`. _It refers to a specific integer location in a `World` (or `Extent` rather)._

``` java
class Block {
    World world;
    Vector3i position;
}
```

(An `Extent` is a parent type of `World`. An `Extent` contains blocks, entities, biomes, and so on. It _could_ refer to a specific area of a `World`, or it could be a virtual area such as a copy of an area of the world. It is similar to `IBlockAccess` from MCP but contains biomes and entity too.)

Here's some examples of Bukkit's `Block`:

``` java
Block block = world.getBlockAt(0, 0, 0);
block.setType(Material.GLASS);
```
## Block from MCP's PoV

`Block` in MCP is a block type. Here are some examples of `Block` being used:

``` java
Block.brick.harvestBlock(world, entity, x, y, z, d);
```

MC does not have an equivalent of Bukkit's `Block` and instead you access blocks on the world like so:

``` java
world.setBlock(x, y, z, block, flag);
```
## How it is currently in Sponge

Currently, `Block` was chosen for consistency reasons. See the tables below.
### Blocks

| Project | Type | Instance | Snapshot |
| --- | --- | --- | --- |
| Sponge | BlockType | Block | BlockSnapshot |
| Bukkit | Material | Block | BlockState |
| MCP | Block | :no_entry_sign: | :no_entry_sign: |
### Entities

| Project | Type | Instance | Snapshot |
| --- | --- | --- | --- |
| Sponge | EntityType | Entity | EntitySnapshot |
| Bukkit | EntityType | Entity | :no_entry_sign: |
| MCP | Class<Entity> | Entity | :no_entry_sign: |
## Other considerations
- The need for a block position object to work with blocks does mean extra work for the GC, but if needed, we can add methods to `Extent` that take x, y, z coordinates, bypassing `Block` entirely.
- Bukkit developers are more familiar with `Block` from Bukkit.
- Having `Block` named so confuses the hell out of those more familiar with MCP's convention.
## Alternatives to `Block`
- `Voxel`
- `BlockLocation`
- `BlockLoc`

We can also leave `Block` named as `Block`.
