### PR TITLE
Improve Query event hierarchy

### DIFF
--- a/src/main/java/org/spongepowered/api/event/server/query/BasicQueryEvent.java
+++ b/src/main/java/org/spongepowered/api/event/server/query/BasicQueryEvent.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.server.query;
+
+/**
+ * Called when the server is queried through the Query protocol, with only basic information requested.
+ */
+public interface BasicQueryEvent extends QueryEvent {
+
+}

--- a/src/main/java/org/spongepowered/api/event/server/query/FullQueryEvent.java
+++ b/src/main/java/org/spongepowered/api/event/server/query/FullQueryEvent.java
@@ -22,7 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.server;
+package org.spongepowered.api.event.server.query;
 
 import java.util.List;
 import java.util.Map;
@@ -30,7 +30,7 @@ import java.util.Map;
 /**
  * Called when the server is queried through the Query protocol, with more detailed information requested.
  */
-public interface FullQueryEvent extends QueryEvent {
+public interface FullQueryEvent extends BasicQueryEvent {
 
     /**
      * Gets the GameId to respond with.

--- a/src/main/java/org/spongepowered/api/event/server/query/QueryEvent.java
+++ b/src/main/java/org/spongepowered/api/event/server/query/QueryEvent.java
@@ -22,7 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.server;
+package org.spongepowered.api.event.server.query;
 
 import org.spongepowered.api.event.GameEvent;
 import org.spongepowered.api.text.message.Message;

--- a/src/main/java/org/spongepowered/api/event/server/query/package-info.java
+++ b/src/main/java/org/spongepowered/api/event/server/query/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.api.event.server.query;


### PR DESCRIPTION
After some thought, I've decided to change `QueryEvent` to a superclass for both `FullQueryEvent`, and the newly created `BasicQueryEvent` (which extend from `QueryEvent` without adding any methods).

The problem with having `QueryEvent` itself being an event is that any plugin listening for it would also receive any `FullQueryEvent`s. While both basic and full queries have common fields, plugins should be able to treat them as separate events, much like subclasses of `BlockEvent`, for example..