### PR TITLE
Added supportsFeatures(Class) method to EntityType

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/EntityType.java
+++ b/src/main/java/org/spongepowered/api/entity/EntityType.java
@@ -36,4 +36,20 @@ public interface EntityType {
      * @return The id
      */
     String getId();
+
+    /**
+     * Checks whether this entity type does support the given feature class
+     * (including interfaces). A feature class is supported if every
+     * {@link Entity} of this entity type can be cast to the given feature
+     * class. This means that every {@link Entity} that is spawned using this
+     * entity type is an instance of either the given feature class or any
+     * subclass of the feature class. This method will always return
+     * <tt>true</tt> for {@link Entity}.class.
+     *
+     * @param featureClass The feature class or interface to check
+     * @return True if every spawned entity is guaranteed to be an instance of
+     *         the given feature class or any of its subclasses. False otherwise
+     */
+    boolean supportsFeatures(Class<?> featureClass);
+
 }


### PR DESCRIPTION
**The Issue**
Currently there is no way to check which entity class is hidden inside an entity type without spawning the entity. 

**PR Breakdown**
A previous suggestion of mine ( return the entity class like bukkit did) has been rejected because it uncovers to much of the internals. So i reverted the logic of checking the class hierarchy 

``` java
Living.class.isAssignableForm(entityType.getEntityClass())
```

 to asking the entity type whether the given class is supported.

``` java
entityType.supportsFeature(Living.class)
```

I'm fine with both ways, but i need at least some way to do that.

Spawning each `EntityType` and then getting the class is no alternative because they affect the world they are spawned in or may not able to spawn in that particular location or world. For example the ender dragon will destroy blocks or will get lost in an unloaded chunk and `Lightning` needs extra data to be spawned.

**Example usage**

``` java
if (entityType.supportsFeature(Living.class)) {
    Living entity = (Living) world.createEntity(entityType, location);
    living.setMaxHealth(100);
} else {
    throw new Exception("Please cleanup your config, " + entityType.getId() + " is no Living Entity!");
}
```

**How i want to use it**
My plugin CrazySpawner, which i want to port to Sponge, has features which uses `EntityProperty`s that are bound to entity classes. On each startup it iterates all `EntityType`s and check whether the entity's class is supported by a given `EntityProperty`. 
After that the list of supported features can be used for ingame commands to create customized entities which can be stored in a config file and can be used in `SpawnTask`s. 
I could have hardcoded the supported `EntityType`s, but that way interface changes and new `EntityType`s would not be supported automatically.
[EntityPropertyHelper](https://github.com/ST-DDT/CrazySpawner/blob/dev/src/main/java/de/st_ddt/crazyspawner/entities/properties/EntityPropertyHelper.java) [EntityProperty](https://github.com/ST-DDT/CrazySpawner/blob/dev/src/main/java/de/st_ddt/crazyspawner/entities/properties/EntityPropertyInterface.java)
My plugin can spawn 58 `EntityType`s with 180 (ingame) configurable `EntityProperty`s.

Create new entity template
`/cspawner ce CREEPER C123`
Change template options
`/cspawner me C123 allowitempickup:true armorhelmet:SLOT1`
`/cspawner me C123 attributefollowrange:1 health:50 customName:"Armored Creeper"`
Spawn entity based on template
`/cms C123`
