### PR TITLE
Fix StatisticGroups

### DIFF
--- a/src/main/java/org/spongepowered/api/stats/Statistic.java
+++ b/src/main/java/org/spongepowered/api/stats/Statistic.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.stats;
 
-import com.google.common.base.Optional;
 import org.spongepowered.api.text.translation.Translatable;
 
 /**
@@ -38,15 +37,6 @@ public interface Statistic extends Translatable {
      * @return The String ID
      */
     String getId();
-
-    /**
-     * Gets the {@link StatisticFormat} of this statistic. If this is not
-     * present that this statistic's format is deferred to its group's default
-     * format.
-     *
-     * @return The format of this statistic, if available
-     */
-    Optional<StatisticFormat> getStatisticFormat();
 
     /**
      * Gets the {@link StatisticGroup} this {@link Statistic} belongs to.

--- a/src/main/java/org/spongepowered/api/stats/StatisticBuilder.java
+++ b/src/main/java/org/spongepowered/api/stats/StatisticBuilder.java
@@ -27,8 +27,6 @@ package org.spongepowered.api.stats;
 
 import org.spongepowered.api.text.translation.Translation;
 
-import javax.annotation.Nullable;
-
 /**
  * Represents a builder interface to create new and custom instances of
  * {@link Statistic}s.
@@ -52,22 +50,13 @@ public interface StatisticBuilder {
     StatisticBuilder id(String id);
 
     /**
-     * Sets the format of the {@link Statistic}. May be null in which case the
-     * group default format will be used instead.
-     *
-     * @param format The format of the statistic
-     * @return This builder
-     */
-    StatisticBuilder format(@Nullable StatisticFormat format);
-
-    /**
      * Sets the {@link StatisticGroup} the {@link Statistic} belongs
      * to.
      *
-     * @param type The statistic group the grouped statistic belongs to
+     * @param group The statistic group the grouped statistic belongs to
      * @return This builder
      */
-    StatisticBuilder group(StatisticGroup type);
+    StatisticBuilder group(StatisticGroup group);
 
     /**
      * Builds and registers an instance of a {@link Statistic}.

--- a/src/main/java/org/spongepowered/api/stats/StatisticFormats.java
+++ b/src/main/java/org/spongepowered/api/stats/StatisticFormats.java
@@ -36,7 +36,7 @@ public final class StatisticFormats {
     public static StatisticFormat COUNT = null;
     /**
      * A statistic measured in centimeters, meters, or kilometers depending on
-     * the magnitude.
+     * the magnitude. The statistic/input is measured in centimeters.
      */
     public static StatisticFormat DISTANCE = null;
     /**
@@ -44,8 +44,8 @@ public final class StatisticFormats {
      */
     public static StatisticFormat FRACTIONAL = null;
     /**
-     * A statistic measured in seconds, minutes, hours, or days depending on the
-     * magnitude.
+     * A statistic measured in minutes, hours, or days depending on the
+     * magnitude. The statistic/input is measured in minutes.
      */
     public static StatisticFormat TIME = null;
 

--- a/src/main/java/org/spongepowered/api/stats/StatisticGroup.java
+++ b/src/main/java/org/spongepowered/api/stats/StatisticGroup.java
@@ -34,11 +34,11 @@ import org.spongepowered.api.text.translation.Translatable;
 public interface StatisticGroup extends Translatable {
 
     /**
-     * Gets the default {@link StatisticFormat} which all statistics without
-     * defined format overrides should be formatted with.
+     * Gets the {@link StatisticFormat} all {@link Statistic}s belonging to this
+     * group should be formatted with.
      *
      * @return The format for statistics in this group
      */
-    StatisticFormat getDefaultStatisticFormat();
+    StatisticFormat getStatisticFormat();
 
 }

--- a/src/main/java/org/spongepowered/api/stats/StatisticGroups.java
+++ b/src/main/java/org/spongepowered/api/stats/StatisticGroups.java
@@ -30,7 +30,25 @@ package org.spongepowered.api.stats;
  */
 public class StatisticGroups {
 
-    public static final StatisticGroup GENERAL = null;
+    /**
+     * General statistics counting the a number in 1.0 steps, that does not fit
+     * anywhere else.
+     */
+    public static final StatisticGroup GENERAL_COUNT = null;
+    /**
+     * General statistics counting the a number in 0.1 steps, that does not fit
+     * anywhere else.
+     */
+    public static final StatisticGroup GENERAL_FRACTIONAL = null;
+    /**
+     * Statistics measuring the time (minutes) spend/passed since a specific
+     * event such as last death.
+     */
+    public static final StatisticGroup TIME_PASSED = null;
+    /**
+     * Statistics measuring the distance (centimeters) moved in a specific way.
+     */
+    public static final StatisticGroup DISTANCE_MOVED = null;
 
     /**
      * Statistic counting the number of killed entities of a specific type.


### PR DESCRIPTION
FIxes #220

The currently suggested `StatisticGroup` layout has some serious disadvantages.

In minecraft there are no groups, but they are quite useful if defined properly.

The old suggestion defines the usage something similar to this:
````java
Map<Statistic, Long> stats = player.getStatisticsByGroup(group);
for (Entry entry : stats) {
    Statistic stat = entry.getKey();
    player.sendMessage(asText(stat) + stat.getFormat().or(group.getDefaultFormat()).format(entry.getValue());
}
````
I considers this malicious and error prone.
So i want to change this to simplyfy the process:
````java
Map<Statistic, Long> stats = player.getStatisticsByGroup(group);
StatisticFormat formatter = group.getFormat();
for (Entry entry : stats) {
    Statistic stat = entry.getKey();
    player.sendMessage(asText(stat) + formatter.format(entry.getValue());
}
````

So basically every statistic group defines a fix format all members use. There are no exceptions from that rule. This also allows a more useful displaying because different categories are not merged randomly.
(First show the general_count, that general_fractional, then the distances, than times spend, or however you want it)

This PR removes the format from the statistic and splits the general group into smaller pieces to ensure that each group only contains stazs with the same format.


As an alternative there are 2 other ways that can be used independently from each other.
- Remove only the Optional from `Statistic.getFormat()`
  -  Because in minecraft every statistic has its own reference to a formatter
- Remove the general group
  - Because the group has nothing in common except that they don't have anything in common