### PR TITLE
Moved getters from Sounds and Rotations to GameRegistry.

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -26,19 +26,13 @@
 package org.spongepowered.api;
 
 import com.google.common.base.Optional;
-
 import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.effect.Sound;
 import org.spongepowered.api.effect.particle.ParticleEffectBuilder;
 import org.spongepowered.api.effect.particle.ParticleType;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.hanging.art.Art;
-import org.spongepowered.api.entity.living.meta.DyeColor;
-import org.spongepowered.api.entity.living.meta.HorseColor;
-import org.spongepowered.api.entity.living.meta.HorseStyle;
-import org.spongepowered.api.entity.living.meta.HorseVariant;
-import org.spongepowered.api.entity.living.meta.OcelotType;
-import org.spongepowered.api.entity.living.meta.RabbitType;
-import org.spongepowered.api.entity.living.meta.SkeletonType;
+import org.spongepowered.api.entity.living.meta.*;
 import org.spongepowered.api.entity.living.villager.Career;
 import org.spongepowered.api.entity.living.villager.Profession;
 import org.spongepowered.api.entity.player.gamemode.GameMode;
@@ -48,6 +42,7 @@ import org.spongepowered.api.item.inventory.ItemStackBuilder;
 import org.spongepowered.api.item.merchant.TradeOfferBuilder;
 import org.spongepowered.api.potion.PotionEffectBuilder;
 import org.spongepowered.api.potion.PotionEffectType;
+import org.spongepowered.api.util.rotation.Rotation;
 import org.spongepowered.api.world.Environment;
 import org.spongepowered.api.world.biome.BiomeType;
 
@@ -390,5 +385,35 @@ public interface GameRegistry {
      * @return The environment list
      */
     List<Environment> getEnvironments();
+
+    /**
+     * Gets the {@link Sound} with the provided id.
+     *
+     * @param id The id of the sound
+     * @return The {@link Sound} with the given id or Optional.absent() if not found.
+     */
+    Optional<Sound> getSound(String id);
+
+    /**
+     * Gets a {@link List} of all possible {@link Sound}s.
+     *
+     * @return The sound list
+     */
+    List<Sound> getSounds();
+
+    /**
+     * Gets the {@link Rotation} with the provided angle.
+     *
+     * @param angle The angle of the rotation
+     * @return The {@link Rotation} with the given id or Optional.absent() if not found.
+     */
+    Optional<Rotation> getRotation(int angle);
+
+    /**
+     * Gets a {@link List} of all possible {@link Rotation}s.
+     *
+     * @return The rotation list
+     */
+    List<Rotation> getRotations();
 
 }

--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -408,12 +408,12 @@ public interface GameRegistry {
     List<Sound> getSounds();
 
     /**
-     * Gets the {@link Rotation} with the provided angle.
+     * Gets the {@link Rotation} with the provided degrees.
      *
-     * @param angle The angle of the rotation
+     * @param degrees The degrees of the rotation
      * @return The {@link Rotation} with the given id or Optional.absent() if not found.
      */
-    Optional<Rotation> getRotation(int angle);
+    Optional<Rotation> getRotation(int degrees);
 
     /**
      * Gets a {@link List} of all possible {@link Rotation}s.

--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -32,7 +32,13 @@ import org.spongepowered.api.effect.particle.ParticleEffectBuilder;
 import org.spongepowered.api.effect.particle.ParticleType;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.hanging.art.Art;
-import org.spongepowered.api.entity.living.meta.*;
+import org.spongepowered.api.entity.living.meta.DyeColor;
+import org.spongepowered.api.entity.living.meta.HorseColor;
+import org.spongepowered.api.entity.living.meta.HorseStyle;
+import org.spongepowered.api.entity.living.meta.HorseVariant;
+import org.spongepowered.api.entity.living.meta.OcelotType;
+import org.spongepowered.api.entity.living.meta.RabbitType;
+import org.spongepowered.api.entity.living.meta.SkeletonType;
 import org.spongepowered.api.entity.living.villager.Career;
 import org.spongepowered.api.entity.living.villager.Profession;
 import org.spongepowered.api.entity.player.gamemode.GameMode;
@@ -70,14 +76,14 @@ public interface GameRegistry {
      * @return The block or Optional.absent() if not found
      */
     Optional<BlockType> getBlock(String id);
- 
+
     /**
      * Gets a list of all available {@link BlockType}s.
      *
      * @return A list containing all block types in registry
      */
     List<BlockType> getBlocks();
- 
+
     /**
      * Gets an {@link ItemType} by its identifier.
      *
@@ -85,7 +91,7 @@ public interface GameRegistry {
      * @return The item or Optional.absent() if not found
      */
     Optional<ItemType> getItem(String id);
- 
+
     /**
      * Gets a list of all available {@link ItemType}s.
      *
@@ -146,7 +152,7 @@ public interface GameRegistry {
 
     /**
      * Gets a new particle builder for the {@link ParticleType}.
-     * 
+     *
      * @param particle The particle type
      * @return The particle effect builder
      */

--- a/src/main/java/org/spongepowered/api/effect/Sounds.java
+++ b/src/main/java/org/spongepowered/api/effect/Sounds.java
@@ -24,13 +24,7 @@
  */
 package org.spongepowered.api.effect;
 
-import com.google.common.base.Optional;
-
-import java.util.List;
-
 public final class Sounds {
-    private Sounds() {
-    }
 
     public static final Sound AMBIENCE_CAVE = null;
     public static final Sound AMBIENCE_RAIN = null;
@@ -239,12 +233,6 @@ public final class Sounds {
     public static final Sound VILLAGER_NO = null;
     public static final Sound VILLAGER_YES = null;
 
-    public static Optional<Sound> getByName(String soundName) {
-        return null;
+    private Sounds() {
     }
-
-    public static List<Sound> getValues() {
-        return null;
-    }
-    
 }

--- a/src/main/java/org/spongepowered/api/util/rotation/Rotations.java
+++ b/src/main/java/org/spongepowered/api/util/rotation/Rotations.java
@@ -24,18 +24,12 @@
  */
 package org.spongepowered.api.util.rotation;
 
-import com.google.common.base.Optional;
-
-import java.util.List;
-
 /**
  * An enumeration of possible rotations for something that can rotate,
  * such as an {@link org.spongepowered.api.item.inventory.ItemStack} within
  * an {@link org.spongepowered.api.entity.hanging.ItemFrame}.
  */
 public final class Rotations {
-    private Rotations() {
-    }
 
     public static final Rotation TOP = null;
     public static final Rotation TOP_RIGHT = null;
@@ -46,12 +40,6 @@ public final class Rotations {
     public static final Rotation LEFT = null;
     public static final Rotation TOP_LEFT = null;
 
-    public static List<Rotation> getValues() {
-        return null;
+    private Rotations() {
     }
-
-    public static Optional<Rotation> getRotationForDegree(int degrees) {
-        return Optional.absent();
-    }
-
 }


### PR DESCRIPTION
This has been done as every other Class like this e.g. Blocks, Items, Environments, Biomes do not have getters. The getters for these should be in GameRegistry as they have to be registered like the above examples.