### PR TITLE
Fix SimpleDispatcher permission handling

### DIFF
--- a/src/main/java/org/spongepowered/api/util/command/dispatcher/SimpleDispatcher.java
+++ b/src/main/java/org/spongepowered/api/util/command/dispatcher/SimpleDispatcher.java
@@ -340,13 +340,14 @@ public class SimpleDispatcher implements Dispatcher {
 
     @Override
     public synchronized boolean testPermission(CommandSource source) {
+     // Return true if source is permitted to execute at least one subcommand
         for (CommandMapping mapping : this.commands.values()) {
-            if (!mapping.getCallable().testPermission(source)) {
-                return false;
+            if (mapping.getCallable().testPermission(source)) {
+                return true; 
             }
         }
 
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
This PR modifies the ``testPermission`` method of ``SimpleDispatcher`` to return ``true`` if the ``CommandSource`` is permitted to execute at least one of the subcommands.

Right now it returns ``false`` if the source is not permitted to execute one of the subcommands.