### PR TITLE
Refactored environments.

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -48,7 +48,7 @@ import org.spongepowered.api.item.inventory.ItemStackBuilder;
 import org.spongepowered.api.item.merchant.TradeOfferBuilder;
 import org.spongepowered.api.potion.PotionEffectBuilder;
 import org.spongepowered.api.potion.PotionEffectType;
-import org.spongepowered.api.world.Environment;
+import org.spongepowered.api.world.DimensionType;
 import org.spongepowered.api.world.biome.BiomeType;
 
 import java.util.Collection;
@@ -369,26 +369,18 @@ public interface GameRegistry {
     Collection<String> getDefaultGameRules();
 
     /**
-     * Gets the {@link Environment} with the provided name. 
+     * Gets the {@link DimensionType} with the provided name. 
      *
-     * @param name The name of the environment
-     * @return The {@link Environment} with the given name or Optional.absent() if not found
+     * @param name The name of the dimension type
+     * @return The {@link DimensionType} with the given name or Optional.absent() if not found
      */
-    Optional<Environment> getEnvironment(String name);
+    Optional<DimensionType> getDimensionType(String name);
 
     /**
-     * Gets the {@link Environment} with the provided id. 
+     * Gets a {@link List} of all possible {@link DimensionType}s.
      *
-     * @param dimensionId The name of the environment
-     * @return The {@link Environment} with the given dimensionId or Optional.absent() if not found
+     * @return The list of all available {@link DimensionType}s
      */
-    Optional<Environment> getEnvironment(int dimensionId);
-
-    /**
-     * Gets a {@link List} of all possible {@link Environment}s.
-     *
-     * @return The environment list
-     */
-    List<Environment> getEnvironments();
+    List<DimensionType> getDimensionTypes();
 
 }

--- a/src/main/java/org/spongepowered/api/world/Dimension.java
+++ b/src/main/java/org/spongepowered/api/world/Dimension.java
@@ -26,22 +26,70 @@
 package org.spongepowered.api.world;
 
 /**
- * Represents the environment of a {@link World}.
+ * Represents the dimension of a {@link World}.
  */
-public interface Environment {
+public interface Dimension {
 
     /**
-     * Returns the dimension id of the current {@link Environment}.
+     * Returns the dimension id of the current {@link Dimension}.
      *
      * @return The dimension id
      */
     int getDimensionId();
 
     /**
-     * Returns the name of this {@link Environment}.
+     * Returns the name of this {@link Dimension}.
      *
      * @return The name
      */
     String getName();
 
+    /**
+     * Returns whether players can respawn within {@link Dimension} after death.
+     *
+     * @return True if players can respawn, false if not
+     */
+    boolean allowsPlayerRespawns();
+
+    /**
+     * Sets whether players in this {@link Dimension} can respawn.
+     *
+     * @param allow Whether players can respawn
+     */
+    void setAllowsPlayerRespawns(boolean allow);
+
+    /**
+     * Returns the minimum spawn height for {@link Dimension}.
+     *
+     * @return The minimum spawn height
+     */
+    int getMinimumSpawnHeight();
+
+    /**
+     * Returns whether water evaporates for {@link Dimension}.
+     *
+     * @return True if water evaporates, false if not
+     */
+    boolean doesWaterEvaporate();
+
+    /**
+     * Sets whether water in this {@link Dimension} evaporates.
+     *
+     * @param evaporates Whether water evaporates
+     */
+    void setWaterEvaporates(boolean evaporates);
+
+    /**
+     * Returns whether this {@link Dimension} has a sky (lack of bedrock).
+     *
+     * @return True if sky is present, false if not
+     */
+    boolean hasSky();
+
+    /**
+     * Get the type of dimension.
+     *
+     * @return The type of dimension
+     */
+    DimensionType getType();
 }

--- a/src/main/java/org/spongepowered/api/world/DimensionType.java
+++ b/src/main/java/org/spongepowered/api/world/DimensionType.java
@@ -22,29 +22,31 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package org.spongepowered.api.world;
 
 /**
- * Holds all possible {@link Environment}s.
+ * Represents a type of {@link Dimension}.
  */
-public final class Environments {
+public interface DimensionType {
 
     /**
-     * The default environment of a {@link World}.
+     * Returns the name of this {@link DimensionType}.
+     *
+     * @return The name
      */
-    public static final Environment OVERWORLD = null;
+    String getName();
 
     /**
-     * The environment of a nether type {@link World}.
+     * Returns whether spawn chunks of this {@link DimensionType} remain loaded when no players are present.
+     *
+     * @return True if spawn chunks of this {@link DimensionType} remain loaded without players, false if not
      */
-    public static final Environment NETHER = null;
+    boolean doesKeepSpawnLoaded();
 
     /**
-     * Environment of the end.
-     */ 
-    public static final Environment END = null;
-
-    private Environments() {}
-
+    * Returns the dimension class for this type.
+    *
+    * @return The dimension class for this type
+    */
+    Class <? extends Dimension> getDimensionClass();
 }

--- a/src/main/java/org/spongepowered/api/world/DimensionTypes.java
+++ b/src/main/java/org/spongepowered/api/world/DimensionTypes.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world;
+
+/**
+ * Holds all possible {@link DimensionType}s.
+ */
+public final class DimensionTypes {
+
+    /**
+     * Represents the default dimension type of a {@link World}.
+     */
+    public static final DimensionType OVERWORLD = null;
+
+    /**
+     * Represents a nether based dimension.
+     */
+    public static final DimensionType NETHER = null;
+
+    /**
+     * Represents an "end" based dimension.
+     */ 
+    public static final DimensionType END = null;
+
+    private DimensionTypes() {}
+
+}

--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -141,11 +141,11 @@ public interface World extends Extent, Viewer, WeatherVolume {
     Map<String, String> getGameRules();
 
     /**
-     * Returns the {@link Environment} of this world.
+     * Returns the {@link Dimension} of this world.
      *
-     * @return The {@link Environment}
+     * @return The {@link Dimension}
      */
-    Environment getEnvironment();
+    Dimension getDimension();
 
     /**
      * Gets the random seed for this world.
@@ -183,4 +183,21 @@ public interface World extends Extent, Viewer, WeatherVolume {
      */
     BiomeManager getBiomeManager();
 
+    /**
+     * Returns whether this {@link World}'s spawn chunks remain loaded when no players are present.
+     * Note: This method will default to this {@link World}'s {@link DimensionType}'s
+     * keepLoaded value unless a plugin overrides it.
+     *
+     * @return True if {@link World} remains loaded without players, false if not
+     */
+    boolean doesKeepSpawnLoaded();
+
+    /**
+     * Sets whether this {@link World}'s spawn chunks remain loaded when no players are present.
+     * Note: This method will override the default {@link DimensionType}'s keepLoaded
+     * value.
+     *
+     * @param keepLoaded Whether this {@link World}'s spawn chunks remain loaded without players
+     */
+    void setKeepSpawnLoaded(boolean keepLoaded);
 }


### PR DESCRIPTION
Since worlds each have their own dimension instance, it makes more sense to register unique dimension types for plugin use. This will essentially work the same as EntityTypes. As an example, if a multiworld plugin wanted to create a world based on a specific Dimension, it would pass the DimensionType to the world creation method to be used. Plugins used to the old "Environment" name should now refer to DimensionType.