### PR TITLE
Improve event system to allow registering events without annotations

### DIFF
--- a/src/main/java/org/spongepowered/api/event/EventHandler.java
+++ b/src/main/java/org/spongepowered/api/event/EventHandler.java
@@ -24,32 +24,18 @@
  */
 package org.spongepowered.api.event;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-import org.spongepowered.api.service.event.EventManager;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
-@Retention(RUNTIME)
-@Target(METHOD)
-public @interface Subscribe {
+/**
+ * Represents a handler accepting events of a specified type.
+ *
+ * @param <T> The type of the event
+ */
+public interface EventHandler<T extends Event> {
 
     /**
-     * The order this handler should be called in relation to other handlers in
-     * the {@link EventManager}.
+     * Called when a event registered to this handler is called.
      *
-     * @return The order the handler should be called in
+     * @param event The called event
      */
-    Order order() default Order.DEFAULT;
-
-    /**
-     * Whether this handler should ignore cancelled events. If enabled the
-     * handler will not be called for any cancelled events.
-     *
-     * @return If the handler should ignore cancelled events
-     */
-    boolean ignoreCancelled() default true;
+    void handle(T event);
 
 }

--- a/src/main/java/org/spongepowered/api/service/event/EventManager.java
+++ b/src/main/java/org/spongepowered/api/service/event/EventManager.java
@@ -25,6 +25,9 @@
 package org.spongepowered.api.service.event;
 
 import org.spongepowered.api.event.Event;
+import org.spongepowered.api.event.EventHandler;
+import org.spongepowered.api.event.Order;
+import org.spongepowered.api.event.Subscribe;
 
 /**
  * Manages the registration of event handlers and the dispatching of events.
@@ -32,13 +35,47 @@ import org.spongepowered.api.event.Event;
 public interface EventManager {
 
     /**
-     * Registers an object to receive {@link Event}s.
+     * Registers {@link Event} methods annotated with @{@link Subscribe} in the
+     * specified object.
      *
-     * @param plugin A plugin instance
+     * @param plugin The plugin instance
      * @param obj The object
-     * @throws IllegalArgumentException Thrown if {@code plugin} is not a plugin instance
+     * @throws IllegalArgumentException Thrown if {@code plugin} is not a plugin
+     *         instance
      */
     void register(Object plugin, Object obj);
+
+    /**
+     * Registers an event handler for a specific event class.
+     *
+     * <p>Normally, the annotation-based way in
+     * {@link #register(Object, Object)} should be preferred over this way. This
+     * method exists primarily to support dynamic event registration like needed
+     * in scripting plugins.</p>
+     *
+     * @param plugin The plugin instance
+     * @param eventClass The event to listen to
+     * @param handler The handler to receive the events
+     * @param <T> The type of the event
+     */
+    <T extends Event> void register(Object plugin, Class<T> eventClass, EventHandler<? super T> handler);
+
+    /**
+     * Registers an event handler with the specified order for a specific event
+     * class.
+     *
+     * <p>Normally, the annotation-based way in
+     * {@link #register(Object, Object)} should be preferred over this way. This
+     * method exists primarily to support dynamic event registration like needed
+     * in scripting plugins.</p>
+     *
+     * @param plugin The plugin instance
+     * @param eventClass The event to listen to
+     * @param order The order the handler will get called at
+     * @param handler The handler to receive the events
+     * @param <T> The type of the event
+     */
+    <T extends Event> void register(Object plugin, Class<T> eventClass, Order order, EventHandler<? super T> handler);
 
     /**
      * Un-registers an object from receiving {@link Event}s.
@@ -48,10 +85,17 @@ public interface EventManager {
     void unregister(Object obj);
 
     /**
+     * Un-registers all event handlers of a plugin.
+     *
+     * @param plugin The plugin instance
+     */
+    void unregisterPlugin(Object plugin);
+
+    /**
      * Calls a {@link Event} to all handlers that handle it.
      *
      * @param event The event
-     * @return True if canceled, false if not
+     * @return True if cancelled, false if not
      */
     boolean post(Event event);
 


### PR DESCRIPTION
This will make a few changes in the event system to add/fix the following:
- Allow registering events without annotations (see #615)
- Fix a few ambiguous Javadocs
- Add a few minor methods