### PR TITLE
Don't use an Optional in `ItemFrame#getItemRotation`

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/hanging/ItemFrame.java
+++ b/src/main/java/org/spongepowered/api/entity/hanging/ItemFrame.java
@@ -50,12 +50,13 @@ public interface ItemFrame extends Hanging {
     void setItem(@Nullable ItemStack item);
 
     /**
-     * Gets the current {@link Rotation} of the {@link ItemStack} if
-     * an ItemStack is currently displayed.
+     * Gets the current {@link Rotation} of the {@link ItemStack}
+     * <p>If the itemframe does not have an {@link ItemStack} inside,
+     * the rotation value will be used once an item is placed inside it.</p>
      *
-     * @return The current item rotation, if available
+     * @return The current item rotation
      */
-    Optional<Rotation> getItemRotation();
+    Rotation getItemRotation();
 
     /**
      * Sets the {@link Rotation} of the item hanging in this item frame.


### PR DESCRIPTION
Currently, `ItemFrame#getItemRotation` returns an `Optional`, as an item isn't always present in the `ItemFrame`. However, the rotation value is still meaningful without an item present.

In Vanilla, removing an item from an item frame preserves its rotation. When any item is placed back into the item frame, it will have the rotation of the last item.

Given that this behavior exists in Vanilla, it should be available to plugins through the API.
