### PR TITLE
Added WorldTypes as in vanilla. (May not needed if forge not supports them).

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -47,6 +47,7 @@ import org.spongepowered.api.item.merchant.TradeOfferBuilder;
 import org.spongepowered.api.potion.PotionEffectBuilder;
 import org.spongepowered.api.potion.PotionEffectType;
 import org.spongepowered.api.world.Environment;
+import org.spongepowered.api.world.WorldType;
 import org.spongepowered.api.world.biome.BiomeType;
 
 import java.util.Collection;
@@ -380,5 +381,28 @@ public interface GameRegistry {
      * @return The environment list
      */
     List<Environment> getEnvironments();
+
+    /**
+     * Gets a the {@link WorldType} with the provided name.
+     * 
+     * @param name The name of the {@link WorldType}
+     * @return The {@link WorldType} with the given name or Optional.absent() if not found
+     */
+    Optional<WorldType> getWorldType(String name);
+
+    /**
+     * Gets a the {@link WorldType} with the provided id.
+     * 
+     * @param id The id of the {@link WorldType}
+     * @return The {@link WorldType} with the given id or Optional.absent() if not found
+     */
+    Optional<WorldType> getWorldType(int id);
+
+    /**
+     * Gets a {@link List} of all possible {@link WorldType}s.
+     *
+     * @return The world type list
+     */
+    List<WorldType> getWorldTypes();
 
 }

--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -139,4 +139,11 @@ public interface World extends Extent, Viewer, WeatherVolume {
      */
     Environment getEnvironment();
 
+    /**
+     * Returns the {@link WorldType} of this world.
+     * 
+     * @return The {@link WorldType}
+     */
+    WorldType getWorldType();
+
 }

--- a/src/main/java/org/spongepowered/api/world/WorldType.java
+++ b/src/main/java/org/spongepowered/api/world/WorldType.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world;
+
+/**
+ * Holds the type of a world.
+ */
+public interface WorldType {
+
+    /**
+     * Returns the vanilla id of this {@link WorldType}.
+     * 
+     * @return The id
+     */
+    int getId();    
+
+    /**
+     * Returns the name of the current {@link WorldType}.
+     * 
+     * @return The name
+     */
+    String getName();
+
+}

--- a/src/main/java/org/spongepowered/api/world/WorldTypes.java
+++ b/src/main/java/org/spongepowered/api/world/WorldTypes.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world;
+
+public final class WorldTypes {
+
+    /**
+     * The {@link WorldType} of default {@link World}s.
+     */
+    public static final WorldType NORMAL = null;
+
+    /**
+     * The {@link WorldType} of flat {@link World}s.
+     */
+    public static final WorldType FLAT = null;
+
+    /**
+     * The {@link WorldType} for {@link World}s with large biomes.
+     */
+    public static final WorldType LARGE_BIOMES = null;
+
+    /**
+     * The {@link WorldType} for {@link World}s with amplified settings.
+     */
+    public static final WorldType AMPLIFIED = null;
+
+    /**
+     * The {@link WorldType} of new customized {@link Worlds} introduced in 1.8;
+     */
+    public static final WorldType CUSTOMIZED = null;
+
+    /**
+     * This {@link WorldType} is used if the {@link World} is set to debug.
+     */
+    public static final WorldType DEBUG = null;
+
+    /**
+     * This is {@link WorldType} for old worlds generated in minecraft 1.1 or lower.
+     */
+    public static final WorldType OLD = null;
+
+}


### PR DESCRIPTION
The type of a world specified in the server config or at generation. May not needed in the api if forge not supports them.
