### PR TITLE
ArmourStands and Entities

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -152,20 +152,6 @@ public interface Entity extends Identifiable, EntityState, DataHolder {
     float getScale();
 
     /**
-     * Returns whether this entity is rendered invisible.
-     *
-     * @return Whether this entity is invisible
-     */
-    boolean isInvisible();
-
-    /**
-     * Sets whether this entity is invisible or not.
-     *
-     * @param invisible Whether this entity is invisible or not
-     */
-    void setInvisible(boolean invisible);
-
-    /**
      * Returns whether this entity is on the ground (not in the air) or not.
      *
      * @return Whether this entity is on the ground or not

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -152,6 +152,20 @@ public interface Entity extends Identifiable, EntityState, DataHolder {
     float getScale();
 
     /**
+     * Returns whether this entity is rendered invisible.
+     *
+     * @return Whether this entity is invisible
+     */
+    boolean isInvisible();
+
+    /**
+     * Sets whether this entity is invisible or not.
+     *
+     * @param invisible Whether this entity is invisible or not
+     */
+    void setInvisible(boolean invisible);
+
+    /**
      * Returns whether this entity is on the ground (not in the air) or not.
      *
      * @return Whether this entity is on the ground or not

--- a/src/main/java/org/spongepowered/api/entity/living/ArmorStand.java
+++ b/src/main/java/org/spongepowered/api/entity/living/ArmorStand.java
@@ -132,18 +132,18 @@ public interface ArmorStand extends Living, ArmorEquipable {
     void setSmall(boolean small);
 
     /**
-     * Returns whether this armor stand is rendered invisible.
+     * Returns whether this armor stand is affected by gravity or not.
      *
-     * @return Whether this armor stand is invisible
+     * @return Whether this armor stand is affected by gravity or not
      */
-    boolean isInvisible();
+    boolean hasGravity();
 
     /**
-     * Sets whether this armor stand is invisible or not.
+     * Sets whether this armor stand is affected by gravity or not.
      *
-     * @param invisible Whether this armor stand is invisible or not
+     * @param gravity Whether this armor stand is affected by gravity
      */
-    void setInvisible(boolean invisible);
+    void setGravity(boolean gravity);
 
     /**
      * Returns whether this armor stand shows arms or not.

--- a/src/main/java/org/spongepowered/api/entity/living/Living.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Living.java
@@ -273,4 +273,18 @@ public interface Living extends Entity {
      * @param visible Whether the custom name is visible
      */
     void setCustomNameVisible(boolean visible);
+
+    /**
+     * Returns whether this entity is rendered invisible.
+     *
+     * @return Whether this entity is invisible
+     */
+    boolean isInvisible();
+
+    /**
+     * Sets whether this entity is invisible or not.
+     *
+     * @param invisible Whether this entity is invisible or not
+     */
+    void setInvisible(boolean invisible);
 }


### PR DESCRIPTION
All entities have the option to be invisible or not so I have moved the getter and setter to Entity. Also I have added noGravity to ArmorStand as that was missing when I was implementing.

Only thing with Entities is that they may have their own setInvisible method so in the implementations the setInvisible will need to be Override so that the correct minecraft method can be ran.