### PR TITLE
Add CatalogedBy annotation to get the Catalog of fake enum types

### DIFF
--- a/src/main/java/org/spongepowered/api/attribute/Attribute.java
+++ b/src/main/java/org/spongepowered/api/attribute/Attribute.java
@@ -26,11 +26,13 @@
 package org.spongepowered.api.attribute;
 
 import com.google.common.base.Predicate;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a type of attribute that can be applied to an {@link
  * AttributeHolder}.
  */
+@CatalogedBy(Attributes.class)
 public interface Attribute {
 
     /**

--- a/src/main/java/org/spongepowered/api/attribute/Operation.java
+++ b/src/main/java/org/spongepowered/api/attribute/Operation.java
@@ -25,10 +25,13 @@
 
 package org.spongepowered.api.attribute;
 
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * Represents a function used by an {@link AttributeModifier} to modify the
  * value of an {@link Attribute}.
  */
+@CatalogedBy(Operations.class)
 public interface Operation extends Comparable<Operation> {
 
     /**

--- a/src/main/java/org/spongepowered/api/block/BlockType.java
+++ b/src/main/java/org/spongepowered/api/block/BlockType.java
@@ -29,6 +29,7 @@ import com.google.common.base.Optional;
 import org.spongepowered.api.item.ItemBlock;
 import org.spongepowered.api.service.persistence.data.DataHolder;
 import org.spongepowered.api.text.translation.Translatable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Describes a base type of block.
@@ -37,6 +38,7 @@ import org.spongepowered.api.text.translation.Translatable;
  * data, such as inventory contents, are considered data, which is provided
  * via {@link DataHolder}.</p>
  */
+@CatalogedBy(BlockTypes.class)
 public interface BlockType extends Translatable {
 
     /**

--- a/src/main/java/org/spongepowered/api/block/tile/TileEntityType.java
+++ b/src/main/java/org/spongepowered/api/block/tile/TileEntityType.java
@@ -25,10 +25,12 @@
 package org.spongepowered.api.block.tile;
 
 import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Describes a type of tile entity.
  */
+@CatalogedBy(TileEntityTypes.class)
 public interface TileEntityType {
 
     /**

--- a/src/main/java/org/spongepowered/api/block/tile/data/BannerPatternShape.java
+++ b/src/main/java/org/spongepowered/api/block/tile/data/BannerPatternShape.java
@@ -24,9 +24,12 @@
  */
 package org.spongepowered.api.block.tile.data;
 
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * A pattern shape which may be applied to a banner.
  */
+@CatalogedBy(BannerPatternShapes.class)
 public interface BannerPatternShape {
 
     /**

--- a/src/main/java/org/spongepowered/api/block/tile/data/NotePitch.java
+++ b/src/main/java/org/spongepowered/api/block/tile/data/NotePitch.java
@@ -26,10 +26,12 @@
 package org.spongepowered.api.block.tile.data;
 
 import org.spongepowered.api.block.tile.Note;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a NotePitch which may be played by a {@link Note} block.
  */
+@CatalogedBy(NotePitches.class)
 public interface NotePitch {
 
     /**

--- a/src/main/java/org/spongepowered/api/block/tile/data/SkullType.java
+++ b/src/main/java/org/spongepowered/api/block/tile/data/SkullType.java
@@ -26,10 +26,12 @@
 package org.spongepowered.api.block.tile.data;
 
 import org.spongepowered.api.text.translation.Translatable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a type of skull.
  */
+@CatalogedBy(SkullTypes.class)
 public interface SkullType extends Translatable {
 
     /**

--- a/src/main/java/org/spongepowered/api/effect/particle/ParticleType.java
+++ b/src/main/java/org/spongepowered/api/effect/particle/ParticleType.java
@@ -25,12 +25,14 @@
 package org.spongepowered.api.effect.particle;
 
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 import java.awt.Color;
 
 /**
  * Represents a particle that can be sent on a Minecraft client.
  */
+@CatalogedBy(ParticleTypes.class)
 public interface ParticleType {
 
     /**

--- a/src/main/java/org/spongepowered/api/effect/sound/SoundType.java
+++ b/src/main/java/org/spongepowered/api/effect/sound/SoundType.java
@@ -24,9 +24,12 @@
  */
 package org.spongepowered.api.effect.sound;
 
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * Represents a sound that can be heard on clients.
  */
+@CatalogedBy(SoundTypes.class)
 public interface SoundType {
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/EntityInteractionType.java
+++ b/src/main/java/org/spongepowered/api/entity/EntityInteractionType.java
@@ -24,9 +24,12 @@
  */
 package org.spongepowered.api.entity;
 
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * Represents a method of interacting with a block or entity.
  */
+@CatalogedBy(EntityInteractionTypes.class)
 public interface EntityInteractionType {
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/EntityType.java
+++ b/src/main/java/org/spongepowered/api/entity/EntityType.java
@@ -26,10 +26,12 @@
 package org.spongepowered.api.entity;
 
 import org.spongepowered.api.text.translation.Translatable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Describes a type of entity.
  */
+@CatalogedBy(EntityTypes.class)
 public interface EntityType extends Translatable {
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/hanging/art/Art.java
+++ b/src/main/java/org/spongepowered/api/entity/hanging/art/Art.java
@@ -25,10 +25,12 @@
 package org.spongepowered.api.entity.hanging.art;
 
 import org.spongepowered.api.entity.hanging.Painting;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a piece of art to be displayed by {@link Painting}s.
  */
+@CatalogedBy(Arts.class)
 public interface Art {
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/living/animal/HorseColor.java
+++ b/src/main/java/org/spongepowered/api/entity/living/animal/HorseColor.java
@@ -25,12 +25,14 @@
 package org.spongepowered.api.entity.living.animal;
 
 import org.spongepowered.api.service.persistence.DataSerializable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
- * Represents the color of a {@link org.spongepowered.api.entity.living.animal.Horse}.
+ * Represents the color of a {@link Horse}.
  * <p>The color of a horse is a genetic trait that can be inherited to a new
  * born horse.</p>
  */
+@CatalogedBy(HorseColors.class)
 public interface HorseColor extends DataSerializable {
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/living/animal/HorseStyle.java
+++ b/src/main/java/org/spongepowered/api/entity/living/animal/HorseStyle.java
@@ -25,12 +25,14 @@
 package org.spongepowered.api.entity.living.animal;
 
 import org.spongepowered.api.service.persistence.DataSerializable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents the style of a {@link org.spongepowered.api.entity.living.animal.Horse}.
  * <p>The style of a horse is applied on top of the {@link HorseColor} of the
  * horse. The style can be inherited to new born child horses.</p>
  */
+@CatalogedBy(HorseStyles.class)
 public interface HorseStyle extends DataSerializable {
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/living/animal/HorseVariant.java
+++ b/src/main/java/org/spongepowered/api/entity/living/animal/HorseVariant.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.entity.living.animal;
 
 import org.spongepowered.api.service.persistence.DataSerializable;
 import org.spongepowered.api.text.translation.Translatable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents the variant of a {@link org.spongepowered.api.entity.living.animal.Horse}.
@@ -33,6 +34,7 @@ import org.spongepowered.api.text.translation.Translatable;
  * Some behaviors limit whether a horse can be chested, wear horse armor, or
  * can be saddled.</p>
  */
+@CatalogedBy(HorseVariants.class)
 public interface HorseVariant extends DataSerializable, Translatable {
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/living/animal/OcelotType.java
+++ b/src/main/java/org/spongepowered/api/entity/living/animal/OcelotType.java
@@ -25,10 +25,12 @@
 package org.spongepowered.api.entity.living.animal;
 
 import org.spongepowered.api.service.persistence.DataSerializable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents the type of ocelot an ocelot is.
  */
+@CatalogedBy(OcelotTypes.class)
 public interface OcelotType extends DataSerializable {
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/living/animal/RabbitType.java
+++ b/src/main/java/org/spongepowered/api/entity/living/animal/RabbitType.java
@@ -25,10 +25,12 @@
 package org.spongepowered.api.entity.living.animal;
 
 import org.spongepowered.api.service.persistence.DataSerializable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a type of {@link Rabbit}.
  */
+@CatalogedBy(RabbitTypes.class)
 public interface RabbitType extends DataSerializable {
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/living/monster/SkeletonType.java
+++ b/src/main/java/org/spongepowered/api/entity/living/monster/SkeletonType.java
@@ -25,12 +25,14 @@
 package org.spongepowered.api.entity.living.monster;
 
 import org.spongepowered.api.service.persistence.DataSerializable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents the type of skeleton a {@link org.spongepowered.api.entity.living.monster.Skeleton}
  * can be. Certain skeleton types define the items a skeleton can equip and
  * can define the various status immunities, such as withering.
  */
+@CatalogedBy(SkeletonTypes.class)
 public interface SkeletonType extends DataSerializable {
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/living/villager/Career.java
+++ b/src/main/java/org/spongepowered/api/entity/living/villager/Career.java
@@ -25,11 +25,13 @@
 package org.spongepowered.api.entity.living.villager;
 
 import org.spongepowered.api.text.translation.Translatable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a Villager Career. A career can define a more specified list
  * of trade offers the villager can give to a player.
  */
+@CatalogedBy(Careers.class)
 public interface Career extends Translatable {
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/living/villager/Profession.java
+++ b/src/main/java/org/spongepowered/api/entity/living/villager/Profession.java
@@ -25,11 +25,13 @@
 package org.spongepowered.api.entity.living.villager;
 
 import org.spongepowered.api.text.translation.Translatable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a Villager Profession. A profession defines the genre of
  * trade offers a villager may offer to a player.
  */
+@CatalogedBy(Professions.class)
 public interface Profession extends Translatable {
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/player/gamemode/GameMode.java
+++ b/src/main/java/org/spongepowered/api/entity/player/gamemode/GameMode.java
@@ -25,10 +25,12 @@
 package org.spongepowered.api.entity.player.gamemode;
 
 import org.spongepowered.api.text.translation.Translatable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a game mode that a {@link org.spongepowered.api.entity.player.Player} may have.
  */
+@CatalogedBy(GameModes.class)
 public interface GameMode extends Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/item/CoalType.java
+++ b/src/main/java/org/spongepowered/api/item/CoalType.java
@@ -26,10 +26,12 @@
 package org.spongepowered.api.item;
 
 import org.spongepowered.api.service.persistence.DataSerializable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents the type of coal.
  */
+@CatalogedBy(CoalTypes.class)
 public interface CoalType extends DataSerializable {
 
     /**

--- a/src/main/java/org/spongepowered/api/item/CookedFish.java
+++ b/src/main/java/org/spongepowered/api/item/CookedFish.java
@@ -26,10 +26,12 @@
 package org.spongepowered.api.item;
 
 import org.spongepowered.api.service.persistence.DataSerializable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a type of cooked fish.
  */
+@CatalogedBy(CookedFishes.class)
 public interface CookedFish extends DataSerializable {
 
     /**

--- a/src/main/java/org/spongepowered/api/item/DyeColor.java
+++ b/src/main/java/org/spongepowered/api/item/DyeColor.java
@@ -25,9 +25,14 @@
 package org.spongepowered.api.item;
 
 import org.spongepowered.api.service.persistence.DataSerializable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 import java.awt.Color;
 
+/**
+ * Represents a color of dye that can be used by various items and blocks.
+ */
+@CatalogedBy(DyeColors.class)
 public interface DyeColor extends DataSerializable {
 
     /**

--- a/src/main/java/org/spongepowered/api/item/DyeColors.java
+++ b/src/main/java/org/spongepowered/api/item/DyeColors.java
@@ -24,6 +24,9 @@
  */
 package org.spongepowered.api.item;
 
+/**
+ * An enumeration of known {@link DyeColor} types.
+ */
 public final class DyeColors {
 
     public static final DyeColor WHITE = null;

--- a/src/main/java/org/spongepowered/api/item/Enchantment.java
+++ b/src/main/java/org/spongepowered/api/item/Enchantment.java
@@ -27,7 +27,12 @@ package org.spongepowered.api.item;
 
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.text.translation.Translatable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
+/**
+ * Represents a modifier on an item that has various effects.
+ */
+@CatalogedBy(Enchantments.class)
 public interface Enchantment extends Translatable {
 
     /**

--- a/src/main/java/org/spongepowered/api/item/Enchantments.java
+++ b/src/main/java/org/spongepowered/api/item/Enchantments.java
@@ -25,6 +25,9 @@
 
 package org.spongepowered.api.item;
 
+/**
+ * An enumeration of known {@link Enchantment} types.
+ */
 public final class Enchantments {
 
     public static final Enchantment PROTECTION = null;

--- a/src/main/java/org/spongepowered/api/item/FireworkShape.java
+++ b/src/main/java/org/spongepowered/api/item/FireworkShape.java
@@ -24,9 +24,12 @@
  */
 package org.spongepowered.api.item;
 
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * Represents a possible shape for a firework explosion.
  */
+@CatalogedBy(FireworkShapes.class)
 public interface FireworkShape {
 
     /**

--- a/src/main/java/org/spongepowered/api/item/Fish.java
+++ b/src/main/java/org/spongepowered/api/item/Fish.java
@@ -26,10 +26,12 @@
 package org.spongepowered.api.item;
 
 import org.spongepowered.api.service.persistence.DataSerializable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a type of raw fish item.
  */
+@CatalogedBy(Fishes.class)
 public interface Fish extends DataSerializable {
 
     /**

--- a/src/main/java/org/spongepowered/api/item/Fishes.java
+++ b/src/main/java/org/spongepowered/api/item/Fishes.java
@@ -25,6 +25,9 @@
 
 package org.spongepowered.api.item;
 
+/**
+ * An enumeration of known {@link Fish} types.
+ */
 public final class Fishes {
 
     public static final Fish COD = null;

--- a/src/main/java/org/spongepowered/api/item/GoldenApple.java
+++ b/src/main/java/org/spongepowered/api/item/GoldenApple.java
@@ -26,10 +26,12 @@
 package org.spongepowered.api.item;
 
 import org.spongepowered.api.service.persistence.DataSerializable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a type of golden apple.
  */
+@CatalogedBy(GoldenApples.class)
 public interface GoldenApple extends DataSerializable {
 
     /**

--- a/src/main/java/org/spongepowered/api/item/GoldenApples.java
+++ b/src/main/java/org/spongepowered/api/item/GoldenApples.java
@@ -25,9 +25,14 @@
 
 package org.spongepowered.api.item;
 
+/**
+ * An enumeration of known {@link GoldenApple} types.
+ */
 public final class GoldenApples {
 
     public static final GoldenApple GOLDEN_APPLE = null;
     public static final GoldenApple ENCHANTED_GOLDEN_APPLE = null;
 
+    private GoldenApples() {
+    }
 }

--- a/src/main/java/org/spongepowered/api/item/ItemType.java
+++ b/src/main/java/org/spongepowered/api/item/ItemType.java
@@ -29,10 +29,12 @@ import com.google.common.base.Optional;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.properties.ItemProperty;
 import org.spongepowered.api.text.translation.Translatable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * A type of item.
  */
+@CatalogedBy(ItemTypes.class)
 public interface ItemType extends Translatable {
 
     /**

--- a/src/main/java/org/spongepowered/api/item/inventory/equipment/EquipmentType.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/equipment/EquipmentType.java
@@ -24,9 +24,12 @@
  */
 package org.spongepowered.api.item.inventory.equipment;
 
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * Equipment types.
  */
+@CatalogedBy(EquipmentTypes.class)
 public interface EquipmentType {
 
     /**

--- a/src/main/java/org/spongepowered/api/potion/PotionEffectType.java
+++ b/src/main/java/org/spongepowered/api/potion/PotionEffectType.java
@@ -26,10 +26,12 @@
 package org.spongepowered.api.potion;
 
 import org.spongepowered.api.text.translation.Translatable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a possible type of {@link PotionEffect}.
  */
+@CatalogedBy(PotionEffectTypes.class)
 public interface PotionEffectType extends Translatable {
 
     /**

--- a/src/main/java/org/spongepowered/api/text/chat/ChatType.java
+++ b/src/main/java/org/spongepowered/api/text/chat/ChatType.java
@@ -24,11 +24,14 @@
  */
 package org.spongepowered.api.text.chat;
 
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * Represents the type of chat a message can be sent to.
  *
  * @see ChatTypes
  */
+@CatalogedBy(ChatTypes.class)
 public interface ChatType {
 
 }

--- a/src/main/java/org/spongepowered/api/text/format/TextStyle.java
+++ b/src/main/java/org/spongepowered/api/text/format/TextStyle.java
@@ -29,6 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 import org.spongepowered.api.util.text.OptBool;
 
 import javax.annotation.Nullable;
@@ -54,6 +55,7 @@ import javax.annotation.Nullable;
  *
  * @see TextStyles
  */
+@CatalogedBy(TextStyles.class)
 public class TextStyle {
 
     /**

--- a/src/main/java/org/spongepowered/api/text/selector/SelectorType.java
+++ b/src/main/java/org/spongepowered/api/text/selector/SelectorType.java
@@ -24,11 +24,14 @@
  */
 package org.spongepowered.api.text.selector;
 
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * Represents a selector type.
  *
  * @see Selectors
  */
+@CatalogedBy(SelectorTypes.class)
 public interface SelectorType {
 
     /**

--- a/src/main/java/org/spongepowered/api/util/annotation/CatalogedBy.java
+++ b/src/main/java/org/spongepowered/api/util/annotation/CatalogedBy.java
@@ -23,17 +23,39 @@
  * THE SOFTWARE.
  */
 
-package org.spongepowered.api.item;
+package org.spongepowered.api.util.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.annotation.Nonnull;
 
 /**
- * An enumeration of known {@link CookedFish} types.
+ * Represents a class that is intended to represent a type of enum, without
+ * using {@link Enum}. The class marked as {@link CatalogedBy} must have a
+ * registrar class that can be queried for all types and subtypes of the
+ * catalog.
  */
-public final class CookedFishes {
+@Nonnull
+@Target(ElementType.TYPE)
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CatalogedBy {
 
-    public static final CookedFish COD = null;
-    public static final CookedFish SALMON = null;
-
-    private CookedFishes() {
-    }
+    /**
+     * Gets the class that is the catalog for this {@link CatalogedBy} type.
+     * Since the type class annotated with {@link CatalogedBy} knows what
+     * the catalog class is, we can safely rely on the value to get all
+     * known instances of the {@link CatalogedBy}.
+     *
+     * <p>This is similar to knowing at runtime that all available
+     * "EntityType"(s) are cataloged in the "EntityTypes" class.</p>
+     *
+     * @return The registrar class of the catalog
+     */
+    Class<?>[] value();
 
 }

--- a/src/main/java/org/spongepowered/api/util/rotation/Rotation.java
+++ b/src/main/java/org/spongepowered/api/util/rotation/Rotation.java
@@ -24,9 +24,12 @@
  */
 package org.spongepowered.api.util.rotation;
 
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * Represents an angle of rotation.
  */
+@CatalogedBy(Rotations.class)
 public interface Rotation {
 
     /**

--- a/src/main/java/org/spongepowered/api/world/DimensionType.java
+++ b/src/main/java/org/spongepowered/api/world/DimensionType.java
@@ -24,9 +24,12 @@
  */
 package org.spongepowered.api.world;
 
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * Represents a type of {@link Dimension}.
  */
+@CatalogedBy(DimensionTypes.class)
 public interface DimensionType {
 
     /**

--- a/src/main/java/org/spongepowered/api/world/biome/BiomeType.java
+++ b/src/main/java/org/spongepowered/api/world/biome/BiomeType.java
@@ -25,11 +25,13 @@
 
 package org.spongepowered.api.world.biome;
 
+import org.spongepowered.api.util.annotation.CatalogedBy;
 import org.spongepowered.api.world.gen.Populator;
 
 /**
  * Represents a biome.
  */
+@CatalogedBy(BiomeTypes.class)
 public interface BiomeType {
 
     /**

--- a/src/main/java/org/spongepowered/api/world/difficulty/Difficulty.java
+++ b/src/main/java/org/spongepowered/api/world/difficulty/Difficulty.java
@@ -24,10 +24,13 @@
  */
 package org.spongepowered.api.world.difficulty;
 
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * Represents a possible difficulty setting.
  *
  * @see Difficulties
  */
+@CatalogedBy(Difficulties.class)
 public interface Difficulty {
 }

--- a/src/main/java/org/spongepowered/api/world/weather/Weather.java
+++ b/src/main/java/org/spongepowered/api/world/weather/Weather.java
@@ -25,9 +25,12 @@
 
 package org.spongepowered.api.world.weather;
 
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * Represents a type of weather.
  */
+@CatalogedBy(Weathers.class)
 public interface Weather {
 
 }

--- a/src/main/java/org/spongepowered/api/world/weather/Weathers.java
+++ b/src/main/java/org/spongepowered/api/world/weather/Weathers.java
@@ -33,4 +33,7 @@ public class Weathers {
     public static final Weather CLEAR = null;
     public static final Weather RAIN = null;
     public static final Weather THUNDER_STORM = null;
+
+    private Weathers() {
+    }
 }


### PR DESCRIPTION
This adds a new annotation that can be used for marking various *types* as *pseudo enumeration types* such that they have a parent class that contains all registered values of that pseudo enum type.

This has repercussions of aiding other utility classes such as [`Coerce`](https://github.com/SpongePowered/SpongeAPI/blob/feature/pseudoenums/src/main/java/org/spongepowered/api/util/Coerce.java#L370). 

Note: This PR does NOT cover the Text API classes as that is due for changes with #425. 

The primary reason for this change is that since our API has avoided using [Java Enums](http://docs.oracle.com/javase/tutorial/java/javaOO/enum.html) due to their limitation of expandability, we have dozens of interfaces signifying a "type" of "something". The problem arises when developers wish to find the available "values" of that "type".

So, the `CatalogedBy` annotation marks the "type" class with a catalog class that contains all default values of that "type". Example:

```java
@CatalogedBy(Itemtypes.class)
public interface ItemType {
    String getId();
}

public final class ItemTypes {
   public static final ItypeType DIAMOND_SWORD = null;
   //... and more
}
```

We can therefor do the following:

```java
public <T> T toPseudoEnum(Class<T> annotated, Object random) {
    Annotation catalog = annotated.getAnnotation(CatalogedBy.class);
    if (catalog instanceof CatalogedBy) {
        Class<?> clazz = ((CatalogedBy) catalog).value();
        // do things with reflection and fields here
        // eventually finding out if the random is of a type of T
    }
```