### PR TITLE
Expand Populator System

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -62,6 +62,9 @@ import org.spongepowered.api.util.rotation.Rotation;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.WorldBuilder;
 import org.spongepowered.api.world.WorldCreationSettings;
+import org.spongepowered.api.world.gen.GeneratorPopulator;
+import org.spongepowered.api.world.gen.Populator;
+import org.spongepowered.api.world.gen.PopulatorFactory;
 import org.spongepowered.api.world.gen.WorldGeneratorModifier;
 
 import java.awt.image.BufferedImage;
@@ -452,5 +455,13 @@ public interface GameRegistry {
      * @param modifier The modifier to register
      */
     void registerWorldGeneratorModifier(PluginContainer plugin, String genId, WorldGeneratorModifier modifier);
+    
+    /**
+     * Gets the {@link PopulatorFactory} for creating {@link Populator}s and
+     * {@link GeneratorPopulator}s.
+     * 
+     * @return The populator factory
+     */
+    PopulatorFactory getPopulatorFactory();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulators/MobSpawnerData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulators/MobSpawnerData.java
@@ -70,7 +70,7 @@ public interface MobSpawnerData extends DataManipulator<MobSpawnerData> {
     short getMinimumSpawnDelay();
 
     /**
-     * Gets the minimum delay between batches of monsters.
+     * Sets the minimum delay between batches of monsters.
      * <p>
      * Each time the timer is reset the new delay is chosen randomly from
      * between the minimum (inclusive) and maximum (exclusive) delays.
@@ -92,7 +92,7 @@ public interface MobSpawnerData extends DataManipulator<MobSpawnerData> {
     short getMaximumSpawnDelay();
 
     /**
-     * Gets the maximum delay between batches of monsters.
+     * Sets the maximum delay between batches of monsters.
      * <p>
      * Each time the timer is reset the new delay is chosen randomly from
      * between the minimum (inclusive) and maximum (exclusive) delays.

--- a/src/main/java/org/spongepowered/api/util/WeightedRandomItemStack.java
+++ b/src/main/java/org/spongepowered/api/util/WeightedRandomItemStack.java
@@ -23,21 +23,45 @@
  * THE SOFTWARE.
  */
 
-package org.spongepowered.api.world;
+package org.spongepowered.api.util;
+
+import org.spongepowered.api.item.inventory.ItemStack;
 
 /**
- * An enumeration of default {@link GeneratorType}s.
+ * Represents an item stack with a range of possible quantities and a numerical weight used for random selection
+ * from a collection of weighted types.
  */
-public final class GeneratorTypes {
+public interface WeightedRandomItemStack {
 
-    public static final GeneratorType DEBUG = null;
-    public static final GeneratorType DEFAULT = null;
-    public static final GeneratorType FLAT = null;
-    public static final GeneratorType NETHER = null;
-    public static final GeneratorType OVERWORLD = null;
-    public static final GeneratorType END = null;
+    /**
+     * Gets the {@link ItemStack}. The quantity of the item will be ignored and
+     * instead set to a value randomly selected from between
+     * {@link #getMinimumQuantity()} (inclusive) and
+     * {@link #getMaximumQuantity()} (exclusive).
+     *
+     * @return The item stack
+     */
+    ItemStack getItemStack();
 
-    private GeneratorTypes() {
-    }
+    /**
+     * Gets the minimum quantity of the item to spawn.
+     * 
+     * @return The minimum quantity
+     */
+    int getMinimumQuantity();
+
+    /**
+     * Gets the maximum quantity of the item to spawn.
+     * 
+     * @return The maximum quantity
+     */
+    int getMaximumQuantity();
+
+    /**
+     * Gets the weight of this item.
+     *
+     * @return The weight
+     */
+    int getWeight();
 
 }

--- a/src/main/java/org/spongepowered/api/world/biome/BiomeType.java
+++ b/src/main/java/org/spongepowered/api/world/biome/BiomeType.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.world.biome;
 
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
+import org.spongepowered.api.world.gen.GeneratorPopulator;
 import org.spongepowered.api.world.gen.Populator;
 
 import java.util.List;
@@ -66,8 +67,28 @@ public interface BiomeType extends CatalogType {
     float getMaxHeight();
 
     /**
-     * Returns a mutable list of {@link Populator}s specific to this
-     * biome. Changing this list will affect population of all new chunks.
+     * Gets a mutable ordered list of {@link GroundCoverLayer}s. These layers
+     * will be applied to the base terrain during the generation phase starting
+     * at the topmost stone block in each column.
+     * 
+     * @return The ground cover layers
+     */
+    List<GroundCoverLayer> getGroundCover();
+
+    /**
+     * Gets a mutable list of {@link GeneratorPopulator}s. These populators work
+     * strictly on a single chunk. They will be executed directly after the
+     * {@link #getGroundCover() ground cover layers} are applied. These
+     * generator populators are typically used to generate large terrain
+     * features, like caves and ravines.
+     *
+     * @return The generator populators
+     */
+    List<GeneratorPopulator> getGeneratorPopulators();
+
+    /**
+     * Returns a mutable list of {@link Populator}s specific to this biome.
+     * Changing this list will affect population of all new chunks.
      *
      * @return The populators
      */

--- a/src/main/java/org/spongepowered/api/world/biome/GroundCoverLayer.java
+++ b/src/main/java/org/spongepowered/api/world/biome/GroundCoverLayer.java
@@ -1,0 +1,140 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.biome;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.spongepowered.api.block.BlockState;
+
+/**
+ * Represents a layer of BlockStates specific to a biome which may be placed in
+ * during generation.
+ */
+public class GroundCoverLayer {
+
+    private BlockState state;
+    private double depth;
+    private double depthVariance;
+
+    /**
+     * Creates a new {@link GroundCoverLayer} with the given BlockState and a
+     * base depth of 1.
+     * 
+     * @param type The BlockState of the layer
+     */
+    public GroundCoverLayer(BlockState type) {
+        this(type, 1, 0);
+    }
+
+    /**
+     * Creates a new {@link GroundCoverLayer} with the given BlockState and base
+     * depth.
+     * 
+     * @param type The BlockState of the layer
+     * @param depth The layer depth
+     */
+    public GroundCoverLayer(BlockState type, double depth) {
+        this(type, depth, 0);
+    }
+
+    /**
+     * Creates a new {@link GroundCoverLayer} with the given BlockState and
+     * depth. The final depth of the layer will vary randomly between
+     * {@code depth} and {@code depth+depthVariance} (both inclusive).
+     * 
+     * @param type The BlockState of the layer
+     * @param depth The layer depth
+     * @param depthVariance The depth variance
+     */
+    public GroundCoverLayer(BlockState type, double depth, double depthVariance) {
+        checkArgument(depth >= 0, "Depth cannot be negative.");
+        checkArgument(depthVariance >= 0, "Depth variance cannot be negative.");
+        checkArgument(depthVariance != 0 || depth != 0, "Depth variance and depth cannot both be zero.");
+        this.state = checkNotNull(type);
+        this.depth = depth;
+        this.depthVariance = depthVariance;
+    }
+
+    /**
+     * Gets the {@link BlockState} for this layer.
+     * 
+     * @return The block state
+     */
+    public BlockState getState() {
+        return this.state;
+    }
+
+    /**
+     * Sets the {@link BlockState} for this layer.
+     * 
+     * @param state The new state
+     */
+    public void setState(BlockState state) {
+        this.state = checkNotNull(state);
+    }
+
+    /**
+     * Gets the base depth of this layer.
+     * 
+     * @return The base depth
+     */
+    public double getBaseDepth() {
+        return this.depth;
+    }
+
+    /**
+     * Sets the base depth of this layer.
+     * 
+     * @param depth The new base depth
+     */
+    public void setBaseDepth(double depth) {
+        checkArgument(depth >= 0, "Depth cannot be negative.");
+        checkArgument(this.depthVariance != 0 || depth != 0, "Depth variance and depth cannot both be zero.");
+        this.depth = depth;
+    }
+
+    /**
+     * Gets the possible variance of the depth of this layer.
+     * 
+     * @return The depth variance
+     */
+    public double getDepthVariance() {
+        return this.depthVariance;
+    }
+
+    /**
+     * Sets the possible variance of the depth of this layer.
+     * 
+     * @param variance The new depth variance
+     */
+    public void setDepthVariance(double variance) {
+        checkArgument(variance >= 0, "Depth variance cannot be negative.");
+        checkArgument(variance != 0 || this.depth != 0, "Depth variance and depth cannot both be zero.");
+        this.depthVariance = variance;
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/GeneratorPopulator.java
+++ b/src/main/java/org/spongepowered/api/world/gen/GeneratorPopulator.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.world.gen;
 
 import org.spongepowered.api.util.gen.BiomeBuffer;
 import org.spongepowered.api.util.gen.MutableBlockBuffer;
+import org.spongepowered.api.world.World;
 
 /**
  * A populator which acts directly on the {@link MutableBlockBuffer} during the
@@ -38,13 +39,14 @@ import org.spongepowered.api.util.gen.MutableBlockBuffer;
 public interface GeneratorPopulator {
 
     /**
-     * Fill the {@link MutableBlockBuffer} with blocks, forming the base
-     * terrain.
+     * Operates on a {@link MutableBlockBuffer} either forming the base terrain
+     * or performing modifications during the generation phase.
      *
+     * @param world The world
      * @param buffer The buffer to apply the changes to. The buffer can be of
-     *        any size.
+     *            any size.
      * @param biomes The biomes for generation
      */
-    void populate(MutableBlockBuffer buffer, BiomeBuffer biomes);
+    void populate(World world, MutableBlockBuffer buffer, BiomeBuffer biomes);
 
 }

--- a/src/main/java/org/spongepowered/api/world/gen/PopulatorFactory.java
+++ b/src/main/java/org/spongepowered/api/world/gen/PopulatorFactory.java
@@ -1,0 +1,234 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen;
+
+import org.spongepowered.api.world.gen.populators.BigMushroom;
+import org.spongepowered.api.world.gen.populators.BlockBlob;
+import org.spongepowered.api.world.gen.populators.Cactus;
+import org.spongepowered.api.world.gen.populators.DesertWell;
+import org.spongepowered.api.world.gen.populators.DoublePlant;
+import org.spongepowered.api.world.gen.populators.Dungeon;
+import org.spongepowered.api.world.gen.populators.EnderCrystalPlatform;
+import org.spongepowered.api.world.gen.populators.Flowers;
+import org.spongepowered.api.world.gen.populators.Forest;
+import org.spongepowered.api.world.gen.populators.Glowstone;
+import org.spongepowered.api.world.gen.populators.HugeTree;
+import org.spongepowered.api.world.gen.populators.IcePath;
+import org.spongepowered.api.world.gen.populators.IceSpike;
+import org.spongepowered.api.world.gen.populators.JungleBush;
+import org.spongepowered.api.world.gen.populators.Lake;
+import org.spongepowered.api.world.gen.populators.Melons;
+import org.spongepowered.api.world.gen.populators.Ore;
+import org.spongepowered.api.world.gen.populators.Pumpkin;
+import org.spongepowered.api.world.gen.populators.RandomFire;
+import org.spongepowered.api.world.gen.populators.RandomLiquids;
+import org.spongepowered.api.world.gen.populators.Reeds;
+import org.spongepowered.api.world.gen.populators.SeaFloor;
+import org.spongepowered.api.world.gen.populators.Shrub;
+import org.spongepowered.api.world.gen.populators.Vines;
+import org.spongepowered.api.world.gen.populators.WaterLily;
+
+/**
+ * A factory for creating new populators for use in modifying WorldGenerators.
+ */
+public interface PopulatorFactory {
+
+    /**
+     * Creates a new {@link BigMushroom} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    BigMushroom.Builder createBigMushroomPopulator();
+
+    /**
+     * Creates a new {@link BlockBlob} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    BlockBlob.Builder createBlockBlockPopulator();
+
+    /**
+     * Creates a new {@link Cactus} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    Cactus.Builder createCactusPopulator();
+
+    /**
+     * Creates a new {@link DesertWell} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    DesertWell.Builder createDesertWellPopulator();
+
+    /**
+     * Creates a new {@link DoublePlant} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    DoublePlant.Builder createDoublePlantPopulator();
+
+    /**
+     * Creates a new {@link Dungeon} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    Dungeon.Builder createDungeonPopulator();
+
+    /**
+     * Creates a new {@link EnderCrystalPlatform} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    EnderCrystalPlatform.Builder createEnderCrystalPlatformPopulator();
+
+    /**
+     * Creates a new {@link Flowers} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    Flowers.Builder createFlowerPopulator();
+
+    /**
+     * Creates a new {@link Forest} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    Forest.Builder createForestPopulator();
+
+    /**
+     * Creates a new {@link Glowstone} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    Glowstone.Builder createGlowstonePopulator();
+
+    /**
+     * Creates a new {@link HugeTree} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    HugeTree.Builder createHugeTreePopulator();
+
+    /**
+     * Creates a new {@link IcePath} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    IcePath.Builder createIcePathPopulator();
+
+    /**
+     * Creates a new {@link IceSpike} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    IceSpike.Builder createIceSpikePopulator();
+
+    /**
+     * Creates a new {@link JungleBush} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    JungleBush.Builder createJungleBushPopulator();
+
+    /**
+     * Creates a new {@link Lake} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    Lake.Builder createLakePopulator();
+
+    /**
+     * Creates a new {@link Melons} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    Melons.Builder createMelonPopulator();
+
+    /**
+     * Creates a new {@link Ore} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    Ore.Builder createOrePopulator();
+
+    /**
+     * Creates a new {@link Pumpkin} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    Pumpkin.Builder createPumpkinPopulator();
+
+    /**
+     * Creates a new {@link RandomFire} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    RandomFire.Builder createRandomFirePopulator();
+
+    /**
+     * Creates a new {@link RandomLiquids} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    RandomLiquids.Builder createRandomLiquidsPopulator();
+
+    /**
+     * Creates a new {@link Reeds} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    Reeds.Builder createReedsPopulator();
+
+    /**
+     * Creates a new {@link SeaFloor} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    SeaFloor.Builder createSeaFloorPopulator();
+
+    /**
+     * Creates a new {@link Shrub} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    Shrub.Builder createShrubPopulator();
+
+    /**
+     * Creates a new {@link Vines} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    Vines.Builder createVinesPopulator();
+
+    /**
+     * Creates a new {@link WaterLily} populator builder.
+     * 
+     * @return A new builder instance
+     */
+    WaterLily.Builder createWaterLilyPopulator();
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/PopulatorObjects.java
+++ b/src/main/java/org/spongepowered/api/world/gen/PopulatorObjects.java
@@ -29,7 +29,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.flowpowered.math.vector.Vector3i;
-import com.google.common.base.Preconditions;
 import org.spongepowered.api.world.Chunk;
 import org.spongepowered.api.world.World;
 

--- a/src/main/java/org/spongepowered/api/world/gen/WorldGeneratorModifier.java
+++ b/src/main/java/org/spongepowered/api/world/gen/WorldGeneratorModifier.java
@@ -29,6 +29,7 @@ import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.GameRegistry;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.world.WorldCreationSettings;
 
 /**
  * If a plugin wishes to modify a world generator, the plugin must register a
@@ -50,13 +51,16 @@ public interface WorldGeneratorModifier extends CatalogType {
      * replace the biome generator, use
      * {@link WorldGenerator#setBiomeGenerator(BiomeGenerator)}. To change
      * terrain population, modify the populator list returned by
-     * {@link WorldGenerator#getPopulators()}.</p>
+     * {@link WorldGenerator#getPopulators()} or
+     * {@link WorldGenerator#getGeneratorPopulators()}.</p>
      *
-     * @param worldName The name of the world.
-     * @param settings A data container with settings, can be used by the plugin
-     *            to modify the world generator.
+     * @param world The creation settings of the world.
+     * @param settings A data container with settings (usually) user-provided
+     *            settings, can be used by the plugin to modify the world
+     *            generator.
      * @param worldGenerator The world generator, should be modified.
+     * @see WorldGenerator Additional information on the generation process
      */
-    void modifyWorldGenerator(String worldName, DataContainer settings, WorldGenerator worldGenerator);
+    void modifyWorldGenerator(WorldCreationSettings world, DataContainer settings, WorldGenerator worldGenerator);
 
 }

--- a/src/main/java/org/spongepowered/api/world/gen/populators/BigMushroom.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/BigMushroom.java
@@ -1,0 +1,163 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.biome.BiomeTypes;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.data.types.BigMushroomType;
+import org.spongepowered.api.world.gen.Populator;
+
+/**
+ * Represents a populator which places a number of large mushrooms. The type of
+ * mushroom to place can be set or can be randomized.
+ */
+public interface BigMushroom extends Populator {
+
+    /**
+     * Gets the type of mushroom being placed by this populator.
+     * <strong>Note:</strong> this type will be ignored if the populator is set
+     * to randomize types {@link #usesRandomizedType()}. If the populator is set
+     * to randomize then this method will return absent.
+     * 
+     * @return The type, if not randomized
+     */
+    Optional<BigMushroomType> getType();
+
+    /**
+     * Sets the type of mushroom to place. Setting the mushroom type will set
+     * {@link #usesRandomizedType()} to false.
+     * 
+     * @param type The new mushroom type
+     */
+    void setType(BigMushroomType type);
+
+    /**
+     * Gets whether this populator is randomizing which type it is placing. If
+     * set the mushroom type will be selected at random for each mushroom that
+     * it places.
+     * 
+     * <p>This defaults to true.</p>
+     * 
+     * @return True if this populator is using randomized mushroom types
+     */
+    boolean usesRandomizedType();
+
+    /**
+     * Sets whether this populator is randomizing which type it is placing. If
+     * set the mushroom type will be selected at random for each mushroom that
+     * it places.
+     * 
+     * @param state The new state
+     */
+    void useRandomizedTypes(boolean state);
+
+    /**
+     * Gets the number of mushrooms which will be attempted to be spawned.
+     * 
+     * <p><strong>Note:</strong> This number is not a definite number and the
+     * final count of mushrooms which are successfully spawned by the populator
+     * will almost always be lower.</p>
+     * 
+     * <p>The default value for this is 1 (from
+     * {@link BiomeTypes#MUSHROOM_ISLAND}.</p>
+     * 
+     * @return The number of mushrooms attempted to be spawned per chunk
+     */
+    int getMushroomsPerChunk();
+
+    /**
+     * Sets the number of mushrooms which will be attempted to be spawned.
+     * 
+     * <p><strong>Note:</strong> This number is not a definite number and the
+     * final count of mushrooms which are successfully spawned by the populator
+     * will almost always be lower.</p>
+     * 
+     * @param count The new amount to attempt to create
+     */
+    void setMushroomsPerChunk(int count);
+
+    /**
+     * A builder for constructing {@link BigMushroom} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the type of mushroom to place. Setting the mushroom type will
+         * set {@link #usesRandomizedType()} to false.
+         * 
+         * <p>Defaults to absent with the
+         * {@link BigMushroom#usesRandomizedType()} flag set to true.</p>
+         * 
+         * @param type The new mushroom type
+         * @return This builder, for chaining
+         */
+        Builder type(BigMushroomType type);
+
+        /**
+         * Sets the number of mushrooms which will be attempted to be spawned.
+         * 
+         * <p><strong>Note:</strong> This number is not a definite number and
+         * the final count of mushrooms which are successfully spawned by the
+         * populator will almost always be lower.</p>
+         * 
+         * @param count The new amount to attempt to create
+         * @return This builder, for chaining
+         */
+        Builder mushroomsPerChunk(int count);
+
+        /**
+         * Sets whether this populator is randomizing which type it is placing.
+         * If set the mushroom type will be selected at random for each mushroom
+         * that it places.
+         * 
+         * <p>This defaults to true.</p>
+         * 
+         * @param state The new state
+         * @return This builder, for chaining
+         */
+        Builder randomizeType();
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link BigMushroom} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        BigMushroom build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/BlockBlob.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/BlockBlob.java
@@ -1,0 +1,171 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
+import org.spongepowered.api.block.BlockState;
+
+/**
+ * Represents a populator which places in a number of 'blobs' of a specific
+ * block state. The 'blob' is here defined as the union of three ellipsoids
+ * whose radii are set randomly between the base radius (inclusive) and the base
+ * radius plus the variance (exclusive).
+ */
+public interface BlockBlob extends Populator {
+
+    /**
+     * Gets the {@link BlockState} that this populator will place down to form
+     * the blob.
+     * 
+     * @return The block state
+     */
+    BlockState getBlock();
+
+    /**
+     * Sets the {@link BlockState} that this populator will place down to form
+     * the blob.
+     * 
+     * @param state The new block state
+     */
+    void setBlock(BlockState state);
+
+    /**
+     * Gets the base radius of the area for the blob.
+     * 
+     * @return The base radius
+     */
+    int getBaseRadius();
+
+    /**
+     * Sets the base radius of the area for the blob, cannot be negative.
+     * 
+     * <p>This defaults to 1.</p>
+     * 
+     * @param radius The new base radius
+     */
+    void setBaseRadius(int radius);
+
+    /**
+     * Gets the radius variance of the blob.
+     * 
+     * @return The radius variance
+     */
+    int getRadiusVariance();
+
+    /**
+     * Sets the radius variance of the blob, must be greater than zero (a
+     * variance of one will correspond to a final radius of
+     * {@code finalRadius = baseRadius + [0,1) = baseRadius }).
+     * 
+     * <p>This defaults to 2.</p>
+     * 
+     * @param variance The new radius variance
+     */
+    void setRadiusVariance(int variance);
+
+    /**
+     * Gets the number of blobs which will be placed per chunk.
+     * 
+     * @return The number of blobs
+     */
+    int getCount();
+
+    /**
+     * Sets the number of blobs to spawn per chunk, must be greater than zero.
+     * 
+     * <p>This defaults to 3.</p>
+     * 
+     * @param count The new number of blobs
+     */
+    void setCount(int count);
+
+    /**
+     * A builder for constructing {@link BlockBlob} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the {@link BlockState} that this populator will place down to
+         * form the blob.
+         * 
+         * @param block the new block state
+         * @return This builder, for chaining
+         */
+        Builder block(BlockState block);
+
+        /**
+         * Sets the base radius of the area for the blob, cannot be negative.
+         * 
+         * <p>This defaults to 1.</p>
+         * 
+         * @param radius The new base radius
+         * @return This builder, for chaining
+         */
+        Builder baseRadius(int radius);
+
+        /**
+         * Sets the radius variance of the blob, must be greater than zero (a
+         * variance of one will correspond to a final radius of
+         * {@code finalRadius = baseRadius + [0,1) = baseRadius }).
+         * 
+         * <p>This defaults to 2.</p>
+         * 
+         * @param variance The new radius variance
+         * @return This builder, for chaining
+         */
+        Builder radiusVariance(int variance);
+
+        /**
+         * Sets the number of blobs to spawn per chunk, must be greater than
+         * zero.
+         * 
+         * <p>This defaults to 3.</p>
+         * 
+         * @param count The number of blobs to spawn
+         * @return This builder, for chaining
+         */
+        Builder blockCount(int count);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link BlockBlob} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        BlockBlob build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/Cactus.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/Cactus.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
+
+/**
+ * Represents a populator which will randomly spawn a number of cacti within the
+ * chunk. The cacti will only be spawned at valid locations, that is on top of a
+ * sand block with no immediately surrounding blocks.
+ */
+public interface Cactus extends Populator {
+
+    /**
+     * Gets the number of cacti to spawn per chunk.
+     * 
+     * @return The number of cacti to spawn
+     */
+    int getCactiPerChunk();
+
+    /**
+     * Sets the number of cacti to spawn per chunk, cannot be negative.
+     * 
+     * @param count The new number of cacti to spawn
+     */
+    void setCactiPerChunk(int count);
+
+    /**
+     * A builder for constructing {@link Cactus} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the number of cacti to spawn per chunk, cannot be negative.
+         * 
+         * @param count The new number of cacti to spawn
+         * @return This builder, for chaining
+         */
+        Builder cactiPerChunk(int count);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link Cactus} populator with the settings
+         * set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        Cactus build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/DesertWell.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/DesertWell.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
+
+/**
+ * Represents a populator which spawns desert wells. The wells will be created
+ * with a random chance of 1 in {@link #getSpawnChance()} and if the spawn
+ * conditions are met (that the block its spawning on is sand).
+ */
+public interface DesertWell extends Populator {
+
+    /**
+     * Gets the chance of a desert well spawning. The final chance is calculated
+     * as {@code if ( [0,chance) == 0 )}.
+     * 
+     * @return The spawn chance of a well
+     */
+    int getSpawnChance();
+
+    /**
+     * Sets the chance of a desert well spawning. The final chance is calculated
+     * as {@code if ( [0,chance) == 0 )}. This must be greater than zero, The
+     * default is 1000.
+     * 
+     * @param chance The new spawn chance
+     */
+    void setSpawnChance(int chance);
+
+    /**
+     * A builder for constructing {@link DesertWell} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the chance of a desert well spawning. The final chance is
+         * calculated as {@code if ( [0,chance) == 0 )}. This must be greater
+         * than zero, The default is 1000.
+         * 
+         * @param chance The new spawn chance
+         * @return This builder, for chaining
+         */
+        Builder chance(int chance);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link DesertWell} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        DesertWell build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/DoublePlant.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/DoublePlant.java
@@ -1,0 +1,147 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import com.google.common.collect.ImmutableSet;
+import org.spongepowered.api.data.types.DoubleSizePlantType;
+import org.spongepowered.api.world.gen.Populator;
+
+import java.util.Collection;
+
+/**
+ * Represents a populator which spawns in an assortment of two block tall
+ * plants. The number of plants attempted to be generated is
+ * {@code final = base + [0,variance) }.
+ */
+public interface DoublePlant extends Populator {
+
+    /**
+     * Gets an immutable set of possible plants which may be selected to be
+     * spawned in by this populator.
+     * 
+     * @return The possible types to be spawned
+     */
+    ImmutableSet<DoubleSizePlantType> getPossibleTypes();
+
+    /**
+     * Sets which plant types may be spawned in by this populator.
+     * 
+     * @param types A collection of possible types
+     */
+    void setPossibleTypes(Collection<DoubleSizePlantType> types);
+
+    /**
+     * Sets which plant types may be spawned in by this populator.
+     * 
+     * @param types Possible types
+     */
+    void setPossibleTypes(DoubleSizePlantType... types);
+
+    /**
+     * Gets the base number of plants to create.
+     * 
+     * @return The base amount
+     */
+    int getBaseAmount();
+
+    /**
+     * Sets the base number of plants to create, cannot be negative.
+     * 
+     * @param count The new base amount
+     */
+    void setBaseAmount(int count);
+
+    /**
+     * Gets the variance in the amount.
+     * 
+     * @return The amount variance
+     */
+    int getAmountVariance();
+
+    /**
+     * Sets the variance in the amount, must be greater than zero.
+     * 
+     * @param variance The new amount variance
+     */
+    void setAmountVariance(int variance);
+
+    /**
+     * A builder for constructing {@link DoublePlant} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets which plant types may be spawned in by this populator.
+         * 
+         * @param types Possible types
+         * @return This builder, for chaining
+         */
+        Builder possibleTypes(DoubleSizePlantType... types);
+
+        /**
+         * Sets which plant types may be spawned in by this populator.
+         * 
+         * @param types A collection of possible types
+         * @return This builder, for chaining
+         */
+        Builder possibleTypes(Collection<DoubleSizePlantType> types);
+
+        /**
+         * Sets the base number of plants to create, cannot be negative.
+         * 
+         * @param count The new base amount
+         * @return This builder, for chaining
+         */
+        Builder perChunk(int count);
+
+        /**
+         * Sets the variance in the amount, must be greater than zero.
+         * 
+         * @param variance The new amount variance
+         * @return This builder, for chaining
+         */
+        Builder perChunkVariance(int variance);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link DoublePlant} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        DoublePlant build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/Dungeon.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/Dungeon.java
@@ -1,0 +1,240 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.data.manipulators.MobSpawnerData;
+import org.spongepowered.api.util.WeightedRandomEntity;
+import org.spongepowered.api.util.WeightedRandomItemStack;
+import org.spongepowered.api.world.gen.Populator;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Represents a which places 'Dungeon's randomly underground. Each dungeon has
+ * some associated MobSpawnerData, and data regarding the contents of any chests
+ * generated within the dungeon.
+ */
+public interface Dungeon extends Populator {
+
+    /**
+     * Gets the number of attempts at randomly spawning a generator per chunk.
+     * 
+     * @return The number of attempts
+     */
+    int getAttemptsPerChunk();
+
+    /**
+     * Sets the number of attempts at randomly spawning a generator per chunk.
+     * The default is 8.
+     * 
+     * @param attempts The new number of attempts
+     */
+    void setAttemptsPerChunk(int attempts);
+
+    /**
+     * Gets the {@link MobSpawnerData} which represents the MobSpawner which
+     * will be created within the dungeon.
+     * 
+     * @return The mob spawner data
+     */
+    MobSpawnerData getSpawnerData();
+
+    /**
+     * Gets a mutable List of possible contents of the chests. Items will be
+     * randomly selected from this list based on weight in order to calculate
+     * the contents of chests placed within the dungeon.
+     * 
+     * @return The contents list
+     */
+    List<WeightedRandomItemStack> getPossibleContents();
+
+    /**
+     * Gets the number of items which will spawn per chest.
+     * 
+     * @return The number of items
+     */
+    int itemCount();
+
+    /**
+     * Sets the number of items which will spawn per chest.
+     * 
+     * @param count The new item count
+     */
+    void setItemCount(int count);
+
+    /**
+     * A builder for constructing {@link Dungeon} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the number of attempts at randomly spawning a generator per
+         * chunk. The default is 8.
+         * 
+         * @param attempts The new number of attempts
+         * @return This builder, for chaining
+         */
+        Builder attempts(int attempts);
+
+        /**
+         * Sets the {@link MobSpawnerData} which represents the MobSpawner which
+         * will be created within the dungeon. Setting this directly will
+         * overwrite the related builder methods.
+         * 
+         * @param data The mob spawner data to use
+         * @return This builder, for chaining
+         */
+        Builder mobSpawnerData(MobSpawnerData data);
+
+        /**
+         * Sets the minimum delay between batches of monsters. <p> Each time the
+         * timer is reset the new delay is chosen randomly from between the
+         * minimum (inclusive) and maximum (exclusive) delays. </p>
+         *
+         * @param delay The new minimum delay, in ticks
+         * @return This builder, for chaining
+         */
+        Builder minimumSpawnDelay(short delay);
+
+        /**
+         * Sets the maximum delay between batches of monsters. <p> Each time the
+         * timer is reset the new delay is chosen randomly from between the
+         * minimum (inclusive) and maximum (exclusive) delays. </p>
+         *
+         * @param delay The new maximum delay, in ticks
+         * @return This builder, for chaining
+         */
+        Builder maximumSpawnDelay(short delay);
+
+        /**
+         * Sets the number of monsters that will attempt to spawn in each batch.
+         *
+         * <p>The actual number of monsters spawned may be less than the
+         * attempted amount if the maximum number of entities allowed in the
+         * area is reached. </p>
+         *
+         * @param count The new count
+         * @return This builder, for chaining
+         */
+        Builder spawnCount(short count);
+
+        /**
+         * Sets the maximum amount of entities that may be within the spawn
+         * range. This monster spawner will cease spawning new entities if this
+         * cap is reached.
+         *
+         * @param count The new maximum amount of nearby entities
+         * @return This builder, for chaining
+         */
+        Builder maximumNearbyEntities(short count);
+
+        /**
+         * Sets the minimum range to the nearest player before this monster
+         * spawner will activate.
+         *
+         * @param range The new required range
+         * @return This builder, for chaining
+         */
+        Builder requiredPlayerRange(short range);
+
+        /**
+         * Sets the range within which the monsters from each batch will be
+         * spawned. <p> The total region within which the monster may be spawned
+         * is defined by a cuboid with dimensions of
+         * {@code range*2+1 x 3 x range*2+1} centered around the monster
+         * spawner. </p>
+         *
+         * @param range The new range
+         * @return This builder, for chaining
+         */
+        Builder spawnRange(short range);
+
+        /**
+         * Defines a number of {@link WeightedRandomEntity}s from which the type
+         * of each batch will be randomly selected based on the weighting value.
+         *
+         * @param entities The possible entities
+         * @return This builder, for chaining
+         */
+        Builder possibleEntities(WeightedRandomEntity... entities);
+
+        /**
+         * Defines a number of {@link WeightedRandomEntity}s from which the type
+         * of each batch will be randomly selected based on the weighting value.
+         *
+         * @param entities The possible entities
+         * @return This builder, for chaining
+         */
+        Builder possibleEntities(Collection<WeightedRandomEntity> entities);
+
+        /**
+         * Defines a number of {@link WeightedRandomItemStack}s from which items
+         * will be randomly selected based on weight in order to calculate the
+         * contents of chests placed within the dungeon.
+         *
+         * @param items The possible items
+         * @return This builder, for chaining
+         */
+        Builder possibleItems(WeightedRandomItemStack... items);
+
+        /**
+         * Defines a number of {@link WeightedRandomItemStack}s from which items
+         * will be randomly selected based on weight in order to calculate the
+         * contents of chests placed within the dungeon.
+         *
+         * @param items The possible items
+         * @return This builder, for chaining
+         */
+        Builder possibleItems(Collection<WeightedRandomItemStack> items);
+
+        /**
+         * Sets the number of items which will spawn per chest.
+         * 
+         * @param count The new item count
+         * @return This builder, for chaining
+         */
+        Builder itemsQuantity(int count);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link Dungeon} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        Dungeon build() throws IllegalStateException;
+
+    }
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/EnderCrystalPlatform.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/EnderCrystalPlatform.java
@@ -1,0 +1,187 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.entity.EnderCrystal;
+
+import org.spongepowered.api.world.gen.Populator;
+
+/**
+ * Represents a populator which randomly generates large obsidian pillars with
+ * {@link EnderCrystal}s at the peak such as are found in the End.
+ */
+public interface EnderCrystalPlatform extends Populator {
+
+    /**
+     * Gets the chance of a pillar spawning in a chunk. The default value is 5
+     * (therefore equating to a 20% chance or 1 in 5).
+     * 
+     * @return The spawn chance
+     */
+    int getSpawnChance();
+
+    /**
+     * Sets the chance of a pillar spawning in a chunk. The default value is 5
+     * (therefore equating to a 20% chance or 1 in 5).
+     * 
+     * @param chance The spawn chance
+     */
+    void setSpawnChance(int chance);
+
+    /**
+     * Gets the base height of the pillar.
+     * 
+     * @return The base height
+     */
+    int getBaseHeight();
+
+    /**
+     * Sets the base height of the pillar.
+     * 
+     * @param height The new base height
+     */
+    void setBaseHeight(int height);
+
+    /**
+     * Gets the height variance of the pillar. The final height will be the base
+     * height plus a random amount between zero (inclusive) and the variance
+     * (exclusive).
+     * 
+     * @return The height variance
+     */
+    int getHeightVariance();
+
+    /**
+     * Sets the height variance of the pillar. The final height will be the base
+     * height plus a random amount between zero (inclusive) and the variance
+     * (exclusive).
+     * 
+     * @param variance The new height variance
+     */
+    void setHeightVariance(int variance);
+
+    /**
+     * Gets the base radius of the pillar.
+     * 
+     * @return The base radius
+     */
+    int getBaseRadius();
+
+    /**
+     * Sets the base radius of the pillar.
+     * 
+     * @param radius The new base radius
+     */
+    void setBaseRadius(int radius);
+
+    /**
+     * Gets the radius variance of the pillar. The final radius will be the base
+     * radius plus a random amount between zero (inclusive) and the variance
+     * (exclusive).
+     * 
+     * @return The radius variance
+     */
+    int getRadiusVariance();
+
+    /**
+     * Sets the radius variance of the pillar. The final radius will be the base
+     * radius plus a random amount between zero (inclusive) and the variance
+     * (exclusive).
+     * 
+     * @param variance The new radius variance
+     */
+    void setRadiusVariance(int variance);
+
+    /**
+     * A builder for constructing {@link EnderCrystalPlatform} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the chance of a pillar spawning in a chunk. The default value is
+         * 5 (therefore equating to a 20% chance or 1 in 5).
+         * 
+         * @param chance The spawn chance
+         * @return This builder, for chaining
+         */
+        Builder chance(int chance);
+
+        /**
+         * Sets the base height of the pillar.
+         * 
+         * @param height The new base height
+         * @return This builder, for chaining
+         */
+        Builder height(int height);
+
+        /**
+         * Sets the height variance of the pillar. The final height will be the
+         * base height plus a random amount between zero (inclusive) and the
+         * variance (exclusive).
+         * 
+         * @param variance The new height variance
+         * @return This builder, for chaining
+         */
+        Builder heightVariance(int variance);
+
+        /**
+         * Sets the base radius of the pillar.
+         * 
+         * @param radius The new base radius
+         * @return This builder, for chaining
+         */
+        Builder radius(int radius);
+
+        /**
+         * Sets the radius variance of the pillar. The final radius will be the
+         * base radius plus a random amount between zero (inclusive) and the
+         * variance (exclusive).
+         * 
+         * @param variance The new radius variance
+         * @return This builder, for chaining
+         */
+        Builder radiusVariance(int variance);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link EnderCrystalPlatform} populator
+         * with the settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        EnderCrystalPlatform build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/Flowers.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/Flowers.java
@@ -1,0 +1,138 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.data.types.PlantType;
+import org.spongepowered.api.world.gen.Populator;
+
+/**
+ * Represents a populator which uses perlin noise to scatter flowers randomly
+ * around a chunk.
+ */
+public interface Flowers extends Populator {
+
+    /**
+     * Gets the number of flowers to attempt to spawn per chunk, must be greater
+     * than zero.
+     * 
+     * @return The number to spawn
+     */
+    int getFlowersPerChunk();
+
+    /**
+     * Sets the number of flowers to attempt to spawn per chunk, must be greater
+     * than zero.
+     * 
+     * @param count The new amount to spawn
+     */
+    void setFlowersPerChunk();
+
+    /**
+     * Gets whether this populator will ignore the set plant type and default to
+     * the biome's flower type.
+     * 
+     * @return Is biome dependent
+     */
+    boolean isBiomeDependent();
+
+    /**
+     * Sets whether this populator will ignore the set tile and default to the
+     * biome's flower type.
+     * 
+     * @param state The new biome dependency state
+     */
+    void setBiomeDependent(boolean state);
+
+    /**
+     * Gets the plant type for this populator to spawn. If the populator is
+     * flagged as being biome dependent ( {@link #isBiomeDependent()} ) then
+     * this will return absent.
+     * 
+     * @return The plant type, or absent if this is biome dependent
+     */
+    Optional<PlantType> getFlowerType();
+
+    /**
+     * Sets the plant type for this populator to spawn. This will automatically
+     * set the {@link #isBiomeDependent()} flag to false.
+     * 
+     * @param type The plant type to spawn
+     */
+    void serFlowerType(PlantType type);
+
+    /**
+     * A builder for constructing {@link Flowers} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the number of flowers to attempt to spawn per chunk, must be
+         * greater than zero.
+         * 
+         * @param count The new amount to spawn
+         * @return This builder, for chaining
+         */
+        Builder perChunk(int count);
+
+        /**
+         * Sets whether this populator will ignore the set tile and default to
+         * the biome's flower type.
+         * 
+         * @param state The new biome dependent state
+         * @return This builder, for chaining
+         */
+        Builder biomeDependant(boolean state);
+
+        /**
+         * Sets the plant type for this populator to spawn. This will
+         * automatically set the {@link #isBiomeDependent()} flag to false.
+         * 
+         * @param type The plant type to spawn
+         * @return This builder, for chaining
+         */
+        Builder type(PlantType type);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link Flowers} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        Flowers build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/Forest.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/Forest.java
@@ -1,0 +1,191 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.types.BiomeTreeType;
+import org.spongepowered.api.world.gen.Populator;
+import com.google.common.base.Optional;
+import org.spongepowered.api.block.BlockState;
+
+/**
+ * A populator which will place several trees into a chunk in order to create a
+ * forest.
+ */
+public interface Forest extends Populator {
+
+    /**
+     * Gets the number of trees to attempt to spawn per chunk, must be greater
+     * than zero.
+     * 
+     * @return The number to spawn
+     */
+    int getTreesPerChunk();
+
+    /**
+     * Sets the number of trees to attempt to spawn per chunk, must be greater
+     * than zero.
+     * 
+     * @param count The new amount to spawn
+     */
+    void setTreesPerChunk(int count);
+
+    /**
+     * Gets whether this populator will ignore the set tree type and default to
+     * the biome's tree type.
+     * 
+     * @return Is biome dependent
+     */
+    boolean isBiomeDependent();
+
+    /**
+     * Gets whether this populator will ignore the set tree type and default to
+     * the biome's tree type.
+     * 
+     * @param state The new biome dependency state
+     */
+    void setBiomeDependent(boolean state);
+
+    /**
+     * Gets the {@link BiomeTreeType} to spawn. If this populator is set to be
+     * biome dependent ( {@link #isBiomeDependent()} ) then this will return
+     * absent.
+     * 
+     * @return The type to spawn, or absent if biome dependent
+     */
+    Optional<BiomeTreeType> getType();
+
+    /**
+     * Sets the {@link BiomeTreeType} to spawn, this automatically sets the
+     * biome dependency flag to false.
+     * 
+     * @param type The new type to spawn
+     */
+    void setType(BiomeTreeType type);
+
+    /**
+     * Gets the {@link BlockState} to spawn the trunk of the tree with. If this
+     * populator is set to be biome dependent ( {@link #isBiomeDependent()} )
+     * then this will return absent.
+     * 
+     * @return The trunk type, or absent if biome dependent
+     */
+    Optional<BlockState> getTrunkMaterial();
+
+    /**
+     * Sets the {@link BlockState} to spawn the trunk of the tree with, this
+     * automatically sets the biome dependency flag to false.
+     * 
+     * @param material The new trunk material
+     */
+    void setTrunkMaterial(BlockState material);
+
+    /**
+     * Gets the {@link BlockState} to spawn the leaves of the tree with. If this
+     * populator is set to be biome dependent ( {@link #isBiomeDependent()} )
+     * then this will return absent.
+     * 
+     * @return The leaves type, or absent if biome dependent
+     */
+    Optional<BlockState> getLeavesMaterial();
+
+    /**
+     * Sets the {@link BlockState} to spawn the leaves of the tree with, this
+     * automatically sets the biome dependency flag to false.
+     * 
+     * @param material The new leaves material
+     */
+    void setLeavesMaterial(BlockState material);
+
+    /**
+     * A builder for constructing {@link Forest} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the number of trees to attempt to spawn per chunk, must be
+         * greater than zero.
+         * 
+         * @param count The new amount to spawn
+         * @return This builder, for chaining
+         */
+        Builder perChunk(int count);
+
+        /**
+         * Gets whether this populator will ignore the set tree type and default
+         * to the biome's tree type.
+         * 
+         * @param state The new biome dependency state
+         * @return This builder, for chaining
+         */
+        Builder biomeDependant(boolean state);
+
+        /**
+         * Sets the {@link BiomeTreeType} to spawn, this automatically sets the
+         * biome dependency flag to false.
+         * 
+         * @param type The new type to spawn
+         * @return This builder, for chaining
+         */
+        Builder type(BiomeTreeType type);
+
+        /**
+         * Sets the {@link BlockState} to spawn the trunk of the tree with, this
+         * automatically sets the biome dependency flag to false.
+         * 
+         * @param material The new trunk material
+         * @return This builder, for chaining
+         */
+        Builder trunk(BlockState material);
+
+        /**
+         * Sets the {@link BlockState} to spawn the leaves of the tree with,
+         * this automatically sets the biome dependency flag to false.
+         * 
+         * @param material The new leaves material
+         * @return This builder, for chaining
+         */
+        Builder leaves(BlockState material);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link Forest} populator with the settings
+         * set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        Forest build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/Glowstone.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/Glowstone.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
+
+/**
+ * Represents a populator which spawns clusters of glowstone.
+ */
+public interface Glowstone extends Populator {
+
+    /**
+     * Gets the number of clusters to attempt to spawn per chunk, must be
+     * greater than zero.
+     * 
+     * @return The number to spawn
+     */
+    int getClustersPerChunk();
+
+    /**
+     * Sets the number of clusters to attempt to spawn per chunk, must be
+     * greater than zero.
+     * 
+     * @param count The new amount to spawn
+     */
+    void setClustersPerChunk(int count);
+
+    /**
+     * Gets the amount of glowstone to attempt to spawn per cluster, must be
+     * greater than zero.
+     * 
+     * @return The number to spawn
+     */
+    int getAttemptsPerCluster();
+
+    /**
+     * Sets the amount of glowstone to attempt to spawn per cluster, must be
+     * greater than zero.
+     * 
+     * @param attempts The new amount to spawn
+     */
+    void setAttemptsPerCluster(int attempts);
+
+    /**
+     * A builder for constructing {@link Glowstone} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the number of clusters to attempt to spawn per chunk, must be
+         * greater than zero.
+         * 
+         * @param count The new amount to spawn
+         * @return This builder, for chaining
+         */
+        Builder perChunk(int count);
+
+        /**
+         * Sets the amount of glowstone to attempt to spawn per cluster, must be
+         * greater than zero.
+         * 
+         * @param attempts The new amount to spawn
+         * @return This builder, for chaining
+         */
+        Builder blocksPerCluster(int attempts);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link Glowstone} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        Glowstone build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/HugeTree.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/HugeTree.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.types.BiomeTreeType;
+import org.spongepowered.api.world.gen.Populator;
+
+/**
+ * Represents a populator which spawns the huge tree variants of the standard
+ * trees.
+ */
+public interface HugeTree extends Populator {
+
+    /**
+     * Gets the number of trees to attempt to spawn per chunk, must be greater
+     * than zero.
+     * 
+     * @return The number to spawn
+     */
+    int getTreesPerChunk();
+
+    /**
+     * Sets the number of trees to attempt to spawn per chunk, must be greater
+     * than zero.
+     * 
+     * @param count The new amount to spawn
+     */
+    void setTreesPerChunk(int count);
+
+    /**
+     * Gets the type of huge tree to spawn.
+     * 
+     * @return The tree type
+     */
+    BiomeTreeType getType();
+
+    /**
+     * Sets the type of huge tree to spawn. If the given type does not have a
+     * valid huge tree equivalent then this method will have no effect.
+     * 
+     * @param type The new tree type
+     */
+    void setType(BiomeTreeType type);
+
+    /**
+     * A builder for constructing {@link HugeTree} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the number of trees to attempt to spawn per chunk, must be
+         * greater than zero.
+         * 
+         * @param count The new amount to spawn
+         * @return This builder, for chaining
+         */
+        Builder perChunk(int count);
+
+        /**
+         * Sets the type of huge tree to spawn. If the given type does not have
+         * a valid huge tree equivalent then this method will have no effect.
+         * 
+         * @param type The new tree type
+         * @return This builder, for chaining
+         */
+        Builder type(BiomeTreeType type);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link HugeTree} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        HugeTree build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/IcePath.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/IcePath.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
+
+/**
+ * Represents a populator which places in a pseudo path of ice.
+ */
+public interface IcePath extends Populator {
+
+    /**
+     * Gets the radius of the path to spawn.
+     * 
+     * @return The path radius
+     */
+    int getRadius();
+
+    /**
+     * Sets the radius of the path to spawn, cannot be negative.
+     * 
+     * @param radius The new path radius
+     */
+    void setRadius(int radius);
+
+    /**
+     * Gets the number of sections to attempt to spawn per chunk, must be
+     * greater than zero.
+     * 
+     * @return The number to spawn
+     */
+    int getSectionsPerChunk();
+
+    /**
+     * Sets the number of sections to attempt to spawn per chunk, must be
+     * greater than zero.
+     * 
+     * @param sections The new amount to spawn
+     */
+    void setSectionsPerChunk(int sections);
+
+    /**
+     * A builder for constructing {@link IcePath} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the radius of the path to spawn, cannot be negative.
+         * 
+         * @param radius The new path radius
+         * @return This builder, for chaining
+         */
+        Builder radius(int radius);
+
+        /**
+         * Sets the number of sections to attempt to spawn per chunk, must be
+         * greater than zero.
+         * 
+         * @param sections The new amount to spawn
+         * @return This builder, for chaining
+         */
+        Builder perChunk(int sections);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link IcePath} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        IcePath build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/IceSpike.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/IceSpike.java
@@ -1,0 +1,184 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
+
+/**
+ * Represents a populator which generates large spikes of Ice.
+ */
+public interface IceSpike extends Populator {
+
+    /**
+     * Gets the base height of the spike.
+     * 
+     * @return The base height
+     */
+    int getBaseHeight();
+
+    /**
+     * Sets the base height of the spike.
+     * 
+     * @param height The new base height
+     */
+    void setBaseHeight(int height);
+
+    /**
+     * Gets the height variance of the spike. The final height will be the base
+     * height plus a random amount between zero (inclusive) and the variance
+     * (exclusive).
+     * 
+     * @return The height variance
+     */
+    int getHeightVariance();
+
+    /**
+     * Sets the height variance of the spike. The final height will be the base
+     * height plus a random amount between zero (inclusive) and the variance
+     * (exclusive).
+     * 
+     * @param variance The new height variance
+     */
+    void setHeightVariance(int variance);
+
+    /**
+     * Gets the chance of the spike much larger than normal. The default value
+     * is 60 (therefore equating to a 1 in 60 chance).
+     * 
+     * @return The spawn chance
+     */
+    int getExtremeSpikeChance();
+
+    /**
+     * Gets the chance of the spike much larger than normal. The default value
+     * is 60 (therefore equating to a 1 in 60 chance).
+     * 
+     * @param chance The new spawn chance
+     */
+    void setExtremeSpikeChance(int chance);
+
+    /**
+     * Gets the base height increase of the extreme spikes.
+     * 
+     * @return The base height increase
+     */
+    int getExtremeSpikeBaseIncrease();
+
+    /**
+     * Sets the base height increase of the extreme spikes.
+     * 
+     * @param increase The new base height increase
+     */
+    void setExtremeSpikeBaseIncrease(int increase);
+
+    /**
+     * Gets the variance in the height increase of extreme spikes. The final
+     * increase will be the base increase plus a random amount between zero
+     * (inclusive) and the variance (exclusive).
+     * 
+     * @return The increase variance
+     */
+    int getExtremeSpikeIncreaseVariance();
+
+    /**
+     * Sets the variance in the height increase of extreme spikes. The final
+     * increase will be the base increase plus a random amount between zero
+     * (inclusive) and the variance (exclusive).
+     * 
+     * @param variance The new increase variance
+     */
+    void setExtremeSpikeIncreaseVariance(int variance);
+
+    /**
+     * A builder for constructing {@link IceSpike} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the base height of the spike.
+         * 
+         * @param height The new base height
+         * @return This builder, for chaining
+         */
+        Builder height(int height);
+
+        /**
+         * Sets the height variance of the spike. The final height will be the
+         * base height plus a random amount between zero (inclusive) and the
+         * variance (exclusive).
+         * 
+         * @param variance The new height variance
+         * @return This builder, for chaining
+         */
+        Builder heightVariance(int variance);
+
+        /**
+         * Gets the chance of the spike much larger than normal. The default
+         * value is 60 (therefore equating to a 1 in 60 chance).
+         * 
+         * @param chance The new spawn chance
+         * @return This builder, for chaining
+         */
+        Builder extremeSpikeChance(int chance);
+
+        /**
+         * Sets the base height increase of the extreme spikes.
+         * 
+         * @param increase The new base height increase
+         * @return This builder, for chaining
+         */
+        Builder extremeSpikeBaseIncrease(int increase);
+
+        /**
+         * Sets the variance in the height increase of extreme spikes. The final
+         * increase will be the base increase plus a random amount between zero
+         * (inclusive) and the variance (exclusive).
+         * 
+         * @param variance The new increase variance
+         * @return This builder, for chaining
+         */
+        Builder extremeSpikeIncreaseVariance(int variance);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link IceSpike} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        IceSpike build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/JungleBush.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/JungleBush.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
+import org.spongepowered.api.block.BlockState;
+
+/**
+ * Represents a populator which creates the ground cover of bushes as found in
+ * jungle biomes.
+ */
+public interface JungleBush extends Populator {
+
+    /**
+     * Gets the {@link BlockState} to spawn the trunk of the brush with.
+     * 
+     * @return The trunk block state
+     */
+    BlockState getTrunkMaterial();
+
+    /**
+     * Sets the {@link BlockState} to spawn the trunk of the brush with.
+     * 
+     * @param material The new trunk block state
+     */
+    void setTrunkMaterial(BlockState material);
+
+    /**
+     * Gets the {@link BlockState} to spawn the leaves of the brush with.
+     * 
+     * @return The leaves block state
+     */
+    BlockState getLeavesMaterial();
+
+    /**
+     * Sets the {@link BlockState} to spawn the leaves of the brush with.
+     * 
+     * @param material The new leaves block state
+     */
+    void setLeavesMaterial(BlockState material);
+
+    /**
+     * A builder for constructing {@link JungleBush} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the {@link BlockState} to spawn the trunk of the brush with.
+         * 
+         * @param material The new trunk block state
+         * @return This builder, for chaining
+         */
+        Builder trunkMaterial(BlockState material);
+
+        /**
+         * Sets the {@link BlockState} to spawn the leaves of the brush with.
+         * 
+         * @param material The new leaves block state
+         * @return This builder, for chaining
+         */
+        Builder leavesMaterial(BlockState material);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link JungleBush} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        JungleBush build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/Lake.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/Lake.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
+import org.spongepowered.api.block.BlockState;
+
+/**
+ * Represents a populator which will attempt to spawn lakes within the chunk
+ * dependending on a random chance.
+ */
+public interface Lake extends Populator {
+
+    /**
+     * Gets the {@link BlockState} of the liquid to fill the lake with.
+     * 
+     * @return The lake block state
+     */
+    BlockState getLiquidType();
+
+    /**
+     * Sets the {@link BlockState} of the liquid to fill the lake with.
+     * 
+     * @param liquid The new lake block state
+     */
+    void setLiquidType(BlockState liquid);
+
+    /**
+     * Gets the chance of a lake spawning in a chunk. The default value is 4 for
+     * water lakes and 80 for lava lakes (therefore equating to a 1 in 4 chance
+     * and a 1 in 80 chance respectively).
+     * 
+     * @return The lake spawn chance
+     */
+    int getLakeChance();
+
+    /**
+     * Sets the chance of a lake spawning in a chunk. The default value is 4 for
+     * water lakes and 80 for lava lakes (therefore equating to a 1 in 4 chance
+     * and a 1 in 80 chance respectively).
+     * 
+     * @param chance The new lake spawn chance
+     */
+    void setLakeChance(int chance);
+
+    /**
+     * A builder for constructing {@link Lake} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the {@link BlockState} of the liquid to fill the lake with.
+         * 
+         * @param liquid The new lake block state
+         * @return This builder, for chaining
+         */
+        Builder liquidType(BlockState liquid);
+
+        /**
+         * Sets the chance of a lake spawning in a chunk. The default value is 4
+         * for water lakes and 80 for lava lakes (therefore equating to a 1 in 4
+         * chance and a 1 in 80 chance respectively).
+         * 
+         * @param chance The new lake spawn chance
+         * @return This builder, for chaining
+         */
+        Builder chance(int chance);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link Lake} populator with the settings
+         * set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        Lake build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/Melons.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/Melons.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
+
+/**
+ * Represents a populator which scatters melons randomly around the chunk.
+ */
+public interface Melons extends Populator {
+
+    /**
+     * Gets the number of melons to attempt to spawn per chunk, must be greater
+     * than zero. The default value is 64.
+     * 
+     * @return The number to spawn
+     */
+    int getMelonsPerChunk();
+
+    /**
+     * Sets the number of melons to attempt to spawn per chunk, must be greater
+     * than zero.
+     * 
+     * @param count The new amount to spawn
+     */
+    void setMelonsPerChunk(int count);
+
+    /**
+     * A builder for constructing {@link Melons} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the number of melons to attempt to spawn per chunk. The default
+         * value is 64.
+         * 
+         * @param count The new amount to spawn
+         * @return This builder, for chaining
+         */
+        Builder perChunk(int count);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link Melons} populator with the settings
+         * set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        Melons build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/Ore.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/Ore.java
@@ -1,0 +1,177 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.world.gen.Populator;
+
+/**
+ * Represents a populator which seeds the underground areas of the chunks with
+ * ores.
+ */
+public interface Ore extends Populator {
+
+    /**
+     * Gets the block to place as ore.
+     * 
+     * @return The ore block
+     */
+    BlockState getOreBlock();
+
+    /**
+     * Sets the block to place as ore.
+     * 
+     * @param block The new ore block
+     */
+    void setOreBlock(BlockState block);
+
+    /**
+     * Gets the size of deposit of ore. This is the number of blocks per clump
+     * of ores spawned.
+     * 
+     * @return The deposit size
+     */
+    int getDepositSize();
+
+    /**
+     * Sets the size of deposit of ore. This is the number of blocks per clump
+     * of ores spawned.
+     * 
+     * @param size The new deposit size
+     */
+    void setDepositSize(int size);
+
+    /**
+     * Gets the number of ore clumps to attempt to spawn per chunk, must be
+     * greater than zero.
+     * 
+     * @return The number of clumps to spawn
+     */
+    int getDepositsPerChunk();
+
+    /**
+     * Sets the number of ore clumps to attempt to spawn per chunk, must be
+     * greater than zero.
+     * 
+     * @param count The new number of clumps to spawn
+     */
+    void setDepositsPerChunk(int count);
+
+    /**
+     * Gets the minimum height that the ore can generate at.
+     * 
+     * @return The minimum height
+     */
+    int getMinHeight();
+
+    /**
+     * Sets the minimum height that the ore can generate at.
+     * 
+     * @param min The new minimum height
+     */
+    void setMinHeight(int min);
+
+    /**
+     * Gets the maximum height that the ore can generate at.
+     * 
+     * @return The maximum height
+     */
+    int getMaxHeight();
+
+    /**
+     * Sets the maximum height that the ore can generate at.
+     * 
+     * @param max The new maximum height
+     */
+    void setMaxHeight(int max);
+
+    /**
+     * A builder for constructing {@link Ore} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the block to place as ore.
+         * 
+         * @param block The new ore block
+         * @return This builder, for chaining
+         */
+        Builder ore(BlockState block);
+
+        /**
+         * Sets the size of deposit of ore. This is the number of blocks per
+         * clump of ores spawned.
+         * 
+         * @param size The new deposit size
+         * @return This builder, for chaining
+         */
+        Builder size(int size);
+
+        /**
+         * Sets the number of ore clumps to attempt to spawn per chunk, must be
+         * greater than zero.
+         * 
+         * @param count The new number of clumps to spawn
+         * @return This builder, for chaining
+         */
+        Builder perChunk(int count);
+
+        /**
+         * Sets the minimum height that the ore can generate at.
+         * 
+         * @param min The new minimum height
+         * @return This builder, for chaining
+         */
+        Builder minHeight(int min);
+
+        /**
+         * Sets the maximum height that the ore can generate at.
+         * 
+         * @param max The new maximum height
+         * @return This builder, for chaining
+         */
+        Builder maxHeight(int max);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link Ore} populator with the settings
+         * set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        Ore build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/Pumpkin.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/Pumpkin.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
+
+/**
+ * Represents a populator which spawns patches of pumpkins randomly within
+ * chunks.
+ */
+public interface Pumpkin extends Populator {
+
+    /**
+     * Gets the number of pumpkins to attempt to spawn per patch, must be
+     * greater than zero. The default value is 64.
+     * 
+     * @return The number to spawn
+     */
+    int getPumpkinsPerChunk();
+
+    /**
+     * Sets the number of pumpkins to attempt to spawn per patch, must be
+     * greater than zero. The default value is 64.
+     * 
+     * @param count The new number to spawn
+     */
+    void setPumpkinsPerChunk(int count);
+
+    /**
+     * Gets the chance of a pumpkin patch spawning within a chunk. The default
+     * value is 32 (which corresponds to a 1 in 32 chance).
+     * 
+     * @return The chance of a patch spawning
+     */
+    int getPumpkinChance();
+
+    /**
+     * Sets the chance of a pumpkin patch spawning within a chunk. The default
+     * value is 32 (which corresponds to a 1 in 32 chance).
+     * 
+     * @param chance The new chance of a patch spawning
+     */
+    void setPumpkinChance(int chance);
+
+    /**
+     * A builder for constructing {@link Pumpkin} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the number of pumpkins to attempt to spawn per patch, must be
+         * greater than zero. The default value is 64.
+         * 
+         * @param count The new number to spawn
+         * @return This builder, for chaining
+         */
+        Builder perChunk(int count);
+
+        /**
+         * Sets the chance of a pumpkin patch spawning within a chunk. The
+         * default value is 32 (which corresponds to a 1 in 32 chance).
+         * 
+         * @param chance The new chance of a patch spawning
+         * @return This builder, for chaining
+         */
+        Builder chance(int chance);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link Pumpkin} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        Pumpkin build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/RandomFire.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/RandomFire.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
+import org.spongepowered.api.block.BlockType;
+
+/**
+ * Represents a populator which creates fires on the surfaces of targeted
+ * blocks. In vanilla this is used to create random fires in the Nether.
+ */
+public interface RandomFire extends Populator {
+
+    /**
+     * Gets the number of fires to attempt to spawn per chunk, must be greater
+     * than zero.
+     * 
+     * @return The number to spawn
+     */
+    int getFirePerChunk();
+
+    /**
+     * Sets the number of fires to attempt to spawn per chunk, must be greater
+     * than zero.
+     * 
+     * @param count The new number to spawn
+     */
+    void setFirePerChunk(int count);
+
+    /**
+     * Gets the block type targeted by this populator, fires will only be
+     * started when on top of this block type.
+     * 
+     * @return The targeted block
+     */
+    BlockType getPlacementTarget();
+
+    /**
+     * Sets the block type targeted by this populator, fires will only be
+     * started when on top of this block type.
+     * 
+     * @param target The new targeted block
+     */
+    void setPlacementTarget(BlockType target);
+
+    /**
+     * A builder for constructing {@link RandomFire} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the number of fires to attempt to spawn per chunk, must be
+         * greater than zero.
+         * 
+         * @param count The new number to spawn
+         * @return This builder, for chaining
+         */
+        Builder perChunk(int count);
+
+        /**
+         * Sets the block type targeted by this populator, fires will only be
+         * started when on top of this block type.
+         * 
+         * @param target The new targeted block
+         * @return This builder, for chaining
+         */
+        Builder placementTarget(BlockType target);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link RandomFire} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        RandomFire build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/RandomLiquids.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/RandomLiquids.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
+import org.spongepowered.api.block.BlockState;
+
+/**
+ * Represents a populator which places random liquid sources in walls of caves
+ * or the terrain of the chunk.
+ */
+public interface RandomLiquids extends Populator {
+
+    /**
+     * Gets the {@link BlockState} of the liquid to fill the lake with.
+     * 
+     * @return The lake block state
+     */
+    BlockState getLiquidType();
+
+    /**
+     * Sets the {@link BlockState} of the liquid to fill the lake with.
+     * 
+     * @param liquid The new lake block state
+     */
+    void setLiquidType(BlockState liquid);
+
+    /**
+     * Gets the number of liquid sources to attempt to spawn per chunk, must be
+     * greater than zero. The default is 20 for lava and 50 for water.
+     * 
+     * @return The number of attempts to make
+     */
+    int getAttemptsPerChunk();
+
+    /**
+     * Sets the number of liquid sources to attempt to spawn per chunk, must be
+     * greater than zero. The default is 20 for lava and 50 for water.
+     * 
+     * @param attempts The new number of attempts to make
+     */
+    void setAttemptsPerChunk(int attempts);
+
+    /**
+     * A builder for constructing {@link RandomLiquids} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the {@link BlockState} of the liquid to fill the lake with.
+         * 
+         * @param liquid The new lake block state
+         * @return This builder, for chaining
+         */
+        Builder liquidType(BlockState liquid);
+
+        /**
+         * Sets the number of liquid sources to attempt to spawn per chunk, must
+         * be greater than zero. The default is 20 for lava and 50 for water.
+         * 
+         * @param attempts The new number of attempts to make
+         * @return This builder, for chaining
+         */
+        Builder perChunk(int attempts);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link RandomLiquids} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        RandomLiquids build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/Reeds.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/Reeds.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
+
+/**
+ * Represents a populator which spawns in reeds near valid water sources within
+ * the chunk.
+ */
+public interface Reeds extends Populator {
+
+    /**
+     * Gets the number of reeds to attempt to spawn per chunk, must be greater
+     * than zero.
+     * 
+     * @return The amount to spawn
+     */
+    int getReedsPerChunk();
+
+    /**
+     * Sets the number of reeds to attempt to spawn per chunk, must be greater
+     * than zero.
+     * 
+     * @param count The new amount to spawn
+     */
+    void setReedsPerChunk(int count);
+
+    /**
+     * A builder for constructing {@link Reeds} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the number of reeds to attempt to spawn per chunk, must be
+         * greater than zero.
+         * 
+         * @param count The new amount to spawn
+         * @return This builder, for chaining
+         */
+        Builder perChunk(int count);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link Reeds} populator with the settings
+         * set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        Reeds build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/SeaFloor.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/SeaFloor.java
@@ -1,0 +1,130 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
+import org.spongepowered.api.block.BlockState;
+
+/**
+ * Represents a populator which places down a disc of material onto the bottom
+ * on an ocean or river.
+ */
+public interface SeaFloor extends Populator {
+
+    /**
+     * Gets the {@link BlockState} to place down.
+     * 
+     * @return The block to place
+     */
+    BlockState getBlock();
+
+    /**
+     * Sets the {@link BlockState} to place down.
+     * 
+     * @param block The new block to place
+     */
+    void setBlock(BlockState block);
+
+    /**
+     * Gets the number of discs to attempt to spawn per chunk, must be greater
+     * than zero.
+     * 
+     * @return The amount to spawn
+     */
+    int getBlocksPerChunk();
+
+    /**
+     * Sets the number of discs to attempt to spawn per chunk, must be greater
+     * than zero.
+     * 
+     * @param count The new amount to spawn
+     */
+    void setBlocksPerChunk(int count);
+
+    /**
+     * Gets the radius of the discs being spawned.
+     * 
+     * @return The disc radius
+     */
+    int getRadius();
+
+    /**
+     * Sets the radius of the discs being spawned.
+     * 
+     * @param radius The new disc radius
+     */
+    void setRadius(int radius);
+
+    /**
+     * A builder for constructing {@link SeaFloor} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the {@link BlockState} to place down.
+         * 
+         * @param block The new block to place
+         * @return This builder, for chaining
+         */
+        Builder block(BlockState block);
+
+        /**
+         * Sets the number of discs to attempt to spawn per chunk, must be greater
+         * than zero.
+         * 
+         * @param count The new amount to spawn
+         * @return This builder, for chaining
+         */
+        Builder perChunk(int count);
+
+        /**
+         * Sets the radius of the discs being spawned.
+         * 
+         * @param radius The new disc radius
+         * @return This builder, for chaining
+         */
+        Builder radius(int radius);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link SeaFloor} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        SeaFloor build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/Shrub.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/Shrub.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.data.types.ShrubType;
+import org.spongepowered.api.world.gen.Populator;
+
+/**
+ * Represents a populator which places down various variants of
+ * {@link ShrubType}s within the chunk.
+ */
+public interface Shrub extends Populator {
+
+    /**
+     * Gets the {@link ShrubType} to place.
+     * 
+     * @return The shrub type
+     */
+    ShrubType getType();
+
+    /**
+     * Sets the {@link ShrubType} to place.
+     * 
+     * @param type The new shrub type
+     */
+    void setType(ShrubType type);
+
+    /**
+     * Gets the number of shrubs to attempt to spawn per chunk, must be greater
+     * than zero.
+     * 
+     * @return The amount of shrubs to spawn
+     */
+    int getShrubsPerChunk();
+
+    /**
+     * Sets the number of shrubs to attempt to spawn per chunk, must be greater
+     * than zero.
+     * 
+     * @param count The new amount of shrubs to spawn
+     */
+    void setShrubsPerChunk(int count);
+
+    /**
+     * A builder for constructing {@link Shrub} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the number of shrubs to attempt to spawn per chunk, must be
+         * greater than zero.
+         * 
+         * @param count The new amount of shrubs to spawn
+         * @return This builder, for chaining
+         */
+        Builder perChunk(int count);
+
+        /**
+         * Sets the {@link ShrubType} to place.
+         * 
+         * @param type The new shrub type
+         * @return This builder, for chaining
+         */
+        Builder type(ShrubType type);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link Shrub} populator with the settings
+         * set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        Shrub build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/Vines.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/Vines.java
@@ -23,21 +23,37 @@
  * THE SOFTWARE.
  */
 
-package org.spongepowered.api.world;
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
 
 /**
- * An enumeration of default {@link GeneratorType}s.
+ * Represents a populator which places large amounts of vines on surfaces within
+ * the chunk.
  */
-public final class GeneratorTypes {
+public interface Vines extends Populator {
 
-    public static final GeneratorType DEBUG = null;
-    public static final GeneratorType DEFAULT = null;
-    public static final GeneratorType FLAT = null;
-    public static final GeneratorType NETHER = null;
-    public static final GeneratorType OVERWORLD = null;
-    public static final GeneratorType END = null;
+    /**
+     * A builder for constructing {@link Vines} populators.
+     */
+    public static interface Builder {
 
-    private GeneratorTypes() {
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link Vines} populator with the settings
+         * set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        Vines build() throws IllegalStateException;
+
     }
-
 }

--- a/src/main/java/org/spongepowered/api/world/gen/populators/WaterLily.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/WaterLily.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.world.gen.populators;
+
+import org.spongepowered.api.world.gen.Populator;
+
+/**
+ * Represents a populator which places in water lilies 
+ */
+public interface WaterLily extends Populator {
+
+    /**
+     * Gets the number of water lilies to attempt to spawn per chunk, must be
+     * greater than zero. The default value is 4.
+     * 
+     * @return The amount to spawn
+     */
+    int getWaterLilyPerChunk();
+
+    /**
+     * Sets the number of water lilies to attempt to spawn per chunk, must be
+     * greater than zero. The default value is 4.
+     * 
+     * @param count The new amount to spawn
+     */
+    void setWaterLilyPerChunk(int count);
+
+    /**
+     * A builder for constructing {@link WaterLily} populators.
+     */
+    public static interface Builder {
+
+        /**
+         * Sets the number of water lilies to attempt to spawn per chunk, must
+         * be greater than zero. The default value is 4.
+         * 
+         * @param count The new amount to spawn
+         * @return This builder, for chaining
+         */
+        Builder perChunk(int count);
+
+        /**
+         * Resets this builder to the default values.
+         * 
+         * @return This builder, for chaining
+         */
+        Builder reset();
+
+        /**
+         * Builds a new instance of a {@link WaterLily} populator with the
+         * settings set within the builder.
+         * 
+         * @return A new instance of the populator
+         * @throws IllegalStateException If there are any settings left unset
+         *             which do not have default values
+         */
+        WaterLily build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populators/package-info.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populators/package-info.java
@@ -23,21 +23,4 @@
  * THE SOFTWARE.
  */
 
-package org.spongepowered.api.world;
-
-/**
- * An enumeration of default {@link GeneratorType}s.
- */
-public final class GeneratorTypes {
-
-    public static final GeneratorType DEBUG = null;
-    public static final GeneratorType DEFAULT = null;
-    public static final GeneratorType FLAT = null;
-    public static final GeneratorType NETHER = null;
-    public static final GeneratorType OVERWORLD = null;
-    public static final GeneratorType END = null;
-
-    private GeneratorTypes() {
-    }
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.world.gen.populators;

--- a/src/main/java/org/spongepowered/api/world/gen/types/BiomeTreeType.java
+++ b/src/main/java/org/spongepowered/api/world/gen/types/BiomeTreeType.java
@@ -23,21 +23,16 @@
  * THE SOFTWARE.
  */
 
-package org.spongepowered.api.world;
+package org.spongepowered.api.world.gen.types;
+
+import org.spongepowered.api.CatalogType;
+
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
- * An enumeration of default {@link GeneratorType}s.
+ * Represents the various types of trees which may be spawned into the world.
  */
-public final class GeneratorTypes {
-
-    public static final GeneratorType DEBUG = null;
-    public static final GeneratorType DEFAULT = null;
-    public static final GeneratorType FLAT = null;
-    public static final GeneratorType NETHER = null;
-    public static final GeneratorType OVERWORLD = null;
-    public static final GeneratorType END = null;
-
-    private GeneratorTypes() {
-    }
+@CatalogedBy(BiomeTreeTypes.class)
+public interface BiomeTreeType extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/world/gen/types/BiomeTreeTypes.java
+++ b/src/main/java/org/spongepowered/api/world/gen/types/BiomeTreeTypes.java
@@ -23,21 +23,23 @@
  * THE SOFTWARE.
  */
 
-package org.spongepowered.api.world;
+package org.spongepowered.api.world.gen.types;
 
 /**
- * An enumeration of default {@link GeneratorType}s.
+ * A enumeration of known {@link BiomeTreeType}s.
  */
-public final class GeneratorTypes {
+public final class BiomeTreeTypes {
 
-    public static final GeneratorType DEBUG = null;
-    public static final GeneratorType DEFAULT = null;
-    public static final GeneratorType FLAT = null;
-    public static final GeneratorType NETHER = null;
-    public static final GeneratorType OVERWORLD = null;
-    public static final GeneratorType END = null;
+    public static final BiomeTreeType OAK = null;
+    public static final BiomeTreeType BIRCH = null;
+    public static final BiomeTreeType TALL_TAIGA = null;
+    public static final BiomeTreeType POINTY_TAIGA = null;
+    public static final BiomeTreeType JUNGLE = null;
+    public static final BiomeTreeType SAVANNA = null;
+    public static final BiomeTreeType CANOPY = null;
+    public static final BiomeTreeType SWAMP = null;
 
-    private GeneratorTypes() {
+    private BiomeTreeTypes() {
     }
 
 }

--- a/src/main/java/org/spongepowered/api/world/gen/types/package-info.java
+++ b/src/main/java/org/spongepowered/api/world/gen/types/package-info.java
@@ -23,21 +23,4 @@
  * THE SOFTWARE.
  */
 
-package org.spongepowered.api.world;
-
-/**
- * An enumeration of default {@link GeneratorType}s.
- */
-public final class GeneratorTypes {
-
-    public static final GeneratorType DEBUG = null;
-    public static final GeneratorType DEFAULT = null;
-    public static final GeneratorType FLAT = null;
-    public static final GeneratorType NETHER = null;
-    public static final GeneratorType OVERWORLD = null;
-    public static final GeneratorType END = null;
-
-    private GeneratorTypes() {
-    }
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.world.gen.types;


### PR DESCRIPTION
In order to finish fleshing out the WorldGenerator the last piece is per-biome populators. So these would be populators which are registered into individual biomes and run on a per biome basis. Additional to the populators each biome needs a special case of the GeneratorPopulator except that it only handles a single collumn within the BlockBuffer in order to replace the blocks within that column to the correct counterparts for the biome. This has been tentatively named a ColumnPopulator (name suggestions wanted).

The order of operations for world generation:
---------------------------------------------
The generation process for chunks is divided into two phases, generation and population. The generation phase is in charge of creating the base terrain shape and generating large terrain features. All operations during the generation phase act upon a BlockBuffer rather than a live chunk object.

Conversely the population phase operates against a live chunk object and has the guarantee that all immediately surrounding chunks have at least passed the generation phase. The population phase is typically used for the placement of small features and objects placed my cross chunk boundaries.

**The generation phase:**
 1. Create the chunk buffer
 2. Call the base GeneratorPopulator to create the base terrain shape
 3. Pass each 1x1 collumn of the chunk to the BiomePopulator
 4. Call each of the GeneratorPopulators registered to the biome
 5. Call each of the GeneratorPopulators registered to the generator
 6. Build the chunk object from the chunk buffer

**The population phase:**
 1. Validate surrounding chunks
 2. Pass the chunk to each of the populators registered to the biome (based off the biome of an arbitrary point in the chunk (16, 0, 16 in vanilla))
 3. Pass the chunk to each of the populators registered to the generator

Additionally
--------------------------------------------
This PR also adds a number of the vanilla `Populator`s, accessible through the `PopulatorFactory` (via the game registry). which may be modified and added to existing worlds or custom world generators in order to gain easy access to the vanilla population procedures.
