### PR TITLE
Fix 'Preparing for Development' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ Are you a talented programmer looking to contribute some code? We'd love the hel
 [MIT License]: http://www.tldrlegal.com/license/mit-license
 [Community Chat]: https://webchat.esper.net/?channels=sponge
 [Development Chat]: https://webchat.esper.net/?channels=spongedev
-[Preparing for Development]: https://docs.spongepowered.org/en/workspace/
+[Preparing for Development]: https://docs.spongepowered.org/en/preparing
 [Javadocs(temporary link)]: http://spongepowered.github.io/SpongeAPI/


### PR DESCRIPTION
Moved to new web page