### PR TITLE
Refactor Projectiles into DamagingProjectile and Projectile

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/projectile/Arrow.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/Arrow.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.entity.projectile;
 /**
  * Represents an Arrow.
  */
-public interface Arrow extends Projectile {
+public interface Arrow extends DamagingProjectile {
 
     /**
      * Returns whether this arrow is a critical arrow or not.

--- a/src/main/java/org/spongepowered/api/entity/projectile/DamagingProjectile.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/DamagingProjectile.java
@@ -22,13 +22,31 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package org.spongepowered.api.entity.projectile;
 
-import org.spongepowered.api.entity.explosive.FusedExplosive;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 
 /**
- * Represents a firework.
+ * Represents entities that act as projectiles and can fly in the air.
+ * For example, Arrows.
  */
-public interface Firework extends Projectile, FusedExplosive {
+public interface DamagingProjectile extends Projectile {
+
+    /**
+     * Gets the damage this projectile will deal to a {@link org.spongepowered.api.entity.living.Living}
+     * if hit.
+     *
+     * @return The damage of this arrow
+     */
+    double getDamage();
+
+    /**
+     * Sets the damage this projectile will deal to a LivingEntity if hit.
+     *
+     * @param damage The damage
+     */
+    void setDamage(double damage);
 
 }

--- a/src/main/java/org/spongepowered/api/entity/projectile/Egg.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/Egg.java
@@ -28,6 +28,6 @@ package org.spongepowered.api.entity.projectile;
 /**
  * Represents a thrown egg.
  */
-public interface Egg extends Projectile {
+public interface Egg extends DamagingProjectile {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/projectile/FishHook.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/FishHook.java
@@ -25,31 +25,35 @@
 package org.spongepowered.api.entity.projectile;
 
 import com.google.common.base.Optional;
-import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.entity.Entity;
 
 import javax.annotation.Nullable;
 
 /**
  * Represents a fish hook.
  */
-public interface FishHook extends Projectile {
+public interface FishHook extends DamagingProjectile {
 
     /**
-     * Sets the hooked item for this fish hook.
-     * <p>The hooked item may change depending on the type of fishing rod
-     * used to cast this fish hook. The hooked item may also be null.</p>
+     * Gets the hooked entity for this fish hook.
+     *
+     * <p>Fishooks can attach to {@link Entity} objects in the world,
+     * as though they are temporarily leashed. The hooked entity may
+     * also be null.</p>
      *
      * @return The hooked item, if available
      */
-    Optional<ItemStack> getHookedItem();
+    Optional<Entity> getHookedEntity();
 
     /**
-     * Sets the hooked item for this fish hook.
-     * <p>The hooked item may change depending on the type of fishing rod
-     * used to cast this fish hook. The hooked item may also be null.</p>
+     * Sets the hooked entity for this fish hook.
      *
-     * @param item The hooked item
+     * <p>Fishooks can attach to {@link Entity} objects in the world,
+     * as though they are temporarily leashed. The hooked entity may
+     * also be null.</p>
+     *
+     * @param entity The hooked entity
      */
-    void setHookedItem(@Nullable ItemStack item);
+    void setHookedEntity(@Nullable Entity entity);
 
 }

--- a/src/main/java/org/spongepowered/api/entity/projectile/Projectile.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/Projectile.java
@@ -52,19 +52,4 @@ public interface Projectile extends Entity {
      */
     void setShooter(ProjectileSource shooter);
 
-    /**
-     * Gets the damage this arrow will deal to a {@link org.spongepowered.api.entity.living.Living}
-     * if hit.
-     *
-     * @return The damage of this arrow
-     */
-    double getDamage();
-
-    /**
-     * Sets the damage this arrow will deal to a LivingEntity if hit.
-     *
-     * @param damage The damage
-     */
-    void setDamage(double damage);
-
 }

--- a/src/main/java/org/spongepowered/api/entity/projectile/Snowball.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/Snowball.java
@@ -28,6 +28,6 @@ package org.spongepowered.api.entity.projectile;
 /**
  * Represents a Snowball.
  */
-public interface Snowball extends Projectile {
+public interface Snowball extends DamagingProjectile {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/projectile/fireball/Fireball.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/fireball/Fireball.java
@@ -25,11 +25,12 @@
 package org.spongepowered.api.entity.projectile.fireball;
 
 import org.spongepowered.api.entity.explosive.Explosive;
+import org.spongepowered.api.entity.projectile.DamagingProjectile;
 import org.spongepowered.api.entity.projectile.Projectile;
 
 /**
  * Represents an abstract fireball, such as {@link SmallFireball}.
  */
-public interface Fireball extends Projectile, Explosive {
+public interface Fireball extends DamagingProjectile, Explosive {
 
 }


### PR DESCRIPTION
As the title states, several projectiles don't actually deal damage.

Fixes #400 

Changes include:

- [x] Firework is now a `FusedExplosive`
- [x] Arrow is a `DamagingProjectile`
- [x] Egg is a `DamagingProjectile`
- [x] FishHook hooks `Entity` and not `ItemStack` and is a `DamagingProjectile`
- [x] Fireball is a `DamagingProjectile`
- [x] Snowball is a `DamagingProjectile`
- [x] Projectile no longer deals damage

This also fixes `EyeOfEnder` no longer damaging per say, but still remaining a `Projectile` for the intent of having a shooter.