### PR TITLE
Refactor GameRegistry

### DIFF
--- a/src/main/java/org/spongepowered/api/CatalogType.java
+++ b/src/main/java/org/spongepowered/api/CatalogType.java
@@ -22,17 +22,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.text.selector;
-
-import org.spongepowered.api.CatalogType;
-import org.spongepowered.api.util.annotation.CatalogedBy;
+package org.spongepowered.api;
 
 /**
- * Represents a selector type.
- *
- * @see Selectors
+ * Represents a type of a catalog that can be used to identify types
+ * without using an {@link Enum}.
  */
-@CatalogedBy(SelectorTypes.class)
-public interface SelectorType extends CatalogType {
+public interface CatalogType {
+
+    /**
+     * Gets the unique identifier of this {@link CatalogType}. The identifier
+     * can be formatted however needed.
+     *
+     * @return The unique identifier of this catalog type
+     */
+    String getId();
+
+    /**
+     * Gets the unique human-readable name of this individual {@link
+     * CatalogType}.
+     *
+     * @return The uniquely identifiable name of this catalog type
+     */
+    String getName();
 
 }

--- a/src/main/java/org/spongepowered/api/CatalogTypes.java
+++ b/src/main/java/org/spongepowered/api/CatalogTypes.java
@@ -1,0 +1,129 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api;
+
+import org.spongepowered.api.attribute.Attribute;
+import org.spongepowered.api.attribute.Operation;
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.block.tile.TileEntityType;
+import org.spongepowered.api.block.tile.data.BannerPatternShape;
+import org.spongepowered.api.effect.particle.ParticleType;
+import org.spongepowered.api.effect.sound.SoundType;
+import org.spongepowered.api.entity.EntityInteractionType;
+import org.spongepowered.api.entity.EntityType;
+import org.spongepowered.api.entity.hanging.art.Art;
+import org.spongepowered.api.entity.living.animal.HorseColor;
+import org.spongepowered.api.entity.living.animal.HorseStyle;
+import org.spongepowered.api.entity.living.animal.HorseVariant;
+import org.spongepowered.api.entity.living.animal.OcelotType;
+import org.spongepowered.api.entity.living.animal.RabbitType;
+import org.spongepowered.api.entity.living.monster.SkeletonType;
+import org.spongepowered.api.entity.living.villager.Career;
+import org.spongepowered.api.entity.living.villager.Profession;
+import org.spongepowered.api.entity.player.gamemode.GameMode;
+import org.spongepowered.api.item.CoalType;
+import org.spongepowered.api.item.CookedFish;
+import org.spongepowered.api.item.DyeColor;
+import org.spongepowered.api.item.Enchantment;
+import org.spongepowered.api.item.FireworkShape;
+import org.spongepowered.api.item.Fish;
+import org.spongepowered.api.item.GoldenApple;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.inventory.equipment.EquipmentType;
+import org.spongepowered.api.potion.PotionEffectType;
+import org.spongepowered.api.scoreboard.Visibility;
+import org.spongepowered.api.scoreboard.critieria.Criterion;
+import org.spongepowered.api.scoreboard.objective.displaymode.ObjectiveDisplayMode;
+import org.spongepowered.api.stats.Statistic;
+import org.spongepowered.api.stats.StatisticFormat;
+import org.spongepowered.api.stats.StatisticGroup;
+import org.spongepowered.api.stats.achievement.Achievement;
+import org.spongepowered.api.text.chat.ChatType;
+import org.spongepowered.api.text.format.TextColor;
+import org.spongepowered.api.text.selector.SelectorType;
+import org.spongepowered.api.util.rotation.Rotation;
+import org.spongepowered.api.world.DimensionType;
+import org.spongepowered.api.world.GeneratorType;
+import org.spongepowered.api.world.biome.BiomeType;
+import org.spongepowered.api.world.difficulty.Difficulty;
+import org.spongepowered.api.world.weather.Weather;
+
+/**
+ * Enumeration of all known {@link CatalogType}s for autocompletion when using the
+ * {@link GameRegistry#getType(Class, String)} and {@link
+ * GameRegistry#getAllOf(Class)}.
+ */
+public final class CatalogTypes {
+
+    public static final Class<Achievement> ACHIEVEMENT = Achievement.class;
+    public static final Class<Art> ART = Art.class;
+    public static final Class<Attribute> ATTRIBUTE = Attribute.class;
+    public static final Class<BannerPatternShape> BANNER_PATTERN_SHAPE = BannerPatternShape.class;
+    public static final Class<BiomeType> BIOME_TYPE = BiomeType.class;
+    public static final Class<BlockType> BLOCK_TYPE = BlockType.class;
+    public static final Class<Career> CAREER = Career.class;
+    public static final Class<ChatType> CHAT_TYPE = ChatType.class;
+    public static final Class<CoalType> COAL_TYPE = CoalType.class;
+    public static final Class<CookedFish> COOKED_FISH = CookedFish.class;
+    public static final Class<Criterion> CRITERION = Criterion.class;
+    public static final Class<Difficulty> DIFFICULTY = Difficulty.class;
+    public static final Class<DimensionType> DIMENSION_TYPE = DimensionType.class;
+    public static final Class<DyeColor> DYE_COLOR = DyeColor.class;
+    public static final Class<Enchantment> ENCHANTMENT = Enchantment.class;
+    public static final Class<EntityInteractionType> ENTITY_INTERACTION_TYPE = EntityInteractionType.class;
+    public static final Class<EntityType> ENTITY_TYPE = EntityType.class;
+    public static final Class<EquipmentType> EQUIPMENT_TYPE = EquipmentType.class;
+    public static final Class<FireworkShape> FIREWORK_SHAPE = FireworkShape.class;
+    public static final Class<Fish> FISH = Fish.class;
+    public static final Class<GameMode> GAME_MODE = GameMode.class;
+    public static final Class<GeneratorType> GENERATOR_TYPE = GeneratorType.class;
+    public static final Class<GoldenApple> GOLDEN_APPLE = GoldenApple.class;
+    public static final Class<HorseColor> HORSE_COLOR = HorseColor.class;
+    public static final Class<HorseStyle> HORSE_STYLE = HorseStyle.class;
+    public static final Class<HorseVariant> HORSE_VARIANT = HorseVariant.class;
+    public static final Class<ItemType> ITEM_TYPE = ItemType.class;
+    public static final Class<ObjectiveDisplayMode> OBJECTIVE_DISPLAY_MODE = ObjectiveDisplayMode.class;
+    public static final Class<OcelotType> OCELOT_TYPE = OcelotType.class;
+    public static final Class<Operation> OPERATION = Operation.class;
+    public static final Class<ParticleType> PARTICLE_TYPE = ParticleType.class;
+    public static final Class<PotionEffectType> POTION_EFFECT_TYPE = PotionEffectType.class;
+    public static final Class<Profession> PROFESSION = Profession.class;
+    public static final Class<RabbitType> RABBIT_TYPE = RabbitType.class;
+    public static final Class<Rotation> ROTATION = Rotation.class;
+    public static final Class<SelectorType> SELECTOR_TYPE = SelectorType.class;
+    public static final Class<SkeletonType> SKELETON_TYPE = SkeletonType.class;
+    public static final Class<SoundType> SOUND_TYPE = SoundType.class;
+    public static final Class<Statistic> STATISTIC = Statistic.class;
+    public static final Class<StatisticFormat> STATISTIC_FORMAT = StatisticFormat.class;
+    public static final Class<StatisticGroup> STATISTIC_GROUP = StatisticGroup.class;
+    public static final Class<TextColor> TEXT_COLOR = TextColor.class;
+    public static final Class<TileEntityType> TILE_ENTITY_TYPE = TileEntityType.class;
+    public static final Class<Visibility> VISIBILITY = Visibility.class;
+    public static final Class<Weather> WEATHER = Weather.class;
+
+    private CatalogTypes() {
+    }
+}

--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -26,78 +26,30 @@
 package org.spongepowered.api;
 
 import com.google.common.base.Optional;
-import org.spongepowered.api.attribute.Attribute;
-import org.spongepowered.api.attribute.AttributeBuilder;
 import org.spongepowered.api.attribute.AttributeCalculator;
-import org.spongepowered.api.attribute.AttributeModifierBuilder;
-import org.spongepowered.api.attribute.Operation;
 import org.spongepowered.api.block.BlockType;
-import org.spongepowered.api.block.tile.TileEntityType;
-import org.spongepowered.api.block.tile.data.BannerPatternShape;
-import org.spongepowered.api.block.tile.data.NotePitch;
-import org.spongepowered.api.block.tile.data.SkullType;
 import org.spongepowered.api.effect.particle.ParticleEffectBuilder;
 import org.spongepowered.api.effect.particle.ParticleType;
-import org.spongepowered.api.effect.sound.SoundType;
-import org.spongepowered.api.entity.EntityInteractionType;
 import org.spongepowered.api.entity.EntityType;
-import org.spongepowered.api.entity.hanging.art.Art;
-import org.spongepowered.api.entity.living.animal.HorseColor;
-import org.spongepowered.api.entity.living.animal.HorseStyle;
-import org.spongepowered.api.entity.living.animal.HorseVariant;
-import org.spongepowered.api.entity.living.animal.OcelotType;
-import org.spongepowered.api.entity.living.animal.RabbitType;
-import org.spongepowered.api.entity.living.monster.SkeletonType;
 import org.spongepowered.api.entity.living.villager.Career;
 import org.spongepowered.api.entity.living.villager.Profession;
-import org.spongepowered.api.entity.player.gamemode.GameMode;
-import org.spongepowered.api.item.CoalType;
-import org.spongepowered.api.item.CookedFish;
-import org.spongepowered.api.item.DyeColor;
-import org.spongepowered.api.item.Enchantment;
-import org.spongepowered.api.item.FireworkEffectBuilder;
-import org.spongepowered.api.item.Fish;
-import org.spongepowered.api.item.GoldenApple;
 import org.spongepowered.api.item.ItemType;
-import org.spongepowered.api.item.inventory.ItemStackBuilder;
-import org.spongepowered.api.item.merchant.TradeOfferBuilder;
 import org.spongepowered.api.item.recipe.RecipeRegistry;
 import org.spongepowered.api.plugin.PluginContainer;
-import org.spongepowered.api.potion.PotionEffectBuilder;
-import org.spongepowered.api.potion.PotionEffectType;
 import org.spongepowered.api.resourcepack.ResourcePack;
-import org.spongepowered.api.scoreboard.ScoreboardBuilder;
-import org.spongepowered.api.scoreboard.TeamBuilder;
-import org.spongepowered.api.scoreboard.Visibility;
-import org.spongepowered.api.scoreboard.critieria.Criterion;
 import org.spongepowered.api.scoreboard.displayslot.DisplaySlot;
-import org.spongepowered.api.scoreboard.objective.ObjectiveBuilder;
-import org.spongepowered.api.scoreboard.objective.displaymode.ObjectiveDisplayMode;
 import org.spongepowered.api.stats.BlockStatistic;
 import org.spongepowered.api.stats.EntityStatistic;
 import org.spongepowered.api.stats.ItemStatistic;
 import org.spongepowered.api.stats.Statistic;
-import org.spongepowered.api.stats.StatisticBuilder;
-import org.spongepowered.api.stats.StatisticFormat;
 import org.spongepowered.api.stats.StatisticGroup;
 import org.spongepowered.api.stats.TeamStatistic;
-import org.spongepowered.api.stats.achievement.Achievement;
-import org.spongepowered.api.stats.achievement.AchievementBuilder;
 import org.spongepowered.api.status.Favicon;
-import org.spongepowered.api.text.chat.ChatType;
 import org.spongepowered.api.text.format.TextColor;
-import org.spongepowered.api.text.format.TextStyle;
-import org.spongepowered.api.text.selector.ArgumentType;
-import org.spongepowered.api.text.selector.SelectorType;
-import org.spongepowered.api.text.translation.Translation;
 import org.spongepowered.api.util.rotation.Rotation;
-import org.spongepowered.api.world.DimensionType;
-import org.spongepowered.api.world.GeneratorType;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.WorldBuilder;
 import org.spongepowered.api.world.WorldCreationSettings;
-import org.spongepowered.api.world.biome.BiomeType;
-import org.spongepowered.api.world.difficulty.Difficulty;
 import org.spongepowered.api.world.gen.WorldGeneratorModifier;
 import org.spongepowered.api.world.storage.WorldProperties;
 
@@ -108,7 +60,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Collection;
-import java.util.Locale;
 import java.util.UUID;
 
 /**
@@ -126,121 +77,44 @@ import java.util.UUID;
 public interface GameRegistry {
 
     /**
-     * Gets a {@link BlockType} by its identifier.
+     * Attempts to retrieve the specific type of {@link CatalogType} based on
+     * the string id given.
      *
-     * @param id The id to look up
-     * @return The block or Optional.absent() if not found
+     * <p>Some types may not be available for various reasons including but not
+     * restricted to: mods adding custom types, plugins providing custom types,
+     * game version changes.</p>
+     *
+     * @param typeClass The class of the type of {@link CatalogType}
+     * @param id The string id of the catalog type
+     * @param <T> The type of catalog type
+     * @return The found catalog type, if available
      */
-    Optional<BlockType> getBlock(String id);
+    <T extends CatalogType> Optional<T> getType(Class<T> typeClass, String id);
 
     /**
-     * Gets a collection of all available {@link BlockType}s.
+     * Gets a collection of all available found specific types of {@link
+     * CatalogType} requested.
      *
-     * @return A collection containing all block types in registry
+     * <p>The presented {@link CatalogType}s may not exist in default catalogs
+     * due to various reasons including but not restricted to: mods, plugins,
+     * game changes.</p>
+     *
+     * @param typeClass The class of {@link CatalogType}
+     * @param <T> The type of {@link CatalogType}
+     * @return A collection of all known types of the requested catalog type
      */
-    Collection<BlockType> getBlocks();
+    <T extends CatalogType> Collection<? extends T> getAllOf(Class<T> typeClass);
 
     /**
-     * Gets an {@link ItemType} by its identifier.
+     * Gets a builder of the desired class type, examples may include:
+     * {@link org.spongepowered.api.attribute.AttributeBuilder},
+     * {@link org.spongepowered.api.item.FireworkEffectBuilder}, etc.
      *
-     * @param id The id to look up
-     * @return The item or Optional.absent() if not found
+     * @param builderClass The class of the builder
+     * @param <T> The type of builder
+     * @return The builder, if available
      */
-    Optional<ItemType> getItem(String id);
-
-    /**
-     * Gets a collection of all available {@link ItemType}s.
-     *
-     * @return A collection containing all item types in registry
-     */
-    Collection<ItemType> getItems();
-
-    /**
-     * Gets a {@link TileEntityType} by its identifier.
-     *
-     * @param id The id to look up
-     * @return The tile entity type or Optional.absent() if not found
-     */
-    Optional<TileEntityType> getTileEntityType(String id);
-
-    /**
-     * Gets a collection of all available {@link TileEntityType}s.
-     *
-     * @return A collection containing all tile entity types in registry
-     */
-    Collection<TileEntityType> getTileEntityTypes();
-
-    /**
-     * Gets a {@link BiomeType} by its identifier.
-     *
-     * @param id The id to look up
-     * @return The biome or Optional.absent() if not found
-     */
-    Optional<BiomeType> getBiome(String id);
-
-    /**
-     * Gets a collection of all available {@link BiomeType}s.
-     *
-     * @return A collection containing all biome types
-     */
-    Collection<BiomeType> getBiomes();
-
-    /**
-     * Get an item stack builder.
-     *
-     * @return The item stack builder
-     */
-    ItemStackBuilder getItemBuilder();
-
-    /**
-     * Get a trade offer builder.
-     *
-     * @return The trade offer builder
-     */
-    TradeOfferBuilder getTradeOfferBuilder();
-
-    /**
-     * Get a potion effect builder.
-     *
-     * @return The potion effect builder
-     */
-    PotionEffectBuilder getPotionEffectBuilder();
-
-    /**
-     * Get an objective builder.
-     *
-     * @return The objective builder
-     */
-    ObjectiveBuilder getObjectiveBuilder();
-
-    /**
-     * Get a team builder.
-     *
-     * @return The team builder
-     */
-    TeamBuilder getTeamBuilder();
-
-    /**
-     * Gets a scoreboard builder.
-     *
-     * @return The scoreboard builder
-     */
-    ScoreboardBuilder getScoreboardBuilder();
-
-    /**
-     * Gets a {@link ParticleType} by name.
-     *
-     * @param name The particle name
-     * @return The corresponding particle or Optional.absent() if not found
-     */
-    Optional<ParticleType> getParticleType(String name);
-
-    /**
-     * Gets a collection of all available {@link ParticleType}s.
-     *
-     * @return A collection containing all particle types in registry
-     */
-    Collection<ParticleType> getParticleTypes();
+    <T> Optional<T> getBuilderOf(Class<T> builderClass);
 
     /**
      * Gets a new particle builder for the {@link ParticleType}.
@@ -251,171 +125,6 @@ public interface GameRegistry {
     ParticleEffectBuilder getParticleEffectBuilder(ParticleType particle);
 
     /**
-     * Gets a {@link SoundType} by name.
-     *
-     * @param name The sound name
-     * @return The sound or Optional.absent() if not found
-     */
-    Optional<SoundType> getSound(String name);
-
-    /**
-     * Gets a collection of all known {@link SoundType}s.
-     *
-     * @return A collection containing all sounds in the registry
-     */
-    Collection<SoundType> getSounds();
-
-    /**
-     * Gets an {@link EntityType} by its identifier.
-     *
-     * @param id The id to look up
-     * @return The entity type or Optional.absent() if not found
-     */
-    Optional<EntityType> getEntity(String id);
-
-    /**
-     * Gets a collection of all available {@link EntityType}s.
-     *
-     * @return A collection containing all entity types in registry
-     */
-    Collection<EntityType> getEntities();
-
-    /**
-     * Gets an {@link Art} by its identifier.
-     *
-     * @param id The id to look up
-     * @return The art piece or Optional.absent() if not found
-     */
-    Optional<Art> getArt(String id);
-
-    /**
-     * Gets a collection of all available {@link Art} pieces.
-     *
-     * @return A collection of all available art pieces
-     */
-    Collection<Art> getArts();
-
-    /**
-     * Gets a {@link DyeColor} by its identifier.
-     *
-     * @param id The id to look up
-     * @return The dye color or Optional.absent() if not found
-     */
-    Optional<DyeColor> getDye(String id);
-
-    /**
-     * Gets a collection of all available {@link DyeColor}s.
-     *
-     * @return A collection containing all dyes in registry
-     */
-    Collection<DyeColor> getDyes();
-
-    /**
-     * Gets a {@link HorseColor} by its identifier.
-     *
-     * @param id The id to look up
-     * @return The horse color or Optional.absent() if not found
-     */
-    Optional<HorseColor> getHorseColor(String id);
-
-    /**
-     * Gets a collection of all available {@link HorseColor}s.
-     *
-     * @return A collection containing all horse colors in registry
-     */
-    Collection<HorseColor> getHorseColors();
-
-    /**
-     * Gets a {@link HorseStyle} by its identifier.
-     *
-     * @param id The id to look up
-     * @return The horse style or Optional.absent() if not found
-     */
-    Optional<HorseStyle> getHorseStyle(String id);
-
-    /**
-     * Gets a collection of all available {@link HorseStyle}s.
-     *
-     * @return A collection containing all horse styles in registry
-     */
-    Collection<HorseStyle> getHorseStyles();
-
-    /**
-     * Gets a {@link HorseVariant} by its identifier.
-     *
-     * @param id The id to look up
-     * @return The horse variant or Optional.absent() if not found
-     */
-    Optional<HorseVariant> getHorseVariant(String id);
-
-    /**
-     * Gets a collection of all available {@link HorseVariant}s.
-     *
-     * @return A collection containing all horse variants in registry
-     */
-    Collection<HorseVariant> getHorseVariants();
-
-    /**
-     * Gets an {@link OcelotType} by its identifier.
-     *
-     * @param id The id to look up
-     * @return The ocelot type or Optional.absent() if not found
-     */
-    Optional<OcelotType> getOcelotType(String id);
-
-    /**
-     * Gets a collection of all available {@link OcelotType}s.
-     *
-     * @return A collection containing all ocelot types in registry
-     */
-    Collection<OcelotType> getOcelotTypes();
-
-    /**
-     * Gets a {@link RabbitType} by its identifier.
-     *
-     * @param id The id to look up
-     * @return The rabbit type or Optional.absent() if not found
-     */
-    Optional<RabbitType> getRabbitType(String id);
-
-    /**
-     * Gets a collection of all available {@link RabbitType}s.
-     *
-     * @return A collection containing all rabbit types in registry
-     */
-    Collection<RabbitType> getRabbitTypes();
-
-    /**
-     * Gets a {@link SkeletonType} by its identifier.
-     *
-     * @param id The id to look up
-     * @return The skeleton type or Optional.absent() if not found
-     */
-    Optional<SkeletonType> getSkeletonType(String id);
-
-    /**
-     * Gets a collection of all available {@link SkeletonType}s.
-     *
-     * @return A collection containing all skeleton types in registry
-     */
-    Collection<SkeletonType> getSkeletonTypes();
-
-    /**
-     * Gets the villager {@link Career} with the specified id.
-     *
-     * @param id The id of the career to return
-     * @return The career with the given id or Optional.absent() if not found
-     */
-    Optional<Career> getCareer(String id);
-
-    /**
-     * Gets all available villager {@link Career}s.
-     *
-     * @return A collection of all villager careers
-     */
-    Collection<Career> getCareers();
-
-    /**
      * Gets all available villager {@link Career}s for the given profession.
      *
      * @param profession The villager profession to collection careers from
@@ -424,65 +133,11 @@ public interface GameRegistry {
     Collection<Career> getCareers(Profession profession);
 
     /**
-     * Gets the villager {@link Profession} with the specified id.
-     *
-     * @param id The id of the profession to return
-     * @return The profession with the given id or Optional.absent() if not found
-     */
-    Optional<Profession> getProfession(String id);
-
-    /**
-     * Gets all available villager {@link Profession}s.
-     *
-     * @return A collection of all villager professions
-     */
-    Collection<Profession> getProfessions();
-
-    /**
-     * Gets a collection of all available {@link GameMode}s.
-     *
-     * @return A collection containing all game modes in registry
-     */
-    // TODO: GameMode from string? Should add 'String getId()' to GameMode if so.
-    Collection<GameMode> getGameModes();
-
-    /**
-     * Gets a collection of all available {@link PotionEffectType}s.
-     *
-     * @return A collection containing all potion effect types in registry
-     */
-    // TODO: PotionEffectType from string? Should add 'String getId()' to PotionEffectType if so.
-    Collection<PotionEffectType> getPotionEffects();
-
-    /**
-     * Gets the {@link Enchantment} with the specified id.
-     *
-     * @param id The id of the enchantment to return
-     * @return The enchantment with the given id or Optional.absent() if not found
-     */
-    Optional<Enchantment> getEnchantment(String id);
-
-    /**
-     * Gets all available {@link Enchantment}s.
-     *
-     * @return A collection of all enchantments
-     */
-    Collection<Enchantment> getEnchantments();
-
-    /**
      * Gets a {@link Collection} of the default GameRules.
      *
      * @return The default GameRules.
      */
     Collection<String> getDefaultGameRules();
-
-    /**
-     * Gets the {@link Statistic} with the specified internal name.
-     *
-     * @param name The name of the statistic to return
-     * @return The statistic or Optional.absent() if not found
-     */
-    Optional<Statistic> getStatistic(String name);
 
     /**
      * Gets the {@link Statistic} for the given {@link StatisticGroup} and
@@ -542,115 +197,11 @@ public interface GameRegistry {
     Collection<Statistic> getStatistics(StatisticGroup statisticGroup);
 
     /**
-     * Gets a collection of all available {@link Statistic}s.
-     *
-     * @return An immutable collection containing all registered statistics
-     */
-    Collection<Statistic> getStatistics();
-
-    /**
-     * Creates a new {@link StatisticBuilder} which may be used to create custom
-     * {@link Statistic}s.
-     *
-     * @return The newly created simple statistic builder
-     */
-    StatisticBuilder getStatisticBuilder();
-
-    /**
-     * Creates a new
-     * {@link org.spongepowered.api.stats.StatisticBuilder.EntityStatisticBuilder}
-     * which may be used to create custom {@link EntityStatistic}s.
-     *
-     * @return The newly created entity statistic builder
-     */
-    StatisticBuilder.EntityStatisticBuilder getEntityStatisticBuilder();
-
-    /**
-     * Creates a new
-     * {@link org.spongepowered.api.stats.StatisticBuilder.BlockStatisticBuilder}
-     * which may be used to create custom {@link BlockStatistic}s.
-     *
-     * @return The newly created block statistic builder
-     */
-    StatisticBuilder.BlockStatisticBuilder getBlockStatisticBuilder();
-
-    /**
-     * Creates a new
-     * {@link org.spongepowered.api.stats.StatisticBuilder.ItemStatisticBuilder}
-     * which may be used to create custom {@link ItemStatistic}s.
-     *
-     * @return The newly created item statistic builder
-     */
-    StatisticBuilder.ItemStatisticBuilder getItemStatisticBuilder();
-
-    /**
-     * Creates a new
-     * {@link org.spongepowered.api.stats.StatisticBuilder.TeamStatisticBuilder}
-     * which may be used to create custom {@link TeamStatistic}s.
-     *
-     * @return The newly created team statistic builder
-     */
-    StatisticBuilder.TeamStatisticBuilder getTeamStatisticBuilder();
-
-    /**
      * Registers a custom statistic.
      *
      * @param stat The custom statistic
      */
     void registerStatistic(Statistic stat);
-
-    /**
-     * Gets the {@link StatisticFormat} with the specified name.
-     *
-     * @param name The name of the statistic format to return
-     * @return The format or Optional.absent() if not found
-     */
-    Optional<StatisticFormat> getStatisticFormat(String name);
-
-    /**
-     * Gets a collection of all available {@link StatisticFormat}s.
-     *
-     * @return An immutable collection containing all available formats
-     */
-    Collection<StatisticFormat> getStatisticFormats();
-
-    /**
-     * Gets the {@link Achievement} with the specified internal name.
-     *
-     * @param name The name of the achievement
-     * @return The achievement or Optional.absent() if not found
-     */
-    Optional<Achievement> getAchievement(String name);
-
-    /**
-     * Gets a collection of all available {@link Achievement}s.
-     *
-     * @return An immutable collection containing all available achievements
-     */
-    Collection<Achievement> getAchievements();
-
-    /**
-     * Creates a new {@link AchievementBuilder} which may be used to create
-     * custom {@link Achievement}s.
-     *
-     * @return The newly created achievement builder
-     */
-    AchievementBuilder getAchievementBuilder();
-
-    /**
-     * Gets the {@link DimensionType} with the provided name.
-     *
-     * @param name The name of the dimension type
-     * @return The {@link DimensionType} with the given name or Optional.absent() if not found
-     */
-    Optional<DimensionType> getDimensionType(String name);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link DimensionType}s.
-     *
-     * @return The collection of all available {@link DimensionType}s
-     */
-    Collection<DimensionType> getDimensionTypes();
 
     /**
      * Gets the {@link Rotation} with the provided degrees.
@@ -659,15 +210,6 @@ public interface GameRegistry {
      * @return The {@link Rotation} with the given degrees or Optional.absent() if not found
      */
     Optional<Rotation> getRotationFromDegree(int degrees);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link Rotation}s.
-     *
-     * @return The collection of all available {@link Rotation}s
-     */
-    Collection<Rotation> getRotations();
-
-    // TODO: Find a better place for these methods
 
     /**
      * Creates a new {@link GameProfile} using the specified unique identifier and name.
@@ -726,59 +268,6 @@ public interface GameRegistry {
     Favicon loadFavicon(BufferedImage image) throws IOException;
 
     /**
-     * Gets the {@link NotePitch} with the provided name.
-     *
-     * @param name The name of the note pitch
-     * @return The {@link NotePitch} with the given name or Optional.absent() if not found
-     */
-    Optional<NotePitch> getNotePitch(String name);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link NotePitch}s.
-     *
-     * @return The collection of all available {@link NotePitch}s
-     */
-    Collection<NotePitch> getNotePitches();
-
-    /**
-     * Gets the {@link SkullType} with the provided name.
-     *
-     * @param name The name of the skull type
-     * @return The {@link SkullType} with the given name or Optional.absent() if not found
-     */
-    Optional<SkullType> getSkullType(String name);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link SkullType}s.
-     *
-     * @return The collection of all available {@link SkullType}s
-     */
-    Collection<SkullType> getSkullTypes();
-
-    /**
-     * Gets the {@link BannerPatternShape} with the provided name.
-     *
-     * @param name The name of the BannerPatternShape
-     * @return The {@link BannerPatternShape} with the given name or Optional.absent() if not found
-     */
-    Optional<BannerPatternShape> getBannerPatternShape(String name);
-
-    /**
-     * Gets the {@link BannerPatternShape} with the provided name.
-     *
-     * @param id The id of the BannerPatternShape
-     * @return The {@link BannerPatternShape} with the given name or Optional.absent() if not found
-     */
-    Optional<BannerPatternShape> getBannerPatternShapeById(String id);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link BannerPatternShape}s.
-     *
-     * @return The collection of all available {@link BannerPatternShape}s
-     */
-    Collection<BannerPatternShape> getBannerPatternShapes();
-
-    /**
      * Retrieves the GameDictionary (item dictionary) for this GameRegistry.
      *
      * @return The item dictionary
@@ -793,260 +282,11 @@ public interface GameRegistry {
     RecipeRegistry getRecipeRegistry();
 
     /**
-     * Gets a collection of all available {@link Difficulty}s.
-     *
-     * @return A collection containing all Difficulties in registry
-     */
-    Collection<Difficulty> getDifficulties();
-
-    /**
-     * Gets a {@link Difficulty} by name.
-     *
-     * @param name The name of the difficulty
-     * @return The difficulty with that name, or {@link Optional#absent()}
-     */
-    Optional<Difficulty> getDifficulty(String name);
-
-    /**
-     * Gets a collection of all available {@link EntityInteractionType}s.
-     *
-     * @return A collection of all available {@link EntityInteractionType}s
-     */
-    Collection<EntityInteractionType> getEntityInteractionTypes();
-
-    /**
-     * Gets an {@link EntityInteractionType} by name.
-     *
-     * @param name The name of the {@link EntityInteractionType}
-     * @return The {@link EntityInteractionType} with that name, or {@link Optional#absent()}
-     */
-    Optional<EntityInteractionType> getEntityInteractionType(String name);
-
-    /**
-     * Gets an {@link Attribute} by name.
-     *
-     * @param name The name of the Attribute
-     * @return The {@link Attribute} with the given name or
-     *         {@link Optional#absent()} if not found
-     */
-    Optional<Attribute> getAttribute(String name);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link Attribute}s.
-     *
-     * @return The collection of all available {@link Attribute}s
-     */
-    Collection<Attribute> getAttributes();
-
-    /**
-     * Gets an {@link Operation} by name.
-     *
-     * @param name The name of the Operation
-     * @return The {@link Operation} with the given name or
-     *         {@link Optional#absent()} if not found
-     */
-    Optional<Operation> getOperation(String name);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link Operation}s.
-     *
-     * @return The collection of all available {@link Operation}s
-     */
-    Collection<Operation> getOperations();
-
-    /**
-     * Gets a new {@link AttributeModifierBuilder}.
-     *
-     * @return A new AttributeModifierBuilder
-     */
-    AttributeModifierBuilder getAttributeModifierBuilder();
-
-    /**
      * Gets the {@link AttributeCalculator}.
      *
      * @return The {@link AttributeCalculator}
      */
     AttributeCalculator getAttributeCalculator();
-
-    /**
-     * Gets a new {@link AttributeBuilder}.
-     *
-     * @return A new AttributeBuilder
-     */
-    AttributeBuilder getAttributeBuilder();
-
-    /**
-     * Gets a {@link CoalType} by name.
-     *
-     * @param name The name of the coal type
-     * @return The coal type or Optional.absent() if not found
-     */
-    Optional<CoalType> getCoalType(String name);
-
-    /**
-     * Gets a collection of all available {@link CoalType}s.
-     *
-     * @return A collection of all coal types
-     */
-    Collection<CoalType> getCoalTypes();
-
-    /**
-     * Gets a {@link Fish} by name.
-     *
-     * @param name The name of the fish type
-     * @return The fish type or Optional.absent() if not found
-     */
-    Optional<Fish> getFishType(String name);
-
-    /**
-     * Gets a collection of all available {@link Fish} types.
-     *
-     * @return A collection of all fish types
-     */
-    Collection<Fish> getFishTypes();
-
-    /**
-     * Gets a {@link CookedFish} by name.
-     *
-     * @param name The name of the cooked fish type
-     * @return The cooked fish type or Optional.absent() if not found
-     */
-    Optional<CookedFish> getCookedFishType(String name);
-
-    /**
-     * Gets a collection of all available {@link CookedFish}s.
-     *
-     * @return A collection of all cooked fish types
-     */
-    Collection<CookedFish> getCookedFishTypes();
-
-    /**
-     * Gets a {@link GoldenApple} by name.
-     *
-     * @param name The name of the golden apple type
-     * @return The golden apple type or Optional.absent() if not found
-     */
-    Optional<GoldenApple> getGoldenAppleType(String name);
-
-    /**
-     * Gets a collection of all available {@link GoldenApple}s.
-     *
-     * @return A collection of all golden apple types
-     */
-    Collection<GoldenApple> getGoldenAppleTypes();
-
-    /**
-     * Gets a new {@link FireworkEffectBuilder}.
-     *
-     * @return A new firework effect builder
-     */
-    FireworkEffectBuilder getFireworkEffectBuilder();
-
-    /**
-     * Gets the {@link TextColor} with the provided name.
-     *
-     * @param name The name of the text color
-     * @return The {@link TextColor} with the given name or Optional.absent() if not found
-     */
-    Optional<TextColor> getTextColor(String name);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link TextColor}s.
-     *
-     * @return The collection of all available {@link TextColor}s
-     */
-    Collection<TextColor> getTextColors();
-
-    /**
-     * Gets the {@link TextStyle} with the provided name.
-     *
-     * @param name The name of the text style
-     * @return The {@link TextStyle} with the given name or Optional.absent() if not found
-     */
-    Optional<TextStyle> getTextStyle(String name);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link TextStyle}s.
-     *
-     * @return The collection of all available {@link TextStyle}s
-     */
-    Collection<TextStyle> getTextStyles();
-
-    /**
-     * Gets the {@link ChatType} with the provided name.
-     *
-     * @param name The name of the chat type
-     * @return The {@link ChatType} with the given name or Optional.absent() if not found
-     */
-    Optional<ChatType> getChatType(String name);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link TextStyle}s.
-     *
-     * @return The collection of all available {@link TextStyle}s
-     */
-    Collection<ChatType> getChatTypes();
-
-    /**
-     * Gets the {@link SelectorType} with the provided name.
-     *
-     * @param name The name of the selector type
-     * @return The {@link SelectorType} with the given name or Optional.absent() if not found
-     */
-    Optional<SelectorType> getSelectorType(String name);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link SelectorType}s.
-     *
-     * @return The list of all available {@link SelectorType}s
-     */
-    Collection<SelectorType> getSelectorTypes();
-
-    /**
-     * Gets the {@link ArgumentType} with the provided name.
-     *
-     * @param name The name of the argument type
-     * @return The {@link ArgumentType} with the given name or Optional.absent() if not found
-     */
-    Optional<ArgumentType<?>> getArgumentType(String name);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link ArgumentType}s.
-     *
-     * @return The list of all available {@link ArgumentType}s
-     */
-    Collection<ArgumentType<?>> getArgumentTypes();
-
-    /**
-     * Gets the {@link Locale} with the provided name.
-     *
-     * @param name The name of the locale
-     * @return The {@link Locale} with the given name or Optional.absent() if not found
-     */
-    Optional<Locale> getLocale(String name);
-
-    /**
-     * Gets the {@link Locale} with the provided ID.
-     *
-     * @param id The ID of the locale
-     * @return The {@link Locale} with the given ID or Optional.absent() if not found
-     */
-    Optional<Locale> getLocaleById(String id);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link Locale}s.
-     *
-     * @return The collection of all available {@link Locale}s
-     */
-    Collection<Locale> getLocales();
-
-    /**
-     * Gets the {@link Translation} with the provided ID.
-     *
-     * @param id The ID of the translation
-     * @return The {@link Translation} with the given ID or Optional.absent() if not found
-     */
-    Optional<Translation> getTranslationById(String id);
 
     /**
      * Gets a {@link ResourcePack} that's already been created by its ID.
@@ -1058,14 +298,6 @@ public interface GameRegistry {
     Optional<ResourcePack> getById(String id);
 
     /**
-     * Gets the {@link DisplaySlot} with the provided name.
-     *
-     * @param name The name of the {@link DisplaySlot}
-     * @return The {@link DisplaySlot} with the given name, if available
-     */
-    Optional<DisplaySlot> getDisplaySlot(String name);
-
-    /**
      * Gets a {@link DisplaySlot} which displays only for teams
      * with the provided color.
      *
@@ -1073,120 +305,6 @@ public interface GameRegistry {
      * @return The {@link DisplaySlot} with the provided color, or Optional.absent() if not found
      */
     Optional<DisplaySlot> getDisplaySlotForColor(TextColor color);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link DisplaySlot}s.
-     *
-     * <p>This includes {@link DisplaySlot}s for all possible {@link TextColor}s.</p>
-     *
-     * @return The Collection of all available {@link DisplaySlot}s
-     */
-    Collection<DisplaySlot> getDisplaySlots();
-
-    /**
-     * Gets the {@link Visibility} with the provided name.
-     *
-     * @param name The name of the {@link Visibility}
-     * @return The {@link Visibility} with the given name, if available
-     */
-    Optional<Visibility> getVisibility(String name);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link Visibility Visibilities}.
-     *
-     * @return The Collection of all available {@link Visibility Visibilities}
-     */
-    Collection<Visibility> getVisibilities();
-
-    /**
-     * Gets the {@link Criterion} with the provided name.
-     *
-     * @param name The name of the {@link Criterion}
-     * @return The {@link Criterion} with the given name, if available
-     */
-    Optional<Criterion> getCriterion(String name);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link Criterion Criteria}.
-     *
-     * @return The Collection of all available {@link Criterion Criteria}
-     */
-    Collection<Criterion> getCriteria();
-
-    /**
-     * Gets the {@link ObjectiveDisplayMode} with the provided name.
-     *
-     * @param name The name of the {@link ObjectiveDisplayMode}
-     * @return The {@link ObjectiveDisplayMode} with the given name, if available
-     */
-    Optional<ObjectiveDisplayMode> getObjectiveDisplayMode(String name);
-
-    /**
-     * Gets a {@link Collection} of all possible {@link ObjectiveDisplayMode}s.
-     *
-     * @return The Collection of all available {@link ObjectiveDisplayMode}s
-     */
-    Collection<ObjectiveDisplayMode> getObjectiveDisplayModes();
-
-    /**
-     * Gets a new {@link WorldBuilder} for creating {@link World}s or
-     * {@link WorldCreationSettings}s.
-     * 
-     * @return A new builder
-     */
-    WorldBuilder getWorldBuilder();
-
-    /**
-     * Gets a new {@link WorldBuilder} for creating {@link World}s or
-     * {@link WorldCreationSettings}s, the builder is then seeded with the
-     * values from the given WorldCreationSettings object.
-     * 
-     * @param settings The seed settings
-     * @return A new seeded builder
-     */
-    WorldBuilder getWorldBuilder(WorldCreationSettings settings);
-
-    /**
-     * Gets a new {@link WorldBuilder} for creating {@link World}s or
-     * {@link WorldCreationSettings}s, the builder is then seeded with the
-     * values from the given WorldProperties object.
-     * 
-     * @param properties The seed properties
-     * @return A new seeded builder
-     */
-    WorldBuilder getWorldBuilder(WorldProperties properties);
-
-    /**
-     * Gets a {@link GeneratorType} by name.
-     * 
-     * @param name The requested name
-     * @return The generator type, if available
-     */
-    Optional<GeneratorType> getGeneratorType(String name);
-
-    /**
-     * Gets a collection of all available {@link GeneratorType}s.
-     * 
-     * @return All available world types
-     */
-    Collection<GeneratorType> getGeneratorTypes();
-
-    /**
-     * Gets the {@link WorldGeneratorModifier} with the provided ID.
-     *
-     * @param id The ID of the world generator
-     *
-     * @return The {@link WorldGeneratorModifier} with the given ID or
-     *         Optional.absent() if not found
-     */
-    Optional<WorldGeneratorModifier> getWorldGeneratorModifier(String id);
-
-    /**
-     * Gets a {@link Collection} of all known {@link WorldGeneratorModifier}s.
-     *
-     * @return The collection of all known {@link WorldGeneratorModifier}s
-     */
-    Collection<WorldGeneratorModifier> getWorldGeneratorModifiers();
 
     /**
      * Registers a {@link WorldGeneratorModifier}, so that the server is able to

--- a/src/main/java/org/spongepowered/api/Server.java
+++ b/src/main/java/org/spongepowered/api/Server.java
@@ -31,6 +31,7 @@ import org.spongepowered.api.net.ChannelRegistrar;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.command.source.ConsoleSource;
 import org.spongepowered.api.world.World;
+import org.spongepowered.api.world.WorldBuilder;
 import org.spongepowered.api.world.WorldCreationSettings;
 import org.spongepowered.api.world.storage.WorldProperties;
 
@@ -185,7 +186,7 @@ public interface Server extends ChannelRegistrar {
     /**
      * Creates a new world from the given {@link WorldCreationSettings}. For the
      * creation of the WorldCreationSettings please see
-     * {@link GameRegistry#getWorldBuilder()}.
+     * {@link WorldBuilder}.
      * 
      * <p>If the world already exists then the existing {@link WorldProperties}
      * are returned else a new world is created and the new WorldProperties

--- a/src/main/java/org/spongepowered/api/attribute/Attribute.java
+++ b/src/main/java/org/spongepowered/api/attribute/Attribute.java
@@ -26,6 +26,7 @@
 package org.spongepowered.api.attribute;
 
 import com.google.common.base.Predicate;
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
@@ -33,14 +34,7 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * {@link AttributeHolder}.
  */
 @CatalogedBy(Attributes.class)
-public interface Attribute {
-
-    /**
-     * Gets the name of this attribute as a string.
-     *
-     * @return The name of this attribute as a string
-     */
-    String getName();
+public interface Attribute extends CatalogType {
 
     /**
      * Gets the minimum value for this attribute.

--- a/src/main/java/org/spongepowered/api/attribute/Operation.java
+++ b/src/main/java/org/spongepowered/api/attribute/Operation.java
@@ -25,6 +25,7 @@
 
 package org.spongepowered.api.attribute;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
@@ -32,14 +33,7 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * value of an {@link Attribute}.
  */
 @CatalogedBy(Operations.class)
-public interface Operation extends Comparable<Operation> {
-
-    /**
-     * Gets the name of this operation.
-     *
-     * @return The name of this operation
-     */
-    String getName();
+public interface Operation extends CatalogType, Comparable<Operation> {
 
     /**
      * Gets the amount the {@link Attribute} should be incremented when this

--- a/src/main/java/org/spongepowered/api/block/BlockType.java
+++ b/src/main/java/org/spongepowered/api/block/BlockType.java
@@ -26,6 +26,7 @@
 package org.spongepowered.api.block;
 
 import com.google.common.base.Optional;
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.item.ItemBlock;
 import org.spongepowered.api.service.persistence.data.DataHolder;
 import org.spongepowered.api.text.translation.Translatable;
@@ -39,7 +40,7 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * via {@link DataHolder}.</p>
  */
 @CatalogedBy(BlockTypes.class)
-public interface BlockType extends Translatable {
+public interface BlockType extends CatalogType, Translatable {
 
     /**
      * Return the internal ID for the block.
@@ -50,7 +51,7 @@ public interface BlockType extends Translatable {
      *
      * @return The id
      */
-    String getId();
+    String getName();
 
     /**
      * Return the default state for this block.

--- a/src/main/java/org/spongepowered/api/block/tile/TileEntityType.java
+++ b/src/main/java/org/spongepowered/api/block/tile/TileEntityType.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.block.tile;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -31,14 +32,7 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * Describes a type of tile entity.
  */
 @CatalogedBy(TileEntityTypes.class)
-public interface TileEntityType {
-
-    /**
-     * Return the internal ID for the tile entity type.
-     *
-     * @return The id
-     */
-    String getId();
+public interface TileEntityType extends CatalogType {
 
     /**
      * Gets the type of {@link BlockType} that this {@link TileEntityType}

--- a/src/main/java/org/spongepowered/api/block/tile/data/BannerPatternShape.java
+++ b/src/main/java/org/spongepowered/api/block/tile/data/BannerPatternShape.java
@@ -24,26 +24,13 @@
  */
 package org.spongepowered.api.block.tile.data;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * A pattern shape which may be applied to a banner.
  */
 @CatalogedBy(BannerPatternShapes.class)
-public interface BannerPatternShape {
-
-    /**
-     * Gets the name of this pattern shape.
-     *
-     * @return The name
-     */
-    String getName();
-
-    /**
-     * Gets the id for this pattern shape.
-     *
-     * @return The id
-     */
-    String getId();
+public interface BannerPatternShape extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/effect/particle/ParticleType.java
+++ b/src/main/java/org/spongepowered/api/effect/particle/ParticleType.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.effect.particle;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -33,14 +34,7 @@ import java.awt.Color;
  * Represents a particle that can be sent on a Minecraft client.
  */
 @CatalogedBy(ParticleTypes.class)
-public interface ParticleType {
-
-    /**
-     * Gets the particle name.
-     *
-     * @return The particle's name
-     */
-    String getName();
+public interface ParticleType extends CatalogType {
 
     /**
      * Gets whether the particle able is to have a motion vector.

--- a/src/main/java/org/spongepowered/api/effect/sound/SoundType.java
+++ b/src/main/java/org/spongepowered/api/effect/sound/SoundType.java
@@ -24,19 +24,13 @@
  */
 package org.spongepowered.api.effect.sound;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a sound that can be heard on clients.
  */
 @CatalogedBy(SoundTypes.class)
-public interface SoundType {
-
-    /**
-     * Gets the sounds name.
-     *
-     * @return The name of this sound
-     */
-    String getName();
+public interface SoundType extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/EntityInteractionType.java
+++ b/src/main/java/org/spongepowered/api/entity/EntityInteractionType.java
@@ -24,19 +24,13 @@
  */
 package org.spongepowered.api.entity;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a method of interacting with a block or entity.
  */
 @CatalogedBy(EntityInteractionTypes.class)
-public interface EntityInteractionType {
-
-    /**
-     * Gets the name of this entity interaction type.
-     *
-     * @return The name of this entity interaction type
-     */
-    String getName();
+public interface EntityInteractionType extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/EntityType.java
+++ b/src/main/java/org/spongepowered/api/entity/EntityType.java
@@ -25,6 +25,7 @@
 
 package org.spongepowered.api.entity;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -32,14 +33,7 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * Describes a type of entity.
  */
 @CatalogedBy(EntityTypes.class)
-public interface EntityType extends Translatable {
-
-    /**
-     * Return the internal ID for the entity type.
-     *
-     * @return The id
-     */
-    String getId();
+public interface EntityType extends CatalogType, Translatable {
 
     /**
      * Returns the entity class for this type.

--- a/src/main/java/org/spongepowered/api/entity/hanging/art/Art.java
+++ b/src/main/java/org/spongepowered/api/entity/hanging/art/Art.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.entity.hanging.art;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.entity.hanging.Painting;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -31,7 +32,7 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * Represents a piece of art to be displayed by {@link Painting}s.
  */
 @CatalogedBy(Arts.class)
-public interface Art {
+public interface Art extends CatalogType {
 
     /**
      * Gets the height in blocks this art piece spans.
@@ -47,10 +48,4 @@ public interface Art {
      */
     int getWidth();
 
-    /**
-     * Gets the given name of this piece of art.
-     *
-     * @return The name of this piece of art
-     */
-    String getName();
 }

--- a/src/main/java/org/spongepowered/api/entity/living/animal/HorseColor.java
+++ b/src/main/java/org/spongepowered/api/entity/living/animal/HorseColor.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.entity.living.animal;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.service.persistence.DataSerializable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -33,13 +34,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * born horse.</p>
  */
 @CatalogedBy(HorseColors.class)
-public interface HorseColor extends DataSerializable {
-
-    /**
-     * Gets the name of this color.
-     *
-     * @return The name of this color
-     */
-    String getName();
+public interface HorseColor extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/living/animal/HorseStyle.java
+++ b/src/main/java/org/spongepowered/api/entity/living/animal/HorseStyle.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.entity.living.animal;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.service.persistence.DataSerializable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -33,13 +34,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * horse. The style can be inherited to new born child horses.</p>
  */
 @CatalogedBy(HorseStyles.class)
-public interface HorseStyle extends DataSerializable {
-
-    /**
-     * Gets the name of this style.
-     *
-     * @return The name of this style
-     */
-    String getName();
+public interface HorseStyle extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/living/animal/HorseVariant.java
+++ b/src/main/java/org/spongepowered/api/entity/living/animal/HorseVariant.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.entity.living.animal;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.service.persistence.DataSerializable;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
@@ -35,13 +36,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * can be saddled.</p>
  */
 @CatalogedBy(HorseVariants.class)
-public interface HorseVariant extends DataSerializable, Translatable {
-
-    /**
-     * Gets the name of this variant.
-     *
-     * @return The name of this variant
-     */
-    String getName();
+public interface HorseVariant extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/living/animal/OcelotType.java
+++ b/src/main/java/org/spongepowered/api/entity/living/animal/OcelotType.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.entity.living.animal;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.service.persistence.DataSerializable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -31,13 +32,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * Represents the type of ocelot an ocelot is.
  */
 @CatalogedBy(OcelotTypes.class)
-public interface OcelotType extends DataSerializable {
-
-    /**
-     * Gets the name of this ocelot type.
-     *
-     * @return The name of this ocelot type
-     */
-    String getName();
+public interface OcelotType extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/living/animal/RabbitType.java
+++ b/src/main/java/org/spongepowered/api/entity/living/animal/RabbitType.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.entity.living.animal;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.service.persistence.DataSerializable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -31,13 +32,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * Represents a type of {@link Rabbit}.
  */
 @CatalogedBy(RabbitTypes.class)
-public interface RabbitType extends DataSerializable {
-
-    /**
-     * Gets the name of this rabbit type.
-     *
-     * @return The name of this rabbit type
-     */
-    String getName();
+public interface RabbitType extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/living/monster/SkeletonType.java
+++ b/src/main/java/org/spongepowered/api/entity/living/monster/SkeletonType.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.entity.living.monster;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.service.persistence.DataSerializable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -33,13 +34,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * can define the various status immunities, such as withering.
  */
 @CatalogedBy(SkeletonTypes.class)
-public interface SkeletonType extends DataSerializable {
-
-    /**
-     * Gets the name of this skeleton type.
-     *
-     * @return The name of this skeleton type
-     */
-    String getName();
+public interface SkeletonType extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/living/villager/Career.java
+++ b/src/main/java/org/spongepowered/api/entity/living/villager/Career.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.entity.living.villager;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -32,7 +33,7 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * of trade offers the villager can give to a player.
  */
 @CatalogedBy(Careers.class)
-public interface Career extends Translatable {
+public interface Career extends CatalogType, Translatable {
 
     /**
      * Gets the parent profession of this career. The profession is permanent
@@ -41,12 +42,5 @@ public interface Career extends Translatable {
      * @return The profession this career belongs to
      */
     Profession getProfession();
-
-    /**
-     * Gets name of this career.
-     *
-     * @return The name of this career
-     */
-    String getName();
 
 }

--- a/src/main/java/org/spongepowered/api/entity/living/villager/Profession.java
+++ b/src/main/java/org/spongepowered/api/entity/living/villager/Profession.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.entity.living.villager;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -32,12 +33,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * trade offers a villager may offer to a player.
  */
 @CatalogedBy(Professions.class)
-public interface Profession extends Translatable {
+public interface Profession extends CatalogType, Translatable {
 
-    /**
-     * Gets the name of this profession.
-     *
-     * @return The name of this profession
-     */
-    String getName();
 }

--- a/src/main/java/org/spongepowered/api/entity/player/gamemode/GameMode.java
+++ b/src/main/java/org/spongepowered/api/entity/player/gamemode/GameMode.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.entity.player.gamemode;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -31,6 +32,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * Represents a game mode that a {@link org.spongepowered.api.entity.player.Player} may have.
  */
 @CatalogedBy(GameModes.class)
-public interface GameMode extends Translatable {
+public interface GameMode extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/item/CoalType.java
+++ b/src/main/java/org/spongepowered/api/item/CoalType.java
@@ -25,6 +25,7 @@
 
 package org.spongepowered.api.item;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.service.persistence.DataSerializable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -32,13 +33,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * Represents the type of coal.
  */
 @CatalogedBy(CoalTypes.class)
-public interface CoalType extends DataSerializable {
-
-    /**
-     * Gets the generic id of this coal type.
-     *
-     * @return The generic id for this coal type
-     */
-    String getId();
+public interface CoalType extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/item/CookedFish.java
+++ b/src/main/java/org/spongepowered/api/item/CookedFish.java
@@ -25,6 +25,7 @@
 
 package org.spongepowered.api.item;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.service.persistence.DataSerializable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -32,13 +33,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * Represents a type of cooked fish.
  */
 @CatalogedBy(CookedFishes.class)
-public interface CookedFish extends DataSerializable {
-
-    /**
-     * Gets the id of this type of cooked fish.
-     *
-     * @return The id of this cooked fish
-     */
-    String getId();
+public interface CookedFish extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/item/DyeColor.java
+++ b/src/main/java/org/spongepowered/api/item/DyeColor.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.item;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.service.persistence.DataSerializable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -33,14 +34,7 @@ import java.awt.Color;
  * Represents a color of dye that can be used by various items and blocks.
  */
 @CatalogedBy(DyeColors.class)
-public interface DyeColor extends DataSerializable {
-
-    /**
-     * Gets the name of this color.
-     *
-     * @return The name of this color
-     */
-    String getName();
+public interface DyeColor extends CatalogType {
 
     /**
      * Gets this dye color as a {@link Color} for easy translation.

--- a/src/main/java/org/spongepowered/api/item/Enchantment.java
+++ b/src/main/java/org/spongepowered/api/item/Enchantment.java
@@ -25,6 +25,7 @@
 
 package org.spongepowered.api.item;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
@@ -33,7 +34,7 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * Represents a modifier on an item that has various effects.
  */
 @CatalogedBy(Enchantments.class)
-public interface Enchantment extends Translatable {
+public interface Enchantment extends CatalogType, Translatable {
 
     /**
      * Gets the id of this enchantment.
@@ -43,7 +44,7 @@ public interface Enchantment extends Translatable {
      *
      * @return The id
      */
-    String getId();
+    String getName();
 
     /**
      * Get the weight of the enchantment.

--- a/src/main/java/org/spongepowered/api/item/FireworkShape.java
+++ b/src/main/java/org/spongepowered/api/item/FireworkShape.java
@@ -24,19 +24,13 @@
  */
 package org.spongepowered.api.item;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a possible shape for a firework explosion.
  */
 @CatalogedBy(FireworkShapes.class)
-public interface FireworkShape {
-
-    /**
-     * Gets the string id of this shape.
-     *
-     * @return The string id of this shape
-     */
-    String getId();
+public interface FireworkShape extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/item/Fish.java
+++ b/src/main/java/org/spongepowered/api/item/Fish.java
@@ -25,6 +25,7 @@
 
 package org.spongepowered.api.item;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.service.persistence.DataSerializable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -32,13 +33,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * Represents a type of raw fish item.
  */
 @CatalogedBy(Fishes.class)
-public interface Fish extends DataSerializable {
-
-    /**
-     * Gets the id of this type of fish.
-     *
-     * @return The id of this type of fish
-     */
-    String getId();
+public interface Fish extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/item/GoldenApple.java
+++ b/src/main/java/org/spongepowered/api/item/GoldenApple.java
@@ -25,6 +25,7 @@
 
 package org.spongepowered.api.item;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.service.persistence.DataSerializable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -32,13 +33,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * Represents a type of golden apple.
  */
 @CatalogedBy(GoldenApples.class)
-public interface GoldenApple extends DataSerializable {
-
-    /**
-     * Gets the id of this type of golden apple.
-     *
-     * @return The id of this type of golden apple
-     */
-    String getId();
+public interface GoldenApple extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/item/ItemType.java
+++ b/src/main/java/org/spongepowered/api/item/ItemType.java
@@ -26,6 +26,7 @@
 package org.spongepowered.api.item;
 
 import com.google.common.base.Optional;
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.properties.ItemProperty;
 import org.spongepowered.api.text.translation.Translatable;
@@ -35,7 +36,7 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * A type of item.
  */
 @CatalogedBy(ItemTypes.class)
-public interface ItemType extends Translatable {
+public interface ItemType extends CatalogType, Translatable {
 
     /**
      * Gets the id of this item.
@@ -45,7 +46,7 @@ public interface ItemType extends Translatable {
      *
      * @return The id
      */
-    String getId();
+    String getName();
 
     /**
      * Get the default maximum quantity for

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackComparators.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackComparators.java
@@ -94,7 +94,7 @@ public final class ItemStackComparators {
             if (o2 == null) {
                 return -1;
             }
-            return o1.getItem().getId().compareTo(o2.getItem().getId());
+            return o1.getItem().getName().compareTo(o2.getItem().getName());
         }
 
     }

--- a/src/main/java/org/spongepowered/api/item/inventory/equipment/EquipmentType.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/equipment/EquipmentType.java
@@ -24,18 +24,13 @@
  */
 package org.spongepowered.api.item.inventory.equipment;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Equipment types.
  */
 @CatalogedBy(EquipmentTypes.class)
-public interface EquipmentType {
+public interface EquipmentType extends CatalogType {
 
-    /**
-     * Identifier for this equipment type.
-     * 
-     * @return the identifier
-     */
-    String getId();
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/properties/EquipmentSlotType.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/properties/EquipmentSlotType.java
@@ -81,7 +81,7 @@ public class EquipmentSlotType extends AbstractInventoryProperty<String, Equipme
         EquipmentType
                 otherValue =
                 Coerce.<EquipmentType>toPseudoEnum(other.getValue(), EquipmentType.class, EquipmentTypes.class, EquipmentTypes.WORN);
-        return this.getValue().getId().compareTo(otherValue.getId());
+        return this.getValue().getName().compareTo(otherValue.getName());
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/item/properties/EquipmentProperty.java
+++ b/src/main/java/org/spongepowered/api/item/properties/EquipmentProperty.java
@@ -70,7 +70,7 @@ public class EquipmentProperty extends AbstractItemProperty<String, EquipmentTyp
     public int compareTo(ItemProperty<?, ?> o) {
         if (o instanceof EquipmentProperty) {
             EquipmentProperty property = (EquipmentProperty) o;
-            return this.getValue().getId().compareTo(property.getValue().getId());
+            return this.getValue().getName().compareTo(property.getValue().getName());
         }
         return this.getClass().getName().compareTo(o.getClass().getName());
     }

--- a/src/main/java/org/spongepowered/api/potion/PotionEffectType.java
+++ b/src/main/java/org/spongepowered/api/potion/PotionEffectType.java
@@ -25,6 +25,7 @@
 
 package org.spongepowered.api.potion;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -32,7 +33,7 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * Represents a possible type of {@link PotionEffect}.
  */
 @CatalogedBy(PotionEffectTypes.class)
-public interface PotionEffectType extends Translatable {
+public interface PotionEffectType extends CatalogType, Translatable {
 
     /**
      * Gets whether this potion effect is applied

--- a/src/main/java/org/spongepowered/api/scoreboard/Visibility.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Visibility.java
@@ -24,18 +24,15 @@
  */
 package org.spongepowered.api.scoreboard;
 
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * Represents a group or groups players to display something to.
  *
  * <p>Usages include nametags and death messages.</p>
  */
-public interface Visibility {
-
-    /**
-     * Gets the name of this visibility.
-     *
-     * @return The name of this visibility
-     */
-    String getName();
+@CatalogedBy(Visibilities.class)
+public interface Visibility extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/scoreboard/critieria/Criterion.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/critieria/Criterion.java
@@ -24,13 +24,14 @@
  */
 package org.spongepowered.api.scoreboard.critieria;
 
-import com.google.common.base.Optional;
-import org.spongepowered.api.text.format.TextColor;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a set of behaviours for an objective, which may cause it to be automatically updated.
  */
-public interface Criterion {
+@CatalogedBy(Criteria.class)
+public interface Criterion extends CatalogType {
 
     /**
      * Gets the name of this criterion.

--- a/src/main/java/org/spongepowered/api/scoreboard/objective/displaymode/ObjectiveDisplayMode.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/objective/displaymode/ObjectiveDisplayMode.java
@@ -24,16 +24,13 @@
  */
 package org.spongepowered.api.scoreboard.objective.displaymode;
 
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * Represents the mode in which to display scores for an {@link org.spongepowered.api.scoreboard.objective.Objective}
  */
-public interface ObjectiveDisplayMode {
-
-    /**
-     * Gets the name of this objective display mode.
-     *
-     * @return The name of this objective display mode
-     */
-    String getName();
+@CatalogedBy(ObjectiveDisplayModes.class)
+public interface ObjectiveDisplayMode extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/stats/Statistic.java
+++ b/src/main/java/org/spongepowered/api/stats/Statistic.java
@@ -25,19 +25,15 @@
 package org.spongepowered.api.stats;
 
 import com.google.common.base.Optional;
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.text.translation.Translatable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents some statistic in Minecraft with a string ID.
  */
-public interface Statistic extends Translatable {
-    
-    /**
-     * Gets the internal name for this statistic.
-     * 
-     * @return The internal name
-     */
-    String getInternalName();
+@CatalogedBy(Statistics.class)
+public interface Statistic extends CatalogType, Translatable {
 
     /**
      * Gets the {@link StatisticFormat} of this statistic. If this is not

--- a/src/main/java/org/spongepowered/api/stats/StatisticFormat.java
+++ b/src/main/java/org/spongepowered/api/stats/StatisticFormat.java
@@ -25,17 +25,14 @@
 
 package org.spongepowered.api.stats;
 
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * Represents the format for a statistic.
  */
-public interface StatisticFormat {
-
-    /**
-     * Gets the name of this format.
-     *
-     * @return The name of this format
-     */
-    String getName();
+@CatalogedBy(StatisticFormats.class)
+public interface StatisticFormat extends CatalogType {
 
     /**
      * Formats the given value from the statistic to a human readable form.

--- a/src/main/java/org/spongepowered/api/stats/StatisticGroup.java
+++ b/src/main/java/org/spongepowered/api/stats/StatisticGroup.java
@@ -25,20 +25,16 @@
 
 package org.spongepowered.api.stats;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.text.translation.Translatable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a group of statistics which may be used to logically group
  * statistics or define expandable sets of statistics for objects such as items.
  */
-public interface StatisticGroup extends Translatable {
-    
-    /**
-     * Gets the internal name for this statistic group.
-     * 
-     * @return The internal name
-     */
-    String getInternalName();
+@CatalogedBy(StatisticGroups.class)
+public interface StatisticGroup extends CatalogType, Translatable {
 
     /**
      * Gets the default {@link StatisticFormat} which all statistics without

--- a/src/main/java/org/spongepowered/api/stats/StatisticGroups.java
+++ b/src/main/java/org/spongepowered/api/stats/StatisticGroups.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.stats;
 /**
  * A utility class for getting all available {@link StatisticGroup}s.
  */
-public class StatisticGroups {
+public final class StatisticGroups {
 
     /**
      * Statistics belonging to the group of 'general' statistics.

--- a/src/main/java/org/spongepowered/api/stats/achievement/Achievement.java
+++ b/src/main/java/org/spongepowered/api/stats/achievement/Achievement.java
@@ -25,23 +25,19 @@
 package org.spongepowered.api.stats.achievement;
 
 import com.google.common.base.Optional;
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.stats.Statistic;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.text.translation.Translation;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 import java.util.Collection;
 
 /**
  * Represents an in-game achievement which may be earned by or given to players.
  */
-public interface Achievement extends Translatable {
-    
-    /**
-     * Gets the internal name for this achievement.
-     * 
-     * @return The internal name
-     */
-    String getInternalName();
+@CatalogedBy(Achievements.class)
+public interface Achievement extends CatalogType, Translatable {
     
     /**
      * Returns the description that describes this achievement.

--- a/src/main/java/org/spongepowered/api/text/chat/ChatType.java
+++ b/src/main/java/org/spongepowered/api/text/chat/ChatType.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.text.chat;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
@@ -32,6 +33,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * @see ChatTypes
  */
 @CatalogedBy(ChatTypes.class)
-public interface ChatType {
+public interface ChatType extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/text/format/TextColor.java
+++ b/src/main/java/org/spongepowered/api/text/format/TextColor.java
@@ -24,7 +24,9 @@
  */
 package org.spongepowered.api.text.format;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 import java.awt.Color;
 
@@ -33,7 +35,8 @@ import java.awt.Color;
  *
  * @see TextColors
  */
-public interface TextColor {
+@CatalogedBy(TextColors.class)
+public interface TextColor extends CatalogType {
 
     /**
      * Returns the corresponding {@link Color} for this {@link TextColor}.

--- a/src/main/java/org/spongepowered/api/text/format/TextColors.java
+++ b/src/main/java/org/spongepowered/api/text/format/TextColors.java
@@ -46,10 +46,19 @@ public final class TextColors {
         private final Color color = new Color(0, 0, 0, 0);
 
         @Override
+        public String getName() {
+            return "NONE";
+        }
+
+        @Override
         public Color getColor() {
             return this.color;
         }
 
+        @Override
+        public String getId() {
+            return "NONE";
+        }
     };
 
     public static final TextColor.Base BLACK = null;

--- a/src/main/java/org/spongepowered/api/util/rotation/Rotation.java
+++ b/src/main/java/org/spongepowered/api/util/rotation/Rotation.java
@@ -24,13 +24,14 @@
  */
 package org.spongepowered.api.util.rotation;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents an angle of rotation.
  */
 @CatalogedBy(Rotations.class)
-public interface Rotation {
+public interface Rotation extends CatalogType {
 
     /**
      * The angle in degrees.

--- a/src/main/java/org/spongepowered/api/world/DimensionType.java
+++ b/src/main/java/org/spongepowered/api/world/DimensionType.java
@@ -24,20 +24,14 @@
  */
 package org.spongepowered.api.world;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a type of {@link Dimension}.
  */
 @CatalogedBy(DimensionTypes.class)
-public interface DimensionType {
-
-    /**
-     * Returns the name of this {@link DimensionType}.
-     *
-     * @return The name
-     */
-    String getName();
+public interface DimensionType extends CatalogType {
 
     /**
      * Returns whether spawn chunks of this {@link DimensionType} remain loaded

--- a/src/main/java/org/spongepowered/api/world/GeneratorType.java
+++ b/src/main/java/org/spongepowered/api/world/GeneratorType.java
@@ -25,6 +25,7 @@
 
 package org.spongepowered.api.world;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.service.persistence.data.DataContainer;
 import org.spongepowered.api.world.gen.WorldGenerator;
 
@@ -32,14 +33,7 @@ import org.spongepowered.api.world.gen.WorldGenerator;
  * Represents a world type. This is in general a {@link WorldGenerator} and the
  * settings for the generator.
  */
-public interface GeneratorType {
-
-    /**
-     * Gets the name of this world type.
-     * 
-     * @return The name
-     */
-    String getName();
+public interface GeneratorType extends CatalogType {
 
     /**
      * Gets a copy of the default settings for the world generator.

--- a/src/main/java/org/spongepowered/api/world/WorldBuilder.java
+++ b/src/main/java/org/spongepowered/api/world/WorldBuilder.java
@@ -32,11 +32,32 @@ import org.spongepowered.api.entity.player.gamemode.GameMode;
 import org.spongepowered.api.entity.player.gamemode.GameModes;
 import org.spongepowered.api.service.persistence.data.DataContainer;
 import org.spongepowered.api.world.gen.WorldGeneratorModifier;
+import org.spongepowered.api.world.storage.WorldProperties;
 
 /**
  * A builder for {@link World}s and {@link WorldCreationSettings}.
  */
 public interface WorldBuilder {
+
+    /**
+     * Fills this {@link WorldBuilder} for creating {@link World}s or
+     * {@link WorldCreationSettings}s, the builder is then seeded with the
+     * values from the given WorldCreationSettings object.
+     *
+     * @param settings The seed settings
+     * @return A new seeded builder
+     */
+    WorldBuilder fill(WorldCreationSettings settings);
+
+    /**
+     * Fills this {@link WorldBuilder} for creating {@link World}s or
+     * {@link WorldCreationSettings}s, the builder is then seeded with the
+     * values from the given WorldProperties object.
+     *
+     * @param properties The seed properties
+     * @return A new seeded builder
+     */
+    WorldBuilder fill(WorldProperties properties);
 
     /**
      * Sets the name of the world.

--- a/src/main/java/org/spongepowered/api/world/biome/BiomeType.java
+++ b/src/main/java/org/spongepowered/api/world/biome/BiomeType.java
@@ -25,6 +25,7 @@
 
 package org.spongepowered.api.world.biome;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 import org.spongepowered.api.world.gen.Populator;
 
@@ -34,14 +35,7 @@ import java.util.List;
  * Represents a biome.
  */
 @CatalogedBy(BiomeTypes.class)
-public interface BiomeType {
-
-    /**
-     * Gets the name of this biome type.
-     *
-     * @return The name of this biome type
-     */
-    String getName();
+public interface BiomeType extends CatalogType {
 
     /**
      * Get the temperature of this biome.

--- a/src/main/java/org/spongepowered/api/world/difficulty/Difficulty.java
+++ b/src/main/java/org/spongepowered/api/world/difficulty/Difficulty.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.world.difficulty;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
@@ -32,5 +33,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * @see Difficulties
  */
 @CatalogedBy(Difficulties.class)
-public interface Difficulty {
+public interface Difficulty extends CatalogType {
+
 }

--- a/src/main/java/org/spongepowered/api/world/weather/Weather.java
+++ b/src/main/java/org/spongepowered/api/world/weather/Weather.java
@@ -25,12 +25,13 @@
 
 package org.spongepowered.api.world.weather;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a type of weather.
  */
 @CatalogedBy(Weathers.class)
-public interface Weather {
+public interface Weather extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/world/weather/Weathers.java
+++ b/src/main/java/org/spongepowered/api/world/weather/Weathers.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.world.weather;
 /**
  * All possible {@link Weather}s in vanilla minecraft.
  */
-public class Weathers {
+public final class Weathers {
 
     public static final Weather CLEAR = null;
     public static final Weather RAIN = null;


### PR DESCRIPTION
GameRegistry as we know it is bloated with all the `getXX(): Optional<?>` methods when all of our "types" aren't conforming to a common standard, some "types" have a `getName()` and others have `getId()`. This PR attempts to unify the types and clean up GameRegistry along with it. 

Adds a handy `CatalogTypes` for indexing known `CatalogType` classes for easy auto completion in Eclipse.