### PR TITLE
Fix Eclipse formatter

### DIFF
--- a/extra/eclipse/sponge_eclipse_formatter.xml
+++ b/extra/eclipse/sponge_eclipse_formatter.xml
@@ -236,7 +236,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>


### PR DESCRIPTION
Right now the Eclipse formatter profile is not usable because it changes almost every javadoc entry like this:

Input:
```java
 * <p>In older versions of Minecraft, block properties were encoded in
 * a block's metadata.</p>
```
Output with the current formatter:
```java
 * <p>
 * In older versions of Minecraft, block properties were encoded in a block's
 * metadata.
 * </p>
```

This PR sets the "Format HTML in comments" option to false.

Output with the changed formatter:
```java
 * <p>In older versions of Minecraft, block properties were encoded in a block's
 * metadata.</p>
```

Another problem is that many javadocs were wrapped although the column width was not reached. When I run the formatter, almost every file changes because of this.

I guess this is related to the rule "Feel free to wrap when it will help with readability" in the Contribution Guidelines.