### PR TITLE
Add CommandBlockSource

### DIFF
--- a/src/main/java/org/spongepowered/api/block/data/CommandBlock.java
+++ b/src/main/java/org/spongepowered/api/block/data/CommandBlock.java
@@ -26,12 +26,12 @@ package org.spongepowered.api.block.data;
 
 import com.google.common.base.Optional;
 import org.spongepowered.api.text.message.Message;
-import org.spongepowered.api.util.command.CommandSource;
+import org.spongepowered.api.util.command.source.CommandBlockSource;
 
 /**
  * Represents a Command Block.
  */
-public interface CommandBlock extends TileEntity, CommandSource {
+public interface CommandBlock extends TileEntity, CommandBlockSource {
 
     /**
      * Gets the currently stored command.

--- a/src/main/java/org/spongepowered/api/util/command/source/CommandBlockSource.java
+++ b/src/main/java/org/spongepowered/api/util/command/source/CommandBlockSource.java
@@ -22,41 +22,29 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.entity.vehicle.minecart;
+package org.spongepowered.api.util.command.source;
 
-import org.spongepowered.api.util.command.source.CommandBlockSource;
+import org.spongepowered.api.util.command.CommandSource;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
 
 /**
- * Represents a minecart with a command block inside it.
+ * Represents a CommandBlock source, either a placed block or a MinecartCommandBlock.
  */
-public interface MinecartCommandBlock extends Minecart, CommandBlockSource {
+public interface CommandBlockSource extends CommandSource {
 
     /**
-     * Gets the current command within this command minecart.
-     *
-     * @return The current command stored
+     * Gets the location of the source.
+     * 
+     * @return The location
      */
-    String getCommand();
+    Location getLocation();
 
     /**
-     * Sets the stored command within this command minecart.
-     *
-     * @param command The command
+     * Gets the world that this source resides in.
+     * 
+     * @return The World
      */
-    void setCommand(String command);
+    World getWorld();
 
-    /**
-     * Gets the current custom name of this command minecart.
-     *
-     * @return The current command name
-     */
-    String getCommandName();
-
-    /**
-     * Sets the custom command name of this command minecart.
-     * <p>Setting the name to null may default to "@".</p>
-     *
-     * @param name The custom name
-     */
-    void setCommandName(String name);
 }


### PR DESCRIPTION
This PR adds a `CommandBlockSource` to act as the specific `CommandSource` for CommandBlock tile entities and MinecartCommandBlock entities.

The related implemenation PR for this is SpongePowered/Sponge#162.