### PR TITLE
Move DisplaySlot methods from Objective to Scoreboard

### DIFF
--- a/src/main/java/org/spongepowered/api/scoreboard/Scoreboard.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Scoreboard.java
@@ -32,6 +32,8 @@ import org.spongepowered.api.scoreboard.objective.Objective;
 
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 /**
  * Represents a scoreboard, which contains {@link Team}s and {@link Objective}s.
  * The server has a default scoreboard, but each {@link org.spongepowered.api.entity.player.Player}
@@ -59,6 +61,20 @@ public interface Scoreboard {
     Optional<Objective> getObjective(DisplaySlot slot);
 
     /**
+     * Sets the specified {@link Objective} in the specified {@link DisplaySlot}, removing
+     * it from any other {@link DisplaySlot}.
+     *
+     * <p>If another objective is set to the same display slot, that objective will
+     * have it's display slot set to <code>null</code>.</p>
+     *
+     * @param objective The {@link Objective} to set
+     * @param displaySlot The {@link DisplaySlot} to the specified {@link Objective} in
+     * @throws IllegalStateException if the specified {@link Objective} does not exist
+     *                               on this scoreboard
+     */
+    void addObjective(Objective objective, @Nullable DisplaySlot displaySlot) throws IllegalStateException;
+
+    /**
      * Gets all {@link Objective}s of a Criteria on this scoreboard.
      *
      * @param criteria {@link Criterion} to search by
@@ -76,12 +92,12 @@ public interface Scoreboard {
     /**
      * Adds the specified {@link Objective} to this scoreboard.
      *
-     * @param team The {@link Objective} add
+     * @param objective The {@link Objective} add
      * @throws IllegalArgumentException if an {@link Objective} with the same
      *             {@link Objective#getName() name} already exists, or if the
      *             specified {@link Objective} has already been added.
      */
-    void addObjective(Objective team) throws IllegalArgumentException;
+    void addObjective(Objective objective) throws IllegalArgumentException;
 
     /**
      * Removes the specified {@link Objective} from this scoreboard.

--- a/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
@@ -89,24 +89,6 @@ public interface Objective {
     void setDisplayMode(ObjectiveDisplayMode displayMode);
 
     /**
-     * Gets the display slot this objective is displayed at.
-     *
-     * @return The display slot for this objective, if set
-     */
-    Optional<DisplaySlot> getDisplaySlot();
-
-    /**
-     * Sets this objective to display on the specified slot for the
-     * scoreboard, removing it from any other display slot.
-     *
-     * <p>If another objective is set to the same display slot, that objective will
-     * have it's display slot set to <code>null</code>.</p>
-     *
-     * @param slot The display slot to change, or null to not display
-     */
-    void setDisplaySlot(@Nullable DisplaySlot slot);
-
-    /**
      * Gets the set of {@link Score}s for this objective.
      *
      * @return The set of {@link Score}s for this objective


### PR DESCRIPTION
Currently, an `Objective`'s display slot is managed through the `Objective` itself.

Since one objective can be present on multiple scoreboards, display slots should be managed through each `Scoreboard` instance. This allows more fine-grained control over display slots (such as setting the same objective in different display slots on different scoreboards).