### PR TITLE
More work on block and biome access interfaces

### DIFF
--- a/src/main/java/org/spongepowered/api/util/gen/MutableBiomeArea.java
+++ b/src/main/java/org/spongepowered/api/util/gen/MutableBiomeArea.java
@@ -25,21 +25,13 @@
 package org.spongepowered.api.util.gen;
 
 import org.spongepowered.api.world.biome.BiomeType;
+import org.spongepowered.api.world.extent.BiomeArea;
 
 /**
  * A mutable buffer for {@link BiomeType} data. This buffer has no direct relation
  * to the world and changes to it are not synchronized to the world.
  */
-public interface MutableBiomeArea extends BiomeBuffer {
-
-    /**
-     * Sets the biome in the buffer at the given position.
-     *
-     * @param x The X position
-     * @param z The Z position
-     * @param biome The new biome
-     */
-    void setBiome(int x, int z, BiomeType biome);
+public interface MutableBiomeArea extends BiomeBuffer, BiomeArea {
 
     /**
      * Fills the entire buffer with the given biome.

--- a/src/main/java/org/spongepowered/api/util/gen/MutableBlockBuffer.java
+++ b/src/main/java/org/spongepowered/api/util/gen/MutableBlockBuffer.java
@@ -26,22 +26,13 @@ package org.spongepowered.api.util.gen;
 
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.world.extent.BlockVolume;
 
 /**
  * A mutable buffer for {@link BlockType} data. This buffer has no direct relation
  * to the world and changes to it are not synchronized to the world.
  */
-public interface MutableBlockBuffer extends BlockBuffer {
-
-    /**
-     * Sets the block in the buffer at the given position.
-     *
-     * @param x The X position
-     * @param y The Y position
-     * @param z The Z position
-     * @param block The new block state
-     */
-    void setBlock(int x, int y, int z, BlockState block);
+public interface MutableBlockBuffer extends BlockBuffer, BlockVolume {
 
     /**
      * Fills the entire buffer with the given block.

--- a/src/main/java/org/spongepowered/api/world/Location.java
+++ b/src/main/java/org/spongepowered/api/world/Location.java
@@ -140,7 +140,8 @@ public class Location {
      * @return The block
      */
     public BlockLoc getBlock() {
-        return getExtent().getBlock(getPosition());
+        Vector3d position = getPosition();
+        return getExtent().getFullBlock(position.getFloorX(), position.getFloorY(), position.getFloorZ());
     }
 
 }

--- a/src/main/java/org/spongepowered/api/world/extent/BiomeArea.java
+++ b/src/main/java/org/spongepowered/api/world/extent/BiomeArea.java
@@ -29,9 +29,7 @@ import com.flowpowered.math.vector.Vector2i;
 import org.spongepowered.api.world.biome.BiomeType;
 
 /**
- * A two-dimensional buffer for {@link BiomeType} data. This buffer has no
- * direct relation to the world and changes to it are not synchronized to the
- * world.
+ * An area containing biomes.
  */
 public interface BiomeArea {
 

--- a/src/main/java/org/spongepowered/api/world/extent/BlockVolume.java
+++ b/src/main/java/org/spongepowered/api/world/extent/BlockVolume.java
@@ -25,8 +25,8 @@
 
 package org.spongepowered.api.world.extent;
 
-import com.flowpowered.math.vector.Vector3d;
-import org.spongepowered.api.block.BlockLoc;
+import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.block.BlockState;
 
 /**
  * A volume containing blocks.
@@ -39,7 +39,7 @@ public interface BlockVolume {
      * @param position The position
      * @return The block
      */
-    BlockLoc getBlock(Vector3d position);
+    BlockState getBlock(Vector3i position);
 
     /**
      * Get a representation of the block at the given position.
@@ -49,6 +49,24 @@ public interface BlockVolume {
      * @param z The Z position
      * @return The block
      */
-    BlockLoc getBlock(int x, int y, int z);
+    BlockState getBlock(int x, int y, int z);
+
+    /**
+     * Sets the block at the given position in the world.
+     *
+     * @param position The position
+     * @param block The block
+     */
+    void setBlock(Vector3i position, BlockState block);
+
+    /**
+     * Sets the block at the given position in the world.
+     *
+     * @param x The X position
+     * @param y The Y position
+     * @param z The Z position
+     * @param block The block
+     */
+    void setBlock(int x, int y, int z, BlockState block);
 
 }

--- a/src/main/java/org/spongepowered/api/world/extent/Extent.java
+++ b/src/main/java/org/spongepowered/api/world/extent/Extent.java
@@ -25,11 +25,31 @@
 
 package org.spongepowered.api.world.extent;
 
+import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.block.BlockLoc;
 import org.spongepowered.api.world.weather.WeatherUniverse;
 
 /**
  * Contains blocks, entities, biomes and weather.
  */
 public interface Extent extends EntityUniverse, WeatherUniverse, BlockVolume, BiomeArea {
+
+    /**
+     * Get a representation of the block at the given position.
+     *
+     * @param position The position
+     * @return The block
+     */
+    BlockLoc getFullBlock(Vector3i position);
+
+    /**
+     * Get a representation of the block at the given position.
+     *
+     * @param x The X position
+     * @param y The Y position
+     * @param z The Z position
+     * @return The block
+     */
+    BlockLoc getFullBlock(int x, int y, int z);
 
 }


### PR DESCRIPTION
- Use BlockState for BlockVolume instead of BlockLoc.
- Make mutable buffers implement their corresponding access interface (hence the previous change).
- Use Vector3i instead of Vector3d for block access.
- Move BlockLoc getters to Extent under the name getFullBlock. Since a BlockLoc requires an Extent, it makes sense that the getters be in Extent instead of BlockVolume (a BlockVolume doesn't necessarily have an Extent).

https://github.com/SpongePowered/Sponge/pull/191