### PR TITLE
Implementation of a context-based permissions API

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/player/User.java
+++ b/src/main/java/org/spongepowered/api/entity/player/User.java
@@ -28,6 +28,7 @@ package org.spongepowered.api.entity.player;
 import com.google.common.base.Optional;
 import org.spongepowered.api.GameProfile;
 import org.spongepowered.api.entity.ArmorEquipable;
+import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.service.persistence.DataSerializable;
 import org.spongepowered.api.util.Identifiable;
 
@@ -37,7 +38,7 @@ import java.util.Date;
  * A User is the data usually associated with a Player that is persisted across server restarts.
  * This is in contrast to Player which represents the ingame entity associated with an online User.
  */
-public interface User extends Identifiable, ArmorEquipable, DataSerializable {
+public interface User extends Identifiable, ArmorEquipable, DataSerializable, Subject {
 
     /**
      * Gets the associated {@link GameProfile} of this player.
@@ -55,7 +56,7 @@ public interface User extends Identifiable, ArmorEquipable, DataSerializable {
 
     /**
      * Checks if this player has joined the server before.
-     * 
+     *
      * @return True If player has joined before
      */
     boolean hasJoinedBefore();
@@ -84,14 +85,14 @@ public interface User extends Identifiable, ArmorEquipable, DataSerializable {
 
     /**
      * Checks if this player is banned.
-     * 
+     *
      * @return True If banned
      */
     boolean isBanned();
 
     /**
      * Checks if this player is whitelisted.
-     * 
+     *
      * @return True If whitelisted
      */
     boolean isWhitelisted();

--- a/src/main/java/org/spongepowered/api/service/permission/MemorySubjectData.java
+++ b/src/main/java/org/spongepowered/api/service/permission/MemorySubjectData.java
@@ -1,0 +1,210 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.permission;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import org.spongepowered.api.service.permission.context.Context;
+import org.spongepowered.api.util.Tristate;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A subject data implementation storing all contained data in memory.
+ *
+ * <p>This class is thread-safe.
+ */
+public class MemorySubjectData implements SubjectData {
+    private final PermissionService service;
+    private final ConcurrentMap<Set<Context>, NodeTree> permissions = Maps.newConcurrentMap();
+    private final ConcurrentMap<Set<Context>, List<Map.Entry<String, String>>> parents = Maps.newConcurrentMap();
+
+    /**
+     * Creates a new subject data instance, using the provided service to request instances of permission subjects.
+     *
+     * @param service The service to request subjects from
+     */
+    public MemorySubjectData(PermissionService service) {
+        checkNotNull(service);
+        this.service = service;
+    }
+
+    @Override
+    public Map<Set<Context>, Map<String, Boolean>> getAllPermissions() {
+        ImmutableMap.Builder<Set<Context>, Map<String, Boolean>> ret = ImmutableMap.builder();
+        for (Map.Entry<Set<Context>, NodeTree> ent : permissions.entrySet()) {
+            ret.put(ent.getKey(), ent.getValue().asMap());
+        }
+        return ret.build();
+    }
+
+    @Override
+    public Map<String, Boolean> getPermissions(Set<Context> contexts) {
+        NodeTree perms = permissions.get(contexts);
+        return perms == null ? Collections.<String, Boolean>emptyMap() : perms.asMap();
+    }
+
+    @Override
+    public boolean setPermission(Set<Context> contexts, String permission, Tristate value) {
+        contexts = ImmutableSet.copyOf(contexts);
+        while (true) {
+            NodeTree oldTree = permissions.get(contexts);
+            if (oldTree != null && oldTree.get(permission) == value) {
+                return false;
+            }
+
+            if (oldTree == null && value != Tristate.UNDEFINED) {
+                if (permissions.putIfAbsent(contexts, NodeTree.of(ImmutableMap.of(permission, value.asBoolean()))) == null) {
+                    break;
+                }
+            } else {
+                if (permissions.replace(contexts, oldTree, oldTree.withValue(permission, value))) {
+                    break;
+                }
+            }
+        }
+        return true;
+
+    }
+
+    @Override
+    public boolean clearPermissions() {
+        boolean wasEmpty = permissions.isEmpty();
+        permissions.clear();
+        return !wasEmpty;
+    }
+
+    @Override
+    public boolean clearPermissions(Set<Context> context) {
+        return permissions.remove(context) != null;
+    }
+
+    @Override
+    public Map<Set<Context>, List<Subject>> getAllParents() {
+        ImmutableMap.Builder<Set<Context>, List<Subject>> ret = ImmutableMap.builder();
+        for (Map.Entry<Set<Context>, List<Map.Entry<String, String>>> ent : parents.entrySet()) {
+            ret.put(ent.getKey(), toSubjectList(ent.getValue()));
+        }
+        return ret.build();
+    }
+
+    List<Subject> toSubjectList(List<Map.Entry<String, String>> parents) {
+        ImmutableList.Builder<Subject> ret = ImmutableList.builder();
+        for (Map.Entry<String, String> ent : parents) {
+            Optional<SubjectCollection> collection = service.getSubjects(ent.getKey());
+            if (!collection.isPresent()) {
+                continue;
+            }
+            ret.add(collection.get().get(ent.getValue()));
+        }
+        return ret.build();
+    }
+
+    @Override
+    public List<Subject> getParents(Set<Context> contexts) {
+        List<Map.Entry<String, String>> ret = parents.get(contexts);
+        return ret == null ? Collections.<Subject>emptyList() : toSubjectList(ret);
+    }
+
+    @Override
+    public boolean addParent(Set<Context> contexts, Subject parent) {
+        contexts = ImmutableSet.copyOf(contexts);
+        while (true) {
+            Map.Entry<String, String> newEnt = Maps.immutableEntry(parent.getContainingCollection().getIdentifier(),
+                    parent.getIdentifier());
+            List<Map.Entry<String, String>> oldParents = parents.get(contexts);
+            List<Map.Entry<String, String>> newParents = ImmutableList.<Map.Entry<String, String>>builder()
+                    .addAll(oldParents == null ? Collections.<Map.Entry<String, String>>emptyList() : oldParents)
+                    .add(newEnt)
+                    .build();
+            if (oldParents != null && oldParents.contains(newEnt)) {
+                return false;
+            }
+
+            if (updateCollection(parents, contexts, oldParents, newParents)) {
+                return true;
+            }
+        }
+    }
+
+    private <K, V> boolean updateCollection(ConcurrentMap<K, V> collection, K key, @Nullable V oldValue, V newValue) {
+        if (oldValue == null) {
+            if (collection.putIfAbsent(key, newValue) == null) {
+                return true;
+            }
+        } else {
+            if (collection.replace(key, oldValue, newValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean removeParent(Set<Context> contexts, Subject parent) {
+        contexts = ImmutableSet.copyOf(contexts);
+        while (true) {
+            Map.Entry<String, String> removeEnt = Maps.immutableEntry(parent.getContainingCollection().getIdentifier(),
+                    parent.getIdentifier());
+            List<Map.Entry<String, String>> oldParents = parents.get(contexts);
+            List<Map.Entry<String, String>> newParents;
+
+            if (oldParents == null || !oldParents.contains(removeEnt)) {
+                return false;
+            }
+            newParents = new ArrayList<Map.Entry<String, String>>(oldParents);
+            newParents.remove(removeEnt);
+
+
+            if (updateCollection(parents, contexts, oldParents, Collections.unmodifiableList(newParents))) {
+                return true;
+            }
+        }
+
+    }
+
+    @Override
+    public boolean clearParents() {
+        boolean wasEmpty = parents.isEmpty();
+        parents.clear();
+        return !wasEmpty;
+    }
+
+    @Override
+    public boolean clearParents(Set<Context> contexts) {
+        return parents.remove(contexts) != null;
+    }
+}

--- a/src/main/java/org/spongepowered/api/service/permission/NodeTree.java
+++ b/src/main/java/org/spongepowered/api/service/permission/NodeTree.java
@@ -1,0 +1,181 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.permission;
+
+import com.google.common.collect.ImmutableMap;
+import org.spongepowered.api.util.Tristate;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * An immutable tree structure for determining node data. Any changes will create new copies of the necessary tree objects.
+ * Keys are case-insensitive.
+ * Segments of nodes are split by the '.' character
+ */
+public class NodeTree {
+    private static final Pattern SPLIT_REGEX = Pattern.compile("\\.");
+    private final Node rootNode;
+
+
+    private static class Node {
+        private Tristate value = Tristate.UNDEFINED;
+        private final Map<String, Node> children;
+
+        private Node(Map<String, Node> children) {
+            this.children = children;
+        }
+    }
+
+    private NodeTree(Tristate value) {
+        this.rootNode = new Node(new HashMap<String, Node>());
+        this.rootNode.value = value;
+    }
+
+    private NodeTree(Node rootNode) {
+        this.rootNode = rootNode;
+    }
+
+    /**
+     * Returns the value assigned to a specific node, or the nearest parent value in the tree if the node itself is undefined.
+     *
+     * @param node The path to get the node value at
+     * @return The tristate value for the given node
+     */
+    public Tristate get(String node) {
+        String[] parts = SPLIT_REGEX.split(node.toLowerCase());
+        Node currentNode = this.rootNode;
+        Tristate lastUndefinedVal = Tristate.UNDEFINED;
+        for (String str : parts) {
+            if (!currentNode.children.containsKey(str)) {
+                break;
+            }
+            currentNode = currentNode.children.get(str);
+            if (currentNode.value != Tristate.UNDEFINED) {
+                lastUndefinedVal = currentNode.value;
+            }
+        }
+        return lastUndefinedVal;
+
+    }
+
+    /**
+     * Convert this node tree into a map of the defined nodes in this tree.
+     *
+     * @return An immutable map representation of the nodes defined in this tree
+     */
+    public Map<String, Boolean> asMap() {
+        ImmutableMap.Builder<String, Boolean> ret = ImmutableMap.builder();
+        for (Map.Entry<String, Node> ent : rootNode.children.entrySet()) {
+            populateMap(ret, ent.getKey(), ent.getValue());
+        }
+        return ret.build();
+    }
+
+    private void populateMap(ImmutableMap.Builder<String, Boolean> values, String prefix, Node currentNode) {
+        if (currentNode.value != Tristate.UNDEFINED) {
+            values.put(prefix, currentNode.value.asBoolean());
+        }
+        for (Map.Entry<String, Node> ent : currentNode.children.entrySet()) {
+            populateMap(values, prefix + '.' + ent.getKey(), ent.getValue());
+        }
+    }
+
+    /**
+     * Return a new NodeTree instance with a single changed value.
+     *
+     * @param node The node path to change the value of
+     * @param value The value to change, or UNDEFINED to remove
+     * @return The new, modified node tree
+     */
+    public NodeTree withValue(String node, Tristate value) {
+        String[] parts = SPLIT_REGEX.split(node.toLowerCase());
+        Node newRoot = new Node(new HashMap<String, Node>(rootNode.children));
+        Node newPtr = newRoot;
+        Node currentPtr = rootNode;
+
+        newPtr.value = currentPtr == null ? Tristate.UNDEFINED : currentPtr.value;
+        for (String part : parts) {
+            Node oldChild = currentPtr == null ? null : currentPtr.children.get(part);
+            Node newChild = new Node(oldChild != null ? new HashMap<String, Node>(oldChild.children) : new HashMap<String, Node>());
+            newPtr.children.put(part, newChild);
+            currentPtr = oldChild;
+            newPtr = newChild;
+        }
+        newPtr.value = value;
+        return new NodeTree(newRoot);
+    }
+
+    /**
+     * Return a modified new node tree with the specified values set.
+     *
+     * @param values The values to set
+     * @return The new node tree
+     */
+    public NodeTree withAll(Map<String, Tristate> values) {
+        NodeTree ret = this;
+        for (Map.Entry<String, Tristate> ent : values.entrySet()) {
+            ret = ret.withValue(ent.getKey(), ent.getValue());
+        }
+        return ret;
+    }
+
+    /**
+     * Create a new node tree with the given values, and a default value of UNDEFINED.
+     *
+     * @param values The values to set
+     * @return The new node tree
+     */
+    public static NodeTree of(Map<String, Boolean> values) {
+        return of(values, Tristate.UNDEFINED);
+    }
+
+    /**
+     * Create a new node tree with the given values, and the specified root fallback value.
+     *
+     * @param values The values to be contained in this node tree
+     * @param defaultValue The fallback value for any completely undefined nodes
+     * @return The newly created node tree
+     */
+    public static NodeTree of(Map<String, Boolean> values, Tristate defaultValue) {
+        NodeTree newTree = new NodeTree(defaultValue);
+        for (Map.Entry<String, Boolean> value : values.entrySet()) {
+            String[] parts = SPLIT_REGEX.split(value.getKey().toLowerCase());
+            Node currentNode = newTree.rootNode;
+            for (String part : parts) {
+                if (currentNode.children.containsKey(part)) {
+                    currentNode = currentNode.children.get(part);
+                } else {
+                    Node newNode = new Node(new HashMap<String, Node>());
+                    currentNode.children.put(part, newNode);
+                    currentNode = newNode;
+                }
+            }
+            currentNode.value = Tristate.fromBoolean(value.getValue());
+        }
+        return newTree;
+    }
+}

--- a/src/main/java/org/spongepowered/api/service/permission/PermissionService.java
+++ b/src/main/java/org/spongepowered/api/service/permission/PermissionService.java
@@ -22,27 +22,68 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package org.spongepowered.api.service.permission;
 
-import com.google.common.annotations.Beta;
-import org.spongepowered.api.entity.player.Player;
+import com.google.common.base.Optional;
+import org.spongepowered.api.service.permission.context.ContextCalculator;
+
+import java.util.Map;
+
 
 /**
- * Returns {@link Subject}s that can be used to test permission.
+ * Represents a provider for permissions. This is the interface that a
+ * permissions plugin must implement to provide permissions for a user.
  */
 public interface PermissionService {
+    static final String SUBJECTS_USER = "user";
+    static final String SUBJECTS_GROUP = "group";
 
     /**
-     * Return a subject for the given player.
+     * Returns the permissions level that describes users. User identifiers are
+     * expected to be UUIDs in RFC4122 string format (This *does* have dashes.
+     * Mojang is stupid).
      *
-     * <p>This method is subject to change because some sort of
-     * "user" object may be introduced.</p>
-     *
-     * @param player The player
-     * @return A subject
+     * @return A subject collection for users
      */
-    @Beta
-    Subject login(Player player);
+    SubjectCollection getUserSubjects();
 
+    /**
+     * Returns the collection of group subjects available.
+     *
+     * @return A collection managing group subjects
+     */
+    SubjectCollection getGroupSubjects();
+
+    /**
+     * This is a transient data object that contains data that will be applied
+     * by default to all subjects.
+     *
+     * @return The default data object, which will accept modifications but which is transient
+     */
+    SubjectData getDefaultData();
+
+    /**
+     * Returns a subject collection with the given identifier.
+     *
+     * @param identifier The identifier
+     * @return a subject collection, or null if this permission service does not
+     *          support alternate subject collections.
+     */
+    Optional<SubjectCollection> getSubjects(String identifier);
+
+    /**
+     * Returns an immutable copy of the mapping of all subject collections
+     * stored by this permission service.
+     *
+     * @return The known subjects for this map
+     */
+    Map<String, SubjectCollection> getKnownSubjects();
+
+    /**
+     * Register a function that calculates contexts relevant to a given user at
+     * the time the function is called.
+     *
+     * @param calculator The context calculator to register
+     */
+    void registerContextCalculator(ContextCalculator calculator);
 }

--- a/src/main/java/org/spongepowered/api/service/permission/Subject.java
+++ b/src/main/java/org/spongepowered/api/service/permission/Subject.java
@@ -25,48 +25,160 @@
 
 package org.spongepowered.api.service.permission;
 
+import com.google.common.base.Optional;
+import org.spongepowered.api.service.permission.context.Context;
+import org.spongepowered.api.util.Tristate;
+import org.spongepowered.api.util.command.CommandSource;
+
+import java.util.List;
+import java.util.Set;
+
 /**
  * A source of permission requests.
  *
- * <p>Authorization checks are made using "permission strings."</p>
+ * <p>Authorization checks are made using "permission strings."
  *
- * <p>Permission strings are hierarchical with each level separated
- * by periods (full stops). An example of a valid permission string is
- * {@code example.function}. Inheritance is implicit; that is,
- * if a subject has been granted {@code example}, then the subject
- * should have also be automatically granted
- * {@code example.function}, {@code example.another},
- * {@code example.deeper.nesting}, and so on. However, implementations
- * may allow administrators to configure "negation" such that
- * {@code example} and all child levels would granted but
- * {@code example.access} would denied (for example).</p>
+ * <p>Permission strings are hierarchical with each level separated by periods
+ * (full stops). An example of a valid permission string is {@code
+ * example.function}. Inheritance is implicit; that is, if a subject has been
+ * granted {@code example}, then the subject should have also be automatically
+ * granted {@code example.function}, {@code example.another}, {@code
+ * example.deeper.nesting}, and so on. However, implementations may allow
+ * administrators to configure "negation" such that {@code example} and all
+ * child levels would granted but {@code example.access} would denied (for
+ * example).
  *
- * <p>Plugins may opt to implement "dynamic" permissions such as
- * {@code example.region.define.&lt;region&gt;} where {@code region}
- * would be a dynamically added level based on the context, though some
- * attention should be made towards the handling of periods / full stops
- * in such cases.</p>
+ * <p>Plugins may opt to implement "dynamic" permissions such as {@code
+ * example.region.define.&lt;region&gt;} where {@code region} would be a
+ * dynamically added level based on the context, though some attention should be
+ * made towards the handling of periods / full stops in such cases.
  *
- * <p>Due to the implicit inheritance, it is recommended that
- * commands that allow a user to "apply" an effect to other users
- * use {@code example.function.self} as the permission for applying
- * this effect to one's self. This allows administrators to grant
- * {@code example.function.self} to permit usage on one's self
- * and grant {@code example.function} to grant usage on other users.</p>
+ * <p>Due to the implicit inheritance, it is recommended that commands that allow a
+ * user to "apply" an effect to other users use {@code example.function.self} as
+ * the permission for applying this effect to one's self. This allows
+ * administrators to grant {@code example.function.self} to permit usage on
+ * one's self and grant {@code example.function} to grant usage on other users.
  *
- * <p>Use a {@link PermissionService} to create instances.</p>
+ * <p>Use a {@link PermissionService} to create instances.
  *
  * @see PermissionService
  */
 public interface Subject {
 
     /**
-     * Test whether the subject is permitted to perform an action given as
-     * the given permission string.
+     * Returns the identifier associated with this subject. May not be
+     * human-readable, but always refers to a single subject
+     *
+     * @return The unique identifier for this subject
+     */
+    String getIdentifier();
+
+    /**
+     * If this subject represents an actual user currently connected, this
+     * method returns this user. This user may in fact be the same as this
+     * subject. Some subjects may never directly map to a command source, while
+     * others may temporarily not have an accessible command source
+     *
+     * @return an optional active command source
+     */
+    Optional<CommandSource> getCommandSource();
+
+    /**
+     * Returns the subject collection this subject is a member of.
+     *
+     * @return The appropriate collection
+     */
+    SubjectCollection getContainingCollection();
+
+    /**
+     * The container for permissions data that *may* be persisted if the service
+     * provider supports it.
+     *
+     * @return The container for permissions data this subject uses
+     */
+    SubjectData getData();
+
+    /**
+     * Returns container for subject data that is guaranteed to be transient
+     * (only lasting for the duration of the subject's session, not persisted).
+     * This might return the same object as {@link #getData()} if the provider
+     * for this service does not implement persistence for permissions data
+     *
+     * @return Transient data storage for this subject
+     */
+    SubjectData getTransientData();
+
+    /**
+     * Test whether the subject is permitted to perform an action given as the
+     * given permission string.
+
+     * @param contexts The set of contexts that represents the subject's current environment
+     * @param permission The permission string
+     * @return True if permission is granted
+     */
+    boolean hasPermission(Set<Context> contexts, String permission);
+
+    /**
+     * Test whether the subject is permitted to perform an action given as the
+     * given permission string.
      *
      * @param permission The permission string
      * @return True if permission is granted
      */
-    boolean isPermitted(String permission);
+    boolean hasPermission(String permission);
 
+    /**
+     * Returns the calculated value set for a given permission.
+     *
+     * @param contexts The contexts to check for permissions in
+     * @param permission The permission to check
+     * @return The tristate true/false/unset value for permissions
+     */
+    Tristate getPermissionValue(Set<Context> contexts, String permission);
+
+    /**
+     * Check if this subject is a child of the given parent in the subject's
+     * current context, traversing inheritance.
+     *
+     * @param parent The parent to check for inheritance
+     * @return Whether this is a child of the given parent
+     */
+    boolean isChildOf(Subject parent);
+
+    /**
+     * Check if this subject is a child of the given parent in the given context
+     * combination, traversing inheritance.
+     *
+     * @param contexts The context combination to check in
+     * @param parent The parent to check for inheritance
+     * @return Whether this is a child of the given parent
+     */
+    boolean isChildOf(Set<Context> contexts, Subject parent);
+
+    /**
+     * Return all parents that this group has in its current context
+     * combination. This must include inherited values if the permissions
+     * service supports inheritance.
+     *
+     * @return An immutable list of parents
+     */
+    List<Subject> getParents();
+
+    /**
+     * Return all parents that this group has. This must include inherited
+     * values if the permissions service supports inheritance.
+     *
+     * @param contexts The set of contexts that represents the subject's current environment
+     * @return An immutable list of parents
+     */
+    List<Subject> getParents(Set<Context> contexts);
+
+    /**
+     * Calculate active contexts, using the {@link org.spongepowered.api.service.permission.context.ContextCalculator}s
+     * from {@link PermissionService#registerContextCalculator(org.spongepowered.api.service.permission.context.ContextCalculator)}.
+     * The result of these calculations may be cached.
+     *
+     * @return An immutable set of active contexts
+     */
+    Set<Context> getActiveContexts();
 }

--- a/src/main/java/org/spongepowered/api/service/permission/SubjectCollection.java
+++ b/src/main/java/org/spongepowered/api/service/permission/SubjectCollection.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.permission;
+
+import org.spongepowered.api.service.permission.context.Context;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Object that manages subjects of a certain type (user, group, etc).
+ */
+public interface SubjectCollection {
+    /**
+     * Return the identifier for the type of subjects this collection contains.
+     *
+     * @return The appropriate identifier
+     */
+    String getIdentifier();
+
+    /**
+     * Returns the subject specified. Will not return null.
+     *
+     * @param identifier The identifier to look up a subject by.
+     *                   Case-insensitive
+     * @return A stored subject if present, otherwise a subject that may be
+     *         stored if data is changed from defaults
+     */
+    Subject get(String identifier);
+
+    /**
+     * Returns whether there is any data stored for the given subject. The
+     * return value of this function does not influence whether or not the
+     * result from {@link #get(String)} should be queried.
+     *
+     * @param identifier The identifier of the given subject
+     * @return whether any data is stored
+     */
+    boolean hasRegistered(String identifier);
+
+    /**
+     * Returns all subjects. The iterator provided by this method may be
+     * populated asynchronously. Be aware that for large collections this method
+     * may be very resource-intensive
+     *
+     * @return An iterable providing all subjects stored by this collection.
+     */
+    Iterable<Subject> getAllSubjects();
+
+    /**
+     * Return all known subjects with the given permission information. Because
+     * no context is passed, only subjects who have this permission globally or
+     * subjects which have accurate context calculations are returned.
+     *
+     * @param permission The permission to check
+     * @return Any subject known to have this permission set, and the value this
+     *         permission is set to
+     */
+    Map<Subject, Boolean> getAllWithPermission(String permission);
+
+    /**
+     * Return all known subjects with the given permission information.
+     *
+     * @param contexts The context combination to check for permissions in
+     * @param permission The permission to check
+     * @return Any subject known to have this permission set, and the value this
+     *         permission is set to
+     */
+    Map<Subject, Boolean> getAllWithPermission(Set<Context> contexts, String permission);
+}

--- a/src/main/java/org/spongepowered/api/service/permission/SubjectData.java
+++ b/src/main/java/org/spongepowered/api/service/permission/SubjectData.java
@@ -1,0 +1,152 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.permission;
+
+import org.spongepowered.api.service.permission.context.Context;
+import org.spongepowered.api.util.Tristate;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Container for a subject's data. This container updates live, and provides raw
+ * data for a subject not taking into account any sort of inheritance.
+ * Basically, this interface is meant to represent what's 'in the file', rather
+ * than the higher-level query methods available in {@link Subject}
+ */
+public interface SubjectData {
+    /**
+     * A convenience constant for the global context combination (the empty
+     * set), if you want your code to look especially fancy.
+     */
+    static final Set<Context> GLOBAL_CONTEXT = Collections.emptySet();
+
+    /**
+     * Return all permissions associated with this data object.
+     *
+     * @return an immutable copy of the mappings between contexts and lists of
+     *         permissions containing every permission registered
+     */
+    Map<Set<Context>, Map<String, Boolean>> getAllPermissions();
+
+    /**
+     * Returns the list of permissions set for the given context. This list is
+     * immutable and is not a live view. If no permissions have been set,
+     * returns an empty list.
+     *
+     * @param contexts The particular context combination to check
+     * @return Any permissions set
+     */
+    Map<String, Boolean> getPermissions(Set<Context> contexts);
+
+    /**
+     * Set a permission to a given value. Setting value as {@link
+     * Tristate#UNDEFINED} unsets the permission. An empty set of contexts
+     * applies this permission to the global context.
+     *
+     *  @param contexts The particular combination of contexts to set this
+     *                  permission in
+     * @param permission The permission to set
+     * @param value The value to set this permission to
+     * @return Whether the operation was successful
+     */
+    boolean setPermission(Set<Context> contexts, String permission, Tristate value);
+
+    /**
+     * Clear all permissions set in any context.
+     *
+     * @return Whether any change occurred
+     */
+    boolean clearPermissions();
+
+    /**
+     * Clear all permissions set in a given context combination. Passing an
+     * empty context set unsets permissions in the global context.
+     *
+     * @param contexts The context combination to clear permissions in
+     * @return Whether any change occurred
+     */
+    boolean clearPermissions(Set<Context> contexts);
+
+    /**
+     * Return all registered parent subjects for all contexts. The returned map
+     * is immutable and not a live view. The results of this method do not
+     * traverse any sort of inheritance structure a permissions plugin may
+     * implement.
+     *
+     * @return All registered parents and the context they are registered in
+     */
+    Map<Set<Context>, List<Subject>> getAllParents();
+
+    /**
+     * Return all registered parent subjects for a given context. The returned
+     * map is immutable and not a live view. The results of this method do not
+     * traverse any sort of inheritance structure a permissions plugin may
+     * implement.
+     *
+     * @param contexts The context to check
+     * @return names of parents valid in the given context
+     */
+    List<Subject> getParents(Set<Context> contexts);
+
+    /**
+     * Adds a parent in a particular context combination. Passing an empty
+     * context combination means the parent is added in the global context
+     *
+     * @param contexts The context combination this operation is applicable to
+     * @param parent The name of the parent to add
+     * @return Whether the operation was successful
+     */
+    boolean addParent(Set<Context> contexts, Subject parent);
+
+    /**
+     * Removes a parent in a particular context combination. Passing an empty
+     * context combination means the parent is removed in the global context.
+     *
+     * @param contexts The context combination this operation is applicable to
+     * @param parent The name of the parent to remove
+     * @return Whether the operation was successful
+     */
+    boolean removeParent(Set<Context> contexts, Subject parent);
+
+    /**
+     * Remove all parents in any context combination.
+     *
+     * @return Whether any change occurred
+     */
+    boolean clearParents();
+
+    /**
+     * Remove all parents in a given context combination. An empty context
+     * combination represents the global context.
+     *
+     * @param contexts The context combination to clear the parents of
+     * @return Whether any change occurred
+     */
+    boolean clearParents(Set<Context> contexts);
+
+}

--- a/src/main/java/org/spongepowered/api/service/permission/context/Context.java
+++ b/src/main/java/org/spongepowered/api/service/permission/context/Context.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.permission.context;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * The context that a permission check occurs in. Instances of a context are
+ * designed to function as cache keys, meaning they should be fairly lightweight
+ * and not hold references to large objects
+ */
+public final class Context {
+    public static final String WORLD_KEY = "world";
+
+    private final String type;
+    private final String name;
+
+    /**
+     * Create a new context instance
+     *
+     * @param type Context type. Must not be null.
+     * @param name Context name. Must not be null.
+     */
+    public Context(String type, String name) {
+        checkNotNull(type, "type");
+        checkNotNull(name, "name");
+        this.type = type;
+        this.name = name;
+    }
+
+    /**
+     * Get the type.
+     *
+     * @return the type of item this context represents, for example for a world
+     *         this would be {@code world}
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Get the name.
+     *
+     * @return the specific name of the item involved in this context, for
+     *         example if the type were {@code world} this would be the name of the
+     *         world.
+     */
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Context context = (Context) o;
+
+        if (!name.equals(context.name)
+                || !type.equals(context.type)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type.hashCode();
+        result = 31 * result + name.hashCode();
+        return result;
+    }
+}

--- a/src/main/java/org/spongepowered/api/service/permission/context/ContextCalculator.java
+++ b/src/main/java/org/spongepowered/api/service/permission/context/ContextCalculator.java
@@ -22,42 +22,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
-package org.spongepowered.api.util.command;
+package org.spongepowered.api.service.permission.context;
 
 import org.spongepowered.api.service.permission.Subject;
-import org.spongepowered.api.text.message.Message;
+
+import java.util.Set;
 
 /**
- * Something that can execute commands.
- *
- * <p>Examples of potential implementations include players, the server console,
- * RCON clients, web-based clients, command blocks, and so on.</p>
+ * Calculate the availability of contexts. These methods may be invoked
+ * frequently, and therefore should be fast.
  */
-public interface CommandSource extends Subject {
+public interface ContextCalculator {
+    /**
+     * Add any contexts this calculator determines to be applicable to the
+     * provided accumulator.
+     *
+     * @param subject The subject being checked
+     * @param accumulator The accumulator to add to
+     */
+    void accumulateContexts(Subject subject, Set<Context> accumulator);
 
     /**
-     * Sends the plain text message(s) to source when possible.
-     * <p>Use {@link #sendMessage(Message...)} for a formatted message.</p>
+     * Checks if a single context is currently applicable to a single subject.
+     * If this calculator does not handle the given type of context, this method
+     * should return false.
      *
-     * @param messages The message(s)
+     * @param context The context being checked
+     * @param subject The subject this context is being checked against
+     * @return Whether the given context is handled by this calculator and is
+     *         applicable to the given subject
      */
-    void sendMessage(String... messages);
-
-    /**
-     * Sends the formatted text message(s) to source when possible. If text formatting
-     * is not supported in the implementation it will be displayed as plain text.
-     *
-     * @param messages The message(s)
-     */
-    void sendMessage(Message... messages);
-
-    /**
-     * Sends the formatted text message(s) to source when possible. If text formatting
-     * is not supported in the implementation it will be displayed as plain text.
-     *
-     * @param messages The messages
-     */
-    void sendMessage(Iterable<Message> messages);
-
+    boolean matches(Context context, Subject subject);
 }

--- a/src/main/java/org/spongepowered/api/service/permission/context/Contextual.java
+++ b/src/main/java/org/spongepowered/api/service/permission/context/Contextual.java
@@ -22,42 +22,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
-package org.spongepowered.api.util.command;
-
-import org.spongepowered.api.service.permission.Subject;
-import org.spongepowered.api.text.message.Message;
+package org.spongepowered.api.service.permission.context;
 
 /**
- * Something that can execute commands.
- *
- * <p>Examples of potential implementations include players, the server console,
- * RCON clients, web-based clients, command blocks, and so on.</p>
+ * A common interface for objects that have a relevant context.
  */
-public interface CommandSource extends Subject {
-
+public interface Contextual {
     /**
-     * Sends the plain text message(s) to source when possible.
-     * <p>Use {@link #sendMessage(Message...)} for a formatted message.</p>
+     * Returns the context most relevant to this object. This context may be the
+     * same across multiple invocations (but may not, so don't count on this
+     * being true).
      *
-     * @param messages The message(s)
+     * @return A given context
      */
-    void sendMessage(String... messages);
-
-    /**
-     * Sends the formatted text message(s) to source when possible. If text formatting
-     * is not supported in the implementation it will be displayed as plain text.
-     *
-     * @param messages The message(s)
-     */
-    void sendMessage(Message... messages);
-
-    /**
-     * Sends the formatted text message(s) to source when possible. If text formatting
-     * is not supported in the implementation it will be displayed as plain text.
-     *
-     * @param messages The messages
-     */
-    void sendMessage(Iterable<Message> messages);
-
+    Context getContext();
 }

--- a/src/main/java/org/spongepowered/api/util/Tristate.java
+++ b/src/main/java/org/spongepowered/api/util/Tristate.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.util;
+
+/**
+ * Represents a simple tristate.
+ */
+public enum Tristate {
+    TRUE(true) {
+        @Override
+        public Tristate and(Tristate other) {
+            return other == TRUE || other == UNDEFINED ? TRUE : FALSE;
+        }
+
+        @Override
+        public Tristate or(Tristate other) {
+            return TRUE;
+        }
+    },
+    FALSE(false) {
+        @Override
+        public Tristate and(Tristate other) {
+            return FALSE;
+        }
+
+        @Override
+        public Tristate or(Tristate other) {
+            return other == TRUE ? TRUE : FALSE;
+        }
+    },
+    UNDEFINED(false) {
+        @Override
+        public Tristate and(Tristate other) {
+            return other;
+        }
+
+        @Override
+        public Tristate or(Tristate other) {
+            return other;
+        }
+    };
+
+    private final boolean val;
+
+    private Tristate(boolean val) {
+        this.val = val;
+    }
+
+    /**
+     * ANDs this tristate with another tristate.
+     *
+     * @param other The tristate to AND with
+     * @return The result
+     */
+    public abstract Tristate and(Tristate other);
+
+    /**
+     * ORs this tristate with another tristate.
+     *
+     * @param other The tristate to OR with
+     * @return The result
+     */
+    public abstract Tristate or(Tristate other);
+
+
+    /**
+     * Returns the boolean representation of this tristate.
+     *
+     * @return The boolean tristate representation
+     */
+    public boolean asBoolean() {
+        return val;
+    }
+
+    /**
+     * Return the appropriate tristate for a given boolean value.
+     *
+     * @param val The boolean value
+     * @return The appropriate tristate
+     */
+    public static Tristate fromBoolean(boolean val) {
+        return val ? TRUE : FALSE;
+    }
+}

--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -29,6 +29,7 @@ import com.flowpowered.math.vector.Vector3i;
 import com.google.common.base.Optional;
 import org.spongepowered.api.effect.Viewer;
 import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.service.permission.context.Contextual;
 import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.api.world.gen.WorldGenerator;
 import org.spongepowered.api.world.storage.WorldStorage;
@@ -40,7 +41,7 @@ import java.util.UUID;
 /**
  * A loaded Minecraft world.
  */
-public interface World extends Extent, Viewer, WeatherVolume {
+public interface World extends Extent, Viewer, WeatherVolume, Contextual {
 
     /**
      * Gets the unique identifier for this world.
@@ -81,7 +82,7 @@ public interface World extends Extent, Viewer, WeatherVolume {
     /**
      * Deletes the given chunk from the world. Returns a {@code boolean}
      * flag for whether the operation was successful.
-     * 
+     *
      * @param chunk The chunk to delete
      * @return Whether the operation was successful
      */
@@ -89,9 +90,9 @@ public interface World extends Extent, Viewer, WeatherVolume {
 
     /**
      * Returns a Collection of all actively loaded chunks in this world.
-     * 
+     *
      * <p>The ordering of the returned chunks is undefined.</p>
-     * 
+     *
      * @return The loaded chunks
      */
     Iterable<Chunk> getLoadedChunks();
@@ -149,21 +150,21 @@ public interface World extends Extent, Viewer, WeatherVolume {
 
     /**
      * Gets the random seed for this world.
-     * 
+     *
      * @return The seed
      */
     long getWorldSeed();
-    
+
     /**
      * Sets the random seed for this world.
-     * 
+     *
      * @param seed The seed
      */
     void setSeed(long seed);
 
     /**
      * Gets the {@link WorldGenerator} for this world.
-     * 
+     *
      * @return The world generator
      */
     WorldGenerator getWorldGenerator();
@@ -171,7 +172,7 @@ public interface World extends Extent, Viewer, WeatherVolume {
     /**
      * Sets the {@link WorldGenerator} for this world to use to create new
      * chunks.
-     * 
+     *
      * @param generator The new generator
      */
     void setWorldGenerator(WorldGenerator generator);
@@ -200,5 +201,5 @@ public interface World extends Extent, Viewer, WeatherVolume {
      * @return The associated world storage
      */
     WorldStorage getWorldStorage();
-    
+
 }

--- a/src/test/java/org/spongepowered/api/service/permission/NodeTreeTest.java
+++ b/src/test/java/org/spongepowered/api/service/permission/NodeTreeTest.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.permission;
+
+import org.junit.Test;
+import org.spongepowered.api.util.Tristate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class NodeTreeTest {
+    @Test
+    public void testAsMap() {
+        final Map<String, Boolean> testPermissions = new HashMap<String, Boolean>();
+        testPermissions.put("generate.rainbow", true);
+        testPermissions.put("generate.sunset", false);
+        testPermissions.put("generate", true);
+        testPermissions.put("generate.thunderstorm.explosive", false);
+
+        NodeTree oldTree = NodeTree.of(testPermissions);
+
+        assertEquals(testPermissions, oldTree.asMap());
+    }
+
+    @Test
+    public void testWithValue() throws Exception {
+        final Map<String, Boolean> testPermissions = new HashMap<String, Boolean>();
+        testPermissions.put("generate.rainbow", true);
+        testPermissions.put("generate.sunset", false);
+        testPermissions.put("generate", true);
+        testPermissions.put("generate.thunderstorm.explosive", false);
+
+        NodeTree oldTree = NodeTree.of(testPermissions);
+        assertEquals(Tristate.FALSE, oldTree.get("generate.thunderstorm.explosive"));
+        NodeTree newTree = oldTree.withValue("generate.thunderstorm.explosive", Tristate.TRUE);
+        assertEquals(Tristate.FALSE, oldTree.get("generate.thunderstorm.explosive"));
+        assertEquals(Tristate.TRUE, newTree.get("generate.thunderstorm.explosive"));
+    }
+
+    @Test
+    public void testWithAll() throws Exception {
+        final Map<String, Boolean> testPermissions = new HashMap<String, Boolean>();
+        testPermissions.put("generate.rainbow", true);
+        testPermissions.put("generate.sunset", false);
+        testPermissions.put("generate", true);
+        testPermissions.put("generate.thunderstorm.explosive", false);
+
+        NodeTree oldTree = NodeTree.of(testPermissions);
+
+        final Map<String, Tristate> newPermissions = new HashMap<String, Tristate>();
+        newPermissions.put("generate.sunset.red", Tristate.TRUE);
+        newPermissions.put("generate.thunderstorm.explosive", Tristate.UNDEFINED);
+        newPermissions.put("something.new", Tristate.FALSE);
+
+        NodeTree newTree = oldTree.withAll(newPermissions);
+
+        assertEquals(Tristate.FALSE, oldTree.get("generate.sunset.red"));
+        assertEquals(Tristate.TRUE, newTree.get("generate.sunset.red"));
+
+        assertEquals(Tristate.FALSE, oldTree.get("generate.thunderstorm.explosive"));
+        assertEquals(Tristate.UNDEFINED, newTree.get("generate.thunderstorm.explosive"));
+
+        assertEquals(Tristate.UNDEFINED, oldTree.get("something.new"));
+        assertEquals(Tristate.FALSE, newTree.get("something.new"));
+    }
+
+    @Test
+    public void testCreateFromValues() throws Exception {
+        final Map<String, Boolean> testPermissions = new HashMap<String, Boolean>();
+        testPermissions.put("generate.rainbow", true);
+        testPermissions.put("generate.sunset", false);
+        testPermissions.put("generate", true);
+        testPermissions.put("generate.thunderstorm.explosive", false);
+
+        NodeTree nodes = NodeTree.of(testPermissions, Tristate.UNDEFINED);
+
+        assertEquals(Tristate.TRUE, nodes.get("generate.rainbow"));
+        assertEquals(Tristate.TRUE, nodes.get("generate.rainbow.double"));
+        assertEquals(Tristate.FALSE, nodes.get("generate.sunset"));
+        assertEquals(Tristate.FALSE, nodes.get("generate.sunset.east"));
+        assertEquals(Tristate.TRUE, nodes.get("generate.thunderstorm"));
+        assertEquals(Tristate.FALSE, nodes.get("generate.thunderstorm.explosive"));
+        assertEquals(Tristate.UNDEFINED, nodes.get("random.perm"));
+    }
+}


### PR DESCRIPTION
This API provides a lot of functionality for permissions providers,
including transient permissions, various contexts, and a basic
inheritance structure. This API is meant to serve as a flexible base to
build on.

There may be some utility classes added as I get to implementing this API in PEX and in Sponge (the default MC permissions system), but this PR has the API as I think is good