### PR TITLE
Add ItemMergeEvent

### DIFF
--- a/src/main/java/org/spongepowered/api/event/entity/item/ItemMergeEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/item/ItemMergeEvent.java
@@ -34,16 +34,16 @@ import org.spongepowered.api.util.event.Cancellable;
 public interface ItemMergeEvent extends EntityEvent, Cancellable {
 
     /**
-     * Gets the first item to be merged.
+     * Gets a copy of the first item to be merged.
      *
-     * @return The first item to be merged
+     * @return A copy of the first item to be merged
      */
     Item getEntity();
 
     /**
-     * Gets the second item to be merged.
+     * Gets a copy of the second item to be merged.
      *
-     * @return The second item to be merged
+     * @return A copy of the second item to be merged
      */
     Item getItemToMerge();
 }

--- a/src/main/java/org/spongepowered/api/event/entity/item/ItemMergeEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/item/ItemMergeEvent.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.entity.item;
+
+import org.spongepowered.api.entity.Item;
+import org.spongepowered.api.event.entity.EntityEvent;
+import org.spongepowered.api.util.event.Cancellable;
+
+/**
+ * Called when an {@link Item} is merged with another {@link Item}.
+ */
+public interface ItemMergeEvent extends EntityEvent, Cancellable {
+
+    /**
+     * Gets the first item to be merged.
+     *
+     * @return The first item to be merged
+     */
+    Item getEntity();
+
+    /**
+     * Gets the second item to be merged.
+     *
+     * @return The second item to be merged
+     */
+    Item getItemToMerge();
+}

--- a/src/main/java/org/spongepowered/api/event/entity/item/package-info.java
+++ b/src/main/java/org/spongepowered/api/event/entity/item/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.api.event.entity.item;


### PR DESCRIPTION
This PR adds an event which is fired when Vanilla attempts to merge two `Item`s together.

Merging occurs when two `Item`s are within 0.5 blocks in either the X or Z axis.

This event allows plugins to detect and cancel `Item` merging.