### PR TITLE
Blazing fast ChunkDataStreams

### DIFF
--- a/src/main/java/org/spongepowered/api/world/storage/ChunkDataStream.java
+++ b/src/main/java/org/spongepowered/api/world/storage/ChunkDataStream.java
@@ -24,10 +24,12 @@
  */
 package org.spongepowered.api.world.storage;
 
-import com.google.common.base.Optional;
 import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.world.Chunk;
 
-import java.util.Iterator;
+import java.util.concurrent.Future;
+
+import javax.annotation.Nullable;
 
 /**
  * A chunk iterator represents a buffer for obtaining chunk data from
@@ -39,9 +41,44 @@ import java.util.Iterator;
  * the chunks represented by {@link DataContainer}s should be avoided
  * <strong>AT ALL COSTS</strong>. The data represented is a copy and
  * therefore shouldn't be considered synchronized to live data.</p>
- * <p>Removing is not supported <strong>AT ALL AND WILL THROW AN EXCEPTION</strong></p>
+ *
+ * <p>This is a data stream from the chunk storage system and should be
+ * used in an asynchronous thread from the main thread.</p>
  *
  */
-public interface ChunkIterator extends Iterator<Optional<DataContainer>> {
+public interface ChunkDataStream {
+
+    /**
+     * Gets the next {@link Chunk} represented by a read only {@link DataContainer}.
+     *
+     * <p>This method BLOCKS the thread until the next available data has been
+     * read.</p>
+     *
+     * <p>This may not return a {@link DataContainer} in the event there is no
+     * chunk data available to read.</p>
+     *
+     * @return The chunk data represented by a data container
+     */
+    @Nullable DataContainer next();
+
+    /**
+     * Checks if there is an available chunk to represent.
+     *
+     * @return Whether there is more data that can be read
+     */
+    boolean hasNext();
+
+    /**
+     * Gets the number of chunks available to read as {@link DataContainer}s.
+     *
+     * @return The number of remaining chunks available to read
+     */
+    int available();
+
+    /**
+     * Resets this stream to read from the beginning of the collection of
+     * chunks.
+     */
+    void reset();
 
 }

--- a/src/main/java/org/spongepowered/api/world/storage/WorldStorage.java
+++ b/src/main/java/org/spongepowered/api/world/storage/WorldStorage.java
@@ -24,12 +24,58 @@
  */
 package org.spongepowered.api.world.storage;
 
+import com.flowpowered.math.vector.Vector3i;
+import com.google.common.base.Optional;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.world.Chunk;
+
 public interface WorldStorage {
 
     /**
-     * Gets a {@link ChunkIterator}.
+     * Gets a {@link ChunkDataStream}.
+     *
+     * <p>Usage of a {@link ChunkDataStream} should be limited to asynchronous
+     * tasks to avoid hanging the main thread.</p>
+     *
      * @return An iterator of generated chunks
      */
-    ChunkIterator getGeneratedChunks();
+    ChunkDataStream getGeneratedChunks();
+
+    /**
+     * Checks if the given chunk coordinates represented by {@link Vector3i}
+     * exist in the world.
+     *
+     * <p>Note that this is an asynchronous check as the storage of chunks
+     * can not be guaranteed to remain in synch with the server, let alone
+     * on the server thread.</p>
+     *
+     * <p>It is imperative to avoid waiting for the {@link ListenableFuture} to complete
+     * its task.</p>
+     *
+     * @param chunkCoords The chunk coordinates
+     * @return Whether the chunk exists or not
+     */
+    ListenableFuture<Boolean> doesChunkExist(Vector3i chunkCoords);
+
+    /**
+     * Gets a {@link DataContainer} including all data related to a {@link Chunk}.
+     *
+     * <p>The container is a read only instance of the data, and therefor
+     * should not be considered as mutable data. Changes are NOT saved, and
+     * the data may not be in synch with the server if the chunk is currently
+     * loaded.</p>
+     *
+     * <p>This may not return a {@link DataContainer} in the event there is no
+     * chunk data generated at the desired coordinates.</p>
+     *
+     * <p>It is imperative to understand that the {@link ListenableFuture} task is
+     * blocking, and should avoid using {@link ListenableFuture#get()} while on the main
+     * thread.</p>
+     *
+     * @param chunkCoords The chunk coordinates
+     * @return The data container representing the chunk data, if available
+     */
+    ListenableFuture<Optional<DataContainer>> getChunkData(Vector3i chunkCoords);
 
 }


### PR DESCRIPTION
Fixes #256 

The previous API did not specify whether `ChunkIterator` would be blocking on the main thread and provided little ways to read specific chunk data.

This adds the ability to get a specific `Chunk`s data via asynchronous [`ListenableFuture`](https://code.google.com/p/guava-libraries/wiki/ListenableFutureExplained) and aids in refining the asynchronous nature of `ChunkDataStream`.