### PR TITLE
Revamp selectors

### DIFF
--- a/src/main/java/org/spongepowered/api/text/selector/Argument.java
+++ b/src/main/java/org/spongepowered/api/text/selector/Argument.java
@@ -72,7 +72,7 @@ public interface Argument<T> {
         boolean isInverted();
 
         /**
-         * Inverts this {@link Invertible} argument and returns the new
+         * Inverts this {@link Argument.Invertible} argument and returns the new
          * {@link Argument}. The new argument will select all targets this
          * argument didn't select.
          *

--- a/src/main/java/org/spongepowered/api/text/selector/ArgumentHolder.java
+++ b/src/main/java/org/spongepowered/api/text/selector/ArgumentHolder.java
@@ -1,0 +1,117 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.text.selector;
+
+import java.util.Set;
+
+/**
+ * Represents a holder of {@link ArgumentHolder}s. This interface is extended
+ * by both Vector3 and Limit. It is also extended by {@link ArgumentType}, as
+ * any {@link ArgumentType} "holds" itself. This also allows for Limit to
+ * have  more strict upper bound on its maximum and minimum to allow a
+ * {@code Limit<Vector3>} without allowing {@code Limit<Object>}.
+ *
+ * @param <T> The type for the value of this argument holder
+ * @see ArgumentType
+ * @see ArgumentTypes
+ */
+public interface ArgumentHolder<T extends ArgumentHolder<?>> {
+
+    /**
+     * Returns the size of the Set from {@link #getTypes()}.
+     * 
+     * @return The size of the Set from {@link #getTypes()}
+     */
+    int getCount();
+
+    /**
+     * Returns a set containing all the {@link ArgumentHolder}s this
+     * {@link ArgumentHolder} holds.
+     * 
+     * @return A set containing all the {@link ArgumentHolder}s this
+     *      {@link ArgumentHolder} holds
+     */
+    Set<T> getTypes();
+
+    /**
+     * Represents the holder of three {@link ArgumentType}s {@code x}, {@code y}
+     * , and {@code z}.
+     *
+     * @param <V> The type of the vector
+     * @param <T> The type of the components of the vector
+     */
+    interface Vector3<V, T> extends ArgumentHolder<ArgumentType<T>> {
+
+        /**
+         * Gets the {@link ArgumentType} for the x coordinate of this
+         * {@link ArgumentHolder.Vector3}.
+         *
+         * @return The x coordinate argument type
+         */
+        ArgumentType<T> x();
+
+        /**
+         * Gets the {@link ArgumentType} for the y coordinate of this
+         * {@link ArgumentHolder.Vector3}.
+         *
+         * @return The y coordinate argument type
+         */
+        ArgumentType<T> y();
+
+        /**
+         * Gets the {@link ArgumentType} for the z coordinate of this
+         * {@link ArgumentHolder.Vector3}.
+         *
+         * @return The z coordinate argument type
+         */
+        ArgumentType<T> z();
+
+    }
+
+    /**
+     * Represents the holder of two objects with a minimal and maximal argument
+     * holder.
+     *
+     * @param <T> The type of the argument holder
+     */
+    interface Limit<T extends ArgumentHolder<?>> extends ArgumentHolder<T> {
+
+        /**
+         * Returns the minimum object of this {@link ArgumentHolder.Limit}.
+         *
+         * @return The minimum object
+         */
+        T minimum();
+
+        /**
+         * Returns the maximum object of this {@link ArgumentHolder.Limit}.
+         *
+         * @return The maximum object
+         */
+        T maximum();
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/selector/ArgumentType.java
+++ b/src/main/java/org/spongepowered/api/text/selector/ArgumentType.java
@@ -24,26 +24,41 @@
  */
 package org.spongepowered.api.text.selector;
 
-import com.google.common.base.Optional;
+import java.util.Set;
 
 /**
- * Represents the type of an {@link Argument}. This may represent a single
- * argument key in a {@link Selector}, or a compound of multiple argument keys.
+ * Represents the type of an {@link Argument}. This represents a single
+ * argument key in a {@link Selector}.
  *
  * @param <T> The type for the value of this argument type
  * @see Selector
  * @see Argument
  * @see ArgumentTypes
  */
-public interface ArgumentType<T> {
+public interface ArgumentType<T> extends ArgumentHolder<ArgumentType<T>> {
 
     /**
-     * Returns the key associated with this {@link ArgumentType}. This will be
-     * available if the argument type is not a compound of several ones.
+     * Returns the key associated with this {@link ArgumentType}.
      *
-     * @return The key of this argument type, if available
+     * @return The key of this argument type
      */
-    Optional<String> getKey();
+    String getKey();
+
+    /**
+     * Returns 1.
+     * 
+     * @return 1
+     */
+    @Override
+    int getCount();
+
+    /**
+     * Returns a set containing this {@link ArgumentType}.
+     * 
+     * @return A set containing this {@link ArgumentType}
+     */
+    @Override
+    Set<ArgumentType<T>> getTypes();
 
     /**
      * Represents an {@link ArgumentType} that can be inverted.
@@ -53,65 +68,6 @@ public interface ArgumentType<T> {
      * @see Argument.Invertible
      */
     interface Invertible<T> extends ArgumentType<T> {
-
-    }
-
-    /**
-     * Represents a compound {@link ArgumentType} representing a 3-dimensional
-     * vector.
-     *
-     * @param <V> The type of the vector
-     * @param <T> The type of the components of the vector
-     */
-    interface Vector3<V, T> extends ArgumentType<V> {
-
-        /**
-         * Gets the {@link ArgumentType} for the x coordinate of this
-         * {@link Vector3} {@link ArgumentType}.
-         *
-         * @return The x coordinate argument type
-         */
-        ArgumentType<T> x();
-
-        /**
-         * Gets the {@link ArgumentType} for the y coordinate of this
-         * {@link Vector3} {@link ArgumentType}.
-         *
-         * @return The y coordinate argument type
-         */
-        ArgumentType<T> y();
-
-        /**
-         * Gets the {@link ArgumentType} for the z coordinate of this
-         * {@link Vector3} {@link ArgumentType}.
-         *
-         * @return The z coordinate argument type
-         */
-        ArgumentType<T> z();
-
-    }
-
-    /**
-     * Represents the holder of two {@link ArgumentType}s with a minimal and
-     * maximal argument type.
-     *
-     * @param <T> The type of the argument type
-     */
-    interface Limit<T extends ArgumentType<?>> {
-
-        /**
-         * Returns the minimum {@link ArgumentType} of this {@link Limit}.
-         *
-         * @return The minimum argument type
-         */
-        T minimum();
-
-        /**
-         * Returns the maximum {@link ArgumentType} of this {@link Limit}.
-         *
-         * @return The maximum argument type
-         */
-        T maximum();
 
     }
 

--- a/src/main/java/org/spongepowered/api/text/selector/ArgumentTypes.java
+++ b/src/main/java/org/spongepowered/api/text/selector/ArgumentTypes.java
@@ -26,11 +26,15 @@ package org.spongepowered.api.text.selector;
 
 import com.flowpowered.math.vector.Vector3d;
 import com.flowpowered.math.vector.Vector3i;
+import com.google.common.base.Optional;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.player.gamemode.GameMode;
+import org.spongepowered.api.scoreboard.Team;
+
+import java.util.Collection;
 
 /**
- * Represents the list of default {@link ArgumentType}s available in Vanilla
+ * Represents the default {@link ArgumentType}s available in Vanilla
  * Minecraft.
  */
 public final class ArgumentTypes {
@@ -44,7 +48,7 @@ public final class ArgumentTypes {
      * <p>In Vanilla, this is represented by the {@code x}, {@code y} and
      * {@code z} selector keys.</p>
      */
-    public static final ArgumentType.Vector3<Vector3i, Integer> POSITION = null;
+    public static final ArgumentHolder.Vector3<Vector3i, Integer> POSITION = null;
 
     /**
      * The argument types representing the radius of the selector.
@@ -52,7 +56,7 @@ public final class ArgumentTypes {
      * <p>In Vanilla, this is represented by the {@code r} (for minimum) and
      * {@code rm} (for maximum) selector keys.</p>
      */
-    public static final ArgumentType.Limit<ArgumentType<Integer>> RADIUS = null;
+    public static final ArgumentHolder.Limit<ArgumentType<Integer>> RADIUS = null;
 
     /**
      * The argument type filtering based on the {@link GameMode} of a player.
@@ -66,7 +70,7 @@ public final class ArgumentTypes {
      * Negative values will reverse the order of targets - for example the
      * farthest targets will be returned first.
      *
-     * <p>The default count for the {@link SelectorTypes#RANDOM_PLAYER} and
+     * <p>The default count for the {@link SelectorTypes#RANDOM} and
      * {@link SelectorTypes#NEAREST_PLAYER} is {@code 1}, therefore a higher
      * number will increase the count instead of limiting it.</p>
      *
@@ -81,12 +85,11 @@ public final class ArgumentTypes {
      * <p>In Vanilla, this is represented by the {@code l} (for maximum) and
      * {@code lm} (for minimum) selector keys.</p>
      */
-    public static final ArgumentType.Limit<ArgumentType<Integer>> LEVEL = null;
+    public static final ArgumentHolder.Limit<ArgumentType<Integer>> LEVEL = null;
 
-    // TODO: Scoreboard API
     /**
-     * The argument type filtering based on the {@link String} of the target.
-     * Inverting this argument type will search for all targets not in the
+     * The argument type filtering based on the {@link Team} of the target.
+     * Inverting this argument type will search for all targets not on the
      * specified team instead.
      *
      * <p>In Vanilla, this is represented by the {@code team} selector key with
@@ -110,17 +113,17 @@ public final class ArgumentTypes {
      * <p>In Vanilla, this is represented by the {@code dx}, {@code dy} and
      * {@code dz} selector keys.</p>
      */
-    public static final ArgumentType.Vector3<Vector3i, Integer> DIMENSION = null;
+    public static final ArgumentHolder.Vector3<Vector3i, Integer> DIMENSION = null;
 
     /**
      * The argument type filtering targets within a specific rotation range.
      *
-     * <p>In Vanilla, the {@link Float}s will be floored to {@link Integer}s and
+     * <p>In Vanilla, the {@link Double}s will be floored to {@link Integer}s and
      * the third float is completely ignored. It is represented by the
      * {@code rx}/{@code ry} (for minimum) and {@code rxm}/{@code rym} selector
      * keys.</p>
      */
-    public static final ArgumentType.Limit<ArgumentType.Vector3<Vector3d, Float>> ROTATION = null;
+    public static final ArgumentHolder.Limit<ArgumentHolder.Vector3<Vector3d, Double>> ROTATION = null;
 
     /**
      * The argument type filtering targets based on the {@link EntityType}.
@@ -129,8 +132,6 @@ public final class ArgumentTypes {
      */
     public static final ArgumentType.Invertible<EntityType> ENTITY_TYPE = null;
 
-    // TODO: Scoreboard API
-
     /**
      * Creates a minimum and maximum {@link ArgumentType} filtering depending on
      * the score of the specified objective.
@@ -138,8 +139,27 @@ public final class ArgumentTypes {
      * @param name The objective name to use
      * @return The created argument type
      */
-    public static ArgumentType.Limit<ArgumentType<Integer>> score(String name) {
+    public static ArgumentHolder.Limit<ArgumentType<Integer>> score(String name) {
         return Selectors.factory.createScoreArgumentType(name);
+    }
+
+    /**
+     * Gets the {@link ArgumentType} with the provided name.
+     *
+     * @param name The name of the argument type
+     * @return The {@link ArgumentType} with the given name or Optional.absent() if not found
+     */
+    public static Optional<ArgumentType<?>> valueOf(String name) {
+        return Selectors.factory.getArgumentType(name);
+    }
+
+    /**
+     * Gets a {@link Collection} of all possible {@link ArgumentType}s.
+     *
+     * @return The list of all available {@link ArgumentType}s
+     */
+    public static Collection<ArgumentType<?>> values() {
+        return Selectors.factory.getArgumentTypes();
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/text/selector/Arguments.java
+++ b/src/main/java/org/spongepowered/api/text/selector/Arguments.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.api.text.selector;
 
+import java.util.Set;
+
 /**
  * Utility class to create {@link Argument}s.
  */
@@ -34,6 +36,8 @@ public final class Arguments {
 
     /**
      * Creates a new {@link Argument} using the specified type and value.
+     * 
+     * <p>If the type is invertible, the {@link Argument} will not be inverted.</p>
      *
      * @param type The type of the argument
      * @param value The value of the argument
@@ -42,19 +46,6 @@ public final class Arguments {
      */
     public static <T> Argument<T> create(ArgumentType<T> type, T value) {
         return Selectors.factory.createArgument(type, value);
-    }
-
-    /**
-     * Creates a new {@link Argument.Invertible} using the specified type and
-     * value. The created {@link Argument} will not be inverted.
-     *
-     * @param type The type of the invertible argument
-     * @param value The value of the invertible argument
-     * @param <T> The type of the argument value
-     * @return The created invertible argument
-     */
-    public static <T> Argument.Invertible<T> create(ArgumentType.Invertible<T> type, T value) {
-        return create(type, value, false);
     }
 
     /**
@@ -70,6 +61,19 @@ public final class Arguments {
      */
     public static <T> Argument.Invertible<T> create(ArgumentType.Invertible<T> type, T value, boolean inverted) {
         return Selectors.factory.createArgument(type, value, inverted);
+    }
+
+    /**
+     * Creates a new set of {@link Argument}s using the specified type and value.
+     *
+     * @param type The type of the arguments
+     * @param value The value of the arguments
+     * @param <T> The type of the arguments' joined value
+     * @param <V> The type of the arguments' sub-values
+     * @return The created argument
+     */
+    public static <T, V> Set<Argument<T>> createSet(ArgumentHolder<? extends ArgumentType<T>> type, V value) {
+        return Selectors.factory.createArguments(type, value);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/text/selector/Selector.java
+++ b/src/main/java/org/spongepowered/api/text/selector/Selector.java
@@ -26,19 +26,39 @@ package org.spongepowered.api.text.selector;
 
 import com.google.common.base.Optional;
 import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.util.command.CommandSource;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.extent.Extent;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Represents an immutable selector of targets, as used in commands.
  *
- * <p>In Vanilla, selectors are mostly represented as plain text, starting with
- * an {@code @} symbol and followed by a single character signifying the type,
- * and finally the (optional) arguments in brackets.</p> <p>As an example, the
- * all player selector is {@code @a}, and with a radius of 20 it would be
- * {@code @a[r=20]}.</p>
+ * <p>
+ * In Vanilla, selectors are mostly represented as plain text, starting with an
+ * {@code @} symbol and followed by a single character signifying the type, and
+ * finally the (optional) arguments in brackets.
+ * </p>
+ * <p>
+ * As an example, the all player selector is {@code @a}, and with a radius of
+ * 20 it would be {@code @a[r=20]}.
+ * </p>
+ * </p>
+ * 
+ * <p>
+ * Additionally, Vanilla will ignore position data unless one of the following
+ * arguments is present:
+ * <ul>
+ *   <li>{@link ArgumentTypes#POSITION}</li>
+ *   <li>{@link ArgumentTypes#DIMENSION}</li>
+ *   <li>{@link ArgumentTypes#RADIUS}</li>
+ * </ul>
+ * All {@code resolve} methods have a look-alike named {@code resolveForce}
+ * which always uses the given position data.
+ * </p>
  *
  * @see <a href="http://minecraft.gamepedia.com/Selector#Target_selectors">
  *      Target selectors on the Minecraft Wiki</a>
@@ -54,7 +74,9 @@ public interface Selector {
 
     /**
      * Returns the argument value for the specified {@link ArgumentType} in this
-     * {@link Selector}.
+     * {@link Selector}. May be used for {@link ArgumentType.Invertible}, but
+     * the inverted state must be checked with
+     * {@link #isInverted(ArgumentType.Invertible)}.
      *
      * @param type The argument type
      * @param <T> The type of the value
@@ -73,6 +95,16 @@ public interface Selector {
     <T> Optional<Argument<T>> getArgument(ArgumentType<T> type);
 
     /**
+     * Returns the {@link Argument.Invertible} for the specified
+     * {@link ArgumentType.Invertible} in this {@link Selector}.
+     *
+     * @param type The argument type
+     * @param <T> The type of the argument value
+     * @return The argument, if available
+     */
+    <T> Optional<Argument.Invertible<T>> getArgument(ArgumentType.Invertible<T> type);
+
+    /**
      * Returns the arguments for this {@link Selector}.
      *
      * @return The arguments for this {@link Selector}
@@ -80,13 +112,50 @@ public interface Selector {
     List<Argument<?>> getArguments();
 
     /**
-     * Resolves this {@link Selector} to a list of entities around (0|0|0) in
-     * the given {@link Extent}.
+     * Checks for the presence of {@code type} in this {@link Selector}.
+     * 
+     * @param type - The {@link ArgumentType} to check for
+     * @return {@code true} if the given type is present in this
+     *         {@link Selector}, otherwise {@code false}
+     */
+    boolean has(ArgumentType<?> type);
+
+    /**
+     * Checks for the inversion state of {@code type} in this {@link Selector}.
+     * 
+     * @param type - The invertible {@link ArgumentType} to check inversion
+     *         status on
+     * @return {@code true} if the given type is inverted in this
+     *         {@link Selector}, otherwise {@code false}
+     */
+    boolean isInverted(ArgumentType.Invertible<?> type);
+
+    /**
+     * Resolves this {@link Selector} to a list of entities around the origin.
      *
-     * @param extent The extent to search for targets
+     * @param origin The source that should be considered the origin of this
+     *        selector
      * @return The matched entities
      */
-    List<Entity> resolve(Extent extent);
+    Set<Entity> resolve(CommandSource origin);
+
+    /**
+     * Resolves this {@link Selector} to a list of entities around (0|0|0) in
+     * the given {@link Extent Extent(s)}.
+     *
+     * @param extent The extents to search for targets
+     * @return The matched entities
+     */
+    Set<Entity> resolve(Extent... extent);
+
+    /**
+     * Resolves this {@link Selector} to a list of entities around (0|0|0) in
+     * the given {@link Extent Extent(s)}.
+     *
+     * @param extent The extents to search for targets
+     * @return The matched entities
+     */
+    Set<Entity> resolve(Collection<? extends Extent> extent);
 
     /**
      * Resolves this {@link Selector} to a list of entities around the given
@@ -95,7 +164,43 @@ public interface Selector {
      * @param location The location to resolve the selector around
      * @return The matched entities
      */
-    List<Entity> resolve(Location location);
+    Set<Entity> resolve(Location location);
+
+    /**
+     * Resolves this {@link Selector} to a list of entities around the origin.
+     *
+     * @param origin The source that should be considered the origin of this
+     *        selector
+     * @return The matched entities
+     */
+    Set<Entity> resolveForce(CommandSource origin);
+
+    /**
+     * Resolves this {@link Selector} to a list of entities around (0|0|0) in
+     * the given {@link Extent Extent(s)}.
+     *
+     * @param extent The extents to search for targets
+     * @return The matched entities
+     */
+    Set<Entity> resolveForce(Extent... extent);
+
+    /**
+     * Resolves this {@link Selector} to a list of entities around (0|0|0) in
+     * the given {@link Extent Extent(s)}.
+     *
+     * @param extent The extents to search for targets
+     * @return The matched entities
+     */
+    Set<Entity> resolveForce(Collection<? extends Extent> extent);
+
+    /**
+     * Resolves this {@link Selector} to a list of entities around the given
+     * {@link Location}.
+     *
+     * @param location The location to resolve the selector around
+     * @return The matched entities
+     */
+    Set<Entity> resolveForce(Location location);
 
     /**
      * Converts this {@link Selector} to a valid selector string.

--- a/src/main/java/org/spongepowered/api/text/selector/SelectorFactory.java
+++ b/src/main/java/org/spongepowered/api/text/selector/SelectorFactory.java
@@ -24,6 +24,12 @@
  */
 package org.spongepowered.api.text.selector;
 
+import com.google.common.base.Optional;
+import org.spongepowered.api.text.selector.ArgumentHolder.Limit;
+
+import java.util.Collection;
+import java.util.Set;
+
 /**
  * Represents the required implementation for the static methods in
  * {@link Selectors}, {@link Arguments} and {@link ArgumentTypes}.
@@ -54,7 +60,22 @@ public interface SelectorFactory {
      * @param name The objective name to use
      * @return The created argument type
      */
-    ArgumentType.Limit<ArgumentType<Integer>> createScoreArgumentType(String name);
+    Limit<ArgumentType<Integer>> createScoreArgumentType(String name);
+
+    /**
+     * Gets the {@link ArgumentType} with the provided name.
+     *
+     * @param name The name of the argument type
+     * @return The {@link ArgumentType} with the given name or Optional.absent() if not found
+     */
+    Optional<ArgumentType<?>> getArgumentType(String name);
+
+    /**
+     * Gets a {@link Collection} of all possible {@link ArgumentType}s.
+     *
+     * @return The list of all available {@link ArgumentType}s
+     */
+    Collection<ArgumentType<?>> getArgumentTypes();
 
     /**
      * Creates a custom {@link ArgumentType} with the specified key.
@@ -96,6 +117,17 @@ public interface SelectorFactory {
      * @return The created invertible argument
      */
     <T> Argument.Invertible<T> createArgument(ArgumentType.Invertible<T> type, T value, boolean inverted);
+
+    /**
+     * Creates a new set of {@link Argument}s using the specified type and value.
+     *
+     * @param type The type of the arguments
+     * @param value The value of the arguments
+     * @param <T> The type of the arguments' joined value
+     * @param <V> The type of the arguments' sub-values
+     * @return The created argument
+     */
+    <T, V> Set<Argument<T>> createArguments(ArgumentHolder<? extends ArgumentType<T>> type, V value);
 
     /**
      * Parses an {@link Argument} from the given argument string.

--- a/src/main/java/org/spongepowered/api/text/selector/SelectorTypes.java
+++ b/src/main/java/org/spongepowered/api/text/selector/SelectorTypes.java
@@ -46,8 +46,10 @@ public final class SelectorTypes {
      */
     public static final SelectorType NEAREST_PLAYER = null;
     /**
-     * The random player selector type.
+     * The random selector type. This targets only players by default, but may
+     * be used with entities if {@link ArgumentTypes#ENTITY_TYPE} is present in
+     * a selector.
      */
-    public static final SelectorType RANDOM_PLAYER = null;
+    public static final SelectorType RANDOM = null;
 
 }


### PR DESCRIPTION
Required revamp to make selectors implementable without lots of hacks. Requirement of https://github.com/SpongePowered/SpongeCommon/pull/14.

#### More details
There was a problem with having `Vector3` as an `ArgumentType`. Because it was an `ArgumentType`  but it's `x/y/z` parts were also `ArgumentTypes` it was unclear which types would be put into the internal `ArgumentType->Argument` map. This resolves the ambiguity by adding an `ArgumentHolder` interface, which is extended by both `Vector3` and `Limit`. This interface is also extended by `ArgumentType`, as any `ArgumentType` "holds" itself. This also allows for `Limit` to have a more strict upper bound on its maximum and minimum to allow a `Limit<Vector3>`.

Additionally, `ArgumentType` was generic and not a part of the `CatalogType` system. This still holds, so `ArgumentTypes` now allows retrieval of an `ArgumentType` via `valueOf(String)` and the (current) set via `values()`.

#### Summary
- `Vector3` and `Limit` are now `ArgumentHolders`
- `ArgumentType` also is a holder, with itself as the only element.
- `ArgumentTypes` has `valueOf` and `values`
- An `ArgumentHolder` can be passed to create a `Set` of arguments (although I think the implementation currently doesn't support using `Limit` as the holder).
- Scoreboard is in Selectors (closes #516)
- Probably a few other things