### PR TITLE
Add PEBKAC Exception and Main class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,8 @@ jar.manifest.mainAttributes(
         "Created-By": System.properties['java.vm.version'] + " (" + System.properties['java.vm.vendor'] + ")",
         "Implementation-Title": name,
         "Implementation-Version": version + "+" + ciSystem + "-b" + buildNumber + ".git-" + commit,
-        "Implementation-Vendor": url)
+        "Implementation-Vendor": url,
+        "Main-Class": "org.spongepowered.api.util.InformativeMain")
 
 task sourceJar(type: Jar) {
 	from sourceSets.main.java

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -5,4 +5,5 @@
     <suppress checks="JavadocMethod" files="^src[\\/]test[\\/]java"/>
     <suppress checks="Indentation" files="package-info\.java"/>
     <suppress checks="AbbreviationAsWordInName" files="TNT"/>
+    <suppress checks="AbbreviationAsWordInName" files="PEBKAC"/>
 </suppressions>

--- a/src/main/java/org/spongepowered/api/util/InformativeMain.java
+++ b/src/main/java/org/spongepowered/api/util/InformativeMain.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.util;
+
+/**
+ * A class containing a main method which throws an Exception to cleanly
+ * indicate to the user than running the jar file was a bad idea.
+ */
+public class InformativeMain {
+
+    /**
+     * The main method which throws a {@link PEBKACException} with some basic
+     * information on how sponge works.
+     * 
+     * @param args The program args
+     * @throws PEBKACException always
+     */
+    public static void main(String[] args) throws PEBKACException {
+        throw new PEBKACException("\n\nOh dear... You have just attempted to run the SpongeAPI jar file.\n"
+                                + "\n"
+                                + "Please Note: This is the binary for the API **ONLY** and running it has absolutely no\n"
+                                + "purpose nor effect. If you wish to use Sponge you will need to locate the correct\n"
+                                + "implementation for the platform you wish to run Sponge on.\n"
+                                + "\n"
+                                + "For information on the correct process for running sponge please see the documentation:\n"
+                                + "\n"
+                                + "\t\tSponge Documentation: https://docs.spongepowered.org/\n"
+                                + "\n"
+                                + "For more general information on the Sponge project please see the FAQ:\n"
+                                + "\n"
+                                + "\t\tSponge FAQ: https://docs.spongepowered.org/en/faq.html\n");
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/util/PEBKACException.java
+++ b/src/main/java/org/spongepowered/api/util/PEBKACException.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.util;
+
+/**
+ * An exception for when a problem exists between keyboard and chair.
+ */
+public class PEBKACException extends UnsupportedOperationException {
+
+    private static final long serialVersionUID = 6434648270429319820L;
+
+    /**
+     * Creates a new {@link PEBKACException} with a null message and cause.
+     */
+    public PEBKACException() {
+        super();
+    }
+
+    /**
+     * Creates a new {@link PEBKACException} with the given message and null
+     * cause.
+     * 
+     * @param msg The exception message
+     */
+    public PEBKACException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * Creates a new {@link PEBKACException} with the given message and cause.
+     * 
+     * @param msg The exception message
+     * @param cause The cause of the exception
+     */
+    public PEBKACException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    /**
+     * Creates a new {@link PEBKACException} with the given cause and a null
+     * message.
+     * 
+     * @param cause The cause of the exception
+     */
+    public PEBKACException(Throwable cause) {
+        super(cause);
+    }
+
+}


### PR DESCRIPTION
This PR creates a main class which throws an exception with some basic information for running sponge. This helps people who unwittingly attempt to run sponge and would otherwise be confused by the `no main manifest attribute, in spongeapi-1.1-SNAPSHOT.jar`.

The message given is this:

```
Oh dear... You have just attempted to run the SpongeAPI jar file.
 
Please Note: This is the binary for the API **ONLY** and running it has absolutely no purpose nor effect.
If you wish to use Sponge you will need to locate the correct implementation for the platform you
wish to run Sponge on.
 
For information on the correct process for running sponge please see the documentation:
 
        Sponge Documentation: https://docs.spongepowered.org/

For more general information on the Sponge project please see the FAQ:
 
        Sponge FAQ: https://docs.spongepowered.org/en/faq.html 
```