### PR TITLE
Fixes for the custom world generator API

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -39,7 +39,6 @@ import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStackBuilder;
 import org.spongepowered.api.item.merchant.TradeOfferBuilder;
 import org.spongepowered.api.item.recipe.RecipeRegistry;
-import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.potion.PotionEffectBuilder;
 import org.spongepowered.api.resourcepack.ResourcePack;
 import org.spongepowered.api.scoreboard.ScoreboardBuilder;
@@ -447,15 +446,10 @@ public interface GameRegistry {
      * Registers a {@link WorldGeneratorModifier}, so that the server is able to
      * use it for modifying the world generator of a new world.
      *
-     * @param plugin The plugin registering the world generator. Will be used to
-     *        prefix the given id.
-     * @param genId An id for the generator. The plugin name may be used for this,
-     *        but it may be anything that doens't contain a space or a colon.
-     *        The full name of the generator modifier will become "pluginId:genId".
      * @param modifier The modifier to register
      */
-    void registerWorldGeneratorModifier(PluginContainer plugin, String genId, WorldGeneratorModifier modifier);
-    
+    void registerWorldGeneratorModifier(WorldGeneratorModifier modifier);
+
     /**
      * Gets the {@link PopulatorFactory} for creating {@link Populator}s and
      * {@link GeneratorPopulator}s.

--- a/src/main/java/org/spongepowered/api/world/gen/WorldGeneratorModifier.java
+++ b/src/main/java/org/spongepowered/api/world/gen/WorldGeneratorModifier.java
@@ -24,18 +24,25 @@
  */
 package org.spongepowered.api.world.gen;
 
-import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.GameRegistry;
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.data.DataContainer;
-import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.world.WorldCreationSettings;
 
 /**
- * If a plugin wishes to modify a world generator, the plugin must register a
- * custom implementation of this interface.
+ * Custom world generation is done using this interface. Any plugin that wishes
+ * to modify the world generator should implement this interface. When the
+ * server admin/player has chosen to use this modifier for a world, the method
+ * {@link #modifyWorldGenerator(WorldCreationSettings, DataContainer, WorldGenerator)}
+ * will be called.
  *
- * @see GameRegistry#registerWorldGeneratorModifier(PluginContainer, String,
- *      WorldGeneratorModifier)
+ * <p>The modifier can change every aspect of terrain generation using the
+ * {@link WorldGenerator} provided as a parameter to {@code modifyWorldGenerator}.
+ * This is no requirement, you can for example replace only the biome generator.
+ * Multiple world generator modifiers can be applied on a single world.</p>
+ *
+ * <p>Implementations of this interface must be registered using 
+ * {@link GameRegistry#registerWorldGeneratorModifier(WorldGeneratorModifier)}.</p>
  */
 public interface WorldGeneratorModifier extends CatalogType {
 
@@ -54,12 +61,22 @@ public interface WorldGeneratorModifier extends CatalogType {
      * {@link WorldGenerator#getGeneratorPopulators()}.</p>
      *
      * @param world The creation settings of the world.
-     * @param settings A data container with settings (usually) user-provided
-     *            settings, can be used by the plugin to modify the world
-     *            generator.
+     * @param settings A data container with (usually) user-provided settings,
+     *        can be used by the plugin to modify the world generator.
      * @param worldGenerator The world generator, should be modified.
      * @see WorldGenerator Additional information on the generation process
      */
     void modifyWorldGenerator(WorldCreationSettings world, DataContainer settings, WorldGenerator worldGenerator);
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This name must be something unique and may not contain spaces. The
+     * same name must be returned every time the method is invoked.</p>
+     *
+     * @return {@inheritDoc}
+     */
+    @Override
+    String getId();
 
 }


### PR DESCRIPTION
I made some small fixes to the world generator API. See also the implementation [over here](https://github.com/SpongePowered/Sponge/pull/238).

#### Changes in this PR

###### GameRegistry changes
Now that the id of a world generator modifiers is supplied by the modifier itself (https://github.com/SpongePowered/SpongeAPI/commit/00bd9cd0ae24a157f73ac7794ee2e5b2961dcb18), the id is no longer needed in the register method.

Also added some documentation on the requirements to the id returned by WorldGeneratorModifier.

###### Give world generator modifiers more context
With the removal of the generator settings from WorldGenerator (this was a last minute change in my last PR), the WorldGeneratorModifier
interface was damaged: there was no way to obtain access to the world seed anymore.

This commit fixes that by replacing the worldname parameter with the newly introduced WorldCreationSettings interface.

#### Why did we need that modifier system, introduces by your last PR, again? Why not let plugins implement WorldGenerator directly? Why not use an event?
For readers not familiar with WorldGeneratorModifier: it is just an interface with the method `void modifyWorldGenerator(WorldCreationSettings, DataContainer, WorldGenerator)`. Implementations are expected to make modifications to the WorldGenerator based on the information provided by WorldCreationSettings and the DataContainer. A modifier can make small modifications (add a tree generator) or control every aspect of world generation. A list of modifiers active for a world is stored in the level_sponge.dat.

Let me answer "why not implement WorldGenerator directly" first. There are two reasons for this choice:
* WorldGenerator is a complex interface to implement correctly. You'll need to implement many methods, make sure the lists are mutable, etc. Plugins can easily make an error here. By having the implementation in Sponge, we know for sure that the implementation is consistent.
* Secondly, you cannot mix two WorldGenerators. However, it's easy to call two WorldGeneratorModifiers after each other. One modifier can add a cave generator, another modifier a tree generator and a third can replace the biome generator.

Then, why I'm not using events? The problem with events is that they are fired for all plugins. By using the modifier system the server admin can select which modifiers are applied to a world (either by a command or by configuration files). The modifier system also allows to get a list of all registered modifiers on the server, so that multiworld plugins can show a nice list of them. In singleplayer, I can imagine the world creation screen having some way to select the modifiers that should be active.