### PR TITLE
Move Unimplementable methods to respected interfaces

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -198,4 +198,18 @@ public interface Entity extends Identifiable, EntityState, DataHolder {
      * @return The delay before catching fire
      */
     int getFireDelay();
+
+    /**
+     * Returns whether this entity will be persistent when no player is near.
+     *
+     * @return True if this entity is persistent
+     */
+    boolean isPersistent();
+
+    /**
+     * Sets whether this entity will be persistent when no player is near.
+     *
+     * @param persistent Whether the entity will be persistent
+     */
+    void setPersistent(boolean persistent);
 }

--- a/src/main/java/org/spongepowered/api/entity/living/Agent.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Agent.java
@@ -24,6 +24,11 @@
  */
 package org.spongepowered.api.entity.living;
 
+import com.google.common.base.Optional;
+import org.spongepowered.api.entity.Entity;
+
+import javax.annotation.Nullable;
+
 /**
  * An Agent represents a {@link Living} that has AI.
  * In the future Sponge will allow for custom AIs, but for now vanilla behavior can only be disabled.
@@ -44,6 +49,48 @@ public interface Agent extends Living {
      */
     void setAiEnabled(boolean aiEnabled);
 
-    // TODO for 1.1 add methods like getTarget, setTarget, etc.
+    /**
+     * Returns whether this entity is leashed.
+     *
+     * @return True if this entity is leashed
+     */
+    boolean isLeashed();
 
+    /**
+     * Sets whether this entity is leashed or not.
+     *
+     * @param leashed Whether this entity is leashed or not
+     */
+    void setLeashed(boolean leashed);
+
+
+    /**
+     * Gets the holder of this leashed entity, if available.
+     *
+     * @return The leash holder, if available
+     */
+    Optional<Entity> getLeashHolder();
+
+    /**
+     * Sets the holder of this leashed entity.
+     *
+     * @param entity The entity to hold the leash
+     */
+    void setLeashHolder(@Nullable Entity entity);
+
+    /**
+     * Returns whether this living entity can pick up items.
+     *
+     * @return Whether this entity can pick up items
+     */
+    boolean getCanPickupItems();
+
+    /**
+     * Sets whether this entity can pick up items or not.
+     *
+     * @param canPickupItems Whether this entity can pick up items
+     */
+    void setCanPickupItems(boolean canPickupItems);
+
+    // TODO for 1.1 add methods like getTarget, setTarget, etc.
 }

--- a/src/main/java/org/spongepowered/api/entity/living/Human.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Human.java
@@ -30,7 +30,7 @@ import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 /**
  * Represents a HumanEntity in game, such as {@link org.spongepowered.api.entity.player.Player}
  */
-public interface Human extends Agent, ProjectileSource {
+public interface Human extends Living, ProjectileSource {
 
     /**
      * Gets the hunger value of this human entity.

--- a/src/main/java/org/spongepowered/api/entity/living/Living.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Living.java
@@ -159,34 +159,6 @@ public interface Living extends Entity {
     void setLastAttacker(@Nullable Living lastAttacker);
 
     /**
-     * Returns whether this entity is leashed.
-     *
-     * @return True if this entity is leashed
-     */
-    boolean isLeashed();
-
-    /**
-     * Sets whether this entity is leashed or not.
-     *
-     * @param leashed Whether this entity is leashed or not
-     */
-    void setLeashed(boolean leashed);
-
-    /**
-     * Gets the holder of this leashed entity, if available.
-     *
-     * @return The leash holder, if available
-     */
-    Optional<Entity> getLeashHolder();
-
-    /**
-     * Sets the holder of this leashed entity.
-     *
-     * @param entity The entity to hold the leash
-     */
-    void setLeashHolder(@Nullable Entity entity);
-
-    /**
      * Gets the height of the eye (camera) of this entity.
      *
      * @return The camera height
@@ -271,20 +243,6 @@ public interface Living extends Entity {
     void setMaxInvulnerabilityTicks(int ticks);
 
     /**
-     * Returns whether this living entity can pick up items.
-     *
-     * @return Whether this entity can pick up items
-     */
-    boolean getCanPickupItems();
-
-    /**
-     * Sets whether this entity can pick up items or not.
-     *
-     * @param canPickupItems Whether this entity can pick up items
-     */
-    void setCanPickupItems(boolean canPickupItems);
-
-    /**
      * Gets the custom display name of this entity.
      * <p>Custom names may appear overhead or when in the line of sight
      * of a player.</p>
@@ -315,18 +273,4 @@ public interface Living extends Entity {
      * @param visible Whether the custom name is visible
      */
     void setCustomNameVisible(boolean visible);
-
-    /**
-     * Returns whether this entity will be persistent when no player is near.
-     *
-     * @return True if this entity is persistent
-     */
-    boolean isPersistent();
-
-    /**
-     * Sets whether this entity will be persistent when no player is near.
-     *
-     * @param persistent Whether the entity will be persistent
-     */
-    void setPersistent(boolean persistent);
 }


### PR DESCRIPTION
In issue #382 these methods are unimplementable because as explained to me, Agent is effectively Minecrafts EntityLiving and Living is Minecrafts EntityLivingBase.

They need to be moved as these methods are not possible in EntityLivingBase.