### PR TITLE
Add explosion events

### DIFF
--- a/src/main/java/org/spongepowered/api/event/entity/EntityExplosionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityExplosionEvent.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.entity;
+
+import org.spongepowered.api.event.block.BulkBlockEvent;
+import org.spongepowered.api.world.Location;
+
+/**
+ * Represents an event when an explosion already has taken place and blocks
+ * are about to be broken/affected.
+ */
+public interface EntityExplosionEvent extends EntityEvent, BulkBlockEvent {
+
+    /**
+     * Gets the location of the explosion. This is separate from the
+     * entity as the entity already blew up.
+     *
+     * @return The location of detonation
+     */
+    Location getExplosionLocation();
+
+    /**
+     * Gets the damaging yield of the explosion to affect blocks.
+     *
+     * <p>The higher the yield, the more blocks are broken. The yield
+     * is between 0 and 100.</p>
+     *
+     * @return The damaging yield of the explosion
+     */
+    double getYield();
+
+    /**
+     * Sets the damaging yield of the explosion to affect blocks.
+     *
+     * <p>The higher the yield, the more blocks are broken. The yield
+     * is between 0 and 100.</p>
+     *
+     * @param yield The damaging yield of the explosion
+     */
+    void setYield(double yield);
+
+}

--- a/src/main/java/org/spongepowered/api/event/entity/ExplosionPrimeEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/ExplosionPrimeEvent.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.entity;
+
+import org.spongepowered.api.entity.explosive.Explosive;
+import org.spongepowered.api.util.event.Cancellable;
+
+/**
+ * Represents an event when an {@link Explosive} is about to explode.
+ *
+ * <p>Explosions usually affect a radius and ignite, depending on the explosion.</p>
+ */
+public interface ExplosionPrimeEvent extends EntityEvent, Cancellable {
+
+    /**
+     * Gets the explosive radius that the {@link Explosive} will affect.
+     *
+     * @return The radius of effect
+     */
+    double getRadius();
+
+    /**
+     * Sets the explosion radius.
+     *
+     * @param radius The explosion radius
+     */
+    void setRadius(double radius);
+
+    /**
+     * Gets whether the explosion will ignite ignitable blocks.
+     *
+     * <p>Blocks that may be ignited include logs, leaves, wool, etc.</p>
+     *
+     * @return Whether this explosion is flamable
+     */
+    boolean isFlamable();
+
+    /**
+     * Sets whether this explosion will be flamable or not.
+     *
+     * <p>Blocks that may be ignited include logs, leaves, wool, etc.</p>
+     *
+     * @param flamable Whether this explosion is flamable
+     */
+    void setFlamable(boolean flamable);
+
+}


### PR DESCRIPTION
Adds two new events to specifically deal with explosives. Fixes #416 


**EntityExplosionEvent**


Is designed for when an explosive entity has detonated and is about to change blocks in the world. 



**ExplosionPrimeEvent**

Is designed for when an explosive entity is primed to detonate (pre-explosion).
