### PR TITLE
Refactor minecart speed methods to be more implementation-friendly

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/vehicle/minecart/Minecart.java
+++ b/src/main/java/org/spongepowered/api/entity/vehicle/minecart/Minecart.java
@@ -54,17 +54,20 @@ public interface Minecart extends Entity {
      *
      * <p>The default value is 0.4.</p>
      *
-     * @param swiftness The new max speed
+     * @param swiftness The new maximum speed
      */
     void setSwiftness(double swiftness);
 
     /**
-     * Gets the maximum speed that this cart is allowed to travel at at the
+     * Gets the maximum speed that this cart is allowed to travel at the
      * instant this method is called.
      *
      * <p>This differs from {@link Minecart#getSwiftness()} in that its value
      * is affected by the block/rail beneath the cart. However, it is still
      * impacted and limited by the cart's swiftness.</p>
+     *
+     * @return The maximum speed at which the minecart may travel at the instant
+     * this method is called
      */
     double getPotentialMaxSpeed();
 

--- a/src/main/java/org/spongepowered/api/entity/vehicle/minecart/Minecart.java
+++ b/src/main/java/org/spongepowered/api/entity/vehicle/minecart/Minecart.java
@@ -41,24 +41,32 @@ public interface Minecart extends Entity {
     boolean isOnRail();
 
     /**
-     * Gets the maximum speed that this cart is
-     * allowed to travel at.
+     * Gets the absolute maximum speed that this cart is allowed to travel at.
      *
-     * <p>The Default value is 0.4.</p>
+     * <p>The default value is 0.4.</p>
      *
      * @return The maximum speed
      */
-    double getMaxSpeed();
+    double getSwiftness();
 
     /**
-     * Sets the maximum speed that this cart is
-     * allowed to travel at.
+     * Sets the absolute maximum speed that this cart is allowed to travel at.
      *
-     * <p>The Default value is 0.4.</p>
+     * <p>The default value is 0.4.</p>
      *
-     * @param maxSpeed The new max speed
+     * @param swiftness The new max speed
      */
-    void setMaxSpeed(double maxSpeed);
+    void setSwiftness(double swiftness);
+
+    /**
+     * Gets the maximum speed that this cart is allowed to travel at at the
+     * instant this method is called.
+     *
+     * <p>This differs from {@link Minecart#getSwiftness()} in that its value
+     * is affected by the block/rail beneath the cart. However, it is still
+     * impacted and limited by the cart's swiftness.</p>
+     */
+    double getPotentialMaxSpeed();
 
     /**
      * Gets whether or not the minecart slows down


### PR DESCRIPTION
This PR refactors the `getMaxSpeed()` and `setMaxSpeed()` methods in the `Minecart` interface to `getSwiftness()` and `setSwiftness()`, respectively. The reasoning behind this change is that Minecraft implements a `getSpeedMethod()` (as per the Forge deobfuscation mapping) which, while similar, is [fundamentally different from its Sponge counterpart](https://github.com/SpongePowered/Sponge/pull/126#discussion_r22542226). This makes implementation difficult if not impossible and would require use of ASM to rewrite vanilla bytecode.

It also adds a `getPotentialMaxSpeed()` method to the interface which will return the maximum speed at which the minecart may travel at the instant the method is called, i.e. the return value of Minecraft's `getMaxSpeed()` method.