### PR TITLE
Add GSON and commons-lang3 to dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,12 +15,12 @@ apply from: 'gradle/java.gradle'
 
 // Project dependencies
 dependencies {
-    compile 'org.slf4j:slf4j-api:1.7.7'
+    compile 'org.slf4j:slf4j-api:1.7.12'
     compile 'com.google.guava:guava:17.0'
     compile 'com.google.code.gson:gson:2.2.4'
     compile 'org.apache.commons:commons-lang3:3.3.2'
     compile 'com.google.code.findbugs:jsr305:1.3.9'
-    compile 'com.google.inject:guice:4.0-beta5'
+    compile 'com.google.inject:guice:4.0'
     compile 'ninja.leaping.configurate:configurate-hocon:1.1.1'
     compile 'com.flowpowered:flow-math:1.0.0'
     compile 'org.ow2.asm:asm:5.0.3'

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,8 @@ apply from: 'gradle/java.gradle'
 dependencies {
     compile 'org.slf4j:slf4j-api:1.7.7'
     compile 'com.google.guava:guava:17.0'
+    compile 'com.google.code.gson:gson:2.2.4'
+    compile 'org.apache.commons:commons-lang3:3.3.2'
     compile 'com.google.code.findbugs:jsr305:1.3.9'
     compile 'com.google.inject:guice:4.0-beta5'
     compile 'ninja.leaping.configurate:configurate-hocon:1.1.1'


### PR DESCRIPTION
This adds 2 new dependencies to SpongeAPI (primarily for plugin authors to use). The distribution of our both implementations will not be affected by this. Both dependencies are already included in Minecraft so this just exposes them to plugin developers.

- **GSON:** As a JSON dependency, see #625. While some may prefer another library to work with JSON (e.g. Jackson), GSON is already included in Minecraft and so we don't need to bundle anything additional. Plugin authors can still bundle an alternative library to work with JSON.

- **commons-lang3:** I'm not completely sure if we should provide this. It contains quite a lot of utilities which make stuff easier to use, and given its size (~600 KB) it would be stupid if plugin developers would need to bundle it (without a dependency in SpongeAPI there is no guarantee it's available in all implementations). It's included in Minecraft already so this would not affect many implementations.

Additionally updated `slf4j-api` to 1.7.12 and Guice to the 1.4 release. Didn't cause any problems in the implementation.