### PR TITLE
Add access to GameProfile cache, a GameProfile resolver and Server.getUser(UUID)

### DIFF
--- a/src/main/java/org/spongepowered/api/service/profile/GameProfileResolver.java
+++ b/src/main/java/org/spongepowered/api/service/profile/GameProfileResolver.java
@@ -1,0 +1,136 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.profile;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import org.spongepowered.api.GameProfile;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * A service which contacts the authentication servers to get a
+ * {@link GameProfile} by a given UUID or name.
+ *
+ * <p>The service may cache the data of a request for faster lookups. Note that
+ * the cached data may not always be up to date.</p>
+ *
+ * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+ * caused by a {@link ProfileNotFoundException} if the profile does not exist or
+ * an {@link IOException} if a network error occurred.</p>
+ */
+public interface GameProfileResolver {
+
+    /**
+     * Looks up a {@link GameProfile} by its unique ID.
+     *
+     * <p>This method checks the local profile cache before contacting the
+     * profile servers. Use {@link #get(UUID, boolean)} to disable the cache
+     * lookup.</p>
+     *
+     * @param uniqueId The unique ID
+     * @return The result of the request
+     */
+    ListenableFuture<GameProfile> get(UUID uniqueId);
+
+    /**
+     * Looks up a {@link GameProfile} by its unique ID.
+     *
+     * @param uniqueId The unique ID
+     * @param useCache true to perform a cache lookup first
+     * @return The result of the request
+     */
+    ListenableFuture<GameProfile> get(UUID uniqueId, boolean useCache);
+
+    /**
+     * Looks up a {@link GameProfile} by its user name (case-insensitive).
+     *
+     * <p>This method checks the local profile cache before contacting the
+     * profile servers. Use {@link #get(String, boolean)} to disable the cache
+     * lookup.</p>
+     *
+     * @param name The username
+     * @return The result of the request
+     */
+    ListenableFuture<GameProfile> get(String name);
+
+    /**
+     * Looks up a {@link GameProfile} by its user name (case-insensitive).
+     *
+     * @param name The username
+     * @param useCache true to perform a cache lookup first
+     * @return The result of the request
+     */
+    ListenableFuture<GameProfile> get(String name, boolean useCache);
+
+    /**
+     * Gets a collection of {@link GameProfile}s by their user names
+     * (case-insensitive).
+     *
+     * @param names The user names
+     * @param useCache true to perform a cache lookup first
+     * @return The result of the request
+     */
+    ListenableFuture<Collection<GameProfile>> getAllByName(Iterable<String> names, boolean useCache);
+
+    /**
+     * Gets a collection of {@link GameProfile}s by their unique IDs.
+     *
+     * @param uniqueIds The UUIDs
+     * @param useCache true to perform a cache lookup first
+     * @return The result of the request
+     */
+    ListenableFuture<Collection<GameProfile>> getAllById(Iterable<UUID> uniqueIds, boolean useCache);
+
+    /**
+     * Gets a collection of all cached {@link GameProfile}s.
+     *
+     * @return A {@link Collection} of {@link GameProfile}s
+     */
+    Collection<GameProfile> getAllCached();
+
+    /**
+     * Returns a collection of matching cached {@link GameProfile}s whose last
+     * known user names start with the given string (case-insensitive).
+     *
+     * <p>This collection may also contain profiles of players who never played
+     * on the server!</p>
+     *
+     * <p>Use
+     * {@link org.spongepowered.api.service.user.UserStorage#match(String)} for
+     * a collection that only contains {@link GameProfile}s with attached
+     * {@link org.spongepowered.api.entity.player.User} data.</p>
+     *
+     * <p>This method only searches the local cache, so the data may not be up
+     * to date.</p>
+     *
+     * @param lastKnownName The user name
+     * @return The result of the request
+     */
+    Collection<GameProfile> match(String lastKnownName);
+
+}

--- a/src/main/java/org/spongepowered/api/service/profile/GameProfileResolver.java
+++ b/src/main/java/org/spongepowered/api/service/profile/GameProfileResolver.java
@@ -111,7 +111,7 @@ public interface GameProfileResolver {
      *
      * @return A {@link Collection} of {@link GameProfile}s
      */
-    Collection<GameProfile> getAllCached();
+    Collection<GameProfile> getAllCachedProfiles();
 
     /**
      * Returns a collection of matching cached {@link GameProfile}s whose last

--- a/src/main/java/org/spongepowered/api/service/profile/GameProfileResolver.java
+++ b/src/main/java/org/spongepowered/api/service/profile/GameProfileResolver.java
@@ -111,7 +111,7 @@ public interface GameProfileResolver {
      *
      * @return A {@link Collection} of {@link GameProfile}s
      */
-    Collection<GameProfile> getAllCachedProfiles();
+    Collection<GameProfile> getCachedProfiles();
 
     /**
      * Returns a collection of matching cached {@link GameProfile}s whose last

--- a/src/main/java/org/spongepowered/api/service/profile/ProfileNotFoundException.java
+++ b/src/main/java/org/spongepowered/api/service/profile/ProfileNotFoundException.java
@@ -22,22 +22,51 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api;
-
-import org.spongepowered.api.util.Identifiable;
+package org.spongepowered.api.service.profile;
 
 /**
- * Represents a name and an associated unique identifier.
- *
- * <p>Use the {@link org.spongepowered.api.service.user.UserStorage} service to
- * obtain the stored data associated with a profile.</p>
+ * Thrown by a profile lookup service if a profile does not exist.
  */
-public interface GameProfile extends Identifiable {
+public class ProfileNotFoundException extends Exception {
+
+    private static final long serialVersionUID = -6165011303382043479L;
 
     /**
-     * Gets the player's last known username.
-     *
-     * @return The player's last known username
+     * Constructs a new {@link ProfileNotFoundException}.
      */
-    String getName();
+    public ProfileNotFoundException() {
+        super();
+    }
+
+    /**
+     * Constructs a new {@link ProfileNotFoundException} with the specified
+     * message.
+     *
+     * @param message The exception message
+     */
+    public ProfileNotFoundException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new {@link ProfileNotFoundException} with the specified
+     * cause and a null message.
+     *
+     * @param cause The cause of this exception
+     */
+    public ProfileNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new {@link ProfileNotFoundException} with the specified
+     * message and cause.
+     *
+     * @param message The exception message
+     * @param cause The cause of this exception
+     */
+    public ProfileNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
 }

--- a/src/main/java/org/spongepowered/api/service/user/UserStorage.java
+++ b/src/main/java/org/spongepowered/api/service/user/UserStorage.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.user;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.GameProfile;
+import org.spongepowered.api.entity.player.Player;
+import org.spongepowered.api.entity.player.User;
+import org.spongepowered.api.service.profile.GameProfileResolver;
+
+import java.util.Collection;
+import java.util.UUID;
+
+/**
+ * Stores the persistent {@link User} data of a {@link Player}.
+ */
+public interface UserStorage {
+
+    /**
+     * Gets the data of a {@link User} by their unique id.
+     *
+     * @param uniqueId The UUID of the user
+     * @return {@link User} or Optional.absent() if not found
+     */
+    Optional<User> get(UUID uniqueId);
+
+    /**
+     * Gets the data of a {@link User} by their last known user name
+     * (case-insensitive).
+     *
+     * <p>To get the current name of a player, use the
+     * {@link GameProfileResolver} service.</p>
+     *
+     * @param lastKnownName The user name
+     * @return {@link User} or Optional.absent() if not found
+     */
+    Optional<User> get(String lastKnownName);
+
+    /**
+     * Gets the data of a {@link User} by their {@link GameProfile}.
+     *
+     * @param profile The profile
+     * @return {@link User} or Optional.absent() if not found
+     */
+    Optional<User> get(GameProfile profile);
+
+    /**
+     * Gets or creates a persistent {@link User} associated with the given
+     * {@link GameProfile}.
+     *
+     * <p>To obtain a {@link GameProfile}, use the {@link GameProfileResolver}.
+     * </p>
+     *
+     * @param profile The profile
+     * @return The user object
+     */
+    User getOrCreate(GameProfile profile);
+
+    /**
+     * Gets the collection of all {@link GameProfile}s with stored {@link User}
+     * data.
+     *
+     * <p>Note that this method is resource-intensive depending on the amount of
+     * stored data.</p>
+     *
+     * <p>Use {@link #get(GameProfile)} to get the {@link User} data
+     * corresponding to a {@link GameProfile}.</p>
+     *
+     * @return A {@link Collection} of {@link GameProfile}s
+     */
+    Collection<GameProfile> getAll();
+
+    /**
+     * Deletes the data associated with a {@link User}.
+     *
+     * <p>This may not work if the user is logged in.</p>
+     *
+     * @param profile The profile of the user to delete
+     * @return true if the deletion was successful
+     */
+    boolean delete(GameProfile profile);
+
+    /**
+     * Deletes the data associated with a {@link User}.
+     *
+     * <p>This may not work if the user is logged in.</p>
+     *
+     * @param user The user to delete
+     * @return true if the deletion was successful
+     */
+    boolean delete(User user);
+
+    /**
+     * Returns a collection of matching {@link GameProfile}s with stored
+     * {@link User} data whose last known user names start with the given string
+     * (case-insensitive).
+     *
+     * <p>Use {@link #get(GameProfile)} to get the {@link User} data
+     * corresponding to a {@link GameProfile}.</p>
+     *
+     * @param lastKnownName The user name
+     * @return The result of the request
+     */
+    Collection<GameProfile> match(String lastKnownName);
+}


### PR DESCRIPTION
This PR adds a service interface that can be used to lookup player UUIDs by name and player names by UUIDS. The service contacts the Mojang auth servers if no cached profile was found in the local cache.
It also adds a ``UserStorage`` interface to get, create or delete a ``User`` object.

This resolves https://github.com/SpongePowered/SpongeAPI/issues/528

Access to cached offline user data is important to:

* complete or validate names of offline players
* lookup the name of an offline player by an UUID stored by a plugin
* ban offline players

Things to discuss:

**Access to the [Name Changes API](http://wiki.vg/Mojang_API#UUID_-.3E_Name_history)?** 
Mojang provides an API which lists up all names and change dates of a player.