### PR TITLE
minor javadoc fixes

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -37,10 +37,10 @@ import org.spongepowered.api.item.ItemType;
 public interface GameRegistry {
 
     /**
-     * Gets a {@link BlockType} by its identifier.
+     * Gets a {@link BlockType} by its identifier, if available.
      *
      * @param id The id to look up
-     * @return The block or null if not found
+     * @return The block
      */
     Optional<BlockType> getBlock(String id);
  
@@ -52,10 +52,10 @@ public interface GameRegistry {
     List<BlockType> getBlocks();
  
     /**
-     * Gets an {@link ItemType} by its identifier.
+     * Gets an {@link ItemType} by its identifier, if available.
      *
      * @param id The id to look up
-     * @return The item or null if not found
+     * @return The item
      */
     Optional<ItemType> getItem(String id);
  

--- a/src/main/java/org/spongepowered/api/Server.java
+++ b/src/main/java/org/spongepowered/api/Server.java
@@ -52,15 +52,15 @@ public interface Server {
     int getMaxPlayers();
 
     /**
-     * Gets a {@link Player} by their unique id
+     * Gets a {@link Player} by their unique id, if available
      *
      * @param uniqueId The UUID to get the player from
-     * @return {@link Player} if available
+     * @return The player
      */
     Optional<Player> getPlayer(UUID uniqueId);
 
     /**
-     * Gets a {@link Player} by their name
+     * Gets a {@link Player} by their name, if available
      *
      * This only works for online players.
      *
@@ -68,7 +68,7 @@ public interface Server {
      * Zidane of today may not be the Zidane of yesterday.</b>
      *
      * @param name The name to get the player from
-     * @return {@link Player} if available
+     * @return The player
      */
     Optional<Player> getPlayer(String name);
 
@@ -80,18 +80,18 @@ public interface Server {
     Collection<World> getWorlds();
 
     /**
-     * Gets a loaded {@link World} by its unique id ({@link UUID}), if any.
+     * Gets a loaded {@link World} by its unique id ({@link UUID}), if available
      *
      * @param uniqueId UUID to lookup
-     * @return The world or null if not found
+     * @return The world
      */
     Optional<World> getWorld(UUID uniqueId);
 
     /**
-     * Gets a loaded {@link World} by name, if any
+     * Gets a loaded {@link World} by name, if available
      *
      * @param worldName Name to lookup
-     * @return The world or null if not found
+     * @return The world
      */
     Optional<World> getWorld(String worldName);
 
@@ -103,8 +103,8 @@ public interface Server {
     void broadcastMessage(Message<?> message);
 
     /**
-     * Gets the bound {@link InetSocketAddress} this server is accepting connections from.
-     * @return The address
+     * Gets the bound {@link InetSocketAddress} this server is accepting connections from, if available
+     * @return The link
      */
     Optional<InetSocketAddress> getBoundAddress();
 

--- a/src/main/java/org/spongepowered/api/block/BlockProperty.java
+++ b/src/main/java/org/spongepowered/api/block/BlockProperty.java
@@ -72,7 +72,7 @@ public interface BlockProperty<T extends Comparable<T>> {
     String getNameForValue(T value);
 
     /**
-     * Get the value representation for the given name.
+     * Get the value representation for the given name, if available.
      *
      * @param name A name that represents a valid value for this property
      * @return A valid value for this property

--- a/src/main/java/org/spongepowered/api/block/BlockState.java
+++ b/src/main/java/org/spongepowered/api/block/BlockState.java
@@ -68,7 +68,7 @@ public interface BlockState {
     Collection<String> getPropertyNames();
 
     /**
-     * Get a property from its name.
+     * Get a property from its name, if available
      *
      * @param name The name of the property
      * @return The property with the given name
@@ -76,7 +76,7 @@ public interface BlockState {
     Optional<BlockProperty<?>> getPropertyByName(String name);
 
     /**
-     * Get the current value of a given property.
+     * Get the current value of a given property, if available
      *
      * @param name Property to get value of
      * @return Current value of the property

--- a/src/main/java/org/spongepowered/api/event/entity/EntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityEvent.java
@@ -33,9 +33,9 @@ import org.spongepowered.api.event.GameEvent;
 public interface EntityEvent extends GameEvent {
 
     /**
-     * Returns the primary entity involved in this event that performs the action.
+     * Returns the primary entity involved in this event.
      *
-     * @return The entity performing the action
+     * @return The entity involved
      */
     Entity getEntity();
 

--- a/src/main/java/org/spongepowered/api/event/player/PlayerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/player/PlayerEvent.java
@@ -35,7 +35,7 @@ import org.spongepowered.api.event.entity.EntityEvent;
 public interface PlayerEvent extends EntityEvent {
 
     /**
-     * Gets the {@link Player} involved involved in this event.
+     * Gets the {@link Player} involved in this event.
      *
      * @return The {@link Player} involved
      */

--- a/src/main/java/org/spongepowered/api/service/scheduler/Scheduler.java
+++ b/src/main/java/org/spongepowered/api/service/scheduler/Scheduler.java
@@ -82,19 +82,19 @@ public interface Scheduler {
     Optional<RepeatingTask> runRepeatingTaskAfter(PluginContainer plugin, Runnable task, long interval, long delay);
 
     /**
-     * Returns a list of all currently scheduled tasks
+     * Returns a {@link Collection} of all currently scheduled tasks
      *
-     * @return A list of scheduled tasks
+     * @return A collection of scheduled tasks
      */
     Collection<Task> getScheduledTasks();
 
     /**
-     * Returns a list of all currently scheduled tasks owned by a
+     * Returns a {@link Collection} of all currently scheduled tasks owned by a
      * certain plugin.
      *
      * @param plugin The plugin to return tasks created by
      *
-     * @return A list of scheduled tasks
+     * @return A collection of scheduled tasks
      */
     Collection<Task> getScheduledTasks(PluginContainer plugin);
 }


### PR DESCRIPTION
Fixed most issues from the Ongoing Minor Issues List: #221 

Also, in EntityEvent the getEntity() javadoc specified the Entity returned as performing an action, but PlayerEvent does not specify the same Entity (In this case a Player) as performing an action, which may be confusing.

For every Optional, there should be something like "if available" in the javadocs.
Should it say "if available" in the method description or in the @ return ?
