### PR TITLE
Entity Fixes

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/living/Sittable.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Sittable.java
@@ -42,5 +42,4 @@ public interface Sittable extends Tameable {
      * @param sitting Whether this entity is sitting
      */
     void setSitting(boolean sitting);
-
 }

--- a/src/main/java/org/spongepowered/api/entity/living/Tameable.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Tameable.java
@@ -26,11 +26,12 @@ package org.spongepowered.api.entity.living;
 
 import com.google.common.base.Optional;
 import org.spongepowered.api.entity.Tamer;
+import org.spongepowered.api.entity.living.animal.Animal;
 
 /**
  * Represents an Agent that can be tamed by a Tamer.
  */
-public interface Tameable extends Agent {
+public interface Tameable extends Animal {
 
     /**
      * Checks if this is tamed
@@ -66,5 +67,4 @@ public interface Tameable extends Agent {
      * @param tamer The Tamer who should own this
      */
     void setOwner(Tamer tamer);
-
 }

--- a/src/main/java/org/spongepowered/api/entity/living/Tameable.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Tameable.java
@@ -29,7 +29,7 @@ import org.spongepowered.api.entity.Tamer;
 import org.spongepowered.api.entity.living.animal.Animal;
 
 /**
- * Represents an Agent that can be tamed by a Tamer.
+ * Represents an Animal that can be tamed by a Tamer.
  */
 public interface Tameable extends Animal {
 

--- a/src/main/java/org/spongepowered/api/entity/living/animal/Horse.java
+++ b/src/main/java/org/spongepowered/api/entity/living/animal/Horse.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
 /**
  * Represents a Horse.
  */
-public interface Horse extends Animal, Tameable {
+public interface Horse extends Tameable {
 
     /**
      * Gets the current style of this Horse.
@@ -102,5 +102,4 @@ public interface Horse extends Animal, Tameable {
      * @param itemStack The saddle item
      */
     void setSaddle(@Nullable ItemStack itemStack);
-
 }

--- a/src/main/java/org/spongepowered/api/entity/living/animal/Ocelot.java
+++ b/src/main/java/org/spongepowered/api/entity/living/animal/Ocelot.java
@@ -31,7 +31,7 @@ import org.spongepowered.api.entity.living.meta.OcelotType;
 /**
  * Represents an Ocelot.
  */
-public interface Ocelot extends Animal, Sittable {
+public interface Ocelot extends Sittable {
 
     /**
      * Gets the current {@link OcelotType} of this ocelot.
@@ -46,5 +46,4 @@ public interface Ocelot extends Animal, Sittable {
      * @param ocelotType The new ocelot type
      */
     void setOcelotType(final OcelotType ocelotType);
-
 }

--- a/src/main/java/org/spongepowered/api/entity/living/animal/Squid.java
+++ b/src/main/java/org/spongepowered/api/entity/living/animal/Squid.java
@@ -30,6 +30,5 @@ import org.spongepowered.api.entity.living.Aquatic;
 /**
  * Represents a Squid.
  */
-public interface Squid extends Aquatic, Animal {
-
+public interface Squid extends Aquatic {
 }

--- a/src/main/java/org/spongepowered/api/entity/living/animal/Wolf.java
+++ b/src/main/java/org/spongepowered/api/entity/living/animal/Wolf.java
@@ -31,6 +31,5 @@ import org.spongepowered.api.entity.living.Sittable;
 /**
  * Represents a Wolf.
  */
-public interface Wolf extends Animal, Sittable, Dyeable {
-
+public interface Wolf extends Sittable, Dyeable {
 }


### PR DESCRIPTION
This is pretty self explanatory but just to elaborate.

Sitting needs to extend Tameable as Sitting can only be accomplished by a Tameable animal.
Tameable needs to extend Animal.
Squid only needs Aquatic as it is not an Animal in Minecraft.

This should fix a few issues that would have arisen if not sorted now.
