### PR TITLE
Make EntityInteractionType into an enum-like class

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -33,6 +33,7 @@ import org.spongepowered.api.block.meta.SkullType;
 import org.spongepowered.api.effect.particle.ParticleEffectBuilder;
 import org.spongepowered.api.effect.particle.ParticleType;
 import org.spongepowered.api.effect.sound.SoundType;
+import org.spongepowered.api.entity.EntityInteractionType;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.hanging.art.Art;
 import org.spongepowered.api.entity.living.animal.DyeColor;
@@ -565,5 +566,20 @@ public interface GameRegistry {
      * @return The difficulty with that name, or {@link Optional#absent()}
      */
     Optional<Difficulty> getDifficulty(String name);
+
+    /**
+     * Gets a collection of all available {@link EntityInteractionType}s.
+     *
+     * @return A collection of all available {@link EntityInteractionType}s
+     */
+    Collection<EntityInteractionType> getEntityInteractionTypes();
+
+    /**
+     * Gets an {@link EntityInteractionType} by name.
+     *
+     * @param name The name of the {@link EntityInteractionType}
+     * @return The {@link EntityInteractionType} with that name, or {@link Optional#absent()}
+     */
+    Optional<EntityInteractionType> getEntityInteractionType(String name);
 
 }

--- a/src/main/java/org/spongepowered/api/entity/EntityInteractionTypes.java
+++ b/src/main/java/org/spongepowered/api/entity/EntityInteractionTypes.java
@@ -26,6 +26,7 @@
 package org.spongepowered.api.entity;
 
 import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.entity.player.gamemode.GameModes;
 
 /**
  * An list {@link EntityInteractionType}s available in Vanilla.
@@ -36,21 +37,22 @@ public final class EntityInteractionTypes {
      * Represents an interaction by "attacking", bound to left
      * click in the client by default.
      */
-    public static final EntityInteractionType LEFT_CLICK = null;
+    public static final EntityInteractionType ATTACK = null;
 
     /**
      * Represents an interaction by middle clicking, bound to the
      * scroll wheel in the client by default.
      *
-     * <p>This is only valid for {@link BlockType}s.</p>
+     * <p>This is only valid for {@link BlockType}s, and has the effect
+     * of giving a player the picked block if in {@link GameModes#CREATIVE}.</p>
      */
-    public static final EntityInteractionType MIDDLE_CLICK = null;
+    public static final EntityInteractionType PICK_BLOCK = null;
 
     /**
      * Represents an interaction by right clicking, bound to right
      * click in the client by default.
      */
-    public static final EntityInteractionType RIGHT_CLICK = null;
+    public static final EntityInteractionType USE = null;
 
     private EntityInteractionTypes() {
 

--- a/src/main/java/org/spongepowered/api/entity/EntityInteractionTypes.java
+++ b/src/main/java/org/spongepowered/api/entity/EntityInteractionTypes.java
@@ -22,18 +22,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package org.spongepowered.api.entity;
 
+import org.spongepowered.api.block.BlockType;
+
 /**
- * Represents a method of interacting with a block or entity.
+ * An list {@link EntityInteractionType}s available in Vanilla.
  */
-public interface EntityInteractionType {
+public final class EntityInteractionTypes {
 
     /**
-     * Gets the name of this entity interaction type.
-     *
-     * @return The name of this entity interaction type
+     * Represents an interaction by "attacking", bound to left
+     * click in the client by default.
      */
-    String getName();
+    public static final EntityInteractionType LEFT_CLICK = null;
 
+    /**
+     * Represents an interaction by middle clicking, bound to the
+     * scroll wheel in the client by default.
+     *
+     * <p>This is only valid for {@link BlockType}s.</p>
+     */
+    public static final EntityInteractionType MIDDLE_CLICK = null;
+
+    /**
+     * Represents an interaction by right clicking, bound to right
+     * click in the client by default.
+     */
+    public static final EntityInteractionType RIGHT_CLICK = null;
+
+    private EntityInteractionTypes() {
+
+    }
 }


### PR DESCRIPTION
Apart from things like `Axis` which aren't Minecraft-specific concepts, any class which would normally be an enum is made into an enum-like class.

This PR changes `EntityInteractType` to follow this convention, and adds corresponding getter methods to `GameRegistry`.