### PR TITLE
[WIP] A better, easier to use Data API

### DIFF
--- a/src/main/java/org/spongepowered/api/block/tile/TileEntity.java
+++ b/src/main/java/org/spongepowered/api/block/tile/TileEntity.java
@@ -25,7 +25,9 @@
 package org.spongepowered.api.block.tile;
 
 import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataObject;
 import org.spongepowered.api.data.DataSerializable;
+import org.spongepowered.api.data.marker.TileEntityData;
 import org.spongepowered.api.world.Location;
 
 /**
@@ -42,7 +44,7 @@ import org.spongepowered.api.world.Location;
  * customizable data associated with a {@link TileEntity} is represented by
  * {@link org.spongepowered.api.data.DataManipulator}.</p>
  */
-public interface TileEntity extends DataHolder, DataSerializable {
+public interface TileEntity extends DataHolder, DataObject<TileEntityData> {
 
     /**
      * Checks for whether the tile entity is currently valid or not.

--- a/src/main/java/org/spongepowered/api/data/DataObject.java
+++ b/src/main/java/org/spongepowered/api/data/DataObject.java
@@ -45,20 +45,18 @@ public interface DataObject<D> {
     /**
      * Sets some value.
      *
-     * @param prop
+     * @param prop The property
      * @param value The value to set
      * @param <E> The type of value
      * @param <V> The subtype of data that this DataObject supports
-     * @return The value
+     * @return This object
      */
     <E, V extends D> DataObject<D> set(Prop<E, V> prop, E value);
 
     /**
      * Gets a data object with further restrictions on data.
      *
-     * <p>
-     *     As an example, use this to get a data "manipulator" from a more generic data object.
-     * </p>
+     * <p>As an example, use this to get a data "manipulator" from a more generic data object.</p>
      *
      * @param clazz The class of data to restrict to
      * @param <V> The type of data to restrict to

--- a/src/main/java/org/spongepowered/api/data/DataObject.java
+++ b/src/main/java/org/spongepowered/api/data/DataObject.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data;
+
+/**
+ * Represents some container of arbitrary data values.
+ *
+ * @param <D> The type of data that this DataObject is restricted to
+ */
+public interface DataObject<D> {
+
+    /**
+     * Gets some value that is known to be present.
+     *
+     * @param prop The property
+     * @param <E> The type of value
+     * @param <V> The subtype of data that this DataObject supports
+     * @return The value
+     * @throws UnsupportedOperationException If the value is not present
+     */
+    <E, V extends D> E getUnsafe(Prop<E, V> prop) throws UnsupportedOperationException;
+
+    /**
+     * Sets some value.
+     *
+     * @param prop
+     * @param value The value to set
+     * @param <E> The type of value
+     * @param <V> The subtype of data that this DataObject supports
+     * @return The value
+     */
+    <E, V extends D> DataObject<D> set(Prop<E, V> prop, E value);
+
+    /**
+     * Gets a data object with further restrictions on data.
+     *
+     * <p>
+     *     As an example, use this to get a data "manipulator" from a more generic data object.
+     * </p>
+     *
+     * @param clazz The class of data to restrict to
+     * @param <V> The type of data to restrict to
+     * @return The nested data object
+     */
+    <V extends D> DataObject<V> get(Class<V> clazz);
+
+}

--- a/src/main/java/org/spongepowered/api/data/Prop.java
+++ b/src/main/java/org/spongepowered/api/data/Prop.java
@@ -24,11 +24,16 @@
  */
 package org.spongepowered.api.data;
 
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.data.props.Props;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
 /**
  * Marker interface for properties of a certain type.
  *
  * @param <E> The type of value that this property has
  * @param <V> The type of {@link DataObject}s this property is restricted to
  */
-public interface Prop<E, V> {
+@CatalogedBy(Props.class)
+public interface Prop<E, V> extends CatalogType {
 }

--- a/src/main/java/org/spongepowered/api/data/Prop.java
+++ b/src/main/java/org/spongepowered/api/data/Prop.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data;
+
+/**
+ * Marker interface for properties of a certain type.
+ *
+ * @param <E> The type of value that this property has
+ * @param <V> The type of {@link DataObject}s this property is restricted to
+ */
+public interface Prop<E, V> {
+}

--- a/src/main/java/org/spongepowered/api/data/marker/BlockData.java
+++ b/src/main/java/org/spongepowered/api/data/marker/BlockData.java
@@ -1,0 +1,4 @@
+package org.spongepowered.api.data.marker;
+
+public interface BlockData extends GameData {
+}

--- a/src/main/java/org/spongepowered/api/data/marker/EntityData.java
+++ b/src/main/java/org/spongepowered/api/data/marker/EntityData.java
@@ -24,5 +24,5 @@
  */
 package org.spongepowered.api.data.marker;
 
-public interface EntityData {
+public interface EntityData extends GameData {
 }

--- a/src/main/java/org/spongepowered/api/data/marker/EntityData.java
+++ b/src/main/java/org/spongepowered/api/data/marker/EntityData.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.marker;
+
+public interface EntityData {
+}

--- a/src/main/java/org/spongepowered/api/data/marker/GameData.java
+++ b/src/main/java/org/spongepowered/api/data/marker/GameData.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.marker;
+
+public interface GameData extends EntityData {
+}

--- a/src/main/java/org/spongepowered/api/data/marker/GameData.java
+++ b/src/main/java/org/spongepowered/api/data/marker/GameData.java
@@ -24,5 +24,5 @@
  */
 package org.spongepowered.api.data.marker;
 
-public interface GameData extends EntityData {
+public interface GameData {
 }

--- a/src/main/java/org/spongepowered/api/data/marker/TileEntityData.java
+++ b/src/main/java/org/spongepowered/api/data/marker/TileEntityData.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.marker;
+
+public interface TileEntityData extends GameData {
+}

--- a/src/main/java/org/spongepowered/api/data/props/Props.java
+++ b/src/main/java/org/spongepowered/api/data/props/Props.java
@@ -26,7 +26,7 @@ package org.spongepowered.api.data.props;
 
 import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.data.Prop;
-import org.spongepowered.api.data.marker.GameData;
+import org.spongepowered.api.data.marker.BlockData;
 import org.spongepowered.api.data.types.BigMushroomType;
 import org.spongepowered.api.data.types.BrickType;
 import org.spongepowered.api.data.types.Comparison;
@@ -58,7 +58,6 @@ public class Props {
     private Props() {}
 
     // Block props
-    // TODO not sure what base type to use here
 
     /*
      TODO a lot of these are "types" of blocks that are incompatible.
@@ -75,30 +74,30 @@ public class Props {
      * Signifies that a block is "attached" or "hanging" on another block.
      * Usually applicable for {@link BlockTypes#TRIPWIRE}.
      */
-    public static final Prop<Boolean, GameData> IS_ATTACHED = null;
+    public static final Prop<Boolean, BlockData> IS_ATTACHED = null;
 
     /**
      * Signifies that a block relies on {@link Axis}.
      */
-    public static final Prop<Axis, GameData> AXIS = null;
+    public static final Prop<Axis, BlockData> AXIS = null;
 
     /**
      * Represents data related to {@link BlockTypes#BROWN_MUSHROOM_BLOCK} and
      * {@link BlockTypes#RED_MUSHROOM_BLOCK}.
      */
-    public static final Prop<BigMushroomType, GameData> BIG_MUSHROOM_TYPE = null;
+    public static final Prop<BigMushroomType, BlockData> BIG_MUSHROOM_TYPE = null;
 
     /**
      * Represents the type of {@link BrickType} for a
      * {@link BlockTypes#STONEBRICK}.
      */
-    public static final Prop<BrickType, GameData> BRICK_TYPE = null;
+    public static final Prop<BrickType, BlockData> BRICK_TYPE = null;
 
     /**
      * Represents the type of {@link Comparison} for a
      * {@link BlockTypes#POWERED_COMPARATOR} or {@link BlockTypes#UNPOWERED_COMPARATOR}.
      */
-    public static final Prop<Comparison, GameData> COMPARISON_TYPE = null;
+    public static final Prop<Comparison, BlockData> COMPARISON_TYPE = null;
 
     // TODO list props?
     /**
@@ -106,14 +105,14 @@ public class Props {
      * Usually applies to {@link BlockTypes#GLASS_PANE},
      * {@link BlockTypes#STAINED_GLASS_PANE}, and several others.
      */
-    public static final Prop<List<Direction>, GameData> CONNECTED_DIRECTIONS = null;
+    public static final Prop<List<Direction>, BlockData> CONNECTED_DIRECTIONS = null;
 
     /**
      * Signifies that a block will "decay" or be removed after a certain time.
      * Usually applicable to {@link BlockTypes#LEAVES} and
      * {@link BlockTypes#LEAVES2}.
      */
-    public static final Prop<Boolean, GameData> IS_DECAYABLE = null;
+    public static final Prop<Boolean, BlockData> IS_DECAYABLE = null;
 
     // naming
     /**
@@ -121,158 +120,158 @@ public class Props {
      * to "rotational" blocks, such as {@link BlockTypes#LOG} and
      * {@link BlockTypes#LOG2} etc.
      */
-    public static final Prop<Direction, GameData> DIRECTION = null;
+    public static final Prop<Direction, BlockData> DIRECTION = null;
 
     /**
      * Represents the type of {@link DirtType} for a
      * {@link BlockTypes#DIRT} block.
      */
-    public static final Prop<DirtType, GameData> DIRT_TYPE = null;
+    public static final Prop<DirtType, BlockData> DIRT_TYPE = null;
 
     /**
      * Signifies that a block is "disarmed". Usually applies to
      * {@link BlockTypes#TRIPWIRE_HOOK}s.
      */
-    public static final Prop<Boolean, GameData> IS_DISARMED = null;
+    public static final Prop<Boolean, BlockData> IS_DISARMED = null;
 
     /**
      * Represents the {@link DisguisedBlockType} of a block. Usually applies
      * to {@link BlockTypes#MONSTER_EGG}.
      */
-    public static final Prop<DisguisedBlockType, GameData> DISGUISED_BLOCK_TYPE = null;
+    public static final Prop<DisguisedBlockType, BlockData> DISGUISED_BLOCK_TYPE = null;
 
     /**
      * Represents the type of a {@link BlockTypes#DOUBLE_PLANT}.
      */
-    public static final Prop<DoubleSizePlantType, GameData> DOUBLE_PLANT_TYPE = null;
+    public static final Prop<DoubleSizePlantType, BlockData> DOUBLE_PLANT_TYPE = null;
 
     /**
      * Signifies whether the block is "extended". Usually applicable to
      * {@link BlockTypes#PISTON}.
      */
-    public static final Prop<Boolean, GameData> IS_EXTENDED = null;
+    public static final Prop<Boolean, BlockData> IS_EXTENDED = null;
 
     /**
      * Signifies that the owner is "filled". Usually applicable to
      * {@link BlockTypes#END_PORTAL_FRAME}.
      */
-    public static final Prop<Boolean, GameData> IS_FILLED = null;
+    public static final Prop<Boolean, BlockData> IS_FILLED = null;
 
     /**
      * Represents the "fluid level" for a liquid block. Usually applicable
      * to {@link BlockTypes#WATER} and {@link BlockTypes#LAVA}
      */
-    public static final Prop<Integer, GameData> FLUID_LEVEL = null;
+    public static final Prop<Integer, BlockData> FLUID_LEVEL = null;
 
     // TODO has bounds
     /**
      * Represents the "growth" of a block. Usually applicable to
      * {@link BlockTypes#WHEAT}, {@link BlockTypes#PUMPKIN_STEM}, etc.
      */
-    public static final Prop<Integer, GameData> GROWTH_STAGE = null;
+    public static final Prop<Integer, BlockData> GROWTH_STAGE = null;
 
     // naming
     /**
      * Represents the "side" that a "hinge" is facing on a door. Usually
      * applicable to {@link BlockTypes#TRAPDOOR} and other doors.
      */
-    public static final Prop<Hinge, GameData> HINGE = null;
+    public static final Prop<Hinge, BlockData> HINGE = null;
 
     /**
      * Represents the {@link InstrumentType}. Usually applicable to
      * {@link BlockTypes#NOTEBLOCK}.
      */
-    public static final Prop<InstrumentType, GameData> INSTRUMENT_TYPE = null;
+    public static final Prop<InstrumentType, BlockData> INSTRUMENT_TYPE = null;
 
     /**
      * Signifies that the owner is "connected" to a wall. Usually applicable to
      * {@link BlockTypes#FENCE_GATE}.
      */
-    public static final Prop<Boolean, GameData> IS_IN_WALL = null;
+    public static final Prop<Boolean, BlockData> IS_IN_WALL = null;
 
     /**
      * Represents the "layer" of an owner. Usually applicable to
      * {@link BlockTypes#CAKE}, {@link BlockTypes#SNOW_LAYER}, etc.
      */
-    public static final Prop<Integer, GameData> LAYER = null;
+    public static final Prop<Integer, BlockData> LAYER = null;
 
     /**
      * Represents the "moisture" level of a block. Usually applicable to
      * {@link BlockTypes#FARMLAND}.
      */
-    public static final Prop<Integer, GameData> MOISTURE = null;
+    public static final Prop<Integer, BlockData> MOISTURE = null;
 
     // WILL_NOT_DROP? Depends on default
     /**
      * Signifies that the owner will drop something. Usually applicable
      * to {@link BlockTypes#SKULL}.
      */
-    public static final Prop<Boolean, GameData> WILL_DROP = null;
+    public static final Prop<Boolean, BlockData> WILL_DROP = null;
 
     /**
      * Signifies that a block is considered "occupied". Usually applicable to
      * {@link BlockTypes#BED}.
      */
-    public static final Prop<Boolean, GameData> IS_OCCUPIED = null;
+    public static final Prop<Boolean, BlockData> IS_OCCUPIED = null;
 
     /**
      * Signifies that a block is "open". Usually applies to all doors.
      */
-    public static final Prop<Boolean, GameData> IS_OPEN = null;
+    public static final Prop<Boolean, BlockData> IS_OPEN = null;
 
     /**
      * Represents the {@link PistonType} of a {@link BlockTypes#PISTON_HEAD}.
      */
-    public static final Prop<PistonType, GameData> PISTON_TYPE = null;
+    public static final Prop<PistonType, BlockData> PISTON_TYPE = null;
 
     /**
      * Represents the "portion" of a block such as the top or bottom half of a
      * door. Usually applies to all {@link BlockTypes#ACACIA_DOOR}, {@link BlockTypes#BIRCH_DOOR},
      * and other doors.
      */
-    public static final Prop<PortionType, GameData> PORTION = null;
+    public static final Prop<PortionType, BlockData> PORTION = null;
 
     /**
      * Signifies that a block is "powered".
      */
-    public static final Prop<Boolean, GameData> IS_POWERED = null;
+    public static final Prop<Boolean, BlockData> IS_POWERED = null;
 
     /**
      * Represents the {@link PrismarineType} of a
      * {@link BlockTypes#PRISMARINE}.
      */
-    public static final Prop<PrismarineType, GameData> PRISMARINE_TYPE = null;
+    public static final Prop<PrismarineType, BlockData> PRISMARINE_TYPE = null;
 
     /**
      * Represents the {@link QuartzType} of a
      * {@link BlockTypes#QUARTZ_BLOCK}.
      */
-    public static final Prop<QuartzType, GameData> QUARTZ_TYPE = null;
+    public static final Prop<QuartzType, BlockData> QUARTZ_TYPE = null;
 
     /**
      * Represents the {@link RailDirection} of a {@link BlockTypes#RAIL} and
      * other types of rails.
      */
-    public static final Prop<RailDirection, GameData> RAIL_DIRECTION = null;
+    public static final Prop<RailDirection, BlockData> RAIL_DIRECTION = null;
 
     // Also "Powered"?
     /**
      * Signifies that a block has some value of redstone power applied to it.
      * Usually applicable for all blocks.
      */
-    public static final Prop<Integer, GameData> REDSTONE_POWERED = null;
+    public static final Prop<Integer, BlockData> REDSTONE_POWERED = null;
 
     /**
      * Signifies that a block is rotated with a {@link Rotation}.
      */
-    public static final Prop<SandType, GameData> SAND_TYPE = null;
+    public static final Prop<SandType, BlockData> SAND_TYPE = null;
 
     /**
      * Represents the {@link SandstoneType} of a sandstone based block. Usually
      * applicable to {@link BlockTypes#SANDSTONE} and
      * {@link BlockTypes#RED_SANDSTONE}.
      */
-    public static final Prop<SandstoneType, GameData> SANDSTONE_TYPE = null;
+    public static final Prop<SandstoneType, BlockData> SANDSTONE_TYPE = null;
 
     /**
      * Signifies that a block is "seamless". Usually applicable to
@@ -280,22 +279,22 @@ public class Props {
      * {@link BlockTypes#DOUBLE_STONE_SLAB2},
      * and {@link BlockTypes#DOUBLE_WOODEN_SLAB}.
      */
-    public static final Prop<Boolean, GameData> IS_SEAMLESS = null;
+    public static final Prop<Boolean, BlockData> IS_SEAMLESS = null;
 
     /**
      * Represents the {@link ShrubType} of a {@link BlockTypes#TALLGRASS}.
      */
-    public static final Prop<ShrubType, GameData> SHRUB_TYPE = null;
+    public static final Prop<ShrubType, BlockData> SHRUB_TYPE = null;
 
     /**
      * Represents the signal strength of some redstone blocks, like {@link BlockTypes#DAYLIGHT_DETECTOR}.
      */
-    public static final Prop<Integer, GameData> SIGNAL_OUTPUT = null;
+    public static final Prop<Integer, BlockData> SIGNAL_OUTPUT = null;
 
     /**
      * Represents the {@link SlabType} of slabs.
      */
-    public static final Prop<SlabType, GameData> SLAB_TYPE = null;
+    public static final Prop<SlabType, BlockData> SLAB_TYPE = null;
 
     // IS_SNOWED?
     /**
@@ -303,35 +302,35 @@ public class Props {
      * to {@link BlockTypes#GRASS}, {@link BlockTypes#DIRT}, and
      * {@link BlockTypes#MYCELIUM}.
      */
-    public static final Prop<Boolean, GameData> HAS_SNOW = null;
+    public static final Prop<Boolean, BlockData> HAS_SNOW = null;
 
     /**
      * Represents the {@link StairShape} of a stair block.
      */
-    public static final Prop<StairShape, GameData> STAIR_SHAPE = null;
+    public static final Prop<StairShape, BlockData> STAIR_SHAPE = null;
 
     /**
      * Represents the {@link StoneType} of a {@link BlockTypes#STONE}.
      */
-    public static final Prop<StoneType, GameData> STONE_TYPE = null;
+    public static final Prop<StoneType, BlockData> STONE_TYPE = null;
 
     /**
      * Signifies that a block is "suspended". Usually applicable to
      * {@link BlockTypes#TRIPWIRE} and {@link BlockTypes#TRIPWIRE_HOOK}.
      */
-    public static final Prop<Boolean, GameData> IS_SUSPENDED = null;
+    public static final Prop<Boolean, BlockData> IS_SUSPENDED = null;
 
     /**
      * Represents the {@link TreeType} for various tree based blocks. Usually
      * applicable to {@link BlockTypes#SAPLING}, {@link BlockTypes#LEAVES},
      * and {@link BlockTypes#LOG}.
      */
-    public static final Prop<TreeType, GameData> TREE_TYPE = null;
+    public static final Prop<TreeType, BlockData> TREE_TYPE = null;
 
     /**
      * Represents the {@link WallType} of a
      * {@link BlockTypes#COBBLESTONE_WALL}.
      */
-    public static final Prop<WallType, GameData> WALL_TYPE = null;
+    public static final Prop<WallType, BlockData> WALL_TYPE = null;
 
 }

--- a/src/main/java/org/spongepowered/api/data/props/Props.java
+++ b/src/main/java/org/spongepowered/api/data/props/Props.java
@@ -1,0 +1,337 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.props;
+
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.data.Prop;
+import org.spongepowered.api.data.marker.GameData;
+import org.spongepowered.api.data.types.BigMushroomType;
+import org.spongepowered.api.data.types.BrickType;
+import org.spongepowered.api.data.types.Comparison;
+import org.spongepowered.api.data.types.DirtType;
+import org.spongepowered.api.data.types.DisguisedBlockType;
+import org.spongepowered.api.data.types.DoubleSizePlantType;
+import org.spongepowered.api.data.types.Hinge;
+import org.spongepowered.api.data.types.InstrumentType;
+import org.spongepowered.api.data.types.PistonType;
+import org.spongepowered.api.data.types.PortionType;
+import org.spongepowered.api.data.types.PrismarineType;
+import org.spongepowered.api.data.types.QuartzType;
+import org.spongepowered.api.data.types.RailDirection;
+import org.spongepowered.api.data.types.SandType;
+import org.spongepowered.api.data.types.SandstoneType;
+import org.spongepowered.api.data.types.ShrubType;
+import org.spongepowered.api.data.types.SlabType;
+import org.spongepowered.api.data.types.StairShape;
+import org.spongepowered.api.data.types.StoneType;
+import org.spongepowered.api.data.types.TreeType;
+import org.spongepowered.api.data.types.WallType;
+import org.spongepowered.api.util.Axis;
+import org.spongepowered.api.util.Direction;
+import org.spongepowered.api.util.rotation.Rotation;
+
+import java.util.List;
+
+public class Props {
+    private Props() {}
+
+    // Block props
+    // TODO not sure what base type to use here
+
+    /*
+     TODO a lot of these are "types" of blocks that are incompatible.
+     Perhaps what is needed is a generic way to access these
+      */
+
+    // TODO missing Dyeable?
+    // TODO missing Rotation
+    // TODO missing Wet
+    // TODO missing base manipulators in data.manipulators.*
+
+    //naming: IS_ATTACHED or ATTACHED
+    /**
+     * Signifies that a block is "attached" or "hanging" on another block.
+     * Usually applicable for {@link BlockTypes#TRIPWIRE}.
+     */
+    public static final Prop<Boolean, GameData> IS_ATTACHED = null;
+
+    /**
+     * Signifies that a block relies on {@link Axis}.
+     */
+    public static final Prop<Axis, GameData> AXIS = null;
+
+    /**
+     * Represents data related to {@link BlockTypes#BROWN_MUSHROOM_BLOCK} and
+     * {@link BlockTypes#RED_MUSHROOM_BLOCK}.
+     */
+    public static final Prop<BigMushroomType, GameData> BIG_MUSHROOM_TYPE = null;
+
+    /**
+     * Represents the type of {@link BrickType} for a
+     * {@link BlockTypes#STONEBRICK}.
+     */
+    public static final Prop<BrickType, GameData> BRICK_TYPE = null;
+
+    /**
+     * Represents the type of {@link Comparison} for a
+     * {@link BlockTypes#POWERED_COMPARATOR} or {@link BlockTypes#UNPOWERED_COMPARATOR}.
+     */
+    public static final Prop<Comparison, GameData> COMPARISON_TYPE = null;
+
+    // TODO list props?
+    /**
+     * Signifies that a block is "connected" to a particular {@link Direction}.
+     * Usually applies to {@link BlockTypes#GLASS_PANE},
+     * {@link BlockTypes#STAINED_GLASS_PANE}, and several others.
+     */
+    public static final Prop<List<Direction>, GameData> CONNECTED_DIRECTIONS = null;
+
+    /**
+     * Signifies that a block will "decay" or be removed after a certain time.
+     * Usually applicable to {@link BlockTypes#LEAVES} and
+     * {@link BlockTypes#LEAVES2}.
+     */
+    public static final Prop<Boolean, GameData> IS_DECAYABLE = null;
+
+    // naming
+    /**
+     * Signifies that a block has a {@link Direction}. Usually applies
+     * to "rotational" blocks, such as {@link BlockTypes#LOG} and
+     * {@link BlockTypes#LOG2} etc.
+     */
+    public static final Prop<Direction, GameData> DIRECTION = null;
+
+    /**
+     * Represents the type of {@link DirtType} for a
+     * {@link BlockTypes#DIRT} block.
+     */
+    public static final Prop<DirtType, GameData> DIRT_TYPE = null;
+
+    /**
+     * Signifies that a block is "disarmed". Usually applies to
+     * {@link BlockTypes#TRIPWIRE_HOOK}s.
+     */
+    public static final Prop<Boolean, GameData> IS_DISARMED = null;
+
+    /**
+     * Represents the {@link DisguisedBlockType} of a block. Usually applies
+     * to {@link BlockTypes#MONSTER_EGG}.
+     */
+    public static final Prop<DisguisedBlockType, GameData> DISGUISED_BLOCK_TYPE = null;
+
+    /**
+     * Represents the type of a {@link BlockTypes#DOUBLE_PLANT}.
+     */
+    public static final Prop<DoubleSizePlantType, GameData> DOUBLE_PLANT_TYPE = null;
+
+    /**
+     * Signifies whether the block is "extended". Usually applicable to
+     * {@link BlockTypes#PISTON}.
+     */
+    public static final Prop<Boolean, GameData> IS_EXTENDED = null;
+
+    /**
+     * Signifies that the owner is "filled". Usually applicable to
+     * {@link BlockTypes#END_PORTAL_FRAME}.
+     */
+    public static final Prop<Boolean, GameData> IS_FILLED = null;
+
+    /**
+     * Represents the "fluid level" for a liquid block. Usually applicable
+     * to {@link BlockTypes#WATER} and {@link BlockTypes#LAVA}
+     */
+    public static final Prop<Integer, GameData> FLUID_LEVEL = null;
+
+    // TODO has bounds
+    /**
+     * Represents the "growth" of a block. Usually applicable to
+     * {@link BlockTypes#WHEAT}, {@link BlockTypes#PUMPKIN_STEM}, etc.
+     */
+    public static final Prop<Integer, GameData> GROWTH_STAGE = null;
+
+    // naming
+    /**
+     * Represents the "side" that a "hinge" is facing on a door. Usually
+     * applicable to {@link BlockTypes#TRAPDOOR} and other doors.
+     */
+    public static final Prop<Hinge, GameData> HINGE = null;
+
+    /**
+     * Represents the {@link InstrumentType}. Usually applicable to
+     * {@link BlockTypes#NOTEBLOCK}.
+     */
+    public static final Prop<InstrumentType, GameData> INSTRUMENT_TYPE = null;
+
+    /**
+     * Signifies that the owner is "connected" to a wall. Usually applicable to
+     * {@link BlockTypes#FENCE_GATE}.
+     */
+    public static final Prop<Boolean, GameData> IS_IN_WALL = null;
+
+    /**
+     * Represents the "layer" of an owner. Usually applicable to
+     * {@link BlockTypes#CAKE}, {@link BlockTypes#SNOW_LAYER}, etc.
+     */
+    public static final Prop<Integer, GameData> LAYER = null;
+
+    /**
+     * Represents the "moisture" level of a block. Usually applicable to
+     * {@link BlockTypes#FARMLAND}.
+     */
+    public static final Prop<Integer, GameData> MOISTURE = null;
+
+    // WILL_NOT_DROP? Depends on default
+    /**
+     * Signifies that the owner will drop something. Usually applicable
+     * to {@link BlockTypes#SKULL}.
+     */
+    public static final Prop<Boolean, GameData> WILL_DROP = null;
+
+    /**
+     * Signifies that a block is considered "occupied". Usually applicable to
+     * {@link BlockTypes#BED}.
+     */
+    public static final Prop<Boolean, GameData> IS_OCCUPIED = null;
+
+    /**
+     * Signifies that a block is "open". Usually applies to all doors.
+     */
+    public static final Prop<Boolean, GameData> IS_OPEN = null;
+
+    /**
+     * Represents the {@link PistonType} of a {@link BlockTypes#PISTON_HEAD}.
+     */
+    public static final Prop<PistonType, GameData> PISTON_TYPE = null;
+
+    /**
+     * Represents the "portion" of a block such as the top or bottom half of a
+     * door. Usually applies to all {@link BlockTypes#ACACIA_DOOR}, {@link BlockTypes#BIRCH_DOOR},
+     * and other doors.
+     */
+    public static final Prop<PortionType, GameData> PORTION = null;
+
+    /**
+     * Signifies that a block is "powered".
+     */
+    public static final Prop<Boolean, GameData> IS_POWERED = null;
+
+    /**
+     * Represents the {@link PrismarineType} of a
+     * {@link BlockTypes#PRISMARINE}.
+     */
+    public static final Prop<PrismarineType, GameData> PRISMARINE_TYPE = null;
+
+    /**
+     * Represents the {@link QuartzType} of a
+     * {@link BlockTypes#QUARTZ_BLOCK}.
+     */
+    public static final Prop<QuartzType, GameData> QUARTZ_TYPE = null;
+
+    /**
+     * Represents the {@link RailDirection} of a {@link BlockTypes#RAIL} and
+     * other types of rails.
+     */
+    public static final Prop<RailDirection, GameData> RAIL_DIRECTION = null;
+
+    // Also "Powered"?
+    /**
+     * Signifies that a block has some value of redstone power applied to it.
+     * Usually applicable for all blocks.
+     */
+    public static final Prop<Integer, GameData> REDSTONE_POWERED = null;
+
+    /**
+     * Signifies that a block is rotated with a {@link Rotation}.
+     */
+    public static final Prop<SandType, GameData> SAND_TYPE = null;
+
+    /**
+     * Represents the {@link SandstoneType} of a sandstone based block. Usually
+     * applicable to {@link BlockTypes#SANDSTONE} and
+     * {@link BlockTypes#RED_SANDSTONE}.
+     */
+    public static final Prop<SandstoneType, GameData> SANDSTONE_TYPE = null;
+
+    /**
+     * Signifies that a block is "seamless". Usually applicable to
+     * {@link BlockTypes#DOUBLE_STONE_SLAB},
+     * {@link BlockTypes#DOUBLE_STONE_SLAB2},
+     * and {@link BlockTypes#DOUBLE_WOODEN_SLAB}.
+     */
+    public static final Prop<Boolean, GameData> IS_SEAMLESS = null;
+
+    /**
+     * Represents the {@link ShrubType} of a {@link BlockTypes#TALLGRASS}.
+     */
+    public static final Prop<ShrubType, GameData> SHRUB_TYPE = null;
+
+    /**
+     * Represents the signal strength of some redstone blocks, like {@link BlockTypes#DAYLIGHT_DETECTOR}.
+     */
+    public static final Prop<Integer, GameData> SIGNAL_OUTPUT = null;
+
+    /**
+     * Represents the {@link SlabType} of slabs.
+     */
+    public static final Prop<SlabType, GameData> SLAB_TYPE = null;
+
+    // IS_SNOWED?
+    /**
+     * Signifies that a block is considered to be "snowed. Usually applicable
+     * to {@link BlockTypes#GRASS}, {@link BlockTypes#DIRT}, and
+     * {@link BlockTypes#MYCELIUM}.
+     */
+    public static final Prop<Boolean, GameData> HAS_SNOW = null;
+
+    /**
+     * Represents the {@link StairShape} of a stair block.
+     */
+    public static final Prop<StairShape, GameData> STAIR_SHAPE = null;
+
+    /**
+     * Represents the {@link StoneType} of a {@link BlockTypes#STONE}.
+     */
+    public static final Prop<StoneType, GameData> STONE_TYPE = null;
+
+    /**
+     * Signifies that a block is "suspended". Usually applicable to
+     * {@link BlockTypes#TRIPWIRE} and {@link BlockTypes#TRIPWIRE_HOOK}.
+     */
+    public static final Prop<Boolean, GameData> IS_SUSPENDED = null;
+
+    /**
+     * Represents the {@link TreeType} for various tree based blocks. Usually
+     * applicable to {@link BlockTypes#SAPLING}, {@link BlockTypes#LEAVES},
+     * and {@link BlockTypes#LOG}.
+     */
+    public static final Prop<TreeType, GameData> TREE_TYPE = null;
+
+    /**
+     * Represents the {@link WallType} of a
+     * {@link BlockTypes#COBBLESTONE_WALL}.
+     */
+    public static final Prop<WallType, GameData> WALL_TYPE = null;
+
+}

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -26,8 +26,10 @@ package org.spongepowered.api.entity;
 
 import com.flowpowered.math.vector.Vector3d;
 import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataObject;
 import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.manipulators.TargetedLocationData;
+import org.spongepowered.api.data.marker.EntityData;
 import org.spongepowered.api.util.Identifiable;
 import org.spongepowered.api.util.RelativePositions;
 import org.spongepowered.api.world.Location;
@@ -54,7 +56,7 @@ import java.util.UUID;
  *
  * <p>Blocks and items (when they are in inventories) are not entities.</p>
  */
-public interface Entity extends Identifiable, DataHolder, DataSerializable {
+public interface Entity extends Identifiable, DataHolder, DataObject<EntityData> {
 
     /**
      * Get the type of entity.


### PR DESCRIPTION
Will elaborate a better description later.

Simply put, the existing Data API is not the best because it is verbose. I want to decrease verbosity, yet keep type safety.

This is done with a generic object-property model that mirrors the current entity-component model, except the guarantees are flexible. In the signature of DataObject, the type parameter reflects how restrictive it is, in terms of marker interfaces.

Here's some code from me playing around earlier:

```java
Block myblock;

// Does not compile
myblock.set(Props.HEALTH, 5.0);

Entity myentity;

myentity.get(PositionData.class).set(X_POSITION, 5.0);

// Does not compile
myentity.get(PositionData.class).set(HEALTH, 9.0);

myentity.set(HEALTH, 5.0);
```


A lot of everything is still stubs. The basic idea is in place, but the values are all missing and I've yet to rework DataManipulators and the like.