### PR TITLE
Make BlockLoc a delegating class like Location

### DIFF
--- a/src/main/java/org/spongepowered/api/block/BlockLoc.java
+++ b/src/main/java/org/spongepowered/api/block/BlockLoc.java
@@ -26,6 +26,7 @@
 package org.spongepowered.api.block;
 
 import com.flowpowered.math.vector.Vector3i;
+import com.google.common.base.Optional;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.service.persistence.data.DataHolder;
 import org.spongepowered.api.util.Direction;
@@ -33,6 +34,8 @@ import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.extent.Extent;
 
 import java.util.Collection;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Represents a block at a specific location in an {@link Extent}.
@@ -44,58 +47,87 @@ import java.util.Collection;
  * <p>Instances are immutable, however, so they will never refer to
  * a different location.</p>
  */
-public interface BlockLoc extends DataHolder {
+public class BlockLoc implements DataHolder {
+
+    private final Extent extent;
+    private final Vector3i position;
+
+    /**
+     * Create a new instance
+     *
+     * @param extent The underlying extent
+     * @param position The position of the block
+     */
+    public BlockLoc(Extent extent, Vector3i position) {
+        checkNotNull(extent, "extent");
+        checkNotNull(position, "position");
+        this.extent = extent;
+        this.position = position;
+    }
 
     /**
      * Get the extent that the block that is referred to resides within.
      *
      * @return The extent
      */
-    Extent getExtent();
+    public Extent getExtent() {
+        return extent;
+    }
 
     /**
      * Get the position of the block.
      *
      * @return The position
      */
-    Vector3i getPosition();
+    public Vector3i getPosition() {
+        return position;
+    }
 
     /**
      * Get the location of the block.
      *
      * @return The location
      */
-    Location getLocation();
+    public Location getLocation() {
+        return new Location(getExtent(), getPosition().toDouble());
+    }
 
     /**
      * Get the X component of this block instance's position.
      *
      * @return The x component
      */
-    int getX();
+    public int getX() {
+        return getPosition().getX();
+    }
 
     /**
      * Get the Y component of this block instance's position.
      *
      * @return The y component
      */
-    int getY();
+    public int getY() {
+        return getPosition().getY();
+    }
 
     /**
      * Get the Z component of this block instance's position.
      *
      * @return The z component
      */
-    int getZ();
+    public int getZ() {
+        return getPosition().getZ();
+    }
 
     /**
      * Gets the block in the given direction of this block.
      *
      * @param direction The direction to look in
-     *
      * @return The block in that direction
      */
-    BlockLoc getRelative(Direction direction);
+    public BlockLoc getRelative(Direction direction) {
+        return new BlockLoc(getExtent(), getPosition().add(direction.toVector3d().toInt()));
+    }
 
     /**
      * Get the base type of block.
@@ -105,14 +137,18 @@ public interface BlockLoc extends DataHolder {
      *
      * @return The type of block
      */
-    BlockType getType();
+    public BlockType getType() {
+        return getExtent().getBlockType(getPosition());
+    }
 
     /**
      * Get the block state for this position.
      *
      * @return The current block state
      */
-    BlockState getState();
+    public BlockState getState() {
+        return getExtent().getBlockState(getPosition());
+    }
 
     /**
      * Replace the block state at this position with a new state.
@@ -121,7 +157,9 @@ public interface BlockLoc extends DataHolder {
      *
      * @param state The new block state
      */
-    void replaceWith(BlockState state);
+    public void replaceWith(BlockState state) {
+        getExtent().setBlockState(getPosition(), state);
+    }
 
     /**
      * Replace the block at this position by a new type.
@@ -130,22 +168,28 @@ public interface BlockLoc extends DataHolder {
      *
      * @param type The new type
      */
-    void replaceWith(BlockType type);
+    public void replaceWith(BlockType type) {
+        getExtent().setBlockType(getPosition(), type);
+    }
 
     /**
      * Replace the block at this position with a copy of the given snapshot.
      *
-     * <p>Changing the snapshot afterwards will not affect the block that
-     * has been placed at this location.</p>
+     * <p>Changing the snapshot afterwards will not affect the block that has
+     * been placed at this location.</p>
      *
      * @param snapshot The snapshot
      */
-    void replaceWith(BlockSnapshot snapshot);
+    public void replaceWith(BlockSnapshot snapshot) {
+        getExtent().setBlockSnapshot(getPosition(), snapshot);
+    }
 
     /**
      * Simulates the interaction with this object as if a player had done so.
      */
-    void interact();
+    public void interact() {
+        getExtent().interactBlock(getPosition());
+    }
 
     /**
      * Simulates the interaction with this object using the given item as if
@@ -153,30 +197,38 @@ public interface BlockLoc extends DataHolder {
      *
      * @param itemStack The item
      */
-    void interactWith(ItemStack itemStack);
+    public void interactWith(ItemStack itemStack) {
+        getExtent().interactBlockWith(getPosition(), itemStack);
+    }
 
     /**
      * Simulate the digging of the block as if a player had done so.
      *
      * @return Whether the block was destroyed
      */
-    boolean dig();
+    public boolean dig() {
+        return getExtent().digBlock(getPosition());
+    }
 
     /**
-     * Simulate the digging of the block with the given tool as if a player
-     * had done so.
+     * Simulate the digging of the block with the given tool as if a player had
+     * done so.
      *
      * @param itemStack The tool
      * @return Whether the block was destroyed
      */
-    boolean digWith(ItemStack itemStack);
+    public boolean digWith(ItemStack itemStack) {
+        return getExtent().digBlockWith(getPosition(), itemStack);
+    }
 
     /**
      * Gets the time it takes to dig this block with a fist in ticks.
      *
      * @return The time in ticks
      */
-    int getDigTime();
+    public int getDigTime() {
+        return getExtent().getBlockDigTime(getPosition());
+    }
 
     /**
      * Gets the time it takes to dig this block the specified item in ticks.
@@ -184,7 +236,9 @@ public interface BlockLoc extends DataHolder {
      * @param itemStack The item to pretend-dig with
      * @return The time in ticks
      */
-    int getDigTimeWith(ItemStack itemStack);
+    public int getDigTimeWith(ItemStack itemStack) {
+        return getExtent().getBlockDigTimeWith(getPosition(), itemStack);
+    }
 
     /**
      * Get the light level for this object.
@@ -193,7 +247,9 @@ public interface BlockLoc extends DataHolder {
      *
      * @return A light level, nominally between 0 and 15, inclusive
      */
-    byte getLuminance();
+    public byte getLuminance() {
+        return getExtent().getLuminance(getPosition());
+    }
 
     /**
      * Get the light level for this object that is caused by an overhead sky.
@@ -203,31 +259,39 @@ public interface BlockLoc extends DataHolder {
      *
      * @return A light level, nominally between 0 and 15, inclusive
      */
-    byte getLuminanceFromSky();
+    public byte getLuminanceFromSky() {
+        return getExtent().getLuminanceFromSky(getPosition());
+    }
 
     /**
-     * Get the light level for this object that is caused by everything
-     * other than the sky.
+     * Get the light level for this object that is caused by everything other
+     * than the sky.
      *
      * <p>Higher levels indicate a higher luminance.</p>
      *
      * @return A light level, nominally between 0 and 15, inclusive
      */
-    byte getLuminanceFromGround();
+    public byte getLuminanceFromGround() {
+        return getExtent().getLuminanceFromGround(getPosition());
+    }
 
     /**
      * Test whether the object is powered.
      *
      * @return Whether powered
      */
-    boolean isPowered();
+    public boolean isPowered() {
+        return getExtent().isBlockPowered(getPosition());
+    }
 
     /**
      * Test whether the object is indirectly powered.
      *
      * @return Whether powered
      */
-    boolean isIndirectlyPowered();
+    public boolean isIndirectlyPowered() {
+        return getExtent().isBlockPowered(getPosition());
+    }
 
     /**
      * Test whether the face in the given direction is powered.
@@ -235,7 +299,9 @@ public interface BlockLoc extends DataHolder {
      * @param direction The direction
      * @return Whether powered
      */
-    boolean isFacePowered(Direction direction);
+    public boolean isFacePowered(Direction direction) {
+        return getExtent().isBlockFacePowered(getPosition(), direction);
+    }
 
     /**
      * Test whether the face in the given direction is indirectly powered.
@@ -243,28 +309,36 @@ public interface BlockLoc extends DataHolder {
      * @param direction The direction
      * @return Whether powered
      */
-    boolean isFaceIndirectlyPowered(Direction direction);
+    public boolean isFaceIndirectlyPowered(Direction direction) {
+        return getExtent().isBlockFaceIndirectlyPowered(getPosition(), direction);
+    }
 
     /**
      * Get all the faces of this block that are directly powered.
      *
      * @return Faces powered
      */
-    Collection<Direction> getPoweredFaces();
+    public Collection<Direction> getPoweredFaces() {
+        return getExtent().getPoweredBlockFaces(getPosition());
+    }
 
     /**
      * Get all faces of this block that are indirectly powered.
      *
      * @return Faces indirectly powered
      */
-    Collection<Direction> getIndirectlyPoweredFaces();
+    public Collection<Direction> getIndirectlyPoweredFaces() {
+        return getExtent().getIndirectlyPoweredBlockFaces(getPosition());
+    }
 
     /**
      * Test whether the the block will block the movement of entities.
      *
      * @return Blocks movement
      */
-    boolean isPassable();
+    public boolean isPassable() {
+        return getExtent().isBlockPassable(getPosition());
+    }
 
     /**
      * Test whether the given face of the block can catch fire.
@@ -272,16 +346,25 @@ public interface BlockLoc extends DataHolder {
      * @param direction The face of the block to check
      * @return Is flammable
      */
-    boolean isFaceFlammable(Direction direction);
+    public boolean isFaceFlammable(Direction direction) {
+        return getExtent().isBlockFlammable(getPosition(), direction);
+    }
 
     /**
      * Get a snapshot of this block at the current point in time.
      *
-     * <p>A snapshot is disconnected from the {@link Extent} that it was
-     * taken from so changes to the original block do not affect the
-     * snapshot.</p>
+     * <p>A snapshot is disconnected from the {@link Extent} that it was taken
+     * from so changes to the original block do not affect the snapshot.</p>
      *
      * @return A snapshot
      */
-    BlockSnapshot getSnapshot();
+    public BlockSnapshot getSnapshot() {
+        return getExtent().getBlockSnapshot(getPosition());
+    }
+
+    @Override
+    public <T> Optional<T> getData(Class<T> dataClass) {
+        return getExtent().getBlockData(getPosition(), dataClass);
+    }
+
 }

--- a/src/main/java/org/spongepowered/api/world/extent/BlockVolume.java
+++ b/src/main/java/org/spongepowered/api/world/extent/BlockVolume.java
@@ -26,7 +26,16 @@
 package org.spongepowered.api.world.extent;
 
 import com.flowpowered.math.vector.Vector3d;
+import com.flowpowered.math.vector.Vector3i;
+import com.google.common.base.Optional;
 import org.spongepowered.api.block.BlockLoc;
+import org.spongepowered.api.block.BlockSnapshot;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.util.Direction;
+
+import java.util.Collection;
 
 /**
  * A volume containing blocks.
@@ -50,5 +59,232 @@ public interface BlockVolume {
      * @return The block
      */
     BlockLoc getBlock(int x, int y, int z);
+
+    /**
+     * Get the base type of block.
+     *
+     * <p>The type does not include block data such as the contents of
+     * inventories.</p>
+     *
+     * @param position The position of the block
+     * @return The type of block
+     */
+    BlockType getBlockType(Vector3i position);
+
+    /**
+     * Get the block state for this position.
+     *
+     * @param position The position of the block
+     * @return The current block state
+     */
+    BlockState getBlockState(Vector3i position);
+
+    /**
+     * Get an instance of the given data class for this block.
+     *
+     * <p>For example, if this block represents a sign,
+     * {@code getBlockData(Sign.class)} would yield an instance of
+     * {@code Sign} to change the contents of the sign. However, if
+     * this block does not represent a sign, then an instance will not
+     * be returned.</p>
+     *
+     * @param position The position of the block
+     * @param dataClass The data class
+     * @param <T> The type of data
+     * @return An instance of the class
+     */
+    <T> Optional<T> getBlockData(Vector3i position, Class<T> dataClass);
+
+    /**
+     * Replace the block state at this position with a new state.
+     *
+     * <p>This will remove any extended block data at the given position.</p>
+     *
+     * @param position The position of the block
+     * @param state The new block state
+     */
+    void setBlockState(Vector3i position, BlockState state);
+
+    /**
+     * Replace the block at this position by a new type.
+     *
+     * <p>This will remove any extended block data at the given position.</p>
+     *
+     * @param position The position of the block
+     * @param type The new type
+     */
+    void setBlockType(Vector3i position, BlockType type);
+
+    /**
+     * Replace the block at this position with a copy of the given snapshot.
+     *
+     * <p>Changing the snapshot afterwards will not affect the block that
+     * has been placed at this location.</p>
+     *
+     * @param position The position of the block
+     * @param snapshot The snapshot
+     */
+    void setBlockSnapshot(Vector3i position, BlockSnapshot snapshot);
+
+    /**
+     * Get a snapshot of this block at the current point in time.
+     *
+     * <p>A snapshot is disconnected from the {@link Extent} that it was
+     * taken from so changes to the original block do not affect the
+     * snapshot.</p>
+     *
+     * @param position The position of the block
+     * @return A snapshot
+     */
+    BlockSnapshot getBlockSnapshot(Vector3i position);
+
+    /**
+     * Simulates the interaction with this object as if a player had done so.
+     *
+     * @param position The position of the block
+     */
+    void interactBlock(Vector3i position);
+
+    /**
+     * Simulates the interaction with this object using the given item as if
+     * the player had done so.
+     *
+     * @param position The position of the block
+     * @param itemStack The item
+     */
+    void interactBlockWith(Vector3i position, ItemStack itemStack);
+
+    /**
+     * Simulate the digging of the block as if a player had done so.
+     *
+     * @return Whether the block was destroyed
+     */
+    boolean digBlock(Vector3i position);
+
+    /**
+     * Simulate the digging of the block with the given tool as if a player
+     * had done so.
+     *
+     * @param position The position of the block
+     * @param itemStack The tool
+     * @return Whether the block was destroyed
+     */
+    boolean digBlockWith(Vector3i position, ItemStack itemStack);
+
+    /**
+     * Gets the time it takes to dig this block with a fist in ticks.
+     *
+     * @param position The position of the block
+     * @return The time in ticks
+     */
+    int getBlockDigTime(Vector3i position);
+
+    /**
+     * Gets the time it takes to dig this block the specified item in ticks.
+     *
+     * @param position The position of the block
+     * @param itemStack The item to pretend-dig with
+     * @return The time in ticks
+     */
+    int getBlockDigTimeWith(Vector3i position, ItemStack itemStack);
+
+    /**
+     * Get the light level for this object.
+     *
+     * <p>Higher levels indicate a higher luminance.</p>
+     *
+     * @param position The position of the block
+     * @return A light level, nominally between 0 and 15, inclusive
+     */
+    byte getLuminance(Vector3i position);
+
+    /**
+     * Get the light level for this object that is caused by an overhead sky.
+     *
+     * <p>Higher levels indicate a higher luminance. If no sky is overheard,
+     * the return value may be 0.</p>
+     *
+     * @param position The position of the block
+     * @return A light level, nominally between 0 and 15, inclusive
+     */
+    byte getLuminanceFromSky(Vector3i position);
+
+    /**
+     * Get the light level for this object that is caused by everything
+     * other than the sky.
+     *
+     * <p>Higher levels indicate a higher luminance.</p>
+     *
+     * @param position The position of the block
+     * @return A light level, nominally between 0 and 15, inclusive
+     */
+    byte getLuminanceFromGround(Vector3i position);
+
+    /**
+     * Test whether the object is powered.
+     *
+     * @param position The position of the block
+     * @return Whether powered
+     */
+    boolean isBlockPowered(Vector3i position);
+
+    /**
+     * Test whether the object is indirectly powered.
+     *
+     * @param position The position of the block
+     * @return Whether powered
+     */
+    boolean isBlockIndirectlyPowered(Vector3i position);
+
+    /**
+     * Test whether the face in the given direction is powered.
+     *
+     * @param position The position of the block
+     * @param direction The direction
+     * @return Whether powered
+     */
+    boolean isBlockFacePowered(Vector3i position, Direction direction);
+
+    /**
+     * Test whether the face in the given direction is indirectly powered.
+     *
+     * @param position The position of the block
+     * @param direction The direction
+     * @return Whether powered
+     */
+    boolean isBlockFaceIndirectlyPowered(Vector3i position, Direction direction);
+
+    /**
+     * Get all the faces of this block that are directly powered.
+     *
+     * @param position The position of the block
+     * @return Faces powered
+     */
+    Collection<Direction> getPoweredBlockFaces(Vector3i position);
+
+    /**
+     * Get all faces of this block that are indirectly powered.
+     *
+     * @param position The position of the block
+     * @return Faces indirectly powered
+     */
+    Collection<Direction> getIndirectlyPoweredBlockFaces(Vector3i position);
+
+    /**
+     * Test whether the the block will block the movement of entities.
+     *
+     * @param position The position of the block
+     * @return Blocks movement
+     */
+    boolean isBlockPassable(Vector3i position);
+
+    /**
+     * Test whether the given face of the block can catch fire.
+     *
+     * @param position The position of the block
+     * @param faceDirection The face of the block to check
+     * @return Is flammable
+     */
+    boolean isBlockFlammable(Vector3i position, Direction faceDirection);
 
 }


### PR DESCRIPTION
This change changes BlockLoc to be a delegate like Location. All the methods (set block, get block, etc.) are then implemented on Extent rather than BlockLoc.

The general consensus the last time that this was discussed (a few months ago) was to implement this change.