### PR TITLE
Improve Scoreboard API

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -232,6 +232,9 @@ public interface GameRegistry {
     /**
      * Gets the main {@link Scoreboard} controlled by the server.
      *
+     * <p>The main scoreboard is the one attached to the
+     * <code>/scoreboard</code> command.</p>
+     *
      * @return The main {@link Scoreboard} controlled by the server
      */
     Scoreboard getMainScoreboard();

--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -25,6 +25,7 @@
 
 package org.spongepowered.api;
 
+import org.spongepowered.api.scoreboard.Scoreboard;
 import org.spongepowered.api.service.persistence.data.DataContainer;
 import org.spongepowered.api.world.gen.WorldGenerator;
 import com.google.common.base.Optional;
@@ -227,6 +228,13 @@ public interface GameRegistry {
      * @return The scoreboard builder
      */
     ScoreboardBuilder getScoreboardBuilder();
+
+    /**
+     * Gets the main {@link Scoreboard} controlled by the server.
+     *
+     * @return The main {@link Scoreboard} controlled by the server
+     */
+    Scoreboard getMainScoreboard();
 
     /**
      * Gets a {@link ParticleType} by name.

--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -25,7 +25,6 @@
 
 package org.spongepowered.api;
 
-import org.spongepowered.api.scoreboard.Scoreboard;
 import org.spongepowered.api.service.persistence.data.DataContainer;
 import org.spongepowered.api.world.gen.WorldGenerator;
 import com.google.common.base.Optional;
@@ -228,16 +227,6 @@ public interface GameRegistry {
      * @return The scoreboard builder
      */
     ScoreboardBuilder getScoreboardBuilder();
-
-    /**
-     * Gets the main {@link Scoreboard} controlled by the server.
-     *
-     * <p>The main scoreboard is the one attached to the
-     * <code>/scoreboard</code> command.</p>
-     *
-     * @return The main {@link Scoreboard} controlled by the server
-     */
-    Scoreboard getMainScoreboard();
 
     /**
      * Gets a {@link ParticleType} by name.

--- a/src/main/java/org/spongepowered/api/scoreboard/Score.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Score.java
@@ -28,6 +28,8 @@ import com.google.common.base.Optional;
 import org.spongepowered.api.scoreboard.objective.Objective;
 import org.spongepowered.api.text.Text;
 
+import java.util.Set;
+
 /**
  * A score entry for an {@link Objective}. Changing this will not affect any other
  * objective or scoreboard.
@@ -56,11 +58,12 @@ public interface Score {
     void setScore(int score);
 
     /**
-     * Returns the parent {@link Objective} this {@link Score} is registered to,
-     * if applicable.
+     * Returns a {@link Set} of parent {@link Objective}s this {@link Score} is
+     * registered to.
      *
-     * @return The parent {@link Objective} this {@link Score} is registered to
+     * @return A {@link Set} of parent {@link Objective} this {@link Score} is
+     *         registered to
      */
-    Optional<Objective> getObjective();
+    Set<Objective> getObjectives();
 
 }

--- a/src/main/java/org/spongepowered/api/scoreboard/Score.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Score.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.scoreboard;
 
+import com.google.common.base.Optional;
 import org.spongepowered.api.scoreboard.objective.Objective;
 import org.spongepowered.api.text.Text;
 
@@ -53,5 +54,13 @@ public interface Score {
      * @param score The new score value
      */
     void setScore(int score);
+
+    /**
+     * Returns the parent {@link Objective} this Score is registered to, if
+     * applicable.
+     *
+     * @return The parent {@link Objective} this Score is registered to
+     */
+    Optional<Objective> getObjective();
 
 }

--- a/src/main/java/org/spongepowered/api/scoreboard/Score.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Score.java
@@ -56,10 +56,10 @@ public interface Score {
     void setScore(int score);
 
     /**
-     * Returns the parent {@link Objective} this Score is registered to, if
-     * applicable.
+     * Returns the parent {@link Objective} this {@link Score} is registered to,
+     * if applicable.
      *
-     * @return The parent {@link Objective} this Score is registered to
+     * @return The parent {@link Objective} this {@link Score} is registered to
      */
     Optional<Objective> getObjective();
 

--- a/src/main/java/org/spongepowered/api/scoreboard/ScoreboardBuilder.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/ScoreboardBuilder.java
@@ -66,6 +66,6 @@ public interface ScoreboardBuilder {
      * @return A new instance of a {@link Scoreboard}
      * @throws IllegalStateException if the {@link Scoreboard} is not complete
      */
-    Objective build() throws IllegalStateException;
+    Scoreboard build() throws IllegalStateException;
 
 }

--- a/src/main/java/org/spongepowered/api/scoreboard/ScoreboardBuilder.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/ScoreboardBuilder.java
@@ -58,7 +58,7 @@ public interface ScoreboardBuilder {
      *
      * @return This builder
      */
-    Scoreboard reset();
+    ScoreboardBuilder reset();
 
     /**
      * Builds an instance of a {@link Scoreboard}.

--- a/src/main/java/org/spongepowered/api/scoreboard/Team.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Team.java
@@ -201,11 +201,12 @@ public interface Team {
     boolean removeUser(User user);
 
     /**
-     * Returns the parent {@link Scoreboard} this {@link Team} is registered to,
-     * if applicable.
+     * Returns a {@link Set} of parent {@link Scoreboard}s this {@link Team} is
+     * registered to.
      *
-     * @return The parent {@link Scoreboard} this {@link Team} is registered to
+     * @return A {@link Set} of parent {@link Scoreboard}s this {@link Team} is
+     *         registered to
      */
-    Optional<Scoreboard> getScoreboard();
+    Set<Scoreboard> getScoreboards();
 
 }

--- a/src/main/java/org/spongepowered/api/scoreboard/Team.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Team.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.scoreboard;
 
 
+import com.google.common.base.Optional;
 import org.spongepowered.api.entity.player.User;
 import org.spongepowered.api.text.format.TextColor;
 import org.spongepowered.api.text.Text;
@@ -198,5 +199,13 @@ public interface Team {
      * @return Whether the {@link User} was on this team
      */
     boolean removeUser(User user);
+
+    /**
+     * Returns the parent {@link Scoreboard} this Team is registered to, if
+     * applicable.
+     *
+     * @return The parent {@link Scoreboard} this Team is registered to
+     */
+    Optional<Scoreboard> getScoreboard();
 
 }

--- a/src/main/java/org/spongepowered/api/scoreboard/Team.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Team.java
@@ -201,10 +201,10 @@ public interface Team {
     boolean removeUser(User user);
 
     /**
-     * Returns the parent {@link Scoreboard} this Team is registered to, if
-     * applicable.
+     * Returns the parent {@link Scoreboard} this {@link Team} is registered to,
+     * if applicable.
      *
-     * @return The parent {@link Scoreboard} this Team is registered to
+     * @return The parent {@link Scoreboard} this {@link Team} is registered to
      */
     Optional<Scoreboard> getScoreboard();
 

--- a/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.scoreboard.objective;
 
 import com.google.common.base.Optional;
 import org.spongepowered.api.scoreboard.Score;
+import org.spongepowered.api.scoreboard.Scoreboard;
 import org.spongepowered.api.scoreboard.critieria.Criterion;
 import org.spongepowered.api.scoreboard.displayslot.DisplaySlot;
 import org.spongepowered.api.scoreboard.objective.displaymode.ObjectiveDisplayMode;
@@ -129,5 +130,13 @@ public interface Objective {
      * @return The {@link Score} for the specified {@link Text}
      */
     Score getScore(Text name);
+
+    /**
+     * Returns the parent {@link Scoreboard} this Objective is registered to, if
+     * applicable.
+     *
+     * @return The parent {@link Scoreboard} this Objective is registered to
+     */
+    Optional<Scoreboard> getScoreboard();
 
 }

--- a/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
@@ -124,7 +124,7 @@ public interface Objective {
     /**
      * Gets an entry's {@link Score} for this Objective.
      *
-     * <p>If the {@link Score} does not exist, it will be created.<x/p>
+     * <p>If the {@link Score} does not exist, it will be created.</p>
      *
      * @param name The name of the {@link Score} to get
      * @return The {@link Score} for the specified {@link Text}
@@ -132,12 +132,12 @@ public interface Objective {
     Score getScore(Text name);
 
     /**
-     * Returns the parent {@link Scoreboard} this {@link Objective} is
-     * registered to, if applicable.
+     * Returns a {@link Set} of parent {@link Scoreboard}s this
+     * {@link Objective} is registered to.
      *
-     * @return The parent {@link Scoreboard} this {@link Objective} is
-     *         registered to
+     * @return A {@link Set} of parent {@link Scoreboard}s this
+     *         {@link Objective} is registered to
      */
-    Optional<Scoreboard> getScoreboard();
+    Set<Scoreboard> getScoreboards();
 
 }

--- a/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
@@ -132,10 +132,11 @@ public interface Objective {
     Score getScore(Text name);
 
     /**
-     * Returns the parent {@link Scoreboard} this Objective is registered to, if
-     * applicable.
+     * Returns the parent {@link Scoreboard} this {@link Objective} is
+     * registered to, if applicable.
      *
-     * @return The parent {@link Scoreboard} this Objective is registered to
+     * @return The parent {@link Scoreboard} this {@link Objective} is
+     *         registered to
      */
     Optional<Scoreboard> getScoreboard();
 


### PR DESCRIPTION
This PR improves the recently added Scoreboard API. A list of the changes is below:

- Add `getScoreboard()` method to `Objective` and `Team`
- Add `getObjective()` method to `Score`
- Add `getMainScoreboard()` method to the registry
- Correct method signature of `ScoreboardBuilder#build()`