### PR TITLE
[WIP] Add CommandResult

### DIFF
--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -905,16 +905,16 @@ public final class SpongeEventFactory {
      * @param arguments The arguments provided
      * @param source The source of the command
      * @param command The command name
-     * @param result The result of the command, or {@code null}
+     * @param result The result of the command, or null
      * @return A new instance of the event
      */
-    public static CommandEvent createCommand(Game game, String arguments, CommandSource source, String command, @Nullable CommandResult result) {
+    public static CommandEvent createCommand(Game game, String arguments, CommandSource source, String command, CommandResult result) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("arguments", arguments);
         values.put("source", source);
         values.put("command", command);
-        values.put("result", result);
+        values.put("result", Optional.fromNullable(result));
         return createEvent(CommandEvent.class, values);
     }
 

--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -32,7 +32,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Maps;
-
 import org.spongepowered.api.Game;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.tile.carrier.BrewingStand;

--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -32,6 +32,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Maps;
+
 import org.spongepowered.api.Game;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.tile.carrier.BrewingStand;
@@ -139,6 +140,7 @@ import org.spongepowered.api.stats.achievement.Achievement;
 import org.spongepowered.api.status.StatusClient;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.Direction;
+import org.spongepowered.api.util.command.CommandResult;
 import org.spongepowered.api.util.command.CommandSource;
 import org.spongepowered.api.util.event.factory.ClassGeneratorProvider;
 import org.spongepowered.api.util.event.factory.EventFactory;
@@ -904,14 +906,16 @@ public final class SpongeEventFactory {
      * @param arguments The arguments provided
      * @param source The source of the command
      * @param command The command name
+     * @param result The result of the command, or {@code null}
      * @return A new instance of the event
      */
-    public static CommandEvent createCommand(Game game, String arguments, CommandSource source, String command) {
+    public static CommandEvent createCommand(Game game, String arguments, CommandSource source, String command, @Nullable CommandResult result) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("arguments", arguments);
         values.put("source", source);
         values.put("command", command);
+        values.put("result", result);
         return createEvent(CommandEvent.class, values);
     }
 

--- a/src/main/java/org/spongepowered/api/event/message/CommandEvent.java
+++ b/src/main/java/org/spongepowered/api/event/message/CommandEvent.java
@@ -27,7 +27,11 @@ package org.spongepowered.api.event.message;
 
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.GameEvent;
+import org.spongepowered.api.util.command.CommandResult;
 import org.spongepowered.api.util.command.CommandSource;
+import com.google.common.base.Optional;
+
+import javax.annotation.Nullable;
 
 /**
  * Fired when a command has been used and needs to be processed.
@@ -60,5 +64,20 @@ public interface CommandEvent extends GameEvent, Cancellable {
      * @return The arguments
      */
     String getArguments();
+
+    /**
+     * The result of the command. This is only available after the execution 
+     * of the command.
+     * 
+     * @return The result of the command, if present
+     */
+    Optional<CommandResult> getResult();
+
+    /**
+     * Sets the result of the command.
+     * 
+     * @param result The result of the command, or null
+     */
+    void setResult(@Nullable CommandResult result);
 
 }

--- a/src/main/java/org/spongepowered/api/service/command/SimpleCommandService.java
+++ b/src/main/java/org/spongepowered/api/service/command/SimpleCommandService.java
@@ -45,6 +45,7 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.command.CommandCallable;
 import org.spongepowered.api.util.command.CommandException;
 import org.spongepowered.api.util.command.CommandMapping;
+import org.spongepowered.api.util.command.CommandResult;
 import org.spongepowered.api.util.command.CommandSource;
 import org.spongepowered.api.util.command.dispatcher.SimpleDispatcher;
 
@@ -95,7 +96,11 @@ public class SimpleCommandService implements CommandService {
     @Subscribe(order = Order.LAST)
     public void onCommandEvent(final CommandEvent event) {
         try {
-            if (call(event.getSource(), event.getCommand() + " " + event.getArguments(), Collections.<String>emptyList())) {
+            CommandResult result = call(event.getSource(), event.getCommand() + " " + event.getArguments(), Collections.<String>emptyList());
+
+            event.setResult(result);
+
+            if (result.wasProcessed()) {
                 event.setCancelled(true);
             }
         } catch (CommandException e) {
@@ -227,7 +232,7 @@ public class SimpleCommandService implements CommandService {
     }
 
     @Override
-    public boolean call(CommandSource source, String arguments, List<String> parents) throws CommandException {
+    public CommandResult call(CommandSource source, String arguments, List<String> parents) throws CommandException {
         return this.dispatcher.call(source, arguments, parents);
     }
 

--- a/src/main/java/org/spongepowered/api/util/command/CommandCallable.java
+++ b/src/main/java/org/spongepowered/api/util/command/CommandCallable.java
@@ -48,10 +48,10 @@ public interface CommandCallable extends CommandCompleter {
      * @param arguments The raw arguments for this command
      * @param parents A stack of parent commands, where the first entry is
      *                the root command
-     * @return Whether a command was processed
+     * @return The result of the command
      * @throws CommandException Thrown on a command error
      */
-    boolean call(CommandSource source, String arguments, List<String> parents) throws CommandException;
+    CommandResult call(CommandSource source, String arguments, List<String> parents) throws CommandException;
 
     /**
      * Test whether this command can probably be executed by the given source.

--- a/src/main/java/org/spongepowered/api/util/command/CommandResult.java
+++ b/src/main/java/org/spongepowered/api/util/command/CommandResult.java
@@ -55,7 +55,7 @@ public class CommandResult {
      * @param queryResult The query result
      * @param resultInfo A map storing additional information
      */
-    protected CommandResult(boolean processed, @Nullable Integer successCount, @Nullable Integer affectedBlocks, @Nullable Integer affectedEntities,
+    CommandResult(boolean processed, @Nullable Integer successCount, @Nullable Integer affectedBlocks, @Nullable Integer affectedEntities,
             @Nullable Integer affectedItems, @Nullable Integer queryResult, @Nullable Map<String, Object> resultInfo) {
         this.processed = processed;
         this.successCount = Optional.fromNullable(successCount);

--- a/src/main/java/org/spongepowered/api/util/command/CommandResult.java
+++ b/src/main/java/org/spongepowered/api/util/command/CommandResult.java
@@ -115,7 +115,8 @@ public class CommandResult {
     }
 
     /**
-     * Gets the query result of the command.
+     * Gets the query result of the command, e.g. the time of the day,
+     * an amount of money or a player's amount of XP.
      *
      * @return The query result of the command, if one exists
      */

--- a/src/main/java/org/spongepowered/api/util/command/CommandResult.java
+++ b/src/main/java/org/spongepowered/api/util/command/CommandResult.java
@@ -1,0 +1,135 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.util.command;
+
+import com.google.common.base.Optional;
+
+import java.util.Collections;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents the result of a command in Sponge.
+ */
+public class CommandResult {
+
+    private final boolean processed;
+    private final Optional<Integer> successCount;
+    private final Optional<Integer> affectedBlocks;
+    private final Optional<Integer> affectedEntities;
+    private final Optional<Integer> affectedItems;
+    private final Optional<Integer> queryResult;
+    private final Map<String, Object> resultInfo;
+
+    /**
+     * Constructs a new command result.
+     * 
+     * @param processed True if the command was processed
+     * @param successCount The success count
+     * @param affectedBlocks The number of affected blocks
+     * @param affectedEntities The number of affected entities
+     * @param affectedItems The number of affected items
+     * @param queryResult The query result
+     * @param resultInfo A map storing additional information
+     */
+    protected CommandResult(boolean processed, @Nullable Integer successCount, @Nullable Integer affectedBlocks, @Nullable Integer affectedEntities,
+            @Nullable Integer affectedItems, @Nullable Integer queryResult, @Nullable Map<String, Object> resultInfo) {
+        this.processed = processed;
+        this.successCount = Optional.fromNullable(successCount);
+        this.affectedBlocks = Optional.fromNullable(affectedBlocks);
+        this.affectedEntities = Optional.fromNullable(affectedEntities);
+        this.affectedItems = Optional.fromNullable(affectedItems);
+        this.queryResult = Optional.fromNullable(queryResult);
+        this.resultInfo = resultInfo != null ? Collections.unmodifiableMap(resultInfo) : Collections.<String, Object>emptyMap();
+    }
+
+    /**
+     * Tests if the command was processed.
+     *
+     * @return True if the command was processed
+     */
+    public boolean wasProcessed() {
+        return this.processed;
+    }
+
+    /**
+     * Gets the success count of the command.
+     * 
+     * @return The success count of the command
+     */
+    public Optional<Integer> getSuccessCount() {
+        return this.successCount;
+    }
+
+    /**
+     * Gets the number of blocks affected by the command.
+     *
+     * @return The number of blocks affected by the command, if such a count
+     *         exists
+     */
+    public Optional<Integer> getAffectedBlocks() {
+        return this.affectedBlocks;
+    }
+
+    /**
+     * Gets the number of entities affected by the command.
+     *
+     * @return The number of entities affected by the command, if such a count
+     *         exists
+     */
+    public Optional<Integer> getAffectedEntities() {
+        return this.affectedEntities;
+    }
+
+    /**
+     * Gets the number of items affected by the command.
+     *
+     * @return The number of items affected by the command, if such a count
+     *         exists
+     */
+    public Optional<Integer> getAffectedItems() {
+        return this.affectedItems;
+    }
+
+    /**
+     * Gets the query result of the command.
+     *
+     * @return The query result of the command, if one exists
+     */
+    public Optional<Integer> getQueryResult() {
+        return this.queryResult;
+    }
+
+    /**
+     * Gets a Map used by the command to store information about what it did.
+     *
+     * @return A Map used by the command to store information about what it did.
+     */
+    public Map<String, Object> getResultInfo() {
+        return this.resultInfo;
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/util/command/CommandResultBuilder.java
+++ b/src/main/java/org/spongepowered/api/util/command/CommandResultBuilder.java
@@ -141,7 +141,7 @@ public class CommandResultBuilder {
      *
      * @return A CommandResult with the specified settings
      */
-    CommandResult build() {
+    public CommandResult build() {
         return new CommandResult(this.processed, this.successCount, this.affectedBlocks, this.affectedEntities, this.affectedItems, this.queryResult,
                 this.resultInfo);
     }

--- a/src/main/java/org/spongepowered/api/util/command/CommandResultBuilder.java
+++ b/src/main/java/org/spongepowered/api/util/command/CommandResultBuilder.java
@@ -99,7 +99,8 @@ public class CommandResultBuilder {
     }
 
     /**
-     * Sets the query result of the command.
+     * Sets the query result of the command, e.g. the time of the day,
+     * an amount of money or a player's amount of XP.
      *
      * @param queryResult The query result of the command
      * @return This builder, for chaining

--- a/src/main/java/org/spongepowered/api/util/command/CommandResultBuilder.java
+++ b/src/main/java/org/spongepowered/api/util/command/CommandResultBuilder.java
@@ -105,7 +105,7 @@ public class CommandResultBuilder {
      * @param queryResult The query result of the command
      * @return This builder, for chaining
      */
-    public  CommandResultBuilder queryResult(@Nullable Integer queryResult) {
+    public CommandResultBuilder queryResult(@Nullable Integer queryResult) {
         this.queryResult = queryResult;
         return this;
     }

--- a/src/main/java/org/spongepowered/api/util/command/CommandResultBuilder.java
+++ b/src/main/java/org/spongepowered/api/util/command/CommandResultBuilder.java
@@ -1,0 +1,147 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.util.command;
+
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+/**
+ * A builder for {@link CommandResult}s.
+ */
+public class CommandResultBuilder {
+
+    private boolean processed;
+    private Integer successCount;
+    private Integer affectedBlocks;
+    private Integer affectedEntities;
+    private Integer affectedItems;
+    private Integer queryResult;
+    private Map<String, Object> resultInfo;
+
+    /**
+     * Sets if the command has been processed.
+     *
+     * @param processed If the command has been processed
+     * @return This builder, for chaining
+     */
+    public CommandResultBuilder processed(boolean processed) {
+        this.processed = processed;
+        return this;
+    }
+
+    /**
+     * Sets if the command has been processed.
+     *
+     * @param successCount If the command has been processed
+     * @return This builder, for chaining
+     */
+    public CommandResultBuilder successCount(@Nullable Integer successCount) {
+        this.successCount = successCount;
+        return this;
+    }
+
+    /**
+     * Sets the amount of blocks affected by the command.
+     *
+     * @param affectedBlocks The amount of blocks affected by the command
+     * @return This builder, for chaining
+     */
+    public CommandResultBuilder affectedBlocks(@Nullable Integer affectedBlocks) {
+        this.affectedBlocks = affectedBlocks;
+        return this;
+    }
+
+    /**
+     * Sets the amount of entities affected by the command.
+     *
+     * @param affectedEntities The amount of entities affected by the command
+     * @return This builder, for chaining
+     */
+    public CommandResultBuilder affectedEntities(@Nullable Integer affectedEntities) {
+        this.affectedEntities = affectedEntities;
+        return this;
+    }
+
+    /**
+     * Sets the amount of items affected by the command.
+     *
+     * @param affectedItems The amount of items affected by the command
+     * @return This builder, for chaining
+     */
+    public CommandResultBuilder affectedItems(@Nullable Integer affectedItems) {
+        this.affectedItems = affectedItems;
+        return this;
+    }
+
+    /**
+     * Sets the query result of the command.
+     *
+     * @param queryResult The query result of the command
+     * @return This builder, for chaining
+     */
+    public  CommandResultBuilder queryResult(@Nullable Integer queryResult) {
+        this.queryResult = queryResult;
+        return this;
+    }
+
+    /**
+     * Adds a key-value pair to the result info map.
+     *
+     * @param key The key.
+     * @param value The value.
+     * @return This builder, for chaining
+     */
+    public CommandResultBuilder resultInfo(String key, Object value) {
+        if (this.resultInfo == null) {
+            this.resultInfo = Maps.<String, Object>newHashMap();
+        }
+        this.resultInfo.put(key, value);
+        return this;
+    }
+
+    /**
+     * Adds a set of key-value pairs result info map.
+     *
+     * @param resultInfo A map of several key-value pairs
+     * @return This builder, for chaining
+     */
+    public CommandResultBuilder resultInfo(@Nullable Map<String, Object> resultInfo) {
+        this.resultInfo = resultInfo;
+        return this;
+    }
+
+    /**
+     * Builds the {@link CommandResult}.
+     *
+     * @return A CommandResult with the specified settings
+     */
+    CommandResult build() {
+        return new CommandResult(this.processed, this.successCount, this.affectedBlocks, this.affectedEntities, this.affectedItems, this.queryResult,
+                this.resultInfo);
+    }
+}

--- a/src/main/java/org/spongepowered/api/util/command/CommandResults.java
+++ b/src/main/java/org/spongepowered/api/util/command/CommandResults.java
@@ -37,31 +37,30 @@ public class CommandResults {
 
     /**
      * Returns a {@link CommandResultBuilder}.
-     * 
+     *
      * @return A new command result builder
      */
-    public static CommandResultBuilder builder() 
-    {
+    public static CommandResultBuilder builder() {
         return new CommandResultBuilder();
     }
 
     /**
-     * Returns a new {@link CommandResult} indicating that a command was processed.
-     * 
-     * @return The command result 
+     * Returns a new {@link CommandResult} indicating that a command was
+     * processed.
+     *
+     * @return The command result
      */
-    public static CommandResult processed() 
-    {
+    public static CommandResult processed() {
         return PROCESSED;
     }
 
     /**
-     * Returns a new {@link CommandResult} indicating that a command was not processed.
-     * 
+     * Returns a new {@link CommandResult} indicating that a command was not
+     * processed.
+     *
      * @return The command result
      */
-    public static CommandResult notProcessed() 
-    {
+    public static CommandResult notProcessed() {
         return NOT_PROCESSED;
     }
 

--- a/src/main/java/org/spongepowered/api/util/command/CommandResults.java
+++ b/src/main/java/org/spongepowered/api/util/command/CommandResults.java
@@ -29,6 +29,9 @@ package org.spongepowered.api.util.command;
  */
 public class CommandResults {
 
+    private static final CommandResult PROCESSED = new CommandResultBuilder().processed(true).build();
+    private static final CommandResult NOT_PROCESSED = new CommandResultBuilder().processed(false).build();
+
     private CommandResults() {
     }
 
@@ -49,7 +52,7 @@ public class CommandResults {
      */
     public static CommandResult processed() 
     {
-        return new CommandResultBuilder().processed(true).build();
+        return PROCESSED;
     }
 
     /**
@@ -59,7 +62,7 @@ public class CommandResults {
      */
     public static CommandResult notProcessed() 
     {
-        return new CommandResultBuilder().processed(false).build();
+        return NOT_PROCESSED;
     }
 
 }

--- a/src/main/java/org/spongepowered/api/util/command/CommandResults.java
+++ b/src/main/java/org/spongepowered/api/util/command/CommandResults.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.util.command;
+
+/**
+ * Utility class to create {@link CommandResult}s.
+ */
+public class CommandResults {
+
+    private CommandResults() {
+    }
+
+    /**
+     * Returns a {@link CommandResultBuilder}.
+     * 
+     * @return A new command result builder
+     */
+    public static CommandResultBuilder builder() 
+    {
+        return new CommandResultBuilder();
+    }
+
+    /**
+     * Returns a new {@link CommandResult} indicating that a command was processed.
+     * 
+     * @return The command result 
+     */
+    public static CommandResult processed() 
+    {
+        return new CommandResultBuilder().processed(true).build();
+    }
+
+    /**
+     * Returns a new {@link CommandResult} indicating that a command was not processed.
+     * 
+     * @return The command result
+     */
+    public static CommandResult notProcessed() 
+    {
+        return new CommandResultBuilder().processed(false).build();
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/util/command/dispatcher/SimpleDispatcher.java
+++ b/src/main/java/org/spongepowered/api/util/command/dispatcher/SimpleDispatcher.java
@@ -37,6 +37,8 @@ import org.spongepowered.api.text.Texts;
 import org.spongepowered.api.util.command.CommandCallable;
 import org.spongepowered.api.util.command.CommandException;
 import org.spongepowered.api.util.command.CommandMapping;
+import org.spongepowered.api.util.command.CommandResult;
+import org.spongepowered.api.util.command.CommandResults;
 import org.spongepowered.api.util.command.CommandSource;
 import org.spongepowered.api.util.command.ImmutableCommandMapping;
 import org.spongepowered.api.util.command.InvocationCommandException;
@@ -315,7 +317,7 @@ public class SimpleDispatcher implements Dispatcher {
     }
 
     @Override
-    public boolean call(CommandSource source, String arguments, List<String> parents) throws CommandException {
+    public CommandResult call(CommandSource source, String arguments, List<String> parents) throws CommandException {
         String[] parts = arguments.split(" +", 2);
         Optional<CommandMapping> mapping = get(parts[0]);
 
@@ -332,9 +334,9 @@ public class SimpleDispatcher implements Dispatcher {
                 throw new InvocationCommandException(t);
             }
 
-            return true;
+            return CommandResults.processed();
         } else {
-            return false;
+            return CommandResults.notProcessed();
         }
     }
 


### PR DESCRIPTION
Continuation of https://github.com/SpongePowered/SpongeAPI/pull/409 and https://github.com/SpongePowered/SpongeAPI/pull/524

This issue explains what command stats are used for: https://github.com/SpongePowered/SpongeAPI/issues/326. I don't know why it was closed.

This PR replaces the ``boolean`` that is returned when a command is called with a ``CommandResult`` object, which stores the command stats ``SuccessCount``, ``AffectedBlocks``, ``AffectedEntities``, ``AffectedItems`` and ``QueryResult``. I also added a ``Map`` for custom data.

The ``CommandResult`` is passed with the ``CommandEvent`` after the execution of the command.

The implementation is based on @AlphaModder's pull request, but uses classes instead of interfaces to make it easier to use the system (similar to the Text API). 

The only thing that changes is that plugin developers now have to use a builder to create a ``CommandResult``:

```java
MyCommand implements CommandCallable {
    CommandResult call(CommandSource source, String arguments, List<String> parents) {
        ...
        return CommandResults.processed(); 
        // equal to CommandResults.builder().setProcessed(true).build();
    }
    ...
}
```

I'm not sure if this is the best way of implementing it. I also thought about a system that uses separate classes for each result data type (similar to the Data API proposal):

```java
CommandResult {
    boolean wasProcessed();
    <T> Optional<T> getData(Class<T extends CommandResultData> clazz);
}
```




