### PR TITLE
Statistics API improvement suggestions

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -64,6 +64,7 @@ import org.spongepowered.api.stats.StatisticBuilder;
 import org.spongepowered.api.stats.StatisticFormat;
 import org.spongepowered.api.stats.StatisticGroup;
 import org.spongepowered.api.stats.TeamStatistic;
+import org.spongepowered.api.stats.achievement.Achievement;
 import org.spongepowered.api.status.Favicon;
 import org.spongepowered.api.text.format.TextColor;
 import org.spongepowered.api.util.rotation.Rotation;
@@ -503,6 +504,13 @@ public interface GameRegistry {
      * @return An immutable collection containing all available formats
      */
     Collection<StatisticFormat> getStatisticFormats();
+
+    /**
+     * Gets a collection of all available {@link Achievement}s.
+     *
+     * @return An immutable collection containing all available achievements
+     */
+    Collection<Achievement> getAchievements();
 
     /**
      * Gets the {@link DimensionType} with the provided name.

--- a/src/main/java/org/spongepowered/api/stats/Statistic.java
+++ b/src/main/java/org/spongepowered/api/stats/Statistic.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.stats;
 
-import com.google.common.base.Optional;
 import org.spongepowered.api.text.translation.Translatable;
 
 /**
@@ -40,13 +39,11 @@ public interface Statistic extends Translatable {
     String getId();
 
     /**
-     * Gets the {@link StatisticFormat} of this statistic. If this is not
-     * present that this statistic's format is deferred to its group's default
-     * format.
+     * Gets the {@link StatisticFormat} of this statistic.
      *
-     * @return The format of this statistic, if available
+     * @return The format of this statistic
      */
-    Optional<StatisticFormat> getStatisticFormat();
+    StatisticFormat getStatisticFormat();
 
     /**
      * Gets the {@link StatisticGroup} this {@link Statistic} belongs to.

--- a/src/main/java/org/spongepowered/api/stats/StatisticFormats.java
+++ b/src/main/java/org/spongepowered/api/stats/StatisticFormats.java
@@ -36,7 +36,7 @@ public final class StatisticFormats {
     public static StatisticFormat COUNT = null;
     /**
      * A statistic measured in centimeters, meters, or kilometers depending on
-     * the magnitude.
+     * the magnitude. The formatter assumes the input are centimeters.
      */
     public static StatisticFormat DISTANCE = null;
     /**
@@ -45,7 +45,7 @@ public final class StatisticFormats {
     public static StatisticFormat FRACTIONAL = null;
     /**
      * A statistic measured in seconds, minutes, hours, or days depending on the
-     * magnitude.
+     * magnitude. The formatter assumes the input are ticks.
      */
     public static StatisticFormat TIME = null;
 

--- a/src/main/java/org/spongepowered/api/stats/StatisticGroup.java
+++ b/src/main/java/org/spongepowered/api/stats/StatisticGroup.java
@@ -25,6 +25,7 @@
 
 package org.spongepowered.api.stats;
 
+import com.google.common.base.Optional;
 import org.spongepowered.api.text.translation.Translatable;
 
 /**
@@ -34,11 +35,11 @@ import org.spongepowered.api.text.translation.Translatable;
 public interface StatisticGroup extends Translatable {
 
     /**
-     * Gets the default {@link StatisticFormat} which all statistics without
-     * defined format overrides should be formatted with.
+     * Gets the {@link StatisticFormat} that if available can be used to format
+     * all {@link Statistic}s belonging to this group.
      *
-     * @return The format for statistics in this group
+     * @return The format for statistics in this group, if available
      */
-    StatisticFormat getDefaultStatisticFormat();
+    Optional<StatisticFormat> getStatisticFormat();
 
 }

--- a/src/main/java/org/spongepowered/api/stats/StatisticGroups.java
+++ b/src/main/java/org/spongepowered/api/stats/StatisticGroups.java
@@ -30,7 +30,14 @@ package org.spongepowered.api.stats;
  */
 public class StatisticGroups {
 
+    /**
+     * Group for statistics that do not match in any group.
+     */
     public static final StatisticGroup GENERAL = null;
+    /**
+     * Statistic counting the distances moved in a specific way.
+     */
+    public static final StatisticGroup DISTANCE_MOVED = null;
 
     /**
      * Statistic counting the number of killed entities of a specific type.
@@ -79,6 +86,13 @@ public class StatisticGroups {
      * team.
      */
     public static final StatisticGroup KILLED_BY_TEAM = null;
+
+    /**
+     * Statistic for internal and plugin statistics, that are not meant to be
+     * displayed. Plugins should avoid displaying statistics in this group to
+     * the user.
+     */
+    public static final StatisticGroup HIDDEN = null;
 
     private StatisticGroups() {
     }

--- a/src/main/java/org/spongepowered/api/stats/Statistics.java
+++ b/src/main/java/org/spongepowered/api/stats/Statistics.java
@@ -27,7 +27,7 @@ package org.spongepowered.api.stats;
 
 /**
  * A utility class for getting all available {@link Statistic}s that are not
- * grouped.
+ * dependent on something like an item type.
  */
 public final class Statistics {
 
@@ -49,7 +49,6 @@ public final class Statistics {
     public static final Statistic DEATHS = null;
     public static final Statistic DISPENSER_INSPECTED = null;
     public static final Statistic DIVE_DISTANCE = null;
-    public static final Statistic DROP = null;
     public static final Statistic DROPPER_INSPECTED = null;
     public static final Statistic ENDERCHEST_OPENED = null;
     public static final Statistic FALL_DISTANCE = null;
@@ -59,7 +58,8 @@ public final class Statistics {
     public static final Statistic FLY_DISTANCE = null;
     public static final Statistic HOPPER_INSPECTED = null;
     public static final Statistic HORSE_DISTANCE = null;
-    public static final Statistic ITEM_ENCHANTED = null;
+    public static final Statistic ITEMS_ENCHANTED = null;
+    public static final Statistic ITEMS_DROPPED = null;
     public static final Statistic NOTEBLOCK_PLAYED = null;
     public static final Statistic NOTEBLOCK_TUNED = null;
     public static final Statistic JUMP = null;
@@ -69,11 +69,11 @@ public final class Statistics {
     public static final Statistic MOB_KILLS = null;
     public static final Statistic PIG_DISTANCE = null;
     public static final Statistic PLAYER_KILLS = null;
-    public static final Statistic PLAY_ONE_MINUTE = null;
     public static final Statistic RECORD_PLAYED = null;
     public static final Statistic SPRINT_DISTANCE = null;
     public static final Statistic SWIM_DISTANCE = null;
     public static final Statistic TALKED_TO_VILLAGER = null;
+    public static final Statistic TIME_PLAYED = null;
     public static final Statistic TIME_SINCE_DEATH = null;
     public static final Statistic TRADED_WITH_VILLAGER = null;
     public static final Statistic TRAPPED_CHEST_TRIGGERED = null;

--- a/src/main/java/org/spongepowered/api/stats/achievement/Achievement.java
+++ b/src/main/java/org/spongepowered/api/stats/achievement/Achievement.java
@@ -28,7 +28,7 @@ import com.google.common.base.Optional;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.text.translation.Translation;
 
-import java.util.List;
+import java.util.Collection;
 
 /**
  * Represents an in-game achievement which may be earned by or given to players.
@@ -52,8 +52,8 @@ public interface Achievement extends Translatable {
     /**
      * Returns the children of this achievement.
      *
-     * @return An immutable list of all children this achievement has
+     * @return An immutable collection of all children this achievement has
      */
-    List<Achievement> getChildren();
+    Collection<Achievement> getChildren();
 
 }


### PR DESCRIPTION
This PR is a collection of improvements i would like add to the Statistics API.
This suggestions are open for discussion, so feel free to comment on or criticize them.

Here is a list of changes with an explanation each.

**Change 1**
* `GameRegistry.getAchievements()`

Currently there is no way to get all Achievements, so i added this method to provide simple access to all Achievements similar to all other entries in the GameRegistry.

`Achievement` does not have a `getId()` method so we cannot get it with that from the registry.
Should that method be added to `Achievement` as well?

**Change 2**
- `Optional<StatisticFormat> Statistic.getStatisticFormat()` 
  - -> `StatisticFormat Statistic.getStatisticFormat()`
- `StatisticFormat StatisticGroup.getDefaultStatisticFormat()`
  - -> `Optional<StatisticFormat> StatisticGroup.getStatisticFormat()`

I flipped the placement of `Optional` to allow some more checks and allow using `Statistic`s without the `StatisticGroup`. Please let me explain.
What does the `StatisticGroup.getDefaultStatisticFormat()` tell us about the group?
It does not tell us anything (for sure) because every `Statistic` in that group is able to overwrite the group's default.
The new `StatisticGroup.getStatisticFormat()` allows the plugins to check whether the group has a fixed format for all elements in it.
If there is no fixed format for all elements then the group is a  general group.

In addition to that the `StatisticGroup` is not present in the minecraft code, so each `Statistic` in our API is never actually bound to a `StatisticGroup`. As a result of this from my point of view it should be possible to display/format the `Statistic`'s value without defaulting to the groups format.
(In fact each minecraft statistic stores its own reference to the format)
You can still check whether the `Statistic` uses its own format or the format of the group.

To sum it up:
* Default Statistic Format does not tell us anything, as long as it can be overwritten
* Fixed Formats for Groups allows distinguishing, between specialized groups and general groups
* Independent statistics should not be made dependent on a group that only contains elements that does not fit anywhere else
* All previous possibilities are preserved

**Change 3**
* `StatisticFormats` javadocs

Plugin authors may want to overwrite the default formatting to make it more readable in a specific context, so they should know the assumed input for the formatter. This is needed for plugin authors  to create their own instances, without looking at any server impl.

It also should guarantee, that if minecraft ever changes their statistic units (for example from ticks to seconds), that the format does still the same.
This is important for own/custom `Statistic`s to format the values properly and allows the plugin author to assign the right formatter to his statistic.

**Change 4**
* `Statistics` javadocs

Due to the addition of the `GENERAL` group that contains all elements that are not grouped/do not fit in any other group, the old javadocs are no longer true, so i changed them to describe the contents more precisely (I hope).

**Change 5**
* `StatisticGroups.DISTANCE_MOVED`

This is a logical group, that contains all statistics measuring the movement of the player, such as `WALK_DISTANCE`. There are quiet a lot elements in this group and all are related to each other so they should be in their own group. Especially if you want to show them together.

* `StatisticGroups.HIDDEN`

This is a logical group, that is meant to contain all `Statistic`s that should never be shown to the user, because the are used for internal counting for achievements or are used for plugins to keep track of a secret value, that may be needed for `Scoreboard`s. This is a reference meant for the check whether a statistic (or its group) is hidden.
````java
boolean hidden = statistic.getGroup() == HIDDEN; // => Do not show to the user.
````

**Change 6**
* `Statistics.DROP` -> `Statistics.ITEMS_DROPPED`

The old name was misleading so I made the name more expressive.

* `Statistics.ITEM_ENCHANTED` -> `Statistics.ITEMS_ENCHANTED`

IMO the plural name fits better in there.

* `Statistics.PLAY_ONE_MINUTE` -> `Statistics.TIME_PLAYED`

The old name was misleading because that value is not measured in minutes at all.
(Instead it is currently measured in ticks), so i changed the name to make it less surprising.

There are probably some other `Statistic`s in there that should be renamed as well. Suggestions?

**Change 7**
* `List<Achievement> Achievement.getChildren()` -> `Collection<Achievement> Achievement.getChildren()`

There is no order in the child/dependent achievements so we should not encourage index access to the child achievements (list). 
In addition to that it is more likely to be a set, because it will never contain duplicates (or at least it should not). But I don't want to limit the server implementations here so i used `Collection` here.
This is basically the same reason why we used `Collection` everywhere in the `GameRegistry`

**End of Changes**

I hope this is persuasive enough. If not please leave a comment, with a notice what i should explain some more.