### PR TITLE
Extracted interface Leashable.

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/living/Agent.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Agent.java
@@ -50,35 +50,6 @@ public interface Agent extends Living {
     void setAiEnabled(boolean aiEnabled);
 
     /**
-     * Returns whether this entity is leashed.
-     *
-     * @return True if this entity is leashed
-     */
-    boolean isLeashed();
-
-    /**
-     * Sets whether this entity is leashed or not.
-     *
-     * @param leashed Whether this entity is leashed or not
-     */
-    void setLeashed(boolean leashed);
-
-
-    /**
-     * Gets the holder of this leashed entity, if available.
-     *
-     * @return The leash holder, if available
-     */
-    Optional<Entity> getLeashHolder();
-
-    /**
-     * Sets the holder of this leashed entity.
-     *
-     * @param entity The entity to hold the leash
-     */
-    void setLeashHolder(@Nullable Entity entity);
-
-    /**
      * Returns whether this living entity can pick up items.
      *
      * @return Whether this entity can pick up items

--- a/src/main/java/org/spongepowered/api/entity/living/Leashable.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Leashable.java
@@ -22,15 +22,44 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+package org.spongepowered.api.entity.living;
 
-package org.spongepowered.api.entity.living.animal;
+import com.google.common.base.Optional;
+import org.spongepowered.api.entity.Entity;
 
-import org.spongepowered.api.entity.living.Ageable;
-import org.spongepowered.api.entity.living.Leashable;
+import javax.annotation.Nullable;
 
 /**
- * Represents an Animal, such as a Cow.
+ * Leashables are entities that can be interacted with by players wielding a {@link org.spongepowered.api.item.ItemTypes#LEAD}
  */
-public interface Animal extends Ageable, Leashable {
+public interface Leashable {
+
+    /**
+     * Returns whether this Leashable is leashed.
+     *
+     * @return True if this Leashable is leashed
+     */
+    boolean isLeashed();
+
+    /**
+     * Sets whether this Leashable is leashed or not.
+     *
+     * @param leashed Whether this Leashable is leashed or not
+     */
+    void setLeashed(boolean leashed);
+
+    /**
+     * Gets the holder of this leashed entity, if available.
+     *
+     * @return The leash holder, if available
+     */
+    Optional<Entity> getLeashHolder();
+
+    /**
+     * Sets the holder of this leashed entity.
+     *
+     * @param entity The entity to hold the leash
+     */
+    void setLeashHolder(@Nullable Entity entity);
 
 }

--- a/src/main/java/org/spongepowered/api/entity/living/golem/Golem.java
+++ b/src/main/java/org/spongepowered/api/entity/living/golem/Golem.java
@@ -26,10 +26,11 @@
 package org.spongepowered.api.entity.living.golem;
 
 import org.spongepowered.api.entity.living.Agent;
+import org.spongepowered.api.entity.living.Leashable;
 
 /**
  * Represents a Golem type mob.
  */
-public interface Golem extends Agent {
+public interface Golem extends Agent, Leashable {
 
 }


### PR DESCRIPTION
Only golems and animals are leashable in vanilla, However other entities are still able to be leashed if forced.

I propose that an entity *other* then what is leashable in vanilla is an implementation specific detail, and should not be included in the API.

However, due to leashable being it's own interface, anyone that wishes to may attempt to cast an not listed as leashable in the API as leashable in order to test whether it happens to be leashable as an implementation detail. This would allow for mods/other server implementations to make anything leashable, whilst leaving room for the sponge mod to refuse to support entities which are currently leashable but not listed as such in the API at any time.