### PR TITLE
Add methods to support key-value options within the permissions inheritance structure

### DIFF
--- a/src/main/java/org/spongepowered/api/service/permission/option/OptionSubject.java
+++ b/src/main/java/org/spongepowered/api/service/permission/option/OptionSubject.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.permission.option;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.service.permission.Subject;
+import org.spongepowered.api.service.permission.context.Context;
+
+import java.util.Set;
+
+public interface OptionSubject extends Subject {
+    @Override
+    OptionSubjectData getData();
+
+    @Override
+    OptionSubjectData getTransientData();
+
+    /**
+     * Get the value of a given option in the given context.
+     *
+     * @param key The key to get an option by. Case-insensitive.
+     * @return The value of the option, if any is present
+     */
+    Optional<String> getOption(Set<Context> contexts, String key);
+
+    /**
+     * Get the value of a given option in the subject's current context
+     *
+     * @param key The key to get an option by. Case-insensitive.
+     * @return The value of the option, if any is present
+     */
+    Optional<String> getOption(String key);
+}

--- a/src/main/java/org/spongepowered/api/service/permission/option/OptionSubjectData.java
+++ b/src/main/java/org/spongepowered/api/service/permission/option/OptionSubjectData.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.permission.option;
+
+import org.spongepowered.api.service.permission.SubjectData;
+import org.spongepowered.api.service.permission.context.Context;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface OptionSubjectData extends SubjectData {
+
+    /**
+     * Return all options for all context combinations currently registered.
+     *
+     * @return An immutable snapshot of all options data
+     */
+    Map<Set<Context>, Map<String, String>> getAllOptions();
+
+    /**
+     * Get options for a specific context combination.
+     *
+     * @param contexts The context combination to get options for
+     * @return All available options, returning an empty map if none are present
+     */
+    Map<String, String> getOptions(Set<Context> contexts);
+
+    /**
+     * Set a specific option to a value.
+     *
+     * @param contexts The context combination to set the given option in
+     * @param key The key to set. Case-insensitive.
+     * @param value The value to set.
+     * @return Whether the operation was successful
+     */
+    boolean setOption(Set<Context> contexts, String key, String value);
+
+    /**
+     * Clear all options in the given context combination.
+     *
+     * @param contexts The context combination
+     * @return Whether the operation was successful (any options were remowed)
+     */
+    boolean clearOptions(Set<Context> contexts);
+
+    /**
+     * Clear all options.
+     *
+     * @return Whether the operation was successful
+     */
+    boolean clearOptions();
+}

--- a/src/main/java/org/spongepowered/api/service/permission/option/package-info.java
+++ b/src/main/java/org/spongepowered/api/service/permission/option/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.service.permission.option;


### PR DESCRIPTION
Options are commonly used for things like a user's prefix and suffix, which are attached to a subject but are often useful to have inherited from defined parents.

These are used as arbitrary metadata for various features, like a prefix, or player-set messages.

Options are implemented as a subinterface of the existing permissions interfaces. This way, plugins can simply check instance and cast from an existing permissions service provider. However, this means that no plugin can provide only options (imo having two separate inheritance systems available through two services would just be a bad idea & create confusion).