### PR TITLE
Add getter and setter for Chat receivers

### DIFF
--- a/src/main/java/org/spongepowered/api/event/entity/player/PlayerChatEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/player/PlayerChatEvent.java
@@ -32,5 +32,17 @@ import org.spongepowered.api.event.message.MessageEvent;
  * Called when a {@link Player} sends a chat message.
  */
 public interface PlayerChatEvent extends MessageEvent, PlayerEvent {
-
+    
+    /*
+     * Returns list of players that recieve the message.
+     *
+     * @return The list of {@link Player}s
+     */
+    List<Player> getReceivers();
+    
+    /*
+     * Sets the list of players who receive the message.
+     *
+     */
+    void setReceivers(List<Player> receivers);
 }

--- a/src/main/java/org/spongepowered/api/event/entity/player/PlayerChatEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/player/PlayerChatEvent.java
@@ -43,6 +43,7 @@ public interface PlayerChatEvent extends MessageEvent, PlayerEvent {
     /*
      * Sets the list of players who receive the message.
      *
+     * @param receivers The list of {@link Player}s
      */
     void setReceivers(List<Player> receivers);
 }


### PR DESCRIPTION
This PR will add the following methods:

List<Player> getReceivers()
void setReceivers(List<Player>)

The reason it should be added is to simplify who/what receives messages.