### PR TITLE
Add more entity related events. Enhance several entity related events. 

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/living/Living.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Living.java
@@ -28,6 +28,7 @@ package org.spongepowered.api.entity.living;
 import com.flowpowered.math.vector.Vector3f;
 import com.google.common.base.Optional;
 import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.player.Player;
 import org.spongepowered.api.potion.PotionEffect;
 import org.spongepowered.api.potion.PotionEffectType;
 
@@ -36,6 +37,12 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+/**
+ * Represents an entity that is living, and therefor can be damaged.
+ *
+ * <p>Living entities can have {@link PotionEffect}s, breathing air
+ * under water, custom names, and become invisible.</p>
+ */
 public interface Living extends Entity {
 
     /**
@@ -287,4 +294,23 @@ public interface Living extends Entity {
      * @param invisible Whether this entity is invisible or not
      */
     void setInvisible(boolean invisible);
+
+    /**
+     * Gets whether this living entity is invisible to the specific
+     * {@link Player} entity.
+     *
+     * @param player The other player to check
+     * @return Whether this entity is invisible to the given player
+     */
+    boolean isInvisibleTo(Player player);
+
+    /**
+     * Sets whether this living entity is rendered invisible to the
+     * given {@link Player} entity.
+     *
+     * @param player The player to toggle invisibility towards
+     * @param invisible Whether this entity is invisible to the targeted
+     *      player
+     */
+    void setInvisibleTo(Player player, boolean invisible);
 }

--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -43,6 +43,7 @@ import org.spongepowered.api.block.data.Lockable;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntityInteractionType;
 import org.spongepowered.api.entity.Item;
+import org.spongepowered.api.entity.Tamer;
 import org.spongepowered.api.entity.player.Player;
 import org.spongepowered.api.entity.player.gamemode.GameMode;
 import org.spongepowered.api.entity.projectile.FishHook;
@@ -651,12 +652,13 @@ public final class SpongeEventFactory {
      * @param newLocation The new location of the entity
      * @return A new instance of the event
      */
-    public static EntityMoveEvent createEntityMove(Game game, Entity entity, Location oldLocation, Location newLocation) {
+    public static EntityMoveEvent createEntityMove(Game game, Entity entity, Location oldLocation, Location newLocation, Vector3f rotation) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", entity);
         values.put("oldLocation", oldLocation);
         values.put("newLocation", newLocation);
+        values.put("rotation", rotation);
         return createEvent(EntityMoveEvent.class, values);
     }
 
@@ -734,10 +736,11 @@ public final class SpongeEventFactory {
      * @param entity The entity involved in this event
      * @return A new instance of the event
      */
-    public static EntityTameEvent createEntityTame(Game game, Entity entity) {
+    public static EntityTameEvent createEntityTame(Game game, Entity entity, Tamer tamer) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", entity);
+        values.put("tamer", tamer);
         return createEvent(EntityTameEvent.class, values);
     }
 
@@ -751,13 +754,15 @@ public final class SpongeEventFactory {
      * @param newLocation The new location of the entity
      * @return A new instance of the event
      */
-    public static EntityTeleportEvent createEntityTeleport(Game game, Cause cause, Entity entity, Location oldLocation, Location newLocation) {
+    public static EntityTeleportEvent createEntityTeleport(Game game, Cause cause, Entity entity, Location oldLocation, Location newLocation, Vector3f rotation, boolean maintainsMomentum) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("cause", Optional.fromNullable(cause));
         values.put("entity", entity);
         values.put("oldLocation", oldLocation);
         values.put("newLocation", newLocation);
+        values.put("rotation", rotation);
+        values.put("keepsMomentum", maintainsMomentum);
         return createEvent(EntityTeleportEvent.class, values);
     }
 
@@ -1158,7 +1163,7 @@ public final class SpongeEventFactory {
      * @param newLocation The new location of the entity
      * @return A new instance of the event
      */
-    public static PlayerMoveEvent createPlayerMove(Game game, Player player, Location oldLocation, Location newLocation) {
+    public static PlayerMoveEvent createPlayerMove(Game game, Player player, Location oldLocation, Location newLocation, Vector3f rotation) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
@@ -1167,6 +1172,7 @@ public final class SpongeEventFactory {
         values.put("player", player);
         values.put("human", player);
         values.put("living", player);
+        values.put("rotation", rotation);
         return createEvent(PlayerMoveEvent.class, values);
     }
 

--- a/src/main/java/org/spongepowered/api/event/entity/EntityEnterPortalEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityEnterPortalEvent.java
@@ -24,35 +24,12 @@
  */
 package org.spongepowered.api.event.entity;
 
-import org.spongepowered.api.entity.living.Ageable;
-import org.spongepowered.api.util.event.Cancellable;
-
 /**
- * Represents an event when two {@link Ageable} entities come together
- * to attempt to produce offspring.
+ * An event when an entity enters a portal.
+ *
+ * <p>The portal can be any type of portal, may teleport
+ * and it may not teleport.</p>
  */
-public interface EntityBreedEvent extends EntityEvent, Cancellable {
-
-    /**
-     * Gets the parent attempting to breed.
-     *
-     * @return The parent attempting to breed
-     */
-    @Override
-    Ageable getEntity();
-
-    /**
-     * Gets the parent attempting to breed.
-     *
-     * @return The parent attempting to breed
-     */
-    Ageable getParent();
-
-    /**
-     * Gets the other parent attempting to breed.
-     *
-     * @return The other parent attempting to breed
-     */
-    Ageable getOtherParent();
+public interface EntityEnterPortalEvent extends EntityEvent {
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/EntityExitPortalEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityExitPortalEvent.java
@@ -24,35 +24,12 @@
  */
 package org.spongepowered.api.event.entity;
 
-import org.spongepowered.api.entity.living.Ageable;
-import org.spongepowered.api.util.event.Cancellable;
-
 /**
- * Represents an event when two {@link Ageable} entities come together
- * to attempt to produce offspring.
+ * An event when an entity exits a portal.
+ *
+ * <p>The portal can be any type of portal, may teleport
+ * and it may not teleport.</p>
  */
-public interface EntityBreedEvent extends EntityEvent, Cancellable {
-
-    /**
-     * Gets the parent attempting to breed.
-     *
-     * @return The parent attempting to breed
-     */
-    @Override
-    Ageable getEntity();
-
-    /**
-     * Gets the parent attempting to breed.
-     *
-     * @return The parent attempting to breed
-     */
-    Ageable getParent();
-
-    /**
-     * Gets the other parent attempting to breed.
-     *
-     * @return The other parent attempting to breed
-     */
-    Ageable getOtherParent();
+public interface EntityExitPortalEvent extends EntityEvent {
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/EntityIgniteEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityIgniteEvent.java
@@ -31,4 +31,18 @@ import org.spongepowered.api.util.event.Cancellable;
  */
 public interface EntityIgniteEvent extends EntityEvent, Cancellable {
 
+    /**
+     * Gets the amount of ticks the entity will remain on fire.
+     *
+     * @return The amount of ticks the entity will remain on fire
+     */
+    int getFireTicks();
+
+    /**
+     * Sets the amount of ticks the entity will remain on fire.
+     *
+     * @param fireTicks The amount of ticks the entity will remain on fire
+     */
+    void setFireTicks(int fireTicks);
+
 }

--- a/src/main/java/org/spongepowered/api/event/entity/EntityInteractEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityInteractEvent.java
@@ -25,10 +25,11 @@
 package org.spongepowered.api.event.entity;
 
 import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.util.event.Cancellable;
 
 /**
  * Called when an {@link Entity} is interacting with something.
  */
-public interface EntityInteractEvent extends EntityEvent {
+public interface EntityInteractEvent extends EntityEvent, Cancellable {
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/EntityMoveEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityMoveEvent.java
@@ -25,6 +25,7 @@
 
 package org.spongepowered.api.event.entity;
 
+import com.flowpowered.math.vector.Vector3f;
 import org.spongepowered.api.util.event.Cancellable;
 import org.spongepowered.api.world.Location;
 
@@ -46,4 +47,18 @@ public interface EntityMoveEvent extends EntityEvent, Cancellable {
      * @return The new location
      */
     Location getNewLocation();
+
+    /**
+     * Gets the rotation the entity is facing.
+     *
+     * @return The rotation the entity is facing
+     */
+    Vector3f getRotation();
+
+    /**
+     * Sets the rotation the entity is facing.
+     *
+     * @param rotation The rotation the entity is facing
+     */
+    void setRotation(Vector3f rotation);
 }

--- a/src/main/java/org/spongepowered/api/event/entity/EntityPotionEffectChangeEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityPotionEffectChangeEvent.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.entity;
+
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.cause.CauseTracked;
+import org.spongepowered.api.potion.PotionEffect;
+import org.spongepowered.api.util.event.Cancellable;
+
+import java.util.Collection;
+
+/**
+ * An event when an {@link Entity} gains or removes a {@link PotionEffect}.
+ *
+ * <p>If the potion effect is being lost, {@link #setPotionEffect(PotionEffect)}
+ * will have no change to the potion effect being removed. If a potion
+ * effect is being removed due to expiration, cancelling the event will
+ * have no change.</p>
+ */
+public interface EntityPotionEffectChangeEvent extends EntityEvent, CauseTracked, Cancellable {
+
+    /**
+     * Gets the {@link PotionEffect} being added or removed.
+     *
+     * @return The potion effect
+     */
+    PotionEffect getPotionEffect();
+
+    /**
+     * Gets whether the entity is gaining the linked {@link PotionEffect}.
+     *
+     * <p>If the potion effect is being lost, {@link #setPotionEffect(PotionEffect)}
+     * will have no change to the potion effect being removed. If a potion
+     * effect is being removed due to expiration, cancelling the event will
+     * have no change.</p>
+     *
+     * @return If the potion effect is being added
+     */
+    boolean isBeingAdded();
+
+    /**
+     * Sets the potion effect to be added to the entity.
+     *
+     * <p>Setting the potion effect only changes the potion effect if the
+     * effect is being added, a check for {@link #isBeingAdded()} is recommended.
+     * </p>
+     *
+     * <p>If the potion effect is being lost, setting the {@link PotionEffect}
+     * will have no change to the potion effect being removed. If a potion
+     * effect is being removed due to expiration, cancelling the event will
+     * have no change.</p>
+     *
+     * @param potionEffect The potion effect to add
+     */
+    void setPotionEffect(PotionEffect potionEffect);
+
+    /**
+     * Gets a copy of all currently active {@link PotionEffect}s on the entity.
+     *
+     * @return A copy of all potion effects active on the entity
+     */
+    Collection<PotionEffect> getCurrentEffects();
+
+}

--- a/src/main/java/org/spongepowered/api/event/entity/EntityTameEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityTameEvent.java
@@ -26,11 +26,19 @@
 package org.spongepowered.api.event.entity;
 
 import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.Tamer;
 import org.spongepowered.api.util.event.Cancellable;
 
 /**
  * Called when an {@link Entity} is tamed.
  */
 public interface EntityTameEvent extends EntityEvent, Cancellable {
+
+    /**
+     * Gets the {@link Tamer} that has tamed the entity in this event.
+     *
+     * @return The tamer that has tamed the entity
+     */
+    Tamer getTamer();
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityTeleportEvent.java
@@ -33,4 +33,20 @@ import org.spongepowered.api.event.cause.CauseTracked;
  */
 public interface EntityTeleportEvent extends EntityMoveEvent, CauseTracked {
 
+    /**
+     * Gets whether the entity teleporting will maintain its momentum
+     * after teleport.
+     *
+     * @return Whether the entity will maintain momentum after teleport
+     */
+    boolean getKeepsMomentum();
+
+    /**
+     * Sets whether the entity teleporting will maintain its momentum
+     * after teleport.
+     *
+     * @param maintainsMomentum Whether the entity will maintain momentum
+     */
+    void setKeepsMomentum(boolean maintainsMomentum);
+
 }

--- a/src/main/java/org/spongepowered/api/event/entity/EntityUnleashEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityUnleashEvent.java
@@ -24,35 +24,19 @@
  */
 package org.spongepowered.api.event.entity;
 
-import org.spongepowered.api.entity.living.Ageable;
+import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.util.event.Cancellable;
 
 /**
- * Represents an event when two {@link Ageable} entities come together
- * to attempt to produce offspring.
+ * An event that is called when an entity becomes unleashed.
  */
-public interface EntityBreedEvent extends EntityEvent, Cancellable {
+public interface EntityUnleashEvent extends EntityEvent, Cancellable {
 
     /**
-     * Gets the parent attempting to breed.
+     * Gets the leash holder of the leash.
      *
-     * @return The parent attempting to breed
+     * @return The leash holder
      */
-    @Override
-    Ageable getEntity();
-
-    /**
-     * Gets the parent attempting to breed.
-     *
-     * @return The parent attempting to breed
-     */
-    Ageable getParent();
-
-    /**
-     * Gets the other parent attempting to breed.
-     *
-     * @return The other parent attempting to breed
-     */
-    Ageable getOtherParent();
+    Entity getLeashHolder();
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/ExplosionPrimeEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/ExplosionPrimeEvent.java
@@ -53,17 +53,17 @@ public interface ExplosionPrimeEvent extends EntityEvent, Cancellable {
      *
      * <p>Blocks that may be ignited include logs, leaves, wool, etc.</p>
      *
-     * @return Whether this explosion is flamable
+     * @return Whether this explosion is flammable
      */
-    boolean isFlamable();
+    boolean isFlammable();
 
     /**
-     * Sets whether this explosion will be flamable or not.
+     * Sets whether this explosion will be flammable or not.
      *
      * <p>Blocks that may be ignited include logs, leaves, wool, etc.</p>
      *
-     * @param flamable Whether this explosion is flamable
+     * @param flammable Whether this explosion is flammable
      */
-    void setFlamable(boolean flamable);
+    void setFlammable(boolean flammable);
 
 }

--- a/src/main/java/org/spongepowered/api/potion/PotionEffect.java
+++ b/src/main/java/org/spongepowered/api/potion/PotionEffect.java
@@ -30,6 +30,9 @@ import org.spongepowered.api.service.persistence.DataSerializable;
 
 /**
  * Represents a possible Potion Effect.
+ *
+ * <p>PotionEffects can be added to {@link Living} entities via
+ * {@link Living#addPotionEffect(PotionEffect, boolean)}.</p>
  */
 public interface PotionEffect extends DataSerializable {
 
@@ -39,14 +42,6 @@ public interface PotionEffect extends DataSerializable {
      * @return The type.
      */
     PotionEffectType getType();
-
-    /**
-     * Applies this potion effect to the specified
-     * {@link Living}.
-     *
-     * @param ent The entity to apply the effect to.
-     */
-    void apply(Living ent);
 
     /**
      * Gets the duration for which this potion effect

--- a/src/main/java/org/spongepowered/api/world/biome/BiomeType.java
+++ b/src/main/java/org/spongepowered/api/world/biome/BiomeType.java
@@ -33,6 +33,13 @@ import org.spongepowered.api.world.gen.Populator;
 public interface BiomeType {
 
     /**
+     * Gets the name of this biome type.
+     *
+     * @return The name of this biome type
+     */
+    String getName();
+
+    /**
      * Get the temperature of this biome.
      *
      * @return The temperature


### PR DESCRIPTION
Achieves the following from the OCD list #221.

Fixes #462 
- [x] `BiomeType` needs a getter for its name
- [x] `Living` needs a class javadoc
- [x] `PotionEffect#apply` is questionable and should possibly be moved to Living
- [x] `EntityBreedEvent` is missing javadoc
- [x] Missing an `EntityUnleashEvent` to match our `EntityLeashEvent`
- [x] getFlamable and setFlamable in `ExplosionPrimeEvent` are misspelled
- [x] Add potion related events
- [x] `EntityInteractEvent` and children should implement Cancellable
- [x] `EntityTameEvent` offers no way either to get the tamer
- [x] EntityTeleportEvent has no velocity methods (for maintaining or changing the velocity of the player after the teleport)
- [x] `EntityIgniteEvent` getter and setter for fire ticks
- [x] `EntityEnterPortalEvent` and `EntityLeavePortalEvent`
- [x] `ExperienceEvent` is missing a javadoc