### PR TITLE
Add variable damage amounts to DamagingProjectile

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/projectile/DamagingProjectile.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/DamagingProjectile.java
@@ -25,6 +25,8 @@
 
 package org.spongepowered.api.entity.projectile;
 
+import org.spongepowered.api.entity.EntityType;
+
 /**
  * Represents entities that act as projectiles and can fly in the air.
  * For example, Arrows.
@@ -35,15 +37,41 @@ public interface DamagingProjectile extends Projectile {
      * Gets the damage this projectile will deal to a {@link org.spongepowered.api.entity.living.Living}
      * if hit.
      *
-     * @return The damage of this arrow
+     * @return The damage to deal
      */
     double getDamage();
 
     /**
      * Sets the damage this projectile will deal to a LivingEntity if hit.
      *
-     * @param damage The damage
+     * @param damage The damage to deal
      */
     void setDamage(double damage);
+
+    /**
+     * Gets the damage this projectile will deal to the specified {@link
+     * EntityType} if hit.
+     *
+     * <p>Note that in events, the damage defined for the provided {@link
+     * EntityType} will take priority over the "default" damage as defined
+     * from {@link #getDamage()}.</p>
+     *
+     * @param entityType The {@link EntityType} to set the damage amount for
+     * @return The damage to deal to the specified {@link EntityType}
+     */
+    double getDamageForEntity(EntityType entityType);
+
+    /**
+     * Sets the damage this projectile will deal to the specified {@link
+     * EntityType} if hit.
+     *
+     * <p>Note that in events, the damage defined for the provided {@link
+     * EntityType} will take priority over the "default" damage as defined
+     * from {@link #getDamage()}.</p>
+     *
+     * @param entityType The {@link EntityType} to set the damage amount for
+     * @param damage The damage to deal to the specified {@link EntityType}
+     */
+    void setDamageForEntity(EntityType entityType, double damage);
 
 }


### PR DESCRIPTION
This PR allows `DamagingProjectile`s to deal variable amounts of damage, depending on the entity hit. An example of this behavior in Vanilla is a blaze taking damage from snowballs, which ordinarily deal no damage.

I've also fixed some minor javadoc issues in `getDamage` and `setDamage`.

This resolves https://github.com/SpongePowered/SpongeAPI/issues/399