### PR TITLE
Expand Block/Item interfaces

### DIFF
--- a/src/main/java/org/spongepowered/api/block/BlockLoc.java
+++ b/src/main/java/org/spongepowered/api/block/BlockLoc.java
@@ -251,6 +251,21 @@ public interface BlockLoc extends DataHolder {
     Collection<Direction> getIndirectlyPoweredFaces();
 
     /**
+     * Test whether the the block will block the movement of entities.
+     * 
+     * @return Blocks movement
+     */
+    boolean isPassable();
+    
+    /**
+     * Test whether the given face of the block can catch fire.
+     * 
+     * @param direction The face of the block to check
+     * @return Is flammable
+     */
+    boolean isFaceFlammable(Direction direction);
+
+    /**
      * Get a snapshot of this block at the current point in time.
      *
      * <p>A snapshot is disconnected from the {@link Extent} that it was

--- a/src/main/java/org/spongepowered/api/block/BlockType.java
+++ b/src/main/java/org/spongepowered/api/block/BlockType.java
@@ -82,4 +82,43 @@ public interface BlockType extends Translatable {
      * @param tickRandomly If the BlockType should tick randomly.
      */
     void setTickRandomly(boolean tickRandomly);
+
+    /**
+     * Gets if the block type is representing a liquid.
+     *
+     * @return Is liquid
+     */
+    boolean isLiquid();
+
+    /**
+     * Gets if a block type is a full and solid block.
+     *
+     * @return Is solid block
+     */
+    boolean isSolidCube();
+
+    /**
+     * Gets if this block is affected by gravity (if it will fall when
+     * unsupported).
+     *
+     * @return Is affected by gravity
+     */
+    boolean isAffectedByGravity();
+
+    /**
+     * Gets if a block should be counted for statistics gathering.
+     * 
+     * @return Is counted for statistics
+     */
+    boolean areStatisticsEnabled();
+
+    /**
+     * Gets the amount of light emitted by this block type. The returned value
+     * is normalized to have a range of 0 to 1 (1 being the maximum light
+     * value), although it is not clamped to this range.
+     * 
+     * @return The amount of light
+     */
+    float getEmittedLight();
+
 }

--- a/src/main/java/org/spongepowered/api/item/ItemType.java
+++ b/src/main/java/org/spongepowered/api/item/ItemType.java
@@ -50,5 +50,12 @@ public interface ItemType extends Translatable {
      * @return Max stack quantity
      */
     int getMaxStackQuantity();
+    
+    /**
+     * Returns the maximum damage an item can take.
+     * 
+     * @return The max damage
+     */
+    int getMaxDamage();
 
 }


### PR DESCRIPTION
This PR expands the `BlockType` and `ItemType` interfaces to provide additional methods providing information about some fundamental properties of the two types.

There is an associated PR in Sponge (86) which implements this API change, found here: https://github.com/SpongePowered/Sponge/pull/86
