### PR TITLE
Statistics/Achievements API improvement: Builders

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -25,8 +25,6 @@
 
 package org.spongepowered.api;
 
-import org.spongepowered.api.stats.achievement.Achievement;
-
 import com.google.common.base.Optional;
 import org.spongepowered.api.attribute.Attribute;
 import org.spongepowered.api.attribute.AttributeBuilder;
@@ -67,6 +65,8 @@ import org.spongepowered.api.stats.StatisticBuilder;
 import org.spongepowered.api.stats.StatisticFormat;
 import org.spongepowered.api.stats.StatisticGroup;
 import org.spongepowered.api.stats.TeamStatistic;
+import org.spongepowered.api.stats.achievement.Achievement;
+import org.spongepowered.api.stats.achievement.AchievementBuilder;
 import org.spongepowered.api.status.Favicon;
 import org.spongepowered.api.text.format.TextColor;
 import org.spongepowered.api.util.rotation.Rotation;
@@ -488,7 +488,7 @@ public interface GameRegistry {
      * Creates a new {@link StatisticBuilder} which may be used to create custom
      * {@link Statistic}s.
      *
-     * @return The newly created simple statistic builder
+     * @return The newly created statistic builder
      */
     StatisticBuilder newStatisticBuilder();
 
@@ -506,21 +506,29 @@ public interface GameRegistry {
      * @return An immutable collection containing all available formats
      */
     Collection<StatisticFormat> getStatisticFormats();
-    
+
     /**
-     * Gets a specific {@link Achievement} by id.
-     * 
-     * @param id The name
-     * @return The achievement
+     * Gets the {@link Achievement} with the specified id.
+     *
+     * @param id The id of the achievement to return
+     * @return The achievement or Optional.absent() if not found
      */
     Optional<Achievement> getAchievement(String id);
-    
+
     /**
      * Gets a collection of all available {@link Achievement}s.
-     * 
+     *
      * @return An immutable collection containing all available achievements
      */
     Collection<Achievement> getAchievements();
+
+    /**
+     * Creates a new {@link AchievementBuilder} which may be used to create
+     * custom {@link Achievement}s.
+     *
+     * @return The newly created achievement builder
+     */
+    AchievementBuilder newAchievementBuilder();
 
     /**
      * Gets the {@link DimensionType} with the provided name.

--- a/src/main/java/org/spongepowered/api/stats/StatisticBuilder.java
+++ b/src/main/java/org/spongepowered/api/stats/StatisticBuilder.java
@@ -27,6 +27,8 @@ package org.spongepowered.api.stats;
 
 import org.spongepowered.api.text.translation.Translation;
 
+import java.util.Map;
+
 import javax.annotation.Nullable;
 
 /**
@@ -39,7 +41,7 @@ public interface StatisticBuilder {
      * Sets the translation for the {@link Statistic}.
      *
      * @param translation The translation for the statistic
-     * @return This builder
+     * @return This builder, for chaining
      */
     StatisticBuilder translation(Translation translation);
 
@@ -47,7 +49,7 @@ public interface StatisticBuilder {
      * Sets the id used to save the current values of the {@link Statistic}.
      *
      * @param id The id used to save the current values of the statistic
-     * @return This builder
+     * @return This builder, for chaining
      */
     StatisticBuilder id(String id);
 
@@ -56,18 +58,39 @@ public interface StatisticBuilder {
      * group default format will be used instead.
      *
      * @param format The format of the statistic
-     * @return This builder
+     * @return This builder, for chaining
      */
     StatisticBuilder format(@Nullable StatisticFormat format);
 
     /**
-     * Sets the {@link StatisticGroup} the {@link Statistic} belongs
-     * to.
+     * Sets the {@link StatisticGroup} the {@link Statistic} belongs to.
      *
      * @param group The statistic group the grouped statistic belongs to
-     * @return This builder
+     * @return This builder, for chaining
      */
     StatisticBuilder group(StatisticGroup group);
+
+    /**
+     * Sets the statistic classes the resulting {@link Statistic} should extend.
+     *
+     * @param classes The statistic classes the resulting sStatistic should
+     *        extend
+     * @return This builder, for chaining
+     * @throws IllegalArgumentException If one or more classes are not supported
+     */
+    StatisticBuilder classes(Class<? extends Statistic> classes) throws IllegalArgumentException;
+
+    /**
+     * Sets the data that may be required to implement the {@link Statistic}
+     * classes that are set in {@link #classes(Class)}.
+     *
+     * @param data The data that may be required to implement the statistic
+     *        classes
+     * @return This builder, for chaining
+     * @throws IllegalArgumentException If one or more values do not match the
+     *         expected values
+     */
+    StatisticBuilder data(Map<String, ?> data) throws IllegalArgumentException;
 
     /**
      * Builds and registers an instance of a {@link Statistic}.

--- a/src/main/java/org/spongepowered/api/stats/achievement/AchievementBuilder.java
+++ b/src/main/java/org/spongepowered/api/stats/achievement/AchievementBuilder.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.stats.achievement;
+
+import org.spongepowered.api.stats.StatisticBuilder;
+import org.spongepowered.api.text.translation.Translation;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents a builder interface to create new and custom instances of
+ * {@link Achievement}s.
+ */
+public interface AchievementBuilder {
+
+    /**
+     * Sets the internal identifier for this {@link Achievement}.
+     *
+     * @param id The id used to save the current state of the achievement
+     * @return This builder, for chaining
+     */
+    AchievementBuilder id(String id);
+
+    /**
+     * Sets the translation for the {@link Achievement}.
+     *
+     * @param translation The translation for the achievement
+     * @return This builder, for chaining
+     */
+    StatisticBuilder translation(Translation translation);
+
+    /**
+     * Sets the description that describes this {@link Achievement}.
+     *
+     * @param description The description of this achievement
+     * @return This builder, for chaining
+     */
+    AchievementBuilder description(Translation description);
+
+    /**
+     * Sets the parent of this {@link Achievement}, if there is one.
+     *
+     * @param parent The parent of this achievement
+     * @return This builder, for chaining
+     */
+    AchievementBuilder parent(@Nullable Achievement parent);
+
+    /**
+     * Builds and registers an instance of an {@link Achievement}.
+     *
+     * @return A new instance of a achievement
+     * @throws IllegalStateException If the achievement is not completed
+     */
+    Achievement buildAndRegister() throws IllegalStateException;
+
+}


### PR DESCRIPTION
**Helper PR for:** https://github.com/SpongePowered/SpongeAPI/pull/220

* Improve `StatisticBuilder`
* Add `AchievementBuilder`

**The Issue**

Currently it is not possible to create specific subtypes of `Statistic`.
This affects:
* `BlockStatistic`
* `EntityStatistic`
* `ItemStatistic`
* `TeamStatistic`

In addition to that it is entirely impossible to create new `Achievement`s.

**PR summary**

This PR allows specifying the subtypes of the `Statistic` that should be created (including custom ones) along with the data that should be returned.
It also allows the creation of new `Achievement`s using a builder that can be obtained from the `GameRegistry`. The custom/created achievement must be granted by plugins, because minecraft does not keep track of that on its own.
I included some javadoc changes to better match the general javadocs.