### PR TITLE
Expand World creation process + Add WorldProperties

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -25,6 +25,8 @@
 
 package org.spongepowered.api;
 
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.world.gen.WorldGenerator;
 import com.google.common.base.Optional;
 import org.spongepowered.api.attribute.Attribute;
 import org.spongepowered.api.attribute.AttributeBuilder;
@@ -91,8 +93,13 @@ import org.spongepowered.api.text.selector.SelectorType;
 import org.spongepowered.api.text.translation.Translation;
 import org.spongepowered.api.util.rotation.Rotation;
 import org.spongepowered.api.world.DimensionType;
+import org.spongepowered.api.world.World;
+import org.spongepowered.api.world.WorldBuilder;
+import org.spongepowered.api.world.WorldCreationSettings;
+import org.spongepowered.api.world.GeneratorType;
 import org.spongepowered.api.world.biome.BiomeType;
 import org.spongepowered.api.world.difficulty.Difficulty;
+import org.spongepowered.api.world.storage.WorldProperties;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -103,6 +110,7 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 
 /**
  * Provides an easy way to retrieve types from a {@link Game}.
@@ -1120,4 +1128,75 @@ public interface GameRegistry {
      * @return The Collection of all available {@link ObjectiveDisplayMode}s
      */
     Collection<ObjectiveDisplayMode> getObjectiveDisplayModes();
+
+    /**
+     * Gets a new {@link WorldBuilder} for creating {@link World}s or
+     * {@link WorldCreationSettings}s.
+     * 
+     * @return A new builder
+     */
+    WorldBuilder getWorldBuilder();
+
+    /**
+     * Gets a new {@link WorldBuilder} for creating {@link World}s or
+     * {@link WorldCreationSettings}s, the builder is then seeded with the
+     * values from the given WorldCreationSettings object.
+     * 
+     * @param settings The seed settings
+     * @return A new seeded builder
+     */
+    WorldBuilder getWorldBuilder(WorldCreationSettings settings);
+
+    /**
+     * Gets a new {@link WorldBuilder} for creating {@link World}s or
+     * {@link WorldCreationSettings}s, the builder is then seeded with the
+     * values from the given WorldProperties object.
+     * 
+     * @param properties The seed properties
+     * @return A new seeded builder
+     */
+    WorldBuilder getWorldBuilder(WorldProperties properties);
+
+    /**
+     * Gets a {@link GeneratorType} by name.
+     * 
+     * @param name The requested name
+     * @return The generator type, if available
+     */
+    Optional<GeneratorType> getGeneratorType(String name);
+
+    /**
+     * Gets a collection of all available {@link GeneratorType}s.
+     * 
+     * @return All available world types
+     */
+    Collection<GeneratorType> getGeneratorTypes();
+
+    /**
+     * Creates and registers a new {@link GeneratorType} with the given name and
+     * {@link WorldGenerator}. An empty {@link DataContainer} will be created
+     * for the settings within {@link GeneratorType#getGeneratorSettings()}.
+     * 
+     * @param name The name of the generator type
+     * @param generator A callable which returns a new world generator
+     * @return The new GeneratorType
+     */
+    GeneratorType registerGeneratorType(String name, Callable<WorldGenerator> generator);
+    
+    /**
+     * Creates and registers a new {@link GeneratorType} with the given name and
+     * {@link WorldGenerator}.
+     * 
+     * <p>The {@link DataContainer} with settings for the world generator is
+     * optional and an empty DataContainer will be created if it is not
+     * provided.</p>
+     * 
+     * @param name The name of the generator type
+     * @param generator A callable which returns a new world generator
+     * @param settings Any settings that the generator uses, or null if no
+     *            settings are used
+     * @return The new GeneratorType
+     */
+    GeneratorType registerGeneratorType(String name, Callable<WorldGenerator> generator, DataContainer settings);
+
 }

--- a/src/main/java/org/spongepowered/api/Server.java
+++ b/src/main/java/org/spongepowered/api/Server.java
@@ -25,12 +25,14 @@
 package org.spongepowered.api;
 
 import com.google.common.base.Optional;
+import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.player.Player;
 import org.spongepowered.api.net.ChannelRegistrar;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.command.source.ConsoleSource;
 import org.spongepowered.api.world.World;
-import org.spongepowered.api.world.gen.WorldGenerator;
+import org.spongepowered.api.world.WorldCreationSettings;
+import org.spongepowered.api.world.storage.WorldProperties;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
@@ -79,12 +81,27 @@ public interface Server extends ChannelRegistrar {
     /**
      * Gets all currently loaded {@link World}s.
      *
-     * @return Collection of loaded worlds
+     * @return A collection of loaded worlds
      */
     Collection<World> getWorlds();
 
     /**
-     * Gets a loaded {@link World} by its unique id ({@link UUID}), if any.
+     * Gets the properties of all unloaded worlds.
+     *
+     * @return A collection of world properties
+     */
+    Collection<WorldProperties> getUnloadedWorlds();
+
+    /**
+     * Gets the properties of all worlds, loaded or otherwise.
+     * 
+     * @return A collection of world properties
+     */
+    Collection<WorldProperties> getAllWorldProperties();
+
+    /**
+     * Gets a loaded {@link World} by its unique id ({@link UUID}), if it
+     * exists.
      *
      * @param uniqueId UUID to lookup
      * @return The world, if found
@@ -92,7 +109,7 @@ public interface Server extends ChannelRegistrar {
     Optional<World> getWorld(UUID uniqueId);
 
     /**
-     * Gets a loaded {@link World} by name, if any.
+     * Gets a loaded {@link World} by name, if it exists.
      *
      * @param worldName Name to lookup
      * @return The world, if found
@@ -100,59 +117,99 @@ public interface Server extends ChannelRegistrar {
     Optional<World> getWorld(String worldName);
 
     /**
-     * Loads a {@link World} from the default storage container.
+     * Loads a {@link World} from the default storage container. If a world with
+     * the given name is already loaded then it is returned instead.
      *
      * @param worldName The name to lookup
-     * @return the world, if found
+     * @return The world, if found
      */
     Optional<World> loadWorld(String worldName);
 
     /**
+     * Loads a {@link World} from the default storage container. If a world with
+     * the given UUID is already loaded then it is returned instead.
+     *
+     * @param uniqueId The UUID to lookup
+     * @return The world, if found
+     */
+    Optional<World> loadWorld(UUID uniqueId);
+
+    /**
+     * Loads a {@link World} from the default storage container. If the world
+     * associated with the given properties is already loaded then it is
+     * returned instead.
+     *
+     * @param properties The properties of the world to load
+     * @return The world, if found
+     */
+    Optional<World> loadWorld(WorldProperties properties);
+
+    /**
+     * Gets the {@link WorldProperties} of a world. If a world with the given
+     * name is loaded then this is equivalent to calling
+     * {@link World#getProperties()}. However, if no loaded world is found then
+     * an attempt will be made to match unloaded worlds.
+     *
+     * @param worldName The name to lookup
+     * @return The world properties, if found
+     */
+    Optional<WorldProperties> getWorldProperties(String worldName);
+
+    /**
+     * Gets the {@link WorldProperties} of a world. If a world with the given
+     * UUID is loaded then this is equivalent to calling
+     * {@link World#getProperties()}. However, if no loaded world is found then
+     * an attempt will be made to match unloaded worlds.
+     *
+     * @param uniqueId The UUID to lookup
+     * @return The world properties, if found
+     */
+    Optional<WorldProperties> getWorldProperties(UUID uniqueId);
+
+    /**
      * Unloads a {@link World}, if there are any connected players in the given
      * world then no operation will occur.
-     *
+     * 
+     * <p>A world which is unloaded will be removed from memory. However if it
+     * is still enabled according to {@link WorldProperties#isEnabled()} then it
+     * will be loaded again if the server is restarted or an attempt is made by
+     * a plugin to transfer an entity to the world using
+     * {@link Entity#transferToWorld(String, com.flowpowered.math.vector.Vector3d)}
+     * </p>
+     * 
      * @param world The world to unload
      * @return Whether the operation was successful
      */
     boolean unloadWorld(World world);
 
     /**
-     * Creates a new world with the given name and generator options.
-     *
-     * <p>If a world with the given name is already loaded then it is returned
-     * instead.</p>
-     *
-     * @param worldName The new world name
-     * @param generator The generator to generate the world with
-     * @param seed The random seed for the world
-     * @return The new world
+     * Creates a new world from the given {@link WorldCreationSettings}. For the
+     * creation of the WorldCreationSettings please see
+     * {@link GameRegistry#getWorldBuilder()}.
+     * 
+     * <p>If the world already exists then the existing {@link WorldProperties}
+     * are returned else a new world is created and the new WorldProperties
+     * returned.</p>
+     * 
+     * <p>Although the world is created it is not loaded at this time. Please
+     * see one of the following methods for loading the world.</p>
+     * 
+     * <ul> <li>{@link #loadWorld(String)}</li> <li>{@link #loadWorld(UUID)}
+     * </li> <li>{@link #loadWorld(WorldProperties)}</li> </ul>
+     * 
+     * @param settings The settings for creation
+     * @return The new or existing world properties, if creation was successful
      */
-    World createWorld(String worldName, WorldGenerator generator, long seed);
+    Optional<WorldProperties> createWorld(WorldCreationSettings settings);
 
     /**
-     * Creates a world with the given generator but using the default seed from
-     * the server settings.
-     *
-     * <p>If a world with the given name is already loaded then it is returned
-     * instead.</p>
-     *
-     * @param worldName The new world name
-     * @param generator The generator to generate the world with
-     * @return The new world
+     * Persists the given {@link WorldProperties} to the world storage for it,
+     * updating any modified values.
+     * 
+     * @param properties The world properties to save
+     * @return True if the save was successful
      */
-    World createWorld(String worldName, WorldGenerator generator);
-
-    /**
-     * Creates a world using the default seed and generator from the server
-     * settings.
-     *
-     * <p>If a world with the given name is already loaded then it is returned
-     * instead.</p>
-     *
-     * @param worldName The new world name
-     * @return The new world
-     */
-    World createWorld(String worldName);
+    boolean saveWorldProperties(WorldProperties properties);
 
     /**
      * Gets the time, in ticks, since this server began running for the current session.

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -32,8 +32,10 @@ import org.spongepowered.api.util.Identifiable;
 import org.spongepowered.api.util.RelativePositions;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
+import org.spongepowered.api.world.storage.WorldProperties;
 
 import java.util.EnumSet;
+import java.util.UUID;
 
 import javax.annotation.Nullable;
 
@@ -108,6 +110,46 @@ public interface Entity extends Identifiable, EntityState, DataHolder {
      */
     boolean setLocationAndRotation(Location location, Vector3d rotation, EnumSet<RelativePositions> relativePositions);
 
+    /**
+     * Sets the location of this entity to a new position in a world which does
+     * not have to be loaded (but must at least be enabled).
+     * 
+     * <p>If the target world is loaded then this is equivalent to
+     * {@link #setLocation(Location)}.</p>
+     * 
+     * <p>If the target world is unloaded but is enabled according to its
+     * {@link WorldProperties#isEnabled()} then this will first load the world
+     * before transferring the entity to that world.</p>
+     * 
+     * <p>If the target world is unloaded and not enabled then the transfer will
+     * fail.</p>
+     *
+     * @param worldName The name of the world to transfer to
+     * @param position The position in the target world
+     * @return True if the teleport was successful
+     */
+    boolean transferToWorld(String worldName, Vector3d position);
+
+    /**
+     * Sets the location of this entity to a new position in a world which does
+     * not have to be loaded (but must at least be enabled).
+     * 
+     * <p>If the target world is loaded then this is equivalent to
+     * {@link #setLocation(Location)}.</p>
+     * 
+     * <p>If the target world is unloaded but is enabled according to its
+     * {@link WorldProperties#isEnabled()} then this will first load the world
+     * before transferring the entity to that world.</p>
+     * 
+     * <p>If the target world is unloaded and not enabled then the transfer will
+     * fail.</p>
+     *
+     * @param uuid The UUID of the target world to transfer to
+     * @param position The position in the target world
+     * @return True if the teleport was successful
+     */
+    boolean transferToWorld(UUID uuid, Vector3d position);
+    
     /**
      * Gets the rotation as a Vector3f.
      *

--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -127,6 +127,7 @@ import org.spongepowered.api.event.world.ChunkPrePopulateEvent;
 import org.spongepowered.api.event.world.ChunkUnforcedEvent;
 import org.spongepowered.api.event.world.ChunkUnloadEvent;
 import org.spongepowered.api.event.world.GameRuleChangeEvent;
+import org.spongepowered.api.event.world.WorldCreateEvent;
 import org.spongepowered.api.event.world.WorldLoadEvent;
 import org.spongepowered.api.event.world.WorldUnloadEvent;
 import org.spongepowered.api.item.inventory.ItemStack;
@@ -145,7 +146,9 @@ import org.spongepowered.api.world.Chunk;
 import org.spongepowered.api.world.ChunkManager.LoadingTicket;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
+import org.spongepowered.api.world.WorldCreationSettings;
 import org.spongepowered.api.world.gen.Populator;
+import org.spongepowered.api.world.storage.WorldProperties;
 import org.spongepowered.api.world.weather.Weather;
 import org.spongepowered.api.world.weather.WeatherUniverse;
 
@@ -1614,6 +1617,22 @@ public final class SpongeEventFactory {
         values.put("name", name);
         values.put("oldValue", oldValue);
         return createEvent(GameRuleChangeEvent.class, values);
+    }
+
+    /**
+     * Creates a new {@link WorldCreateEvent}.
+     *
+     * @param game The game instance for this {@link GameEvent}
+     * @param properties The properties of the new world
+     * @param settings The creation settings
+     * @return A new instance of the event
+     */
+    public static WorldCreateEvent createWorldCreate(Game game, WorldProperties properties, WorldCreationSettings settings) {
+        Map<String, Object> values = Maps.newHashMap();
+        values.put("game", game);
+        values.put("worldProperties", properties);
+        values.put("worldCreationSettings", settings);
+        return createEvent(WorldCreateEvent.class, values);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/event/world/WorldCreateEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/WorldCreateEvent.java
@@ -22,36 +22,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.world;
 
-import org.spongepowered.api.util.annotation.CatalogedBy;
+package org.spongepowered.api.event.world;
+
+import org.spongepowered.api.event.GameEvent;
+import org.spongepowered.api.world.WorldCreationSettings;
+import org.spongepowered.api.world.storage.WorldProperties;
+
 
 /**
- * Represents a type of {@link Dimension}.
+ * An event for when a world has been created. Often paired with a
+ * {@link WorldLoadEvent}, but that is not guaranteed.
  */
-@CatalogedBy(DimensionTypes.class)
-public interface DimensionType {
+public interface WorldCreateEvent extends GameEvent {
 
     /**
-     * Returns the name of this {@link DimensionType}.
-     *
-     * @return The name
+     * Gets the properties of the newly created world.
+     * 
+     * @return The properties
      */
-    String getName();
-
+    WorldProperties getWorldProperties();
+    
     /**
-     * Returns whether spawn chunks of this {@link DimensionType} remain loaded
-     * when no players are present.
-     *
-     * @return True if spawn chunks of this {@link DimensionType} remain loaded
-     *         without players, false if not
+     * Gets the {@link WorldCreationSettings} used to create the world.
+     * 
+     * @return The creation settings
      */
-    boolean doesKeepSpawnLoaded();
-
-    /**
-     * Returns the dimension class for this type.
-     *
-     * @return The dimension class for this type
-     */
-    Class<? extends Dimension> getDimensionClass();
+    WorldCreationSettings getWorldCreationSettings();
+    
 }

--- a/src/main/java/org/spongepowered/api/world/GeneratorType.java
+++ b/src/main/java/org/spongepowered/api/world/GeneratorType.java
@@ -22,36 +22,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package org.spongepowered.api.world;
 
-import org.spongepowered.api.util.annotation.CatalogedBy;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.world.gen.WorldGenerator;
 
 /**
- * Represents a type of {@link Dimension}.
+ * Represents a world type. This is in general a {@link WorldGenerator} and the
+ * settings for the generator.
  */
-@CatalogedBy(DimensionTypes.class)
-public interface DimensionType {
+public interface GeneratorType {
 
     /**
-     * Returns the name of this {@link DimensionType}.
-     *
+     * Gets the name of this world type.
+     * 
      * @return The name
      */
     String getName();
 
     /**
-     * Returns whether spawn chunks of this {@link DimensionType} remain loaded
-     * when no players are present.
-     *
-     * @return True if spawn chunks of this {@link DimensionType} remain loaded
-     *         without players, false if not
+     * Creates a new {@link WorldGenerator} for this world type.
+     * 
+     * @return The new generator
      */
-    boolean doesKeepSpawnLoaded();
+    WorldGenerator createGenerator();
 
     /**
-     * Returns the dimension class for this type.
-     *
-     * @return The dimension class for this type
+     * Gets a copy of the settings for the world generator.
+     * 
+     * @return The settings
      */
-    Class<? extends Dimension> getDimensionClass();
+    DataContainer getGeneratorSettings();
+
 }

--- a/src/main/java/org/spongepowered/api/world/GeneratorTypes.java
+++ b/src/main/java/org/spongepowered/api/world/GeneratorTypes.java
@@ -22,36 +22,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package org.spongepowered.api.world;
 
-import org.spongepowered.api.util.annotation.CatalogedBy;
-
 /**
- * Represents a type of {@link Dimension}.
+ * An enumeration of default {@link GeneratorType}s.
  */
-@CatalogedBy(DimensionTypes.class)
-public interface DimensionType {
+public final class GeneratorTypes {
 
-    /**
-     * Returns the name of this {@link DimensionType}.
-     *
-     * @return The name
-     */
-    String getName();
+    public static final GeneratorType DEFAULT = null;
+    public static final GeneratorType FLAT = null;
+    public static final GeneratorType LARGE_BIOMES = null;
+    public static final GeneratorType AMPLIFIED = null;
+    public static final GeneratorType SUPER_FLAT = null;
+    public static final GeneratorType DEBUG = null;
 
-    /**
-     * Returns whether spawn chunks of this {@link DimensionType} remain loaded
-     * when no players are present.
-     *
-     * @return True if spawn chunks of this {@link DimensionType} remain loaded
-     *         without players, false if not
-     */
-    boolean doesKeepSpawnLoaded();
+    private GeneratorTypes() {
+    }
 
-    /**
-     * Returns the dimension class for this type.
-     *
-     * @return The dimension class for this type
-     */
-    Class<? extends Dimension> getDimensionClass();
 }

--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -35,6 +35,7 @@ import org.spongepowered.api.util.Identifiable;
 import org.spongepowered.api.world.difficulty.Difficulty;
 import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.api.world.gen.WorldGenerator;
+import org.spongepowered.api.world.storage.WorldProperties;
 import org.spongepowered.api.world.storage.WorldStorage;
 
 import java.util.Map;
@@ -53,22 +54,22 @@ public interface World extends Extent, Viewer, Contextual, Identifiable {
     Difficulty getDifficulty();
 
     /**
-     * Sets the {@link Difficulty} setting for this world.
-     *
-     * @param difficulty Difficulty of the world
-     */
-    void setDifficulty(Difficulty difficulty);
-
-    /**
      * Gets the name of the world.
      *
-     * <p>The world name may randomly generated or user-defined. It may or
-     * may not be safe to be used in a filename.</p>
+     * <p>The world name may randomly generated or user-defined. It may or may
+     * not be safe to be used in a filename.</p>
      *
      * @return The world name
      * @see #getUniqueId() A method to get a unique identifier
      */
     String getName();
+
+    /**
+     * Returns whether this world is loaded.
+     *
+     * @return True if this world is loaded
+     */
+    boolean isLoaded();
 
     /**
      * Get the loaded chunk at the given position.
@@ -89,8 +90,8 @@ public interface World extends Extent, Viewer, Contextual, Identifiable {
     Optional<Chunk> loadChunk(Vector3i position, boolean shouldGenerate);
 
     /**
-     * Unloads the given chunk from the world. Returns a {@code boolean}
-     * flag for whether the operation was successful.
+     * Unloads the given chunk from the world. Returns a {@code boolean} flag
+     * for whether the operation was successful.
      *
      * @param chunk The chunk to unload
      * @return Whether the operation was successful
@@ -135,18 +136,9 @@ public interface World extends Extent, Viewer, Contextual, Identifiable {
     Optional<String> getGameRule(String gameRule);
 
     /**
-     * Sets the specified GameRule value. If one with this name
-     * does not exist, it will be created.
-     *
-     * @param gameRule The name of the GameRule.
-     * @param value The value to set the GameRule to.
-     */
-    void setGameRule(String gameRule, String value);
-
-    /**
-     * Gets a {@link Map} of all GameRules with values in this world.
-     **
-     * @return A collection of GameRules.
+     * Gets a map of the currently set game rules and their values.
+     * 
+     * @return An immutable map of the game rules
      */
     Map<String, String> getGameRules();
 
@@ -165,13 +157,6 @@ public interface World extends Extent, Viewer, Contextual, Identifiable {
     long getWorldSeed();
 
     /**
-     * Sets the random seed for this world.
-     *
-     * @param seed The seed
-     */
-    void setSeed(long seed);
-
-    /**
      * Gets the {@link WorldGenerator} for this world.
      *
      * @return The world generator
@@ -187,20 +172,22 @@ public interface World extends Extent, Viewer, Contextual, Identifiable {
     void setWorldGenerator(WorldGenerator generator);
 
     /**
-     * Returns whether this {@link World}'s spawn chunks remain loaded when no players are present.
-     * Note: This method will default to this {@link World}'s {@link DimensionType}'s
-     * keepLoaded value unless a plugin overrides it.
+     * Returns whether this {@link World}'s spawn chunks remain loaded when no
+     * players are present. Note: This method will default to this {@link World}
+     * 's {@link DimensionType}'s keepLoaded value unless a plugin overrides it.
      *
-     * @return True if {@link World} remains loaded without players, false if not
+     * @return True if {@link World} remains loaded without players, false if
+     *         not
      */
     boolean doesKeepSpawnLoaded();
 
     /**
-     * Sets whether this {@link World}'s spawn chunks remain loaded when no players are present.
-     * Note: This method will override the default {@link DimensionType}'s keepLoaded
-     * value.
+     * Sets whether this {@link World}'s spawn chunks remain loaded when no
+     * players are present. Note: This method will override the default
+     * {@link DimensionType}'s keepLoaded value.
      *
-     * @param keepLoaded Whether this {@link World}'s spawn chunks remain loaded without players
+     * @param keepLoaded Whether this {@link World}'s spawn chunks remain loaded
+     *            without players
      */
     void setKeepSpawnLoaded(boolean keepLoaded);
 
@@ -224,5 +211,20 @@ public interface World extends Extent, Viewer, Contextual, Identifiable {
      * @param scoreboard The scoreboard to set
      */
     void setScoreboard(Scoreboard scoreboard);
+
+    /**
+     * Gets the {@link WorldCreationSettings} which were used to create this
+     * world.
+     * 
+     * @return The settings
+     */
+    WorldCreationSettings getCreationSettings();
+
+    /**
+     * Gets the properties for this world.
+     * 
+     * @return The properties
+     */
+    WorldProperties getProperties();
 
 }

--- a/src/main/java/org/spongepowered/api/world/WorldBorder.java
+++ b/src/main/java/org/spongepowered/api/world/WorldBorder.java
@@ -181,14 +181,16 @@ public interface WorldBorder {
     void setDamageThreshold(double distance);
 
     /**
-     * Get the damage done to a player per second when outside the buffer.
+     * Get the damage done to a player per block per tick when outside the
+     * buffer.
      *
      * @return The damage amount
      */
     int getDamageAmount();
 
     /**
-     * Set the damage done to a player per second when outside the buffer.
+     * Set the damage done to a player per block per tick when outside the
+     * buffer.
      *
      * @param damage The damage amount
      */

--- a/src/main/java/org/spongepowered/api/world/WorldBuilder.java
+++ b/src/main/java/org/spongepowered/api/world/WorldBuilder.java
@@ -1,0 +1,161 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.player.gamemode.GameMode;
+import org.spongepowered.api.entity.player.gamemode.GameModes;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+
+/**
+ * A builder for {@link World}s and {@link WorldCreationSettings}.
+ */
+public interface WorldBuilder {
+
+    /**
+     * Sets the name of the world.
+     * 
+     * @param name The name
+     * @return The builder, for chaining
+     */
+    WorldBuilder name(String name);
+
+    /**
+     * Sets the world as enabled. A world which is enabled but unloaded may be
+     * loaded automatically if an attempt is made to transfer an entity to the
+     * world using {@link Entity#transferToWorld} .
+     * 
+     * @param state Should be enabled
+     * @return The builder, for chaining
+     */
+    WorldBuilder enabled(boolean state);
+
+    /**
+     * Sets whether the world should load when the server starts up.
+     * 
+     * @param state Should load on startup
+     * @return The builder, for chaining
+     */
+    WorldBuilder loadsOnStartup(boolean state);
+
+    /**
+     * Sets whether the spawn chunks of the world should remain loaded when no
+     * players are present.
+     * 
+     * @param state Should keep spawn loaded
+     * @return The builder, for chaining
+     */
+    WorldBuilder keepsSpawnLoaded(boolean state);
+
+    /**
+     * Sets the seed of the world. If not specified this will default to using a
+     * random seed.
+     * 
+     * @param seed The seed
+     * @return The builder, for chaining
+     */
+    WorldBuilder seed(long seed);
+
+    /**
+     * Sets the default {@link GameMode} of the world. If not specified this
+     * will default to {@link GameModes#SURVIVAL}.
+     * 
+     * @param gameMode The gamemode
+     * @return The builder, for chaining
+     */
+    WorldBuilder gameMode(GameMode gameMode);
+
+    /**
+     * Sets the generator type of the world.
+     * 
+     * @param type The type
+     * @return The builder, for chaining
+     */
+    WorldBuilder generator(GeneratorType type);
+
+    /**
+     * Sets the dimension type of the world.
+     * 
+     * @param type The type
+     * @return The builder, for chaining
+     */
+    WorldBuilder dimensionType(DimensionType type);
+
+    /**
+     * Sets whether this world should generate map features such as villages and
+     * strongholds. If not specified this will default to true.
+     * 
+     * @param enabled Are map features enabled
+     * @return The builder, for chaining
+     */
+    WorldBuilder usesMapFeatures(boolean enabled);
+
+    /**
+     * Sets whether hardcore mode is enabled. On servers this will cause players
+     * to be banned upon death, on clients the world will be deleted! If not
+     * specified this will default to false.
+     * 
+     * @param enabled Is hardcore mode enabled
+     * @return The builder, for chaining
+     */
+    WorldBuilder hardcore(boolean enabled);
+
+    /**
+     * Sets any extra settings required by the {@link GeneratorType}. If not
+     * specified these will default to the settings within
+     * {@link GeneratorType#getGeneratorSettings()}.
+     * 
+     * @param settings The generator settings
+     * @return The builder, for chaining
+     */
+    WorldBuilder generatorSettings(DataContainer settings);
+
+    /**
+     * Resets this builder to a clean state.
+     *
+     * @return This builder, for chaining
+     */
+    WorldBuilder reset();
+
+    /**
+     * Attempts to create a {@link World} from the specified parameters.
+     * 
+     * @return The world, if successful
+     * @throws IllegalStateException If any required parameters are missing
+     */
+    Optional<World> build() throws IllegalStateException;
+
+    /**
+     * Attempts to create a {@link WorldCreationSettings} which may be later
+     * used to create a world.
+     * 
+     * @return The world settings
+     * @throws IllegalStateException If any required parameters are missing
+     */
+    WorldCreationSettings buildSettings() throws IllegalStateException;
+
+}

--- a/src/main/java/org/spongepowered/api/world/WorldCreationSettings.java
+++ b/src/main/java/org/spongepowered/api/world/WorldCreationSettings.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world;
+
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.player.gamemode.GameMode;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+
+/**
+ * A representation of the settings which define a world for creation.
+ */
+public interface WorldCreationSettings {
+
+    /**
+     * Gets the name of the world.
+     * 
+     * @return The name
+     */
+    String getWorldName();
+
+    /**
+     * Gets whether this world is enabled. A world which is enabled but unloaded
+     * may be loaded automatically if an attempt is made to transfer an entity
+     * to the world using {@link Entity#transferToWorld} .
+     * 
+     * @return Is enabled
+     */
+    boolean isEnabled();
+
+    /**
+     * Gets whether this world will load when the server starts up.
+     * 
+     * @return Loads on startup
+     */
+    boolean loadOnStartup();
+
+    /**
+     * Returns whether spawn chunks of this world remain loaded when no players
+     * are present.
+     *
+     * @return True if spawn chunks of this world remain loaded without players,
+     *         false if not
+     */
+    boolean doesKeepSpawnLoaded();
+
+    /**
+     * Gets the seed of the world.
+     * 
+     * @return The seed
+     */
+    long getSeed();
+
+    /**
+     * Gets the default gamemode of the world.
+     * 
+     * @return The gamemode
+     */
+    GameMode getGameMode();
+
+    /**
+     * Gets the type of the generator for the world.
+     * 
+     * @return The generator type
+     */
+    GeneratorType getGeneratorType();
+
+    /**
+     * Gets whether map features are enabled to be generated into the world.
+     * 
+     * @return Are map features enabled
+     */
+    boolean usesMapFeatures();
+
+    /**
+     * Gets whether hardcore mode is enabled in this world.
+     * 
+     * @return Is hardcore
+     */
+    boolean isHardcore();
+
+    /**
+     * Gets whether commands are allowed in this world.
+     * 
+     * @return Are commands allowed
+     */
+    boolean commandsAllowed();
+
+    /**
+     * Gets whether the bonus chest should be created in this world.
+     * 
+     * @return Should create bonus chest
+     */
+    boolean bonusChestEnabled();
+
+    /**
+     * Gets the dimension type for the world.
+     * 
+     * @return The dimension type
+     */
+    DimensionType getDimensionType();
+
+    /**
+     * Gets a {@link DataContainer} of any extra settings required by the
+     * generator.
+     * 
+     * @return The generator settings
+     */
+    DataContainer getGeneratorSettings();
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/BiomeGenerator.java
+++ b/src/main/java/org/spongepowered/api/world/gen/BiomeGenerator.java
@@ -45,6 +45,6 @@ public interface BiomeGenerator {
      * @param width The width of the area (X-axis size)
      * @param length The length of the area (Z-axis size)
      */
-    void getBiomesForArea(World world, MutableBiomeArea buffer, int x, int z, int width, int length);
+    void generateBiomes(World world, MutableBiomeArea buffer, int x, int z, int width, int length);
 
 }

--- a/src/main/java/org/spongepowered/api/world/gen/WorldGenerator.java
+++ b/src/main/java/org/spongepowered/api/world/gen/WorldGenerator.java
@@ -47,14 +47,6 @@ public interface WorldGenerator {
     void generateChunk(World world, MutableBlockBuffer buffer, Vector3i position);
 
     /**
-     * Gets whether map features are enabled and if this generator will be
-     * creating structures (such as villages and strongholds etc.)
-     *
-     * @return Map features enabled
-     */
-    boolean areMapFeaturesEnabled();
-
-    /**
      * Gets an ordered collection of {@link Populator}s which are applied
      * globally.
      *
@@ -63,13 +55,13 @@ public interface WorldGenerator {
     Iterable<Populator> getGlobalPopulators();
 
     /**
-     * Inserts a new populator to this Biome's ordered collection of
+     * Inserts a new populator to this generator's ordered collection of
      * populators. The new populator is inserted at the given index. If the
      * index is larger than the current amount of populators then the new
      * populator in inserted at the end of the collection.
      *
      * @param populator The new populator
-     * @param index THe index to insert the populator at
+     * @param index The index to insert the populator at
      */
     void insertPopulator(Populator populator, int index);
 

--- a/src/main/java/org/spongepowered/api/world/storage/WorldProperties.java
+++ b/src/main/java/org/spongepowered/api/world/storage/WorldProperties.java
@@ -1,0 +1,383 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.storage;
+
+import com.flowpowered.math.vector.Vector3i;
+import com.google.common.base.Optional;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.player.gamemode.GameMode;
+import org.spongepowered.api.service.persistence.DataSerializable;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+import org.spongepowered.api.world.DimensionType;
+import org.spongepowered.api.world.GeneratorType;
+import org.spongepowered.api.world.WorldBorder;
+import org.spongepowered.api.world.difficulty.Difficulty;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Represents the WorldProperties which are persisted across runtime instances.
+ */
+public interface WorldProperties extends DataSerializable {
+
+    /**
+     * Gets whether this world is enabled. A world which is enabled but unloaded
+     * may be loaded automatically if an attempt is made to transfer an entity
+     * to the world using {@link Entity#transferToWorld} .
+     * 
+     * @return Is enabled
+     */
+    boolean isEnabled();
+
+    /**
+     * Sets this world as enabled. A world which is enabled but unloaded may be
+     * loaded automatically if an attempt is made to transfer an entity to the
+     * world using {@link Entity#transferToWorld} .
+     * 
+     * @param state The new state
+     */
+    void setEnabled(boolean state);
+
+    /**
+     * Gets whether this world will load when the server starts up.
+     * 
+     * @return Loads on startup
+     */
+    boolean loadOnStartup();
+
+    /**
+     * Sets whether this world should load when the server starts up.
+     * 
+     * @param state Should load on startup
+     */
+    void setLoadOnStartup(boolean state);
+
+    /**
+     * Gets whether spawn chunks of this world remain loaded when no players
+     * are present.
+     *
+     * @return True if spawn chunks of this world remain loaded without players,
+     *         false if not
+     */
+    boolean doesKeepSpawnLoaded();
+
+    /**
+     * Sets whether the spawn chunks of the world should remain loaded when no
+     * players are present.
+     * 
+     * @param state Should keep spawn loaded
+     */
+    void setKeepSpawnLoaded(boolean state);
+
+    /**
+     * Gets the name of this world.
+     * 
+     * @return The name
+     */
+    String getWorldName();
+
+    /**
+     * Gets the {@link UUID} of the world.
+     * 
+     * @return The unique Id
+     */
+    UUID getUniqueId();
+
+    /**
+     * Gets the default spawn position of this world.
+     * 
+     * @return The spawn position
+     */
+    Vector3i getSpawnPosition();
+
+    /**
+     * Sets the default spawn position of this world.
+     * 
+     * @param position The spawn position
+     */
+    void setSpawnPosition(Vector3i position);
+
+    /**
+     * Gets the type of the generator for this world.
+     * 
+     * @return The type
+     */
+    GeneratorType getGeneratorType();
+
+    /**
+     * Gets the seed of this world.
+     * 
+     * @return The seed
+     */
+    long getSeed();
+
+    /**
+     * Gets the number of ticks which have occurred since the world was created.
+     * 
+     * @return The total time in ticks
+     */
+    long getTotalTime();
+
+    /**
+     * Gets the time of day, in ticks. The total number of ticks in a day is
+     * 24000, however this value does not reset to zero at the start of each day
+     * but rather keeps counting passed 24000.
+     * 
+     * @return The time of day
+     */
+    long getWorldTime();
+
+    /**
+     * Sets the time of day, in ticks. The total number of ticks in a day is
+     * 24000, however this value does not reset to zero at the start of each day
+     * but rather keeps counting passed 24000.
+     * 
+     * @param time The time of day
+     */
+    void setWorldTime(long time);
+
+    /*
+     * TODO pending decision on handling client only API
+     * 
+     * Gets the Unix time stamp of when this world was last played on.
+     * 
+     * @return The time this world was last loaded
+     */
+    // long getLastTimePlayed();
+
+    /**
+     * Gets the {@link DimensionType} of this world.
+     * 
+     * @return The dimension type
+     */
+    DimensionType getDimensionType();
+
+    /**
+     * Gets whether this world is currently experiencing rain/snow/cloud-cover
+     * (depending on the biome of a specific location).
+     * 
+     * @return Is raining
+     */
+    boolean isRaining();
+
+    /**
+     * Sets whether this world is currently experiencing rain/snow/cloud-cover
+     * (depending on the biome of a specific location).
+     * 
+     * @param state Is raining
+     */
+    void setRaining(boolean state);
+
+    /**
+     * Gets the number of ticks until the weather is next toggled to a new
+     * random value.
+     * 
+     * @return The time until the weather changes
+     */
+    int getRainTime();
+
+    /**
+     * Sets the number of ticks until the weather is next toggled to a new
+     * random value.
+     * 
+     * @param time The time until the weather changes
+     */
+    void setRainTime(int time);
+
+    /**
+     * Gets whether this world is currently experiencing a lightning storm.
+     * 
+     * @return Is thundering
+     */
+    boolean isThundering();
+
+    /**
+     * Sets whether this world is currently experiencing a lightning storm.
+     * 
+     * @param state Is thundering
+     */
+    void setThundering(boolean state);
+
+    /**
+     * Gets the number of ticks until the {@link #isThundering()} state is
+     * toggled to a new random value.
+     * 
+     * @return The time until the thundering state changes
+     */
+    int getThunderTime();
+
+    /**
+     * Sets the number of ticks until the {@link #isThundering()} state is
+     * toggled to a new random value.
+     * 
+     * @param time The time until the thundering state changes
+     */
+    void setThunderTime(int time);
+
+    /**
+     * Gets the default {@link GameMode} of this world.
+     * 
+     * @return The game mode
+     */
+    GameMode getGameMode();
+
+    /**
+     * Sets the default {@link GameMode} of this world.
+     * 
+     * @param gamemode The game mode
+     */
+    void setGameMode(GameMode gamemode);
+
+    /**
+     * Gets whether this world will generate map features such as villages and
+     * strongholds.
+     * 
+     * @return Whether map features enabled
+     */
+    boolean usesMapFeatures();
+
+    /**
+     * Sets whether this world will generate map features such as villages and
+     * strongholds.
+     * 
+     * @param state Whether map features enabled
+     */
+    void setMapFeaturesEnabled(boolean state);
+
+    /**
+     * Gets whether this world is set to hardcore mode.
+     * 
+     * @return Is hardcore
+     */
+    boolean isHardcore();
+
+    /**
+     * Sets whether this world is set to hardcore mode.
+     * 
+     * @param state Is hardcore
+     */
+    void setHardcore(boolean state);
+
+    /**
+     * Gets whether commands are allowed within this world. May not be respected
+     * when not in single player.
+     * 
+     * @return Whether commands are allowed
+     */
+    boolean areCommandsAllowed();
+
+    /**
+     * Sets whether commands are allowed within this world. May not be respected
+     * when not in single player.
+     * 
+     * @param state Whether commands are allowed
+     */
+    void setCommandsAllowed(boolean state);
+
+    /**
+     * Gets whether this world has been initialized.
+     * 
+     * @return Is initialized
+     */
+    boolean isInitialized();
+
+    /**
+     * Gets the difficulty of this world.
+     * 
+     * @return The difficulty
+     */
+    Difficulty getDifficulty();
+
+    /**
+     * Sets the difficulty of this world.
+     * 
+     * @param difficulty The difficulty
+     */
+    void setDifficulty(Difficulty difficulty);
+
+    /**
+     * Gets the {@link WorldBorder} of this world.
+     * 
+     * @return The world border
+     */
+    WorldBorder getWorldBorder();
+
+    /**
+     * Gets the specified GameRule value.
+     **
+     * @param gameRule The name of the GameRule.
+     * @return The GameRule value, if it exists.
+     */
+    Optional<String> getGameRule(String gameRule);
+
+    /**
+     * Gets a map of the currently set game rules and their values.
+     * 
+     * @return An immutable map of the game rules
+     */
+    Map<String, String> getGameRules();
+
+    /**
+     * Sets the specified GameRule value. If one with this name does not exist,
+     * it will be created.
+     *
+     * @param gameRule The name of the GameRule.
+     * @param value The value to set the GameRule to.
+     */
+    void setGameRule(String gameRule, String value);
+
+    /**
+     * Gets a {@link DataContainer} containing any additional properties for
+     * this world. The returned data is a snapshot of the data and is not live.
+     * 
+     * @return Any additional properties
+     */
+    DataContainer getAdditionalProperties();
+
+    /**
+     * Gets a section of the additional properties returned by
+     * {@link #getAdditionalProperties()}. The returned data is a snapshot of
+     * the data and is not live.
+     * 
+     * @param path The path for the section.
+     * @return The data view representing the requested section
+     */
+    Optional<DataView> getPropertySection(DataQuery path);
+
+    /**
+     * Sets a path within the additional data to the given {@link DataView}. If
+     * you are using this to store data related to your mod/plugin is is HIGHLY
+     * recommended that the identifier you pass in be your mod/plugin id.
+     * 
+     * @param path The path for the section
+     * @param data The new data
+     */
+    void setPropertySection(DataQuery path, DataView data);
+
+}

--- a/src/main/java/org/spongepowered/api/world/storage/WorldStorage.java
+++ b/src/main/java/org/spongepowered/api/world/storage/WorldStorage.java
@@ -84,5 +84,13 @@ public interface WorldStorage {
      * @return The data container representing the chunk data, if available
      */
     ListenableFuture<Optional<DataContainer>> getChunkData(Vector3i chunkCoords);
+    
+    /**
+     * Gets the {@link WorldProperties} of this storage. In the vanilla storage
+     * medium this represents the data available in the level.dat file.
+     * 
+     * @return The world properties
+     */
+    WorldProperties getWorldProperties();
 
 }


### PR DESCRIPTION
This PR expands the process for creating worlds.

Notable new classes:
- `WorldBuilder` This is a builder which can produce instances of `WorldCreationSettings` or `World`s directly.
- `WorldCreationSettings` Holds information which is used to define a new world for creation.
- `WorldProperties` defines numerous properties about the world (essentially a representation of the data with the `level.dat` file).
- `GeneratorType` This is a representation of what you may also think of as a world type, it holds a generator and some settings. Examples are flatland or amplified.