### PR TITLE
Add irc protocol links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A Minecraft plugin API (not including an implementation). It is licensed under t
 * [Source]
 * [Issues]
 * [Wiki]
-* [Community Chat]: #sponge on irc.esper.net
-* [Development Chat]: #spongedev on irc.esper.net
+* [Community Chat]: [#sponge on irc.esper.net]
+* [Development Chat]: [#spongedev on irc.esper.net]
 * [Preparing for Development]
 * [Javadocs(temporary link)]
 
@@ -41,6 +41,8 @@ Are you a talented programmer looking to contribute some code? We'd love the hel
 [Source]: https://github.com/SpongePowered/SpongeAPI/
 [MIT License]: http://www.tldrlegal.com/license/mit-license
 [Community Chat]: https://webchat.esper.net/?channels=sponge
+[#sponge on irc.esper.net]: irc://irc.esper.net/#sponge
 [Development Chat]: https://webchat.esper.net/?channels=spongedev
+[#spongedev on irc.esper.net]: irc://irc.esper.net/#spongedev
 [Preparing for Development]: https://docs.spongepowered.org/en/preparing/
 [Javadocs(temporary link)]: http://spongepowered.github.io/SpongeAPI/


### PR DESCRIPTION
Anybody think I should use `ircs://` links? My reasoning in not doing so is I know I had to go and download an openssl dll and shove it in some arcane folder to even enable ssl at all in mIRC.

Not sure if anybody cares, or if that has even been patched in some form by now.

For those saying it's a stupid formatting PR, you're right. Blame @gabizou.