### PR TITLE
Add ExplosiveProjectile

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/projectile/explosive/ExplosiveProjectile.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/explosive/ExplosiveProjectile.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.entity.projectile.explosive;
+
+import org.spongepowered.api.entity.explosive.Explosive;
+import org.spongepowered.api.entity.projectile.DamagingProjectile;
+
+/**
+ * Represents an {@link DamagingProjectile} which is also an {@link Explosive}
+ */
+public interface ExplosiveProjectile extends DamagingProjectile, Explosive {
+
+    /**
+     * Gets the explosion power of this explosive projectile.
+     *
+     * <p>Explosion power must be equal to or greater than zero. Explosion
+     * power defines the amount of block damage an explosive projectile will do upon
+     * exploding.</p>
+     *
+     * @return The explosion power
+     */
+    int getExplosionPower();
+
+    /**
+     * Sets the explosion power of this Large Fireball.
+     *
+     * <p>Explosion power must be equal to or greater than zero. Explosion
+     * power defines the amount of block damage an explosive projectile will do upon
+     * exploding.</p>
+     *
+     * @param explosionPower The explosion power
+     */
+    void setExplosionPower(int explosionPower);
+
+}

--- a/src/main/java/org/spongepowered/api/entity/projectile/explosive/ExplosiveProjectile.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/explosive/ExplosiveProjectile.java
@@ -28,7 +28,7 @@ import org.spongepowered.api.entity.explosive.Explosive;
 import org.spongepowered.api.entity.projectile.DamagingProjectile;
 
 /**
- * Represents an {@link DamagingProjectile} which is also an {@link Explosive}
+ * Represents a {@link DamagingProjectile} which is also an {@link Explosive}
  */
 public interface ExplosiveProjectile extends DamagingProjectile, Explosive {
 

--- a/src/main/java/org/spongepowered/api/entity/projectile/explosive/ExplosiveProjectile.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/explosive/ExplosiveProjectile.java
@@ -28,7 +28,7 @@ import org.spongepowered.api.entity.explosive.Explosive;
 import org.spongepowered.api.entity.projectile.DamagingProjectile;
 
 /**
- * Represents a {@link DamagingProjectile} which is also an {@link Explosive}
+ * Represents a {@link DamagingProjectile} which is also an {@link Explosive}.
  */
 public interface ExplosiveProjectile extends DamagingProjectile, Explosive {
 

--- a/src/main/java/org/spongepowered/api/entity/projectile/explosive/WitherSkull.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/explosive/WitherSkull.java
@@ -23,31 +23,11 @@
  * THE SOFTWARE.
  */
 
-package org.spongepowered.api.entity.projectile.fireball;
+package org.spongepowered.api.entity.projectile.explosive;
 
 /**
- * Represents a Ghast fireball.
+ * Represents a Wither Skull.
  */
-public interface LargeFireball extends Fireball {
-
-    /**
-     * gets the explosion power of this Large Fireball.
-     * <p>Explosion power must be equal to or greater than zero. Explosion
-     * power defines the amount of block damage a fireball will do upon
-     * exploding.</p>
-     *
-     * @return The explosion power
-     */
-    int getExplosionPower();
-
-    /**
-     * Sets the explosion power of this Large Fireball.
-     * <p>Explosion power must be equal to or greater than zero. Explosion
-     * power defines the amount of block damage a fireball will do upon
-     * exploding.</p>
-     *
-     * @param explosionPower The explosion power
-     */
-    void setExplosionPower(int explosionPower);
+public interface WitherSkull extends ExplosiveProjectile {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/projectile/explosive/fireball/Fireball.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/explosive/fireball/Fireball.java
@@ -22,12 +22,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+package org.spongepowered.api.entity.projectile.explosive.fireball;
 
-package org.spongepowered.api.entity.projectile.fireball;
+import org.spongepowered.api.entity.projectile.explosive.ExplosiveProjectile;
 
 /**
- * Represents a Wither Skull.
+ * Represents an abstract fireball, such as {@link SmallFireball}.
  */
-public interface WitherSkull extends Fireball {
+public interface Fireball extends ExplosiveProjectile {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/projectile/explosive/fireball/LargeFireball.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/explosive/fireball/LargeFireball.java
@@ -22,14 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.entity.projectile.fireball;
 
-import org.spongepowered.api.entity.explosive.Explosive;
-import org.spongepowered.api.entity.projectile.DamagingProjectile;
+package org.spongepowered.api.entity.projectile.explosive.fireball;
 
 /**
- * Represents an abstract fireball, such as {@link SmallFireball}.
+ * Represents a Ghast fireball.
  */
-public interface Fireball extends DamagingProjectile, Explosive {
+public interface LargeFireball extends Fireball {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/projectile/explosive/fireball/SmallFireball.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/explosive/fireball/SmallFireball.java
@@ -23,4 +23,11 @@
  * THE SOFTWARE.
  */
 
-@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.entity.projectile.fireball;
+package org.spongepowered.api.entity.projectile.explosive.fireball;
+
+/**
+ * Represents a Blaze fireball.
+ */
+public interface SmallFireball extends Fireball {
+
+}

--- a/src/main/java/org/spongepowered/api/entity/projectile/explosive/fireball/package-info.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/explosive/fireball/package-info.java
@@ -23,11 +23,4 @@
  * THE SOFTWARE.
  */
 
-package org.spongepowered.api.entity.projectile.fireball;
-
-/**
- * Represents a Blaze fireball.
- */
-public interface SmallFireball extends Fireball {
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.entity.projectile.explosive.fireball;


### PR DESCRIPTION
This PR creates a new `ExplosiveProjectile` interface, which represents projectiles such as `WitherSkull`s and `Fireball`s which create an explosion in addition to functioning as `Projectile`s.

Following the discussion in issue https://github.com/SpongePowered/SpongeAPI/issues/339, I've decided not to create a separation between block damaging and non block damaging projectiles.

This resolves https://github.com/SpongePowered/SpongeAPI/issues/339