### PR TITLE
Repair Travis Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: java
 jdk:
   - openjdk6


### PR DESCRIPTION
Currently, travis cannot build any branches, PR and even master of SpongeAPI due to some odd interaction with their Docker containers killing the build processes. 

This removes the `sudo: false` line enabling container builds, but this allows branches to build again on travis without issue.