### PR TITLE
Don't allow primitives to be null, as well as reference types

### DIFF
--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -554,15 +554,17 @@ public final class SpongeEventFactory {
      * @param entity The entity involved in this event
      * @param location The location of death
      * @param droppedItems The items to drop
+     * @param exp The experience to give, or take for negative values
      * @return A new instance of the event
      */
-    public static EntityDeathEvent createEntityDeath(Game game, Cause cause, Entity entity, Location location, Collection<Item> droppedItems) {
+    public static EntityDeathEvent createEntityDeath(Game game, Cause cause, Entity entity, Location location, Collection<Item> droppedItems, int exp) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("cause", Optional.fromNullable(cause));
         values.put("entity", entity);
         values.put("droppedItems", droppedItems);
         values.put("location", location);
+        values.put("exp", exp);
         return createEvent(EntityDeathEvent.class, values);
     }
 
@@ -1074,10 +1076,14 @@ public final class SpongeEventFactory {
      * @param location The location of death
      * @param deathMessage The message to show to the player because they died
      * @param droppedItems The items to drop
+     * @param exp The experience to give, or take for negative values
+     * @param newExperience The new experience the player will have towards the next level
+     * @param newLevel The new level the player will have after death
+     * @param keepsLevel Whether the player keeps all of their exp on death
      * @return A new instance of the event
      */
     public static PlayerDeathEvent createPlayerDeath(Game game, Cause cause, Player player, Location location, Message deathMessage,
-            Collection<Item> droppedItems) {
+            Collection<Item> droppedItems, int exp, int newExperience, int newLevel, boolean keepsLevel, boolean keepsInventory) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("cause", Optional.fromNullable(cause));
@@ -1088,6 +1094,11 @@ public final class SpongeEventFactory {
         values.put("human", player);
         values.put("living", player);
         values.put("droppedItems", droppedItems);
+        values.put("exp", exp);
+        values.put("newExperience", newExperience);
+        values.put("newLevel", newLevel);
+        values.put("keepsLevel", keepsLevel);
+        values.put("keepsInventory", keepsInventory);
         return createEvent(PlayerDeathEvent.class, values);
     }
 

--- a/src/main/java/org/spongepowered/api/event/entity/living/player/PlayerDeathEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/player/PlayerDeathEvent.java
@@ -53,7 +53,7 @@ public interface PlayerDeathEvent extends HumanDeathEvent, PlayerEvent {
      *
      * @return Whether the player keeps their inventory on death
      */
-    boolean getKeepsInventory();
+    boolean keepsInventory();
 
     /**
      * Sets if the player keeps their inventory on death.
@@ -67,7 +67,7 @@ public interface PlayerDeathEvent extends HumanDeathEvent, PlayerEvent {
      *
      * @return Whether the player keeps all of their EXP on death
      */
-    boolean getKeepsLevel();
+    boolean keepsLevel();
 
     /**
      * Sets if the player keeps all of their EXP on death.

--- a/src/main/java/org/spongepowered/api/event/entity/living/player/PlayerDeathEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/player/PlayerDeathEvent.java
@@ -53,7 +53,7 @@ public interface PlayerDeathEvent extends HumanDeathEvent, PlayerEvent {
      *
      * @return Whether the player keeps their inventory on death
      */
-    boolean keepsInventory();
+    boolean getKeepsInventory();
 
     /**
      * Sets if the player keeps their inventory on death.
@@ -67,7 +67,7 @@ public interface PlayerDeathEvent extends HumanDeathEvent, PlayerEvent {
      *
      * @return Whether the player keeps all of their EXP on death
      */
-    boolean keepsLevel();
+    boolean getKeepsLevel();
 
     /**
      * Sets if the player keeps all of their EXP on death.

--- a/src/main/java/org/spongepowered/api/util/event/factory/ClassGenerator.java
+++ b/src/main/java/org/spongepowered/api/util/event/factory/ClassGenerator.java
@@ -58,6 +58,7 @@ import static org.objectweb.asm.Opcodes.RETURN;
 import static org.objectweb.asm.Opcodes.V1_6;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.objectweb.asm.ClassWriter;
@@ -84,7 +85,7 @@ class ClassGenerator {
 
     private final PropertySearchStrategy propertySearch = new AccessorFirstStrategy();
     private NullPolicy nullPolicy = NullPolicy.DISABLE_PRECONDITIONS;
-    private final List<String> primitivePropertyExceptions = Collections.singletonList("cancelled");
+    private final List<String> primitivePropertyExceptions = ImmutableList.of("cancelled");
 
     /**
      * Insert the necessary methods to unbox a primitive type (if the given type

--- a/src/main/java/org/spongepowered/api/util/event/factory/ClassGenerator.java
+++ b/src/main/java/org/spongepowered/api/util/event/factory/ClassGenerator.java
@@ -59,6 +59,7 @@ import static org.objectweb.asm.Opcodes.V1_6;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Label;
@@ -70,6 +71,8 @@ import org.spongepowered.api.util.reflect.PropertySearchStrategy;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -81,6 +84,7 @@ class ClassGenerator {
 
     private final PropertySearchStrategy propertySearch = new AccessorFirstStrategy();
     private NullPolicy nullPolicy = NullPolicy.DISABLE_PRECONDITIONS;
+    private final List<String> primitivePropertyExceptions = Collections.singletonList("cancelled");
 
     /**
      * Insert the necessary methods to unbox a primitive type (if the given type
@@ -255,7 +259,7 @@ class ClassGenerator {
                     boolean useNullTest = (this.nullPolicy == NullPolicy.NON_NULL_BY_DEFAULT && !property.hasNullable())
                             || (this.nullPolicy == NullPolicy.NULL_BY_DEFAULT && property.hasNonnull());
 
-                    if (useNullTest && !property.getType().isPrimitive()) {
+                    if (useNullTest && (!property.getType().isPrimitive() || !this.primitivePropertyExceptions.contains(property.getName()))) {
                         Label afterNullTest = new Label();
                         mv.visitVarInsn(ALOAD, 2);
                         mv.visitJumpInsn(IFNONNULL, afterNullTest);

--- a/src/main/java/org/spongepowered/api/util/reflect/AccessorFirstStrategy.java
+++ b/src/main/java/org/spongepowered/api/util/reflect/AccessorFirstStrategy.java
@@ -50,6 +50,7 @@ public class AccessorFirstStrategy implements PropertySearchStrategy {
 
     private static final Pattern ACCESSOR = Pattern.compile("^get([A-Z].*)");
     private static final Pattern ACCESSOR_BOOL = Pattern.compile("^is([A-Z].*)");
+    private static final Pattern ACCESSOR_KEEPS = Pattern.compile("^(keeps[A-Z].*)");
     private static final Pattern MUTATOR = Pattern.compile("^set([A-Z].*)");
 
     /**
@@ -95,8 +96,12 @@ public class AccessorFirstStrategy implements PropertySearchStrategy {
             if (m.matches() && method.getReturnType().equals(boolean.class)) {
                 return getPropertyName(m.group(1));
             }
-        }
 
+            m = ACCESSOR_KEEPS.matcher(method.getName());
+            if (m.matches() && method.getReturnType().equals(boolean.class)) {
+                return getPropertyName(m.group(1));
+            }
+        }
         return null;
     }
 

--- a/src/test/java/org/spongepowered/api/util/event/factory/ClassGeneratorProviderTest.java
+++ b/src/test/java/org/spongepowered/api/util/event/factory/ClassGeneratorProviderTest.java
@@ -108,6 +108,14 @@ public class ClassGeneratorProviderTest {
         assertThat(result.getChar(), is((char) 0));
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testCreate_UnsetPrimitivesWithNonNull() throws Exception {
+        ClassGeneratorProvider provider = createProvider();
+        provider.setNullPolicy(NullPolicy.NON_NULL_BY_DEFAULT);
+        EventFactory<PrimitiveContainer> factory = provider.create(PrimitiveContainer.class, Object.class);
+        factory.apply(Collections.<String, Object>emptyMap());
+    }
+
     @Test
     public void testCreate_BoxedPrimitives() throws Exception {
         ClassGeneratorProvider provider = createProvider();


### PR DESCRIPTION
See issue https://github.com/SpongePowered/SpongeAPI/issues/439 for a description of the problem.

This **correctly** breaks the build - many event factories don't specif all the needed parameters to construct an event. The fixes can be added to this PR, or go in a separate one.