### PR TITLE
Add SimpleCommandBase. Fixes #523

### DIFF
--- a/src/main/java/org/spongepowered/api/util/command/SimpleCommandBase.java
+++ b/src/main/java/org/spongepowered/api/util/command/SimpleCommandBase.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.api.util.command;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -61,5 +85,5 @@ public abstract class SimpleCommandBase implements CommandCallable {
     public List<String> getSuggestions(CommandSource source, String arguments) throws CommandException {
         return Collections.<String>emptyList();
     }
-    
+
 }

--- a/src/main/java/org/spongepowered/api/util/command/SimpleCommandBase.java
+++ b/src/main/java/org/spongepowered/api/util/command/SimpleCommandBase.java
@@ -29,7 +29,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.Texts;
 
 /**
  * An abstract base class that can be extended to easily create simple commands.
@@ -44,15 +47,32 @@ public abstract class SimpleCommandBase implements CommandCallable {
     /**
      * Creates a new command.
      *
-     * @param permission The permission needed to execute the command
+     * @param permission The permission needed to execute the command,
+     *        or {@code null} to permit all users
      * @param shortDescription A command description
      * @param help A formatted help message
      * @param usage A description of the command arguments
      */
-    public SimpleCommandBase(String permission, String shortDescription, Text help, String usage) {
-        this.permission = checkNotNull(permission, "permission");
+    public SimpleCommandBase(@Nullable String permission, String shortDescription, Text help, String usage) {
+        this.permission = permission;
         this.shortDescription = checkNotNull(shortDescription, "shortDescription");
         this.help = checkNotNull(help, "help");
+        this.usage = checkNotNull(usage, "usage");
+    }
+    
+    /**
+     * Creates a new command. Generates the help message from the command
+     * description.
+     *
+     * @param permission The permission needed to execute the command,
+     *        or {@code null} to permit all users
+     * @param shortDescription A command description
+     * @param usage A description of the command arguments
+     */
+    public SimpleCommandBase(@Nullable String permission, String shortDescription, String usage) {
+        this.permission = permission;
+        this.shortDescription = checkNotNull(shortDescription, "shortDescription");
+        this.help = Texts.of(shortDescription);
         this.usage = checkNotNull(usage, "usage");
     }
 

--- a/src/main/java/org/spongepowered/api/util/command/SimpleCommandBase.java
+++ b/src/main/java/org/spongepowered/api/util/command/SimpleCommandBase.java
@@ -78,7 +78,7 @@ public abstract class SimpleCommandBase implements CommandCallable {
 
     @Override
     public boolean testPermission(CommandSource source) {
-        return source.hasPermission(this.permission);
+        return this.permission == null ? true : source.hasPermission(this.permission);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/util/command/SimpleCommandBase.java
+++ b/src/main/java/org/spongepowered/api/util/command/SimpleCommandBase.java
@@ -50,15 +50,10 @@ public abstract class SimpleCommandBase implements CommandCallable {
      * @param usage A description of the command arguments
      */
     public SimpleCommandBase(String permission, String shortDescription, Text help, String usage) {
-        checkNotNull(permission);
-        checkNotNull(shortDescription);
-        checkNotNull(help);
-        checkNotNull(usage);
-
-        this.permission = permission;
-        this.shortDescription = shortDescription;
-        this.help = help;
-        this.usage = usage;
+        this.permission = checkNotNull(permission, "permission");
+        this.shortDescription = checkNotNull(shortDescription, "shortDescription");
+        this.help = checkNotNull(help, "help");
+        this.usage = checkNotNull(usage, "usage");
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/util/command/SimpleCommandBase.java
+++ b/src/main/java/org/spongepowered/api/util/command/SimpleCommandBase.java
@@ -1,0 +1,65 @@
+package org.spongepowered.api.util.command;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.spongepowered.api.text.Text;
+
+/**
+ * An abstract base class that can be extended to easily create simple commands.
+ */
+public abstract class SimpleCommandBase implements CommandCallable {
+
+    private final String permission;
+    private final String shortDescription;
+    private final Text help;
+    private final String usage;
+
+    /**
+     * Creates a new command.
+     *
+     * @param permission The permission needed to execute the command
+     * @param shortDescription A command description
+     * @param help A formatted help message
+     * @param usage A description of the command arguments
+     */
+    public SimpleCommandBase(String permission, String shortDescription, Text help, String usage) {
+        checkNotNull(permission);
+        checkNotNull(shortDescription);
+        checkNotNull(help);
+        checkNotNull(usage);
+
+        this.permission = permission;
+        this.shortDescription = shortDescription;
+        this.help = help;
+        this.usage = usage;
+    }
+
+    @Override
+    public boolean testPermission(CommandSource source) {
+        return source.hasPermission(this.permission);
+    }
+
+    @Override
+    public String getShortDescription(CommandSource source) {
+        return this.shortDescription;
+    }
+
+    @Override
+    public Text getHelp(CommandSource source) {
+        return this.help;
+    }
+
+    @Override
+    public String getUsage(CommandSource source) {
+        return this.usage;
+    }
+
+    @Override
+    public List<String> getSuggestions(CommandSource source, String arguments) throws CommandException {
+        return Collections.<String>emptyList();
+    }
+    
+}


### PR DESCRIPTION
This PR adds a simple abstract implementation of ``CommandCallable`` (like ``SimpleDispatcher`` implementation for ``Dispatcher``).

Plugin developers can extend the class to create simple commands, without implementing all methods of ``CommandCallable``:

```java
public class SendCommand extends SimpleCommandBase {
    public SendCommand() {
        super(
                "simplemail.write", // permission
                "Send a mail", // description
                Texts.of("Send a server mail to a player."), // help
                "<player> <msg>"); // usage
    }

    @Override
    public boolean call(CommandSource source, String arguments, List<String> parents) throws CommandException {
        // command logic...
    }
}
```

I did not name this ``Command`` or ``AbstractCommand`` because I want to reserve those names for an annotation based Command API.

#523 