### PR TITLE
Improved getMinAxis() and getMaxAxis()

### DIFF
--- a/src/main/java/org/spongepowered/api/math/Vector2d.java
+++ b/src/main/java/org/spongepowered/api/math/Vector2d.java
@@ -27,6 +27,8 @@ package org.spongepowered.api.math;
 
 import java.io.Serializable;
 
+import org.spongepowered.api.util.Axis;
+
 /**
  * Represent a 2 component vector using doubles. It is immutable and all vectors
  * returned by the methods are new instances.
@@ -339,14 +341,14 @@ public interface Vector2d extends Comparable<Vector2d>, Serializable, Cloneable 
      *
      * @return The axis with minimal value
      */
-    int getMinAxis();
+    Axis getMinAxis();
 
     /**
      * Return the axis with the maximum value.
      *
      * @return The axis with maximum value
      */
-    int getMaxAxis();
+    Axis getMaxAxis();
 
     /**
      * Returns this vector as a Vector3d, using the value 0 for component z.

--- a/src/main/java/org/spongepowered/api/math/Vector2f.java
+++ b/src/main/java/org/spongepowered/api/math/Vector2f.java
@@ -27,6 +27,8 @@ package org.spongepowered.api.math;
 
 import java.io.Serializable;
 
+import org.spongepowered.api.util.Axis;
+
 /**
  * Represent a 2 component vector using floats. It is immutable and all vectors
  * returned by the methods are new instances.
@@ -463,14 +465,14 @@ public interface Vector2f extends Comparable<Vector2f>, Serializable, Cloneable 
      *
      * @return The axis with minimal value
      */
-    int getMinAxis();
+    Axis getMinAxis();
 
     /**
      * Return the axis with the maximum value.
      *
      * @return The axis with maximum value
      */
-    int getMaxAxis();
+    Axis getMaxAxis();
 
     /**
      * Returns this vector as a Vector3f, using the value 0 for component z.

--- a/src/main/java/org/spongepowered/api/math/Vector2i.java
+++ b/src/main/java/org/spongepowered/api/math/Vector2i.java
@@ -27,6 +27,8 @@ package org.spongepowered.api.math;
 
 import java.io.Serializable;
 
+import org.spongepowered.api.util.Axis;
+
 /**
  * Represent a 2 component vector using ints. It is immutable and all vectors
  * returned by the methods are new instances. Double overloads are floored to
@@ -420,14 +422,14 @@ public interface Vector2i extends Comparable<Vector2i>, Serializable, Cloneable 
      *
      * @return The axis with minimal value
      */
-    int getMinAxis();
+    Axis getMinAxis();
 
     /**
      * Return the axis with the maximum value.
      *
      * @return The axis with maximum value
      */
-    int getMaxAxis();
+    Axis getMaxAxis();
 
     /**
      * Returns this vector as a Vector3i, using the value 0 for component z.

--- a/src/main/java/org/spongepowered/api/math/Vector3d.java
+++ b/src/main/java/org/spongepowered/api/math/Vector3d.java
@@ -27,6 +27,8 @@ package org.spongepowered.api.math;
 
 import java.io.Serializable;
 
+import org.spongepowered.api.util.Axis;
+
 /**
  * Represent a 3 component vector using doubles. It is immutable and all vectors
  * returned by the methods are new instances.
@@ -380,14 +382,14 @@ public interface Vector3d extends Comparable<Vector3d>, Serializable, Cloneable 
      *
      * @return The axis with minimal value
      */
-    int getMinAxis();
+    Axis getMinAxis();
 
     /**
      * Returns the axis with the maximum value.
      *
      * @return The axis with maximum value
      */
-    int getMaxAxis();
+    Axis getMaxAxis();
 
     /**
      * Returns this vector as a Vector2d, discarding the component z.

--- a/src/main/java/org/spongepowered/api/math/Vector3f.java
+++ b/src/main/java/org/spongepowered/api/math/Vector3f.java
@@ -27,6 +27,8 @@ package org.spongepowered.api.math;
 
 import java.io.Serializable;
 
+import org.spongepowered.api.util.Axis;
+
 /**
  * Represent a 3 component vector using floats. It is immutable and all vectors
  * returned by the methods are new instances.
@@ -525,14 +527,14 @@ public interface Vector3f extends Comparable<Vector3f>, Serializable, Cloneable 
      *
      * @return The axis with minimal value
      */
-    int getMinAxis();
+    Axis getMinAxis();
 
     /**
      * Returns the axis with the maximum value.
      *
      * @return The axis with maximum value
      */
-    int getMaxAxis();
+    Axis getMaxAxis();
 
     /**
      * Returns this vector as a Vector2f, discarding the component z.

--- a/src/main/java/org/spongepowered/api/math/Vector3i.java
+++ b/src/main/java/org/spongepowered/api/math/Vector3i.java
@@ -27,6 +27,8 @@ package org.spongepowered.api.math;
 
 import java.io.Serializable;
 
+import org.spongepowered.api.util.Axis;
+
 /**
  * Represent a 3 component vector using ints. It is immutable and all vectors
  * returned by the methods are new instances. Double overloads are floored to
@@ -475,14 +477,14 @@ public interface Vector3i extends Comparable<Vector3i>, Serializable, Cloneable 
      *
      * @return The axis with minimal value
      */
-    int getMinAxis();
+    Axis getMinAxis();
 
     /**
      * Returns the axis with the maximum value.
      *
      * @return The axis with maximum value
      */
-    int getMaxAxis();
+    Axis getMaxAxis();
 
     /**
      * Returns this vector as a Vector2i, discarding the component z.


### PR DESCRIPTION
Changed `getMinAxis()` and `getMaxAxis()` to use the new `Axis` enum.
