### PR TITLE
Expand Persistence API

### DIFF
--- a/src/main/java/org/spongepowered/api/service/persistence/DataSerializableBuilder.java
+++ b/src/main/java/org/spongepowered/api/service/persistence/DataSerializableBuilder.java
@@ -22,23 +22,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package org.spongepowered.api.service.persistence;
 
+import com.google.common.base.Optional;
 import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataView;
 
 /**
- * Represents an object that can be represented by a {@link DataContainer}.
- * <p>DataContainers received from {@link DataSerializable#toContainer()}
- * should be considered to be copies of the original data, and therefor,
- * thread safe.</p>
+ * Represents a builder that can take a {@link DataContainer} and create a
+ * new instance of a {@link DataSerializable}. The builder should be a
+ * singleton and may not exist for every data serializable.
+ *
+ * @param <T> The type of data serializable this builder can build
  */
-public interface DataSerializable {
+public interface DataSerializableBuilder<T extends DataSerializable> {
 
     /**
-     * Serializes this object into a comprehensible {@link DataContainer}.
+     * Attempts to build the provided {@link DataSerializable} from the given
+     * {@link DataView}. If the {@link DataView} is invalid or
+     * missing necessary information to complete building the
+     * {@link DataSerializable}, {@link Optional#absent()} may be returned.
      *
-     * @return A newly created DataContainer
+     * @param container The container containing all necessary data
+     * @return The instance of the {@link DataSerializable}, if successful
+     * @throws InvalidDataException In the event that the builder is unable to
+     *     properly construct the data serializable from the data view
      */
-    DataContainer toContainer();
+    Optional<T> build(DataView container) throws InvalidDataException;
 
 }

--- a/src/main/java/org/spongepowered/api/service/persistence/DataSource.java
+++ b/src/main/java/org/spongepowered/api/service/persistence/DataSource.java
@@ -48,7 +48,17 @@ public interface DataSource {
      * @return The newly deserialized object, if available
      * @throws InvalidDataException If the data is incompatible with this source
      */
-    <T extends DataSerializable> Optional<DataContainer> deserialize(Class<T> clazz) throws InvalidDataException;
+    <T extends DataSerializable> Optional<T> deserialize(Class<T> clazz)
+            throws InvalidDataException;
+
+    /**
+     * Deserializes all data existing in this source into a single {@link
+     * DataContainer}. This can be used for passing around data containers
+     * without knowing the contents.
+     *
+     * @return A data container containing all data from this source
+     */
+    Optional<DataContainer> deserialize();
 
     /**
      * Serializes the given {@link DataSerializable} to this source.

--- a/src/main/java/org/spongepowered/api/service/persistence/DataSourceFactory.java
+++ b/src/main/java/org/spongepowered/api/service/persistence/DataSourceFactory.java
@@ -25,7 +25,7 @@
 package org.spongepowered.api.service.persistence;
 
 import com.google.common.base.Optional;
-import com.typesafe.config.Config;
+import ninja.leaping.configurate.ConfigurationNode;
 
 /**
  * A standard factory to create {@link DataSource}s to serialize and deserialize
@@ -43,6 +43,6 @@ public interface DataSourceFactory {
      * @param config The configuration to configure the DataSource
      * @return The newly created data source, if available
      */
-    Optional<DataSource> createSource(Config config);
+    Optional<DataSource> createSource(ConfigurationNode config);
 
 }

--- a/src/main/java/org/spongepowered/api/service/persistence/InvalidDataException.java
+++ b/src/main/java/org/spongepowered/api/service/persistence/InvalidDataException.java
@@ -24,8 +24,31 @@
  */
 package org.spongepowered.api.service.persistence;
 
+import org.spongepowered.api.service.persistence.data.DataView;
+
+/**
+ * An exception that occurs when a {@link DataSerializableBuilder} or
+ * {@link DataSource} is unable to handle an operation, which can include:
+ * {@link DataSerializableBuilder#build(DataView)}, {@link DataSource#deserialize()},
+ * etc.
+ */
 public class InvalidDataException extends UnsupportedOperationException {
 
     private static final long serialVersionUID = -754482190837922531L;
 
+    /**
+     * Creates a new {@link InvalidDataException} with no message.
+     */
+    public InvalidDataException() {
+        super();
+    }
+
+    /**
+     * Creates a new {@link InvalidDataException} with a message.
+     *
+     * @param message The message to display with the exception
+     */
+    public InvalidDataException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/org/spongepowered/api/service/persistence/SerializationService.java
+++ b/src/main/java/org/spongepowered/api/service/persistence/SerializationService.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.service.persistence;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+
+/**
+ * A service that manages {@link DataSerializableBuilder}s and sometimes the
+ * deserialization of various {@link DataSerializable}s.
+ */
+public interface SerializationService {
+
+    /**
+     * Registers a {@link DataSerializableBuilder} that will dynamically build
+     * the given {@link DataSerializable} from a {@link DataContainer}.
+     *
+     * <p>Builders may not always exist for a given {@link DataSerializable},
+     * nor is it guaranteed that a provided builder will function with all
+     * {@link DataContainer}s.
+     * </p>
+     *
+     * @param clazz The class of the {@link DataSerializable}
+     * @param builder The builder that can build the data serializable
+     * @param <T> The type of data serializable
+     */
+    <T extends DataSerializable> void registerBuilder(Class<T> clazz,
+            DataSerializableBuilder<T> builder);
+
+    /**
+     * Attempts to retrieve the {@link DataSerializableBuilder} for the desired {@link
+     * DataSerializable} class.
+     *
+     * <p>Builders may not always exist for a given {@link DataSerializable}, nor is it
+     * guaranteed that a provided builder will function with all {@link DataContainer}s.</p>
+     *
+     * @param clazz The class of the data serializable
+     * @param <T> The type of data serializable
+     * @return The builder, if available
+     */
+    <T extends DataSerializable>  Optional<DataSerializableBuilder<T>> getBuilder(Class<T> clazz);
+
+}

--- a/src/main/java/org/spongepowered/api/service/persistence/data/DataQuery.java
+++ b/src/main/java/org/spongepowered/api/service/persistence/data/DataQuery.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.service.persistence.data;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -135,4 +136,20 @@ public final class DataQuery {
         return asString(String.valueOf(separator));
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.parts);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final DataQuery other = (DataQuery) obj;
+        return Objects.equal(this.parts, other.parts);
+    }
 }

--- a/src/main/java/org/spongepowered/api/service/persistence/data/DataView.java
+++ b/src/main/java/org/spongepowered/api/service/persistence/data/DataView.java
@@ -26,6 +26,8 @@ package org.spongepowered.api.service.persistence.data;
 
 import com.google.common.base.Optional;
 import org.spongepowered.api.service.persistence.DataSerializable;
+import org.spongepowered.api.service.persistence.DataSerializableBuilder;
+import org.spongepowered.api.service.persistence.SerializationService;
 
 import java.util.List;
 import java.util.Map;
@@ -40,7 +42,9 @@ public interface DataView {
 
     /**
      * Gets the parent container of this DataView.
+     *
      * <p>Every DataView will always have a {@link DataContainer}.</p>
+     *
      * <p>For any {@link DataContainer}, this will return itself.</p>
      *
      * @return The parent container
@@ -50,8 +54,10 @@ public interface DataView {
     /**
      * Gets the current path of this {@link DataView} from its root
      * {@link DataContainer}.
+     *
      * <p>For any {@link DataContainer} itself, this will return an
      * empty string as it is the root of the path.</p>
+     *
      * <p>The full path will always include this {@link DataView}s name
      * at the end of the path.</p>
      *
@@ -61,6 +67,7 @@ public interface DataView {
 
     /**
      * Gets the name of this individual {@link DataView} in the path.
+     *
      * <p>This will always be the final substring of the full path
      * from {@link #getCurrentPath()}.</p>
      *
@@ -71,6 +78,7 @@ public interface DataView {
     /**
      * Gets the parent {@link DataView} of this view. The parent directly
      * contains this view according to the {@link #getCurrentPath()}.
+     *
      * <p>For any {@link DataContainer}, this will return an absent parent.</p>
      *
      * @return The parent data view containing this view
@@ -78,10 +86,12 @@ public interface DataView {
     Optional<DataView> getParent();
 
     /**
-     * Gets a set containing all keys in this {@link DataView}.
+     * Gets a collection containing all keys in this {@link DataView}.
+     *
      * <p>If deep is set to true, then this will contain all the keys
      * within any child {@link DataView}s (and their children, etc).
      * These will be in a valid path notation for you to use.</p>
+     *
      * <p>If deep is set to false, then this will contain only the keys
      * of any direct children, and not their own children.</p>
      *
@@ -92,9 +102,11 @@ public interface DataView {
 
     /**
      * Gets a Map containing all keys and their values for this {@link DataView}.
+     *
      * <p>If deep is set to true, then this will contain all the keys and
      * values within any child {@link DataView}s (and their children,
      * etc). These keys will be in a valid path notation for you to use.</p>
+     *
      * <p>If deep is set to false, then this will contain only the keys and
      * values of any direct children, and not their own children.</p>
      *
@@ -152,6 +164,7 @@ public interface DataView {
     /**
      * Creates a new {@link DataView} with the given data at the desired
      * path.
+     *
      * <p>If any data existed at the given path, that data will be overwritten
      * with the newly constructed {@link DataView}.</p>
      *
@@ -163,6 +176,7 @@ public interface DataView {
 
     /**
      * Gets the {@link DataView} by path, if available.
+     *
      * <p>If a {@link DataView} does not exist, or the data residing at
      * the path is not an instance of a {@link DataView}, an absent is
      * returned.</p>
@@ -174,6 +188,7 @@ public interface DataView {
 
     /**
      * Gets the {@link Boolean} by path, if available.
+     *
      * <p>If a {@link Boolean} does not exist, or the data residing at
      * the path is not an instance of a {@link Boolean}, an absent is
      * returned.</p>
@@ -185,6 +200,7 @@ public interface DataView {
 
     /**
      * Gets the {@link Integer} by path, if available.
+     *
      * <p>If a {@link Integer} does not exist, or the data residing at
      * the path is not an instance of a {@link Integer}, an absent is
      * returned.</p>
@@ -196,6 +212,7 @@ public interface DataView {
 
     /**
      * Gets the {@link Long} by path, if available.
+     *
      * <p>If a {@link Long} does not exist, or the data residing at
      * the path is not an instance of a {@link Long}, an absent is
      * returned.</p>
@@ -207,6 +224,7 @@ public interface DataView {
 
     /**
      * Gets the {@link Double} by path, if available.
+     *
      * <p>If a {@link Double} does not exist, or the data residing at
      * the path is not an instance of a {@link Double}, an absent is
      * returned.</p>
@@ -218,6 +236,7 @@ public interface DataView {
 
     /**
      * Gets the {@link String} by path, if available.
+     *
      * <p>If a {@link String} does not exist, or the data residing at
      * the path is not an instance of a {@link String}, an absent is
      * returned.</p>
@@ -229,6 +248,7 @@ public interface DataView {
 
     /**
      * Gets the {@link List} of something by path, if available.
+     *
      * <p>If a {@link List} of something does not exist, or the data
      * residing at the path is not an instance of a {@link List} of something,
      * an absent is returned.</p>
@@ -240,6 +260,7 @@ public interface DataView {
 
     /**
      * Gets the {@link List} of {@link String} by path, if available.
+     *
      * <p>If a {@link List} of {@link String} does not exist, or the data
      * residing at the path is not an instance of a {@link List} of
      * {@link String}, an absent is returned.</p>
@@ -251,6 +272,7 @@ public interface DataView {
 
     /**
      * Gets the {@link List} of {@link Character} by path, if available.
+     *
      * <p>If a {@link List} of {@link Character} does not exist, or the data
      * residing at the path is not an instance of a {@link List} of
      * {@link Character}, an absent is returned.</p>
@@ -262,6 +284,7 @@ public interface DataView {
 
     /**
      * Gets the {@link List} of {@link Boolean} by path, if available.
+     *
      * <p>If a {@link List} of {@link Boolean} does not exist, or the data
      * residing at the path is not an instance of a {@link List} of
      * {@link Boolean}, an absent is returned.</p>
@@ -273,6 +296,7 @@ public interface DataView {
 
     /**
      * Gets the {@link List} of {@link Byte} by path, if available.
+     *
      * <p>If a {@link List} of {@link Byte} does not exist, or the data
      * residing at the path is not an instance of a {@link List} of
      * {@link Byte}, an absent is returned.</p>
@@ -284,6 +308,7 @@ public interface DataView {
 
     /**
      * Gets the {@link List} of {@link Short} by path, if available.
+     *
      * <p>If a {@link List} of {@link Short} does not exist, or the data
      * residing at the path is not an instance of a {@link List} of
      * {@link Short}, an absent is returned.</p>
@@ -295,6 +320,7 @@ public interface DataView {
 
     /**
      * Gets the {@link List} of {@link Integer} by path, if available.
+     *
      * <p>If a {@link List} of {@link Integer} does not exist, or the data
      * residing at the path is not an instance of a {@link List} of
      * {@link Integer}, an absent is returned.</p>
@@ -306,6 +332,7 @@ public interface DataView {
 
     /**
      * Gets the {@link List} of {@link Long} by path, if available.
+     *
      * <p>If a {@link List} of {@link Long} does not exist, or the data
      * residing at the path is not an instance of a {@link List} of
      * {@link Long}, an absent is returned.</p>
@@ -317,6 +344,7 @@ public interface DataView {
 
     /**
      * Gets the {@link List} of {@link Float} by path, if available.
+     *
      * <p>If a {@link List} of {@link Float} does not exist, or the data
      * residing at the path is not an instance of a {@link List} of
      * {@link Float}, an absent is returned.</p>
@@ -328,6 +356,7 @@ public interface DataView {
 
     /**
      * Gets the {@link List} of {@link Double} by path, if available.
+     *
      * <p>If a {@link List} of {@link Double} does not exist, or the data
      * residing at the path is not an instance of a {@link List} of
      * {@link Double}, an absent is returned.</p>
@@ -339,6 +368,7 @@ public interface DataView {
 
     /**
      * Gets the {@link List} of {@link Map} by path, if available.
+     *
      * <p>If a {@link List} of {@link Map} does not exist, or the data
      * residing at the path is not an instance of a {@link List} of
      * {@link Map}, an absent is returned.</p>
@@ -350,14 +380,21 @@ public interface DataView {
 
     /**
      * Gets the {@link DataSerializable} object by path, if available.
+     *
      * <p>If a {@link DataSerializable} exists, but is not the proper class
      * type, or there is no data at the path given, an absent is returned.</p>
      *
+     * <p>It is important that the {@link SerializationService} provided is the same one that
+     * has registered many of the {@link DataSerializableBuilder}s to ensure the {@link
+     * DataSerializable} requested can be returned.</p>
+     *
      * @param path The path of the value to get
      * @param clazz The class of the {@link DataSerializable}
+     * @param service The serialization service to use for retrieving data serializable builders
      * @param <T> The type of {@link DataSerializable} object
      * @return The deserialized object, if available
      */
-    <T extends DataSerializable> Optional<T> getSerializable(DataQuery path, Class<T> clazz);
+    <T extends DataSerializable> Optional<T> getSerializable(DataQuery path,
+            Class<T> clazz, SerializationService service);
 
 }

--- a/src/main/java/org/spongepowered/api/service/persistence/data/MemoryDataContainer.java
+++ b/src/main/java/org/spongepowered/api/service/persistence/data/MemoryDataContainer.java
@@ -22,23 +22,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service.persistence;
+package org.spongepowered.api.service.persistence.data;
 
-import org.spongepowered.api.service.persistence.data.DataContainer;
+import com.google.common.base.Optional;
 
-/**
- * Represents an object that can be represented by a {@link DataContainer}.
- * <p>DataContainers received from {@link DataSerializable#toContainer()}
- * should be considered to be copies of the original data, and therefor,
- * thread safe.</p>
- */
-public interface DataSerializable {
+public class MemoryDataContainer extends MemoryDataView implements DataContainer {
 
-    /**
-     * Serializes this object into a comprehensible {@link DataContainer}.
-     *
-     * @return A newly created DataContainer
-     */
-    DataContainer toContainer();
+    @Override
+    public Optional<DataView> getParent() {
+        return Optional.absent();
+    }
 
+    @Override
+    public final DataContainer getContainer() {
+        return this;
+    }
 }

--- a/src/main/java/org/spongepowered/api/service/persistence/data/MemoryDataView.java
+++ b/src/main/java/org/spongepowered/api/service/persistence/data/MemoryDataView.java
@@ -1,0 +1,590 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.persistence.data;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.spongepowered.api.service.persistence.DataSerializable;
+import org.spongepowered.api.service.persistence.DataSerializableBuilder;
+import org.spongepowered.api.service.persistence.SerializationService;
+import org.spongepowered.api.util.Coerce;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Default implementation of a {@link DataView} being used in memory.
+ */
+public class MemoryDataView implements DataView {
+
+    protected final Map<String, Object> map = Maps.newLinkedHashMap();
+    private final DataContainer container;
+    private final DataView parent;
+    private final DataQuery path;
+
+    protected MemoryDataView() {
+        checkState(this instanceof DataContainer,"Cannot construct a root MemoryDataView without a container!");
+        this.path = new DataQuery();
+        this.parent = this;
+        this.container = (DataContainer) this;
+    }
+
+    protected MemoryDataView(DataView parent, DataQuery path) {
+        checkArgument(path.getParts().size() >= 1, "Path must have at least one part");
+        this.parent = parent;
+        this.container = parent.getContainer();
+        this.path = parent.getCurrentPath().then(path);
+    }
+
+    @Override
+    public DataContainer getContainer() {
+        return this.container;
+    }
+
+    @Override
+    public DataQuery getCurrentPath() {
+        return this.path;
+    }
+
+    @Override
+    public String getName() {
+        List<String> parts = this.path.getParts();
+        return parts.isEmpty() ? "" : parts.get(parts.size() - 1);
+    }
+
+    @Override
+    public Optional<DataView> getParent() {
+        return Optional.fromNullable(this.parent);
+    }
+
+    @Override
+    public Set<DataQuery> getKeys(boolean deep) {
+        ImmutableSet.Builder<DataQuery> builder = ImmutableSet.builder();
+
+        for (Map.Entry<String, Object> entry : this.map.entrySet()) {
+            builder.add(new DataQuery(entry.getKey()));
+        }
+        if (deep) {
+            for (Map.Entry<String, Object> entry : this.map.entrySet()) {
+                if (entry.getValue() instanceof DataView) {
+                    for (DataQuery query : ((DataView) entry.getValue()).getKeys(true)) {
+                        builder.add(new DataQuery(entry.getKey()).then(query));
+                    }
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    @Override
+    public Map<DataQuery, Object> getValues(boolean deep) {
+        ImmutableMap.Builder<DataQuery, Object> builder = ImmutableMap
+                .builder();
+        for (DataQuery query : getKeys(deep)) {
+            Object value = get(query).get();
+            if (value instanceof DataView) {
+                builder.put(query, ((DataView) value).get(new DataQuery()).get());
+            } else {
+                builder.put(query, get(query).get());
+            }
+        }
+        return builder.build();
+    }
+
+    @Override
+    public boolean contains(DataQuery path) {
+        checkNotNull(path);
+        List<DataQuery> queryParts = path.getQueryParts();
+
+        if (queryParts.size() == 1) {
+            String key = queryParts.get(0).getParts().get(0);
+            return this.map.containsKey(key);
+        } else {
+            DataQuery subQuery = queryParts.get(0);
+            Optional<DataView> subViewOptional = this.getView(subQuery);
+            if (!subViewOptional.isPresent()) {
+                return false;
+            }
+            List<String> subParts = Lists.newArrayListWithCapacity(queryParts.size() - 1);
+            for (int i = 1; i < queryParts.size(); i++) {
+                subParts.add(queryParts.get(i).asString("."));
+            }
+            return subViewOptional.get().contains(new DataQuery(subParts));
+        }
+    }
+
+    @Override
+    public Optional<Object> get(DataQuery path) {
+        checkNotNull(path);
+        List<DataQuery> queryParts = path.getQueryParts();
+
+        int sz = queryParts.size();
+
+        if (sz == 0) {
+            return Optional.<Object>of(this);
+        }
+
+        if (sz == 1) {
+            String key = queryParts.get(0).getParts().get(0);
+            if (this.map.containsKey(key)) {
+                return Optional.of(this.map.get(key));
+            } else {
+                return Optional.absent();
+            }
+        }
+        DataQuery subQuery = queryParts.get(0);
+        Optional<DataView> subViewOptional = this.getView(subQuery);
+        DataView subView;
+        if (!subViewOptional.isPresent()) {
+            return Optional.absent();
+        } else {
+            subView = subViewOptional.get();
+        }
+        List<String> subParts = Lists.newArrayListWithCapacity(queryParts.size() - 1);
+        for (int i = 1; i < queryParts.size(); i++) {
+            subParts.add(queryParts.get(i).asString("."));
+        }
+        return subView.get(new DataQuery(subParts));
+
+    }
+
+    @Override
+    public void set(DataQuery path, Object value) {
+        checkNotNull(path);
+        checkNotNull(value);
+        checkState(this.container != null);
+
+        if (value instanceof DataView) {
+            checkArgument(!(value).equals(this));
+            copyDataView(path, (DataView) value);
+        }
+
+        List<String> parts = path.getParts();
+        if (parts.size() > 1) {
+            String subKey = parts.get(0);
+            DataQuery subQuery = new DataQuery(subKey);
+            Optional<DataView> subViewOptional = this.getView(subQuery);
+            DataView subView;
+            if (!subViewOptional.isPresent()) {
+                this.createView(subQuery);
+                subView = (DataView) this.map.get(subKey);
+            } else {
+                subView = subViewOptional.get();
+            }
+            List<String> subParts = Lists.newArrayListWithCapacity(parts.size() - 1);
+            for (int i = 1; i < parts.size(); i++) {
+                subParts.add(parts.get(i));
+            }
+            subView.set(new DataQuery(subParts), value);
+        } else {
+            if (value instanceof Object[]) {
+                List<?> list = ImmutableList.copyOf((Object[]) value);
+                this.map.put(parts.get(0), list);
+            }
+            this.map.put(parts.get(0), value);
+        }
+    }
+
+    private void copyDataView(DataQuery path, DataView value) {
+        Collection<DataQuery> valueKeys = value.getKeys(true);
+        for (DataQuery oldKey : valueKeys) {
+            set(path.then(oldKey), value.get(oldKey));
+        }
+    }
+
+    @Override
+    public void remove(DataQuery path) {
+        checkNotNull(path);
+        List<String> parts = path.getParts();
+        if (parts.size() > 1) {
+            String subKey = parts.get(0);
+            DataQuery subQuery = new DataQuery(subKey);
+            Optional<DataView> subViewOptional = this.getView(subQuery);
+            DataView subView;
+            if (!subViewOptional.isPresent()) {
+                return;
+            } else {
+                subView = subViewOptional.get();
+            }
+            List<String> subParts = Lists.newArrayListWithCapacity(parts.size() - 1);
+            for (int i = 1; i < parts.size(); i++) {
+                subParts.add(parts.get(i));
+            }
+            subView.remove(new DataQuery(subParts));
+        } else {
+            this.map.remove(parts.get(0));
+        }
+    }
+
+    @Override
+    public DataView createView(DataQuery path) {
+        checkNotNull(path);
+        List<DataQuery> queryParts = path.getQueryParts();
+
+        int sz = queryParts.size();
+
+        checkArgument(sz != 0, "The size of the query must be at least 1");
+
+        if (sz == 1) {
+            DataQuery key = queryParts.get(0);
+            DataView result = new MemoryDataView(this, key);
+            this.map.put(key.getParts().get(0), result);
+            return result;
+        } else {
+            List<String> subParts = Lists
+                    .newArrayListWithCapacity(queryParts.size() - 1);
+            for (int i = 1; i < sz; i++) {
+                subParts.add(queryParts.get(i).asString('.'));
+            }
+            DataQuery subQuery = new DataQuery(subParts);
+            DataView subView = (DataView) this.map.get(queryParts.get(0).asString('.'));
+            if (subView == null) {
+                subView = new MemoryDataView(this.parent, queryParts.get(0));
+                this.map.put(queryParts.get(0).asString('.'), subView);
+            }
+            return subView.createView(subQuery);
+        }
+    }
+
+    @Override
+    public DataView createView(DataQuery path, Map<?, ?> map) {
+        checkNotNull(path);
+        DataView section = createView(path);
+
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            if (entry.getValue() instanceof Map) {
+                section.createView(new DataQuery('.', entry.getKey().toString()), (Map<?, ?>) entry.getValue());
+            } else {
+                section.set(new DataQuery('.', entry.getKey().toString()), entry.getValue());
+            }
+        }
+        return section;
+    }
+
+    @Override
+    public Optional<DataView> getView(DataQuery path) {
+        Optional<Object> val = get(path);
+        if (val.isPresent()) {
+            if (val.get() instanceof DataView) {
+                return Optional.of((DataView) val.get());
+            }
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<Boolean> getBoolean(DataQuery path) {
+        Optional<Object> val = get(path);
+        if (val.isPresent()) {
+            return Coerce.asBoolean(val.get());
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<Integer> getInt(DataQuery path) {
+        Optional<Object> val = get(path);
+        if (val.isPresent()) {
+            return Coerce.asInteger(val.get());
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<Long> getLong(DataQuery path) {
+        Optional<Object> val = get(path);
+        if (val.isPresent()) {
+            return Coerce.asLong(val.get());
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<Double> getDouble(DataQuery path) {
+        Optional<Object> val = get(path);
+        if (val.isPresent()) {
+            return Coerce.asDouble(val.get());
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<String> getString(DataQuery path) {
+        Optional<Object> val = get(path);
+        if (val.isPresent()) {
+            return Coerce.asString(val.get());
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<List<?>> getList(DataQuery path) {
+        Optional<Object> val = get(path);
+        if (val.isPresent()) {
+            if (val.get() instanceof List<?>) {
+                return Optional.<List<?>>of(ImmutableList.copyOf((List<?>) val.get()));
+            }
+            if (val.get() instanceof Object[]) {
+                return Optional.<List<?>>of(ImmutableList.copyOf((Object[]) val.get()));
+            }
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<List<String>> getStringList(DataQuery path) {
+        Optional<List<?>> list = getUnsafeList(path);
+
+        if (!list.isPresent()) {
+            return Optional.absent();
+        }
+
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+
+        for (Object object : list.get()) {
+            Optional<String> optional = Coerce.asString(object);
+            if (optional.isPresent()) {
+                builder.add(optional.get());
+            }
+        }
+        return Optional.of((List<String>) builder.build());
+    }
+
+    private Optional<List<?>> getUnsafeList(DataQuery path) {
+        Optional<Object> val = get(path);
+        if (val.isPresent()) {
+            if (val.get() instanceof List<?>) {
+                return Optional.<List<?>>of((List<?>) val.get());
+            } else if (val.get() instanceof Object[]) {
+                return Optional.<List<?>>of(Arrays.asList(((Object[]) val.get())));
+            } else {
+                return Optional.absent();
+            }
+        } else {
+            return Optional.absent();
+        }
+    }
+
+    @Override
+    public Optional<List<Character>> getCharacterList(DataQuery path) {
+        Optional<List<?>> list = getUnsafeList(path);
+
+        if (!list.isPresent()) {
+            return Optional.absent();
+        }
+
+        ImmutableList.Builder<Character> builder = ImmutableList.builder();
+
+        for (Object object : list.get()) {
+            Optional<Character> optional = Coerce.asChar(object);
+            if (optional.isPresent()) {
+                builder.add(optional.get());
+            }
+        }
+        return Optional.of((List<Character>) builder.build());
+    }
+
+    @Override
+    public Optional<List<Boolean>> getBooleanList(DataQuery path) {
+        Optional<List<?>> list = getUnsafeList(path);
+
+        if (!list.isPresent()) {
+            return Optional.absent();
+        }
+
+        ImmutableList.Builder<Boolean> builder = ImmutableList.builder();
+
+        for (Object object : list.get()) {
+            Optional<Boolean> optional = Coerce.asBoolean(object);
+            if (optional.isPresent()) {
+                builder.add(optional.get());
+            }
+        }
+        return Optional.of((List<Boolean>) builder.build());
+    }
+
+    @Override
+    public Optional<List<Byte>> getByteList(DataQuery path) {
+        Optional<List<?>> list = getUnsafeList(path);
+
+        if (!list.isPresent()) {
+            return Optional.absent();
+        }
+
+        ImmutableList.Builder<Byte> builder = ImmutableList.builder();
+
+        for (Object object : list.get()) {
+            Optional<Byte> optional = Coerce.asByte(object);
+            if (optional.isPresent()) {
+                builder.add(optional.get());
+            }
+        }
+        return Optional.of((List<Byte>) builder.build());
+    }
+
+    @Override
+    public Optional<List<Short>> getShortList(DataQuery path) {
+        Optional<List<?>> list = getUnsafeList(path);
+
+        if (!list.isPresent()) {
+            return Optional.absent();
+        }
+
+        ImmutableList.Builder<Short> builder = ImmutableList.builder();
+
+        for (Object object : list.get()) {
+            Optional<Short> optional = Coerce.asShort(object);
+            if (optional.isPresent()) {
+                builder.add(optional.get());
+            }
+        }
+        return Optional.of((List<Short>) builder.build());
+    }
+
+    @Override
+    public Optional<List<Integer>> getIntegerList(DataQuery path) {
+        Optional<List<?>> list = getUnsafeList(path);
+
+        if (!list.isPresent()) {
+            return Optional.absent();
+        }
+
+        ImmutableList.Builder<Integer> builder = ImmutableList.builder();
+
+        for (Object object : list.get()) {
+            Optional<Integer> optional = Coerce.asInteger(object);
+            if (optional.isPresent()) {
+                builder.add(optional.get());
+            }
+        }
+        return Optional.of((List<Integer>) builder.build());
+    }
+
+    @Override
+    public Optional<List<Long>> getLongList(DataQuery path) {
+        Optional<List<?>> list = getUnsafeList(path);
+
+        if (!list.isPresent()) {
+            return Optional.absent();
+        }
+
+        ImmutableList.Builder<Long> builder = ImmutableList.builder();
+
+        for (Object object : list.get()) {
+            Optional<Long> optional = Coerce.asLong(object);
+            if (optional.isPresent()) {
+                builder.add(optional.get());
+            }
+        }
+        return Optional.of((List<Long>) builder.build());
+    }
+
+    @Override
+    public Optional<List<Float>> getFloatList(DataQuery path) {
+        Optional<List<?>> list = getUnsafeList(path);
+
+        if (!list.isPresent()) {
+            return Optional.absent();
+        }
+
+        ImmutableList.Builder<Float> builder = ImmutableList.builder();
+
+        for (Object object : list.get()) {
+            Optional<Float> optional = Coerce.asFloat(object);
+            if (optional.isPresent()) {
+                builder.add(optional.get());
+            }
+        }
+        return Optional.of((List<Float>) builder.build());
+    }
+
+    @Override
+    public Optional<List<Double>> getDoubleList(DataQuery path) {
+        Optional<List<?>> list = getUnsafeList(path);
+
+        if (!list.isPresent()) {
+            return Optional.absent();
+        }
+
+        ImmutableList.Builder<Double> builder = ImmutableList.builder();
+
+        for (Object object : list.get()) {
+            Optional<Double> optional = Coerce.asDouble(object);
+            if (optional.isPresent()) {
+                builder.add(optional.get());
+            }
+        }
+        return Optional.of((List<Double>) builder.build());
+    }
+
+    @Override
+    public Optional<List<Map<?, ?>>> getMapList(DataQuery path) {
+        Optional<List<?>> list = getUnsafeList(path);
+
+        if (!list.isPresent()) {
+            return Optional.absent();
+        }
+
+        ImmutableList.Builder<Map<?, ?>> builder = ImmutableList.builder();
+
+        for (Object object : list.get()) {
+            if (object instanceof Map) {
+                builder.add((Map<?, ?>) object);
+            }
+        }
+
+        return Optional.of((List<Map<?, ?>>) builder.build());
+    }
+
+    @Override
+    public <T extends DataSerializable> Optional<T> getSerializable(DataQuery path, Class<T> clazz, SerializationService service) {
+        checkNotNull(path);
+        checkNotNull(clazz);
+        checkNotNull(service);
+        Optional<DataView> optional = getView(path);
+
+        if (!optional.isPresent()) {
+            return Optional.absent();
+        }
+
+        Optional<DataSerializableBuilder<T>> builderOptional = service.getBuilder(clazz);
+        if (!builderOptional.isPresent()) {
+            return Optional.absent();
+        } else {
+            return builderOptional.get().build(optional.get());
+        }
+    }
+}

--- a/src/test/java/org/spongepowered/api/service/persistence/data/MemoryDataTest.java
+++ b/src/test/java/org/spongepowered/api/service/persistence/data/MemoryDataTest.java
@@ -1,0 +1,267 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.persistence.data;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.spongepowered.api.service.persistence.DataSerializableBuilder;
+import org.spongepowered.api.service.persistence.SerializationService;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class MemoryDataTest {
+
+    @Test
+    public void testCreateDataView() {
+        new MemoryDataContainer();
+    }
+
+    @Test
+    public void testCreateView() {
+        DataContainer container = new MemoryDataContainer();
+        DataQuery tempQuery = new DataQuery("foo", "bar", "baz");
+        container.createView(tempQuery);
+        assertTrue(container.getView(tempQuery).isPresent());
+    }
+
+    @Test
+    public void testSetData() {
+        DataContainer container = new MemoryDataContainer();
+        DataQuery testQuery = new DataQuery('.', "foo.bar");
+        container.set(testQuery, 1);
+        Optional<Integer> optional = container.getInt(testQuery);
+        assertTrue(optional.isPresent());
+    }
+
+    @Test
+    public void testIncorrectType() {
+        DataContainer container = new MemoryDataContainer();
+        DataQuery testQuery = new DataQuery("foo", "bar");
+        container.set(testQuery, "foo");
+        Optional<Integer> optional = container.getInt(testQuery);
+        assertTrue(!optional.isPresent());
+    }
+
+    @Test
+    public void testNumbers() {
+        DataContainer container = new MemoryDataContainer();
+        DataQuery testQuery = new DataQuery("foo", "bar");
+        container.set(testQuery, 1.0D);
+        Optional<Integer> integerOptional = container.getInt(testQuery);
+        assertTrue(integerOptional.isPresent());
+        assertTrue(integerOptional.get() == 1);
+        Optional<Long> longOptional = container.getLong(testQuery);
+        assertTrue(longOptional.isPresent());
+        assertTrue(longOptional.get() == 1L);
+        Optional<Double> doubleOptional = container.getDouble(testQuery);
+        assertTrue(doubleOptional.isPresent());
+        assertTrue(doubleOptional.get() == 1.0D);
+    }
+
+    @Test
+    public void testBoolean() {
+        DataContainer container = new MemoryDataContainer();
+        DataQuery testQuery = new DataQuery("foo", "bar");
+        container.set(testQuery, false);
+        Optional<Boolean> booleanOptional = container.getBoolean(testQuery);
+        assertTrue(booleanOptional.isPresent());
+        assertTrue(!booleanOptional.get());
+    }
+
+    @Test
+    public void testString() {
+        DataContainer container = new MemoryDataContainer();
+        DataQuery testQuery = new DataQuery("foo", "bar");
+        container.set(testQuery, "foo");
+        Optional<String> stringOptional = container.getString(testQuery);
+        assertTrue(stringOptional.isPresent());
+        assertTrue(stringOptional.get().equals("foo"));
+    }
+
+    @Test
+    public void testAbsents() {
+        DataContainer container = new MemoryDataContainer();
+        DataQuery testQuery = new DataQuery("foo", "bar", "baz");
+        assertTrue(!container.get(testQuery).isPresent());
+        assertTrue(!container.getBoolean(testQuery).isPresent());
+        assertTrue(!container.getBooleanList(testQuery).isPresent());
+        assertTrue(!container.getByteList(testQuery).isPresent());
+        assertTrue(!container.getCharacterList(testQuery).isPresent());
+        assertTrue(!container.getDouble(testQuery).isPresent());
+        assertTrue(!container.getDoubleList(testQuery).isPresent());
+        assertTrue(!container.getFloatList(testQuery).isPresent());
+        assertTrue(!container.getInt(testQuery).isPresent());
+        assertTrue(!container.getIntegerList(testQuery).isPresent());
+        assertTrue(!container.getList(testQuery).isPresent());
+        assertTrue(!container.getLong(testQuery).isPresent());
+        assertTrue(!container.getLongList(testQuery).isPresent());
+        assertTrue(!container.getMapList(testQuery).isPresent());
+        assertTrue(!container.getShortList(testQuery).isPresent());
+        assertTrue(!container.getString(testQuery).isPresent());
+        assertTrue(!container.getStringList(testQuery).isPresent());
+        assertTrue(!container.getView(testQuery).isPresent());
+    }
+
+    @Test
+    public void testNumberedLists() {
+        DataContainer container = new MemoryDataContainer();
+        DataQuery testQuery = new DataQuery("foo", "bar", "baz");
+        List<Integer> intList = ImmutableList.of(1, 2, 3, 4);
+        container.set(testQuery, intList);
+        assertTrue(container.getIntegerList(testQuery).isPresent());
+        assertTrue(container.getIntegerList(testQuery).get().equals(intList));
+
+        List<Double> doubleList = ImmutableList.of(1.0D, 2.0D, 3.0D, 4.0D);
+        container.set(testQuery, doubleList);
+        assertTrue(container.getDoubleList(testQuery).isPresent());
+        assertTrue(container.getDoubleList(testQuery).get().equals(doubleList));
+
+        List<Short> shortList = ImmutableList.of((short) 1, (short) 2, (short) 3, (short) 4);
+        container.set(testQuery, shortList);
+        assertTrue(container.getShortList(testQuery).isPresent());
+        assertTrue(container.getShortList(testQuery).get().equals(shortList));
+
+        List<Byte> byteList = ImmutableList.of((byte) 1, (byte) 2, (byte) 3, (byte) 4);
+        container.set(testQuery, byteList);
+        assertTrue(container.getByteList(testQuery).isPresent());
+        assertTrue(container.getByteList(testQuery).get().equals(byteList));
+
+    }
+
+    @Test
+    public void testEmptyQuery() {
+        DataContainer container = new MemoryDataContainer();
+        DataQuery query = new DataQuery("");
+        container.set(query, "foo");
+        assertTrue(container.get(query).isPresent());
+        assertTrue(container.get(query).get().equals("foo"));
+    }
+
+    @Test
+    public void testContainsEmpty() {
+        DataContainer container = new MemoryDataContainer();
+        DataQuery query = new DataQuery("");
+        assertTrue(!container.contains(query));
+        container.set(query, "foo");
+        assertTrue(container.contains(query));
+        query = new DataQuery('.', "foo.bar");
+        assertTrue(!container.contains(query));
+        container.set(query, "baz");
+        assertTrue(container.contains(query));
+    }
+
+    @Test
+    public void testGetName() {
+        DataContainer container = new MemoryDataContainer();
+        assertTrue(container.getName() !=  null);
+    }
+
+    @Test
+    public void testGetSerializable() {
+        SerializationService service = Mockito.mock(SerializationService.class);
+        DataSerializableBuilder<SimpleDataSerializable> builder = new SimpleDataBuilder();
+        Mockito.stub(service.getBuilder(SimpleDataSerializable.class)).toReturn(Optional.of(builder));
+
+        List<String> myList = ImmutableList.of("foo", "bar", "baz");
+
+        SimpleDataSerializable temp = new SimpleDataSerializable(1, 2.0, "foo", myList);
+        DataContainer container = temp.toContainer();
+
+        Optional<SimpleDataSerializable> fromContainer = container.getSerializable(new DataQuery(),
+                                                                         SimpleDataSerializable
+                                                                                 .class, service);
+        assertTrue(fromContainer.isPresent());
+        assertTrue(Objects.equal(fromContainer.get(), temp));
+
+    }
+
+    @Test
+    public void testGetKeys() {
+        Set<DataQuery> queries = Sets.newHashSet();
+
+        queries.add(new DataQuery("foo"));
+        queries.add(new DataQuery("foo", "bar"));
+        queries.add(new DataQuery("foo", "bar", "baz"));
+        queries.add(new DataQuery("bar"));
+        DataView view = new MemoryDataContainer();
+        view.set(new DataQuery("foo"), "foo");
+        view.set(new DataQuery("foo", "bar"), "foobar");
+        view.set(new DataQuery("foo", "bar", "baz"), "foobarbaz");
+        view.set(new DataQuery("bar"), 1);
+
+        Set<DataQuery> testQueries = Sets.newHashSet();
+        testQueries.add(new DataQuery("foo"));
+        testQueries.add(new DataQuery("bar"));
+        Set<DataQuery> shallowKeys = view.getKeys(false);
+        assertTrue(shallowKeys.equals(testQueries));
+        Set<DataQuery> deepKeys = view.getKeys(true);
+        assertTrue(deepKeys.containsAll(queries));
+    }
+
+    @Test
+    public void testGetMaps() {
+        List<DataQuery> queries = Lists.newArrayList();
+
+        queries.add(new DataQuery("foo"));
+        queries.add(new DataQuery("foo", "bar"));
+        queries.add(new DataQuery("foo", "bar", "baz"));
+        queries.add(new DataQuery("bar"));
+        DataView view = new MemoryDataContainer();
+        view.set(new DataQuery("foo"), "foo");
+        view.set(new DataQuery("foo", "bar"), "foobar");
+        view.set(new DataQuery("foo", "bar", "baz"), "foobarbaz");
+        view.set(new DataQuery("bar"), 1);
+
+        Map<DataQuery, Object> shallowMap = Maps.newHashMap();
+        shallowMap.put(new DataQuery("foo"), "foo");
+        shallowMap.put(new DataQuery("bar"), 1);
+
+        Map<DataQuery, Object> deepMap = Maps.newHashMap();
+        deepMap.put(new DataQuery("foo"), "foo");
+        deepMap.put(new DataQuery("foo", "bar"), "foobar");
+        deepMap.put(new DataQuery("foo", "bar", "baz"), "foobarbaz");
+        deepMap.put(new DataQuery("bar"), 1);
+
+        List<DataQuery> testQueries = Lists.newArrayList();
+        testQueries.add(new DataQuery("foo"));
+        testQueries.add(new DataQuery("bar"));
+        Map<DataQuery, Object> shallowValues = view.getValues(false);
+        assertTrue(shallowValues.keySet().equals(shallowMap.keySet()));
+        Map<DataQuery, Object> deepValues = view.getValues(true);
+        assertTrue(deepValues.keySet().equals(deepMap.keySet()));
+    }
+
+}

--- a/src/test/java/org/spongepowered/api/service/persistence/data/SimpleDataBuilder.java
+++ b/src/test/java/org/spongepowered/api/service/persistence/data/SimpleDataBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.persistence.data;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.service.persistence.DataSerializableBuilder;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+
+import java.util.List;
+
+class SimpleDataBuilder implements DataSerializableBuilder<SimpleDataSerializable> {
+
+    @Override
+    public Optional<SimpleDataSerializable> build(final DataView container) {
+
+        Optional<Integer> testInt = container.getInt(new DataQuery("myInt"));
+        if (!testInt.isPresent()) {
+            throw new InvalidDataException("Missing important data: {myInt}");
+        }
+        Optional<Double> testDouble = container.getDouble(new DataQuery("myDouble"));
+        if (!testDouble.isPresent()) {
+            throw new InvalidDataException("Missing important data: {myDouble}");
+        }
+        Optional<String> testString = container.getString(new DataQuery("myString"));
+        if (!testString.isPresent()) {
+            throw new InvalidDataException("Missing important data: {myString}");
+        }
+        Optional<List<String>> testList = container.getStringList(new DataQuery("myStringList"));
+        if (!testList.isPresent()) {
+            throw new InvalidDataException("Missing important data: {myStringList}");
+        }
+
+        return Optional.of(new SimpleDataSerializable(testInt.get(),
+                                                      testDouble.get(),
+                                                      testString.get(),
+                                                      testList.get()));
+    }
+}

--- a/src/test/java/org/spongepowered/api/service/persistence/data/SimpleDataSerializable.java
+++ b/src/test/java/org/spongepowered/api/service/persistence/data/SimpleDataSerializable.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.persistence.data;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import org.spongepowered.api.service.persistence.DataSerializable;
+
+import java.util.Arrays;
+import java.util.List;
+
+class SimpleDataSerializable implements DataSerializable {
+
+    private final int testInt;
+    private final double testDouble;
+    private final String testString;
+    private final String[] testList;
+
+    SimpleDataSerializable(int testInt, double testDouble, String testString,
+                                  List<String> testList) {
+        this.testInt = testInt;
+        this.testDouble = testDouble;
+        this.testString = testString;
+        this.testList = testList.toArray(new String[] {});
+    }
+
+    public int getTestInt() {
+        return this.testInt;
+    }
+
+    public double getTestDouble() {
+        return this.testDouble;
+    }
+
+    public String getTestString() {
+        return this.testString;
+    }
+
+    public List<String> getTestList() {
+        return ImmutableList.copyOf(this.testList);
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = new MemoryDataContainer();
+        container.set(new DataQuery("myInt"), this.testInt);
+        container.set(new DataQuery("myDouble"), this.testDouble);
+        container.set(new DataQuery("myString"), this.testString);
+        container.set(new DataQuery("myStringList"), this.testList);
+        return container;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.testInt, this.testDouble, this.testString, this.testList);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final SimpleDataSerializable other = (SimpleDataSerializable) obj;
+        return Objects.equal(this.testInt, other.testInt)
+                && Objects.equal(this.testDouble, other.testDouble)
+                && Objects.equal(this.testString, other.testString)
+                && Arrays.equals(this.testList, other.testList);
+    }
+}

--- a/src/test/java/org/spongepowered/api/util/CoerceTest.java
+++ b/src/test/java/org/spongepowered/api/util/CoerceTest.java
@@ -1,0 +1,259 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.util;
+
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.base.Optional;
+import org.junit.Test;
+
+
+public class CoerceTest {
+
+    @Test
+    public void testAsCharacter() {
+        String character = "myChar";
+        Optional<Character> optional = Coerce.asChar(character);
+        assertTrue(optional.isPresent());
+        assertTrue(optional.get() == 'm');
+
+        char myChar = 'm';
+        Optional<Character> optional1 = Coerce.asChar(myChar);
+        assertTrue(optional1.isPresent());
+        assertTrue(optional1.get() == 'm');
+
+        int myInt = 1;
+        Optional<Character> optional2 = Coerce.asChar(myInt);
+        assertTrue(optional2.isPresent());
+        assertTrue(optional2.get() == '1');
+
+        Optional<Character> nullOptional = Coerce.asChar(null);
+        assertTrue(!nullOptional.isPresent());
+    }
+
+    @Test
+    public void testAsBoolean() throws Exception {
+        Object myBool = Boolean.TRUE;
+        Optional<Boolean> optional = Coerce.asBoolean(myBool);
+        assertTrue(optional.isPresent());
+        assertTrue(optional.get());
+
+        Optional<Boolean> nullBoolean = Coerce.asBoolean(null);
+        assertTrue(!nullBoolean.isPresent());
+
+        Optional<Boolean> invalidBoolean = Coerce.asBoolean("foo");
+        assertTrue(!nullBoolean.isPresent());
+    }
+
+    @Test
+    public void testAsByte() {
+        String character = "1";
+        Optional<Byte> optional = Coerce.asByte(character);
+        assertTrue(optional.isPresent());
+        assertTrue(optional.get() == 1);
+
+        char myChar = '1';
+        Optional<Byte> optional1 = Coerce.asByte(myChar);
+        assertTrue(optional1.isPresent());
+        assertTrue(optional1.get() == 1);
+
+        String invalidString = "foo";
+        Optional<Byte> invalidOptional = Coerce.asByte(invalidString);
+        assertTrue(!invalidOptional.isPresent());
+
+        int myInt = 1;
+        Optional<Byte> optional2 = Coerce.asByte(myInt);
+        assertTrue(optional2.isPresent());
+        assertTrue(optional2.get() == 1);
+
+
+
+        Optional<Byte> nullOptional = Coerce.asByte(null);
+        assertTrue(!nullOptional.isPresent());
+    }
+
+    @Test
+    public void testAsShort() {
+        String character = "1";
+        Optional<Short> optional = Coerce.asShort(character);
+        assertTrue(optional.isPresent());
+        assertTrue(optional.get() == 1);
+
+        char myChar = '1';
+        Optional<Short> optional1 = Coerce.asShort(myChar);
+        assertTrue(optional1.isPresent());
+        assertTrue(optional1.get() == 1);
+
+        String invalidString = "foo";
+        Optional<Short> invalidOptional = Coerce.asShort(invalidString);
+        assertTrue(!invalidOptional.isPresent());
+
+        int myInt = 1;
+        Optional<Short> optional2 = Coerce.asShort(myInt);
+        assertTrue(optional2.isPresent());
+        assertTrue(optional2.get() == 1);
+
+
+
+        Optional<Short> nullOptional = Coerce.asShort(null);
+        assertTrue(!nullOptional.isPresent());
+    }
+
+    @Test
+    public void testAsLong() {
+        String character = "1";
+        Optional<Long> optional = Coerce.asLong(character);
+        assertTrue(optional.isPresent());
+        assertTrue(optional.get() == 1);
+
+        char myChar = '1';
+        Optional<Long> optional1 = Coerce.asLong(myChar);
+        assertTrue(optional1.isPresent());
+        assertTrue(optional1.get() == 1);
+
+        String invalidString = "foo";
+        Optional<Long> invalidOptional = Coerce.asLong(invalidString);
+        assertTrue(!invalidOptional.isPresent());
+
+        int myInt = 1;
+        Optional<Long> optional2 = Coerce.asLong(myInt);
+        assertTrue(optional2.isPresent());
+        assertTrue(optional2.get() == 1);
+
+
+
+        Optional<Long> nullOptional = Coerce.asLong(null);
+        assertTrue(!nullOptional.isPresent());
+    }
+
+    @Test
+    public void testAsFloat() {
+        String character = "1";
+        Optional<Float> optional = Coerce.asFloat(character);
+        assertTrue(optional.isPresent());
+        assertTrue(optional.get() == 1);
+
+        char myChar = '1';
+        Optional<Float> optional1 = Coerce.asFloat(myChar);
+        assertTrue(optional1.isPresent());
+        assertTrue(optional1.get() == 1);
+
+        String invalidString = "foo";
+        Optional<Float> invalidOptional = Coerce.asFloat(invalidString);
+        assertTrue(!invalidOptional.isPresent());
+
+        int myInt = 1;
+        Optional<Float> optional2 = Coerce.asFloat(myInt);
+        assertTrue(optional2.isPresent());
+        assertTrue(optional2.get() == 1);
+
+
+
+        Optional<Float> nullOptional = Coerce.asFloat(null);
+        assertTrue(!nullOptional.isPresent());
+    }
+
+    @Test
+    public void testAsDouble() {
+        String character = "1";
+        Optional<Double> optional = Coerce.asDouble(character);
+        assertTrue(optional.isPresent());
+        assertTrue(optional.get() == 1);
+
+        char myChar = '1';
+        Optional<Double> optional1 = Coerce.asDouble(myChar);
+        assertTrue(optional1.isPresent());
+        assertTrue(optional1.get() == 1);
+
+        String invalidString = "foo";
+        Optional<Double> invalidOptional = Coerce.asDouble(invalidString);
+        assertTrue(!invalidOptional.isPresent());
+
+        int myInt = 1;
+        Optional<Double> optional2 = Coerce.asDouble(myInt);
+        assertTrue(optional2.isPresent());
+        assertTrue(optional2.get() == 1);
+
+
+
+        Optional<Double> nullOptional = Coerce.asDouble(null);
+        assertTrue(!nullOptional.isPresent());
+    }
+
+    @Test
+    public void testAsInteger() {
+        String character = "1";
+        Optional<Integer> optional = Coerce.asInteger(character);
+        assertTrue(optional.isPresent());
+        assertTrue(optional.get() == 1);
+
+        char myChar = '1';
+        Optional<Integer> optional1 = Coerce.asInteger(myChar);
+        assertTrue(optional1.isPresent());
+        assertTrue(optional1.get() == 1);
+
+        String invalidString = "foo";
+        Optional<Integer> invalidOptional = Coerce.asInteger(invalidString);
+        assertTrue(!invalidOptional.isPresent());
+
+        int myInt = 1;
+        Optional<Integer> optional2 = Coerce.asInteger(myInt);
+        assertTrue(optional2.isPresent());
+        assertTrue(optional2.get() == 1);
+
+
+
+        Optional<Integer> nullOptional = Coerce.asInteger(null);
+        assertTrue(!nullOptional.isPresent());
+    }
+
+    @Test
+    public void testAsString() {
+        String character = "1";
+        Optional<String> optional = Coerce.asString(character);
+        assertTrue(optional.isPresent());
+        assertTrue(optional.get().equals("1"));
+
+        char myChar = '1';
+        Optional<String> optional1 = Coerce.asString(myChar);
+        assertTrue(optional1.isPresent());
+        assertTrue(optional1.get().equals("1"));
+
+        String invalidString = "foo";
+        Optional<String> message = Coerce.asString(invalidString);
+        assertTrue(message.isPresent());
+        assertTrue(message.get().equals("foo"));
+
+        int myInt = 1;
+        Optional<String> optional2 = Coerce.asString(myInt);
+        assertTrue(optional2.isPresent());
+        assertTrue(optional2.get().equals("1"));
+
+
+        Optional<String> nullOptional = Coerce.asString(null);
+        assertTrue(!nullOptional.isPresent());
+    }
+}


### PR DESCRIPTION
This implements the commonly used [`DataView`](https://github.com/SpongePowered/SpongeAPI/blob/feature/persistence-memory/src/main/java/org/spongepowered/api/service/persistence/data/DataView.java) as a usable data structure that can be used by both implementation and plugins alike. 

This also expands on the Persistence API by creating a usable `SerializationService` that enables the registration of custom serialization for various `DataSerializable`s, this allows for implementations to register `DataSerializableBuilder`s for various things like `ItemStack`s, `Entity`, etc. This can also be used by plugins to enable serialization and deserialization of their own `DataSerializable`s.


Design Proposal for a usable Persistence API
----------------

Many developers have been eager to use utilities for manipulating Minecraft data with "NBT API
Utility Library API Lib Protocol API Minecraft NBT Library" when in fact, the biggest issue is
that none of these "libraries" really solved any of the problems of manipulating raw data of
entities, blocks, etc. and overall, they have many downsides:

* NBT data is an implementation detail, which involves the developer knowing the (*data format*)
and the volatility of the data they're manipulating, which presents the following problems:
    * Generally, *Minecraft* has a defined data format for many things that can't be changed due to
   backwards compatibility
    * Users of NBT data rely on this as a pseudo *protocol* but they also depend on this to store
     their custom data wherever they please as long as it doesn't break the system
    * Creating custom data involves knowledge of the NBT format and system of how custom data can
  be stored.
* NBT itself is an implementation detail. Creating an API based on NBT and the systems using NBT
means:
    * We can't hope to expand the "customizability" of the storage systems since any NBT API is
  entirely at the whim of the *implementation* of NBT in Minecraft Server.

### Design Goals


The aim of Persistence is to address these shortcomings with the following:

* Design an abstract [data structure](http://en.wikipedia.org/wiki/Data_structure) that
facilitates representing any and all data from any source that can be understood by anything
using the data structure
* Add `DataSerializable` as a marker that something *can* be serialized and deserialized to and
from any `DataSource`.
* Enable utilization of custom `DataSource`s to serialize `DataContainer`s to any storage medium
    * This allows for world data to be serialized and deserialized to alternative storage mediums
 like SQL, MongoDB, H2, etc.
* Create a `SerializationService` that allows dynamic registration of `DataSerializable`s to
allow deserialization of `DataContainer` to the instance of `DataSerializable`
* Facilitate manipulation of `DataSerializable` data with `DataContainer`:
    * Depending on the `DataSerializable`, the `DataContainer` may be mutable and changes may apply
 back to the `DataSerializable` instance, other cases may not
    * Developers can rely on the Persistence API to handle any custom data as necessary
 * The format of the data stored in a `DataContainer` produced from a `DataSerializable` may
 change, but that is all *implementation*

### Let's get Started!

To begin, we have to entirely forget about NBT and the implementation detail of how Minecraft
persists data. Got it? Good.

##### DataSerializable? What's that?

In traditional Java, there is the [`Serializable`](http://docs.oracle.com/javase/7/docs/api/java/io/Serializable.html)
interface. `Serializable` basically defines
that the implementing object can serialize to any ObjectOutputStream and deserialize from any
ObjectInputStream. This is kinda close to what we want to achieve, but it's not at all the best
idea since we don't want to have *instances* of `ItemStack` to deserialize an `ItemStack`.

This is where `DataSerializable` comes in. It presents itself being able to *serialize* all of
its data to a `DataContainer`. The implementation decides the format and content to serialize to
`DataContainer`, but it is always a usable `DataContainer`.

##### Ok, but what is a DataContainer?

`DataContainer` is the abstract data structure that is used throughout the Persistence API. It
allows to storing various data as necessary and can be querried for data with `DataQuery`. The
container has a default implementation that is backed by a map, but again, that is
*implementation* detail.

##### Fine, but tell me about Serialization!
So, we've established that we have `DataSerializable`s that serialize their data to
`DataContainer`s, but how do we use that to store the data to, say, SQL? I present `DataSource`.

`DataSource` is the common man's source for data. It is a representation of a *source* of data.
The implementation of a `DataSource` decides what it can *serialize* and *deserialize*, since not
 all `DataSource`s are meant to handle all data.

##### So, I can use a DataSource, but how do I *get* one?
`DataSourceFactory`. It's also an *implementation* detail, but it is meant for `DataSource`
providers to create, as necessary, `DataSource`s for a particular *source*. Both `DataSource` and
 `DataSourceFactory` are meant to be implemented for any particular cause. It is expected that
 there will be "Persistence Libraries" to create various implementations to have
 `MySQLDataSourceFactory` or `AnvilDataSourceFactory`. The `DataSourceFactory` takes in a
 `ConfigurationNode` that defines where the `DataSource` is aimed at.

##### So now what?
Now, we've established that we can

- Get a `DataContainer` containing all data from a`DataSerializable`
- Get a `DataSource` from an implemenation of `DataSourceFactory` to send a `DataContainer` to
serialize

But now we want to **deserialize** a `DataContainer` into a `DataSerializable`.

##### I present `SerializationService`
`SerializationService` is a "Service" registrar for `DataSerializable`s and their respective
`DataSerializableBuilder`s. In essence, after the game has initialized, various
`DataSerializable`s should have a `DataSerializableBuilder` registered with the
`SerializationService`. The service allows for retrieving a `DataSerializableBuilder` that can
deserialize a `DataContainer` into an instance of `DataSerializable`. This is integral to the
Persistence API as it allows for developers to provide their own custom `DataSerializable`
objects for serialization and deserialization for any `DataSource` medium.

##### Is that it?
As far as Persistence API is concerned, that is the system in a nutshell. Provided that the
registration of all `DataSerializable` with its proper `DataSerializableBuilder` is done,
developers can expect to have minimal issue with creating their own custom `DataSource`s and
their respective `DataSourceFactory`.

Usability
------

The intended use of Persistence API is not simply to allow modifications being made to the
internal data of entities, blocks, etc., it's intended to allow a full API for *persisting* data.

As we come to understand, `DataSerializable`s chuck their data into a `DataContainer` for the
developer to *do anything to their hearts content*.

What this API does allow to do is create a `NBTDataSourceFactory` that allows reading and storing
 data backed by Minecraft's NBT format into a still understandable `DataContainer`. The
 `DataContainer` does not always persist to the stored data, but it does allow for manipulating
 raw data presented by the Minecraft persistence service.

Features *not* included in this PR
-------------
Reading through this description, the following features are intentionally excluded:

- __NBT API__ - As mentioned at the beginning of the description, there is little sense to create
 an `NBTDataContainer` as NBT itself is just another data structure. The `AnvilChunkLoader` to
 become an `AnvilDataSource` where it can contain its own methods to read the raw NBT data into a
  `DataContainer`.
- Representing custom data belonging to entities, blocks, etc. It isn't within the scope of
Persistence to recognize custom data, but it is within the scope of the relative API's to
represent custom data. All Persistence aims to achieve is the ability to fetch the raw data as a
`DataContainer` from any `DataSerializable`. The format of the data is *implementation* detail.
