### PR TITLE
Add immutable data holders and necessary builders.

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.attribute.AttributeCalculator;
 import org.spongepowered.api.attribute.AttributeModifierBuilder;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.data.DataManipulatorRegistry;
+import org.spongepowered.api.data.ImmutableDataRegistry;
 import org.spongepowered.api.data.types.Career;
 import org.spongepowered.api.data.types.Profession;
 import org.spongepowered.api.effect.particle.ParticleEffectBuilder;
@@ -431,6 +432,13 @@ public interface GameRegistry {
      * @return The manipulator registry
      */
     DataManipulatorRegistry getManipulatorRegistry();
+
+    /**
+     * Retrieves the {@link ImmutableDataRegistry} for this {@link GameRegistry}.
+     *
+     * @return The immutable data registry
+     */
+    ImmutableDataRegistry getImmutableDataRegistry();
 
     /**
      * Gets a {@link ResourcePack} that's already been created by its ID.

--- a/src/main/java/org/spongepowered/api/block/BlockSnapshot.java
+++ b/src/main/java/org/spongepowered/api/block/BlockSnapshot.java
@@ -24,7 +24,10 @@
  */
 package org.spongepowered.api.block;
 
+import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.extent.Extent;
 
 /**
  * A mutable complete representation of a block type and its associated data.
@@ -34,7 +37,7 @@ import org.spongepowered.api.world.Location;
  *
  * @see Location
  */
-public interface BlockSnapshot {
+public interface BlockSnapshot extends DataSerializable {
 
     /**
      * Get the block state for this snapshot.
@@ -42,5 +45,29 @@ public interface BlockSnapshot {
      * @return The stored block state
      */
     BlockState getState();
+
+    /**
+     * Sets the {@link BlockState} for this {@link BlockSnapshot}.
+     *
+     * @param blockState The block state to set
+     */
+    void setBlockState(BlockState blockState);
+
+    /**
+     * Gets the {@link Vector3i} of this {@link BlockSnapshot}. The vector and
+     * this snapshot may be out of sync with regards to actual data at the
+     * vector, however, the {@link BlockState} remains immutable.
+     *
+     * @return The vector location of this snapshot
+     */
+    Vector3i getLocation();
+
+    /**
+     * Sets the {@link Vector3i} location of this {@link BlockSnapshot} that
+     * can be applied to {@link Extent}s.
+     *
+     * @param location The vector location to set
+     */
+    void setLocation(Vector3i location);
 
 }

--- a/src/main/java/org/spongepowered/api/block/BlockStateBuilder.java
+++ b/src/main/java/org/spongepowered/api/block/BlockStateBuilder.java
@@ -25,26 +25,29 @@
 package org.spongepowered.api.block;
 
 import org.spongepowered.api.data.DataManipulator;
-import org.spongepowered.api.data.ImmutableDataHolder;
+import org.spongepowered.api.data.ImmutableDataBuilder;
 
 /**
- * Represents a block using {@link BlockType} and a list of
- * {@link DataManipulator} instances.
+ * An {@link ImmutableDataBuilder} for a {@link BlockState}. Just like the
+ * {@link ImmutableDataBuilder}, the {@link DataManipulator}s passed in to
+ * create a {@link BlockState} are copied on creation.
  *
- * <p>States are instances of {@link ImmutableDataHolder}s and therefor once
- * created, cannot be changed. All retrievals of {@link DataManipulator}s are
- * copies.</p>
+ * <p>Note that upon creation, the {@link BlockType} must be set for validation
+ * of {@link DataManipulator}s, otherwise exceptions may be thrown.</p>
  */
-public interface BlockState extends ImmutableDataHolder<BlockState> {
+public interface BlockStateBuilder extends ImmutableDataBuilder<BlockState, BlockStateBuilder> {
 
     /**
-     * Get the base type of block.
+     * Sets the {@link BlockType} for the {@link BlockState} to build.
      *
-     * <p>The type does not include block data such as the contents of
-     * inventories.</p>
+     * <p>The {@link BlockType} is used for some pre-validation on addition of
+     * {@link DataManipulator}s through {@link #add(DataManipulator)}. It is
+     * important to understand that not all manipulators are compatible with
+     * all {@link BlockType}s.</p>
      *
-     * @return The type of block
+     * @param blockType The block type
+     * @return This builder, for chaining
      */
-    BlockType getType();
+    BlockStateBuilder blockType(BlockType blockType);
 
 }

--- a/src/main/java/org/spongepowered/api/data/ImmutableDataBuilder.java
+++ b/src/main/java/org/spongepowered/api/data/ImmutableDataBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data;
+
+import org.spongepowered.api.service.persistence.DataBuilder;
+
+/**
+ * A builder, much like a normal {@link DataBuilder} except that it builds
+ * {@link ImmutableDataHolder}s. While the {@link ImmutableDataHolder} is like
+ * a {@link DataHolder}, it is immutable.
+ *
+ * @param <H> The type of {@link ImmutableDataHolder}
+ * @param <E> The extended {@link ImmutableDataBuilder}
+ */
+public interface ImmutableDataBuilder<H extends ImmutableDataHolder<H>, E extends ImmutableDataBuilder<H, E>> extends DataBuilder<H> {
+
+    /**
+     * Adds the given {@link DataManipulator} to the builder. The
+     * {@link DataManipulator} is copied when the {@link ImmutableDataHolder}
+     * is created.
+     *
+     * @param manipulator The manipulator to add
+     * @param <M> The maipulator type
+     * @return This builder, for chaining
+     */
+    <M extends DataManipulator<M>> E add(M manipulator);
+
+    /**
+     * Copies all known {@link DataManipulator}s from the given
+     * {@link ImmutableDataHolder}. This is a defensive copy as
+     * {@link DataManipulator} is mutable.
+     *
+     * @param holder The {@link ImmutableDataHolder} to copy from
+     * @return This builder for chaining
+     */
+    E from(H holder);
+
+    /**
+     * Resets this builder to a "default" state such that there is no
+     * remaining {@link DataManipulator}s to set. This is to be the presumed
+     * "default" state.
+     *
+     * @return This builder, for chaining
+     */
+    H reset();
+
+    /**
+     * Attempts to build a new {@link ImmutableDataHolder}.
+     *
+     * @return The new immutable data holder
+     */
+    H build();
+
+}

--- a/src/main/java/org/spongepowered/api/data/ImmutableDataHolder.java
+++ b/src/main/java/org/spongepowered/api/data/ImmutableDataHolder.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableCollection;
+
+/**
+ * Represents an immutable variant of the {@link DataHolder} where once built,
+ * the {@link ImmutableDataHolder} can not be modified.
+ *
+ * @see DataHolder
+ * @param <T> The sub type of immutable data holder
+ */
+public interface ImmutableDataHolder<T extends ImmutableDataHolder<T>> extends DataSerializable {
+
+    /**
+     * Get a copy of all properties defined on this
+     * {@link ImmutableDataHolder}, with their current values.
+     *
+     * @return A collection of all known manipulators
+     */
+    ImmutableCollection<DataManipulator<?>> getManipulators();
+
+    /**
+     * Gets an instance of the given data class for this
+     * {@link ImmutableDataHolder}.
+     *
+     * <p>If there is no pre-existing data that can be represented by the given
+     * {@link DataManipulator} class, {@link Optional#absent()} is returned.
+     * </p>
+     *
+     * @param manipulatorClass The data class
+     * @param <M> The type of data
+     * @return An instance of the class, if not available
+     */
+    <M extends DataManipulator<M>> Optional<M> getManipulator(Class<M> manipulatorClass);
+
+    /**
+     * Gets an altered copy of this {@link ImmutableDataHolder} with the given
+     * {@link DataManipulator} modified data. If the data is not compatible for
+     * any reason, {@link Optional#absent()} is returned.
+     *
+     * <p>This does not alter the current {@link ImmutableDataHolder}.</p>
+     *
+     * @param manipulator The new manipulator containing data
+     * @return A new immutable data holder with the given manipulator
+     */
+    <M extends DataManipulator<M>> Optional<T> withData(M manipulator);
+
+}

--- a/src/main/java/org/spongepowered/api/data/ImmutableDataRegistry.java
+++ b/src/main/java/org/spongepowered/api/data/ImmutableDataRegistry.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.GameState;
+
+/**
+ * A registry of {@link ImmutableDataHolder}s and their respective
+ * {@link ImmutableDataBuilder}s. Registration should occur prior to
+ * {@link GameState#SERVER_ABOUT_TO_START}.
+ */
+public interface ImmutableDataRegistry {
+
+    /**
+     * Registers the given {@link ImmutableDataHolder} class with it's
+     * associated {@link ImmutableDataBuilder}. The builder can be used to
+     * create new instances of the given {@link ImmutableDataHolder} for data
+     * retrieval, data representation, etc.
+     *
+     * @param manipulatorClass The class of the immutable data holder
+     * @param builder The builder instance of the immutable data holder
+     * @param <T> The type of immutable data holder
+     * @param <B> The type of immutable data builder
+     */
+    <T extends ImmutableDataHolder<T>, B extends ImmutableDataBuilder<T, B>> void register(Class<T> manipulatorClass, B builder);
+
+    /**
+     * Attempts to retrieve the builder for the given
+     * {@link ImmutableDataHolder}.
+     *
+     * <p>If the {@link ImmutableDataHolder} was not registered, multiple
+     * systems could fail to retrieve specific data.</p>
+     *
+     * @param manipulatorClass The immutable data holder class
+     * @param <T> The type of immutable data holder
+     * @param <B> The type of immutable data builder
+     * @return The builder, if available
+     */
+    <T extends ImmutableDataHolder<T>, B extends ImmutableDataBuilder<T, B>> Optional<B> getBuilder(Class<T> manipulatorClass);
+
+}

--- a/src/main/java/org/spongepowered/api/service/persistence/SerializationService.java
+++ b/src/main/java/org/spongepowered/api/service/persistence/SerializationService.java
@@ -47,8 +47,7 @@ public interface SerializationService {
      * @param builder The builder that can build the data serializable
      * @param <T> The type of data serializable
      */
-    <T extends DataSerializable> void registerBuilder(Class<T> clazz,
-            DataBuilder<T> builder);
+    <T extends DataSerializable> void registerBuilder(Class<T> clazz, DataBuilder<T> builder);
 
     /**
      * Attempts to retrieve the {@link DataBuilder} for the desired 


### PR DESCRIPTION
This creates the ability to have immutable `DataHolder`s without worrying about leaking mutable data or having to "defensively clone `DataHolder`s".