### PR TITLE
Standardize use of getEntity() in UserEvent and subclasses

### DIFF
--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -951,6 +951,7 @@ public final class SpongeEventFactory {
         values.put("cause", Optional.fromNullable(cause));
         values.put("block", block);
         values.put("entity", player);
+        values.put("user", player);
         values.put("replacementBlock", replacementBlock);
         values.put("blockFaceDirection", direction);
         values.put("exp", exp);
@@ -969,6 +970,7 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
+        values.put("user", player);
         values.put("fishHook", fishHook);
         return createEvent(PlayerCastFishingLineEvent.class, values);
     }
@@ -986,6 +988,7 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
+        values.put("user", player);
         values.put("fishHook", fishHook);
         values.put("caughtEntity", Optional.fromNullable(caughtEntity));
         return createEvent(PlayerHookedEntityEvent.class, values);
@@ -1007,6 +1010,7 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
+        values.put("user", player);
         values.put("fishHook", fishHook);
         values.put("caughtEntity", Optional.fromNullable(caughtEntity));
         values.put("caughtItem", Optional.fromNullable(caughtItem));
@@ -1032,6 +1036,7 @@ public final class SpongeEventFactory {
         values.put("cause", Optional.fromNullable(cause));
         values.put("block", block);
         values.put("entity", player);
+        values.put("user", player);
         values.put("replacementBlock", replacementBlock);
         values.put("blockFaceDirection", direction);
         return createEvent(PlayerChangeBlockEvent.class, values);
@@ -1050,6 +1055,7 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
+        values.put("user", player);
         values.put("newGameMode", newGameMode);
         values.put("oldGameMode", oldGameMode);
         return createEvent(PlayerChangeGameModeEvent.class, values);
@@ -1068,6 +1074,7 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
+        values.put("user", player);
         values.put("fromWorld", fromWorld);
         values.put("toWorld", toWorld);
         return createEvent(PlayerChangeWorldEvent.class, values);
@@ -1085,7 +1092,9 @@ public final class SpongeEventFactory {
     public static PlayerChatEvent createPlayerChat(Game game, Player player, CommandSource source, Text message) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
+        values.put("user", player);
         values.put("entity", player);
+        values.put("user", player);
         values.put("source", source);
         values.put("message", message);
         return createEvent(PlayerChatEvent.class, values);
@@ -1113,6 +1122,7 @@ public final class SpongeEventFactory {
         values.put("game", game);
         values.put("cause", Optional.fromNullable(cause));
         values.put("entity", player);
+        values.put("user", player);
         values.put("deathMessage", deathMessage);
         values.put("location", location);
         values.put("exp", exp);
@@ -1137,6 +1147,7 @@ public final class SpongeEventFactory {
         values.put("game", game);
         values.put("cause", Optional.fromNullable(cause));
         values.put("entity", player);
+        values.put("user", player);
         values.put("droppedItems", droppedItems);
         return createEvent(PlayerDropItemEvent.class, values);
     }
@@ -1161,6 +1172,7 @@ public final class SpongeEventFactory {
         values.put("cause", Optional.fromNullable(cause));
         values.put("block", block);
         values.put("entity", player);
+        values.put("user", player);
         values.put("droppedItems", droppedItems);
         values.put("dropChance", dropChance);
         values.put("silkTouch", silkTouch);
@@ -1185,6 +1197,7 @@ public final class SpongeEventFactory {
         values.put("cause", Optional.fromNullable(cause));
         values.put("block", block);
         values.put("entity", player);
+        values.put("user", player);
         values.put("interactionType", interactionType);
         values.put("clickedPosition", Optional.fromNullable(location));
         return createEvent(PlayerInteractBlockEvent.class, values);
@@ -1205,6 +1218,7 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
+        values.put("user", player);
         values.put("targetEntity", targetEntity);
         values.put("interactionType", interactionType);
         values.put("clickedPosition", Optional.fromNullable(location));
@@ -1225,6 +1239,7 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
+        values.put("user", player);
         values.put("interactionType", interactionType);
         values.put("clickedPosition", Optional.fromNullable(location));
         return createEvent(PlayerInteractEvent.class, values);
@@ -1242,6 +1257,7 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
+        values.put("user", player);
         values.put("joinMessage", joinMessage);
         return createEvent(PlayerJoinEvent.class, values);
     }
@@ -1260,6 +1276,7 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
+        values.put("user", player);
         values.put("oldLocation", oldLocation);
         values.put("newLocation", newLocation);
         values.put("rotation", rotation);
@@ -1279,6 +1296,7 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
+        values.put("user", player);
         values.put("items", items);
         values.put("inventory", inventory);
         return createEvent(PlayerPickUpItemEvent.class, values);
@@ -1302,6 +1320,7 @@ public final class SpongeEventFactory {
         values.put("cause", Optional.fromNullable(cause));
         values.put("block", block);
         values.put("entity", player);
+        values.put("user", player);
         values.put("replacementBlock", replacementBlock);
         values.put("blockFaceDirection", direction);
         return createEvent(PlayerPlaceBlockEvent.class, values);
@@ -1319,6 +1338,7 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
+        values.put("user", player);
         values.put("quitMessage", quitMessage);
         return createEvent(PlayerQuitEvent.class, values);
     }
@@ -1336,6 +1356,7 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
+        values.put("user", player);
         values.put("respawnLocation", respawnLocation);
         values.put("bedSpawn", bedSpawn);
         return createEvent(PlayerRespawnEvent.class, values);
@@ -1352,6 +1373,7 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
+        values.put("user", player);
         return createEvent(PlayerUpdateEvent.class, values);
     }
 
@@ -1388,6 +1410,7 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
+        values.put("user", player);
         values.put("achievement", achievement);
         return createEvent(AchievementEvent.class, values);
     }
@@ -1407,6 +1430,7 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
+        values.put("user", player);
         values.put("changedStatistic", changedStatistic);
         values.put("newValue", newValue);
         values.put("oldValue", oldValue);

--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -951,8 +951,8 @@ public final class SpongeEventFactory {
         values.put("cause", Optional.fromNullable(cause));
         values.put("block", block);
         values.put("entity", player);
-        values.put("user", player);
         values.put("replacementBlock", replacementBlock);
+        values.put("user", player);
         values.put("blockFaceDirection", direction);
         values.put("exp", exp);
         return createEvent(PlayerBreakBlockEvent.class, values);
@@ -1036,8 +1036,8 @@ public final class SpongeEventFactory {
         values.put("cause", Optional.fromNullable(cause));
         values.put("block", block);
         values.put("entity", player);
-        values.put("user", player);
         values.put("replacementBlock", replacementBlock);
+        values.put("user", player);
         values.put("blockFaceDirection", direction);
         return createEvent(PlayerChangeBlockEvent.class, values);
     }
@@ -1055,9 +1055,9 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
-        values.put("user", player);
         values.put("newGameMode", newGameMode);
         values.put("oldGameMode", oldGameMode);
+        values.put("user", player);
         return createEvent(PlayerChangeGameModeEvent.class, values);
     }
 
@@ -1074,9 +1074,9 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
-        values.put("user", player);
         values.put("fromWorld", fromWorld);
         values.put("toWorld", toWorld);
+        values.put("user", player);
         return createEvent(PlayerChangeWorldEvent.class, values);
     }
 
@@ -1092,11 +1092,10 @@ public final class SpongeEventFactory {
     public static PlayerChatEvent createPlayerChat(Game game, Player player, CommandSource source, Text message) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("user", player);
         values.put("entity", player);
-        values.put("user", player);
         values.put("source", source);
         values.put("message", message);
+        values.put("user", player);
         return createEvent(PlayerChatEvent.class, values);
     }
 
@@ -1122,8 +1121,8 @@ public final class SpongeEventFactory {
         values.put("game", game);
         values.put("cause", Optional.fromNullable(cause));
         values.put("entity", player);
-        values.put("user", player);
         values.put("deathMessage", deathMessage);
+        values.put("user", player);
         values.put("location", location);
         values.put("exp", exp);
         values.put("newExperience", newExperience);
@@ -1147,8 +1146,8 @@ public final class SpongeEventFactory {
         values.put("game", game);
         values.put("cause", Optional.fromNullable(cause));
         values.put("entity", player);
-        values.put("user", player);
         values.put("droppedItems", droppedItems);
+        values.put("user", player);
         return createEvent(PlayerDropItemEvent.class, values);
     }
 
@@ -1197,8 +1196,8 @@ public final class SpongeEventFactory {
         values.put("cause", Optional.fromNullable(cause));
         values.put("block", block);
         values.put("entity", player);
-        values.put("user", player);
         values.put("interactionType", interactionType);
+        values.put("user", player);
         values.put("clickedPosition", Optional.fromNullable(location));
         return createEvent(PlayerInteractBlockEvent.class, values);
     }
@@ -1218,9 +1217,9 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
-        values.put("user", player);
         values.put("targetEntity", targetEntity);
         values.put("interactionType", interactionType);
+        values.put("user", player);
         values.put("clickedPosition", Optional.fromNullable(location));
         return createEvent(PlayerInteractEntityEvent.class, values);
     }
@@ -1239,8 +1238,8 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
-        values.put("user", player);
         values.put("interactionType", interactionType);
+        values.put("user", player);
         values.put("clickedPosition", Optional.fromNullable(location));
         return createEvent(PlayerInteractEvent.class, values);
     }
@@ -1257,8 +1256,8 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
-        values.put("user", player);
         values.put("joinMessage", joinMessage);
+        values.put("user", player);
         return createEvent(PlayerJoinEvent.class, values);
     }
 
@@ -1276,9 +1275,9 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
-        values.put("user", player);
         values.put("oldLocation", oldLocation);
         values.put("newLocation", newLocation);
+        values.put("user", player);
         values.put("rotation", rotation);
         return createEvent(PlayerMoveEvent.class, values);
     }
@@ -1296,8 +1295,8 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
-        values.put("user", player);
         values.put("items", items);
+        values.put("user", player);
         values.put("inventory", inventory);
         return createEvent(PlayerPickUpItemEvent.class, values);
     }
@@ -1320,8 +1319,8 @@ public final class SpongeEventFactory {
         values.put("cause", Optional.fromNullable(cause));
         values.put("block", block);
         values.put("entity", player);
-        values.put("user", player);
         values.put("replacementBlock", replacementBlock);
+        values.put("user", player);
         values.put("blockFaceDirection", direction);
         return createEvent(PlayerPlaceBlockEvent.class, values);
     }
@@ -1338,8 +1337,8 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
-        values.put("user", player);
         values.put("quitMessage", quitMessage);
+        values.put("user", player);
         return createEvent(PlayerQuitEvent.class, values);
     }
 
@@ -1356,9 +1355,9 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
-        values.put("user", player);
         values.put("respawnLocation", respawnLocation);
         values.put("bedSpawn", bedSpawn);
+        values.put("user", player);
         return createEvent(PlayerRespawnEvent.class, values);
     }
 

--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -952,10 +952,6 @@ public final class SpongeEventFactory {
         values.put("block", block);
         values.put("entity", player);
         values.put("replacementBlock", replacementBlock);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         values.put("blockFaceDirection", direction);
         values.put("exp", exp);
         return createEvent(PlayerBreakBlockEvent.class, values);
@@ -973,10 +969,6 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         values.put("fishHook", fishHook);
         return createEvent(PlayerCastFishingLineEvent.class, values);
     }
@@ -994,10 +986,6 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         values.put("fishHook", fishHook);
         values.put("caughtEntity", Optional.fromNullable(caughtEntity));
         return createEvent(PlayerHookedEntityEvent.class, values);
@@ -1019,10 +1007,6 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         values.put("fishHook", fishHook);
         values.put("caughtEntity", Optional.fromNullable(caughtEntity));
         values.put("caughtItem", Optional.fromNullable(caughtItem));
@@ -1049,10 +1033,6 @@ public final class SpongeEventFactory {
         values.put("block", block);
         values.put("entity", player);
         values.put("replacementBlock", replacementBlock);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         values.put("blockFaceDirection", direction);
         return createEvent(PlayerChangeBlockEvent.class, values);
     }
@@ -1072,10 +1052,6 @@ public final class SpongeEventFactory {
         values.put("entity", player);
         values.put("newGameMode", newGameMode);
         values.put("oldGameMode", oldGameMode);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         return createEvent(PlayerChangeGameModeEvent.class, values);
     }
 
@@ -1094,10 +1070,6 @@ public final class SpongeEventFactory {
         values.put("entity", player);
         values.put("fromWorld", fromWorld);
         values.put("toWorld", toWorld);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         return createEvent(PlayerChangeWorldEvent.class, values);
     }
 
@@ -1116,10 +1088,6 @@ public final class SpongeEventFactory {
         values.put("entity", player);
         values.put("source", source);
         values.put("message", message);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         return createEvent(PlayerChatEvent.class, values);
     }
 
@@ -1146,11 +1114,7 @@ public final class SpongeEventFactory {
         values.put("cause", Optional.fromNullable(cause));
         values.put("entity", player);
         values.put("deathMessage", deathMessage);
-        values.put("player", player);
-        values.put("user", player);
         values.put("location", location);
-        values.put("human", player);
-        values.put("living", player);
         values.put("exp", exp);
         values.put("newExperience", newExperience);
         values.put("newLevel", newLevel);
@@ -1174,10 +1138,6 @@ public final class SpongeEventFactory {
         values.put("cause", Optional.fromNullable(cause));
         values.put("entity", player);
         values.put("droppedItems", droppedItems);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         return createEvent(PlayerDropItemEvent.class, values);
     }
 
@@ -1201,10 +1161,6 @@ public final class SpongeEventFactory {
         values.put("cause", Optional.fromNullable(cause));
         values.put("block", block);
         values.put("entity", player);
-        values.put("user", player);
-        values.put("player", player);
-        values.put("human", player);
-        values.put("living", player);
         values.put("droppedItems", droppedItems);
         values.put("dropChance", dropChance);
         values.put("silkTouch", silkTouch);
@@ -1229,11 +1185,7 @@ public final class SpongeEventFactory {
         values.put("cause", Optional.fromNullable(cause));
         values.put("block", block);
         values.put("entity", player);
-        values.put("human", player);
-        values.put("living", player);
         values.put("interactionType", interactionType);
-        values.put("player", player);
-        values.put("user", player);
         values.put("clickedPosition", Optional.fromNullable(location));
         return createEvent(PlayerInteractBlockEvent.class, values);
     }
@@ -1255,10 +1207,6 @@ public final class SpongeEventFactory {
         values.put("entity", player);
         values.put("targetEntity", targetEntity);
         values.put("interactionType", interactionType);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         values.put("clickedPosition", Optional.fromNullable(location));
         return createEvent(PlayerInteractEntityEvent.class, values);
     }
@@ -1278,10 +1226,6 @@ public final class SpongeEventFactory {
         values.put("game", game);
         values.put("entity", player);
         values.put("interactionType", interactionType);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         values.put("clickedPosition", Optional.fromNullable(location));
         return createEvent(PlayerInteractEvent.class, values);
     }
@@ -1299,10 +1243,6 @@ public final class SpongeEventFactory {
         values.put("game", game);
         values.put("entity", player);
         values.put("joinMessage", joinMessage);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         return createEvent(PlayerJoinEvent.class, values);
     }
 
@@ -1322,10 +1262,6 @@ public final class SpongeEventFactory {
         values.put("entity", player);
         values.put("oldLocation", oldLocation);
         values.put("newLocation", newLocation);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         values.put("rotation", rotation);
         return createEvent(PlayerMoveEvent.class, values);
     }
@@ -1344,10 +1280,6 @@ public final class SpongeEventFactory {
         values.put("game", game);
         values.put("entity", player);
         values.put("items", items);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         values.put("inventory", inventory);
         return createEvent(PlayerPickUpItemEvent.class, values);
     }
@@ -1371,10 +1303,6 @@ public final class SpongeEventFactory {
         values.put("block", block);
         values.put("entity", player);
         values.put("replacementBlock", replacementBlock);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         values.put("blockFaceDirection", direction);
         return createEvent(PlayerPlaceBlockEvent.class, values);
     }
@@ -1392,10 +1320,6 @@ public final class SpongeEventFactory {
         values.put("game", game);
         values.put("entity", player);
         values.put("quitMessage", quitMessage);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         return createEvent(PlayerQuitEvent.class, values);
     }
 
@@ -1414,10 +1338,6 @@ public final class SpongeEventFactory {
         values.put("entity", player);
         values.put("respawnLocation", respawnLocation);
         values.put("bedSpawn", bedSpawn);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         return createEvent(PlayerRespawnEvent.class, values);
     }
 
@@ -1432,10 +1352,6 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
-        values.put("player", player);
-        values.put("user", player);
-        values.put("human", player);
-        values.put("living", player);
         return createEvent(PlayerUpdateEvent.class, values);
     }
 
@@ -1472,10 +1388,6 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
-        values.put("living", player);
-        values.put("human", player);
-        values.put("player", player);
-        values.put("user", player);
         values.put("achievement", achievement);
         return createEvent(AchievementEvent.class, values);
     }
@@ -1495,10 +1407,6 @@ public final class SpongeEventFactory {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("entity", player);
-        values.put("living", player);
-        values.put("human", player);
-        values.put("player", player);
-        values.put("user", player);
         values.put("changedStatistic", changedStatistic);
         values.put("newValue", newValue);
         values.put("oldValue", oldValue);

--- a/src/main/java/org/spongepowered/api/event/entity/living/LivingEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/LivingEvent.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.event.entity.living;
 
-import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.event.entity.EntityEvent;
 
@@ -38,5 +37,6 @@ public interface LivingEvent extends EntityEvent {
      *
      * @return The {@link Living} involved
      */
-    Entity getEntity();
+    @Override
+    Living getEntity();
 }

--- a/src/main/java/org/spongepowered/api/event/entity/living/LivingEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/LivingEvent.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.event.entity.living;
 
+import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.event.entity.EntityEvent;
 
@@ -37,8 +38,5 @@ public interface LivingEvent extends EntityEvent {
      *
      * @return The {@link Living} involved
      */
-    Living getLiving();
-
-    @Override
-    Living getEntity();
+    Entity getEntity();
 }

--- a/src/main/java/org/spongepowered/api/event/entity/living/human/HumanEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/human/HumanEvent.java
@@ -37,5 +37,6 @@ public interface HumanEvent extends LivingEvent {
      *
      * @return The {@link Human} involved
      */
+    @Override
     Human getEntity();
 }

--- a/src/main/java/org/spongepowered/api/event/entity/living/human/HumanEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/human/HumanEvent.java
@@ -37,11 +37,5 @@ public interface HumanEvent extends LivingEvent {
      *
      * @return The {@link Human} involved
      */
-    Human getHuman();
-
-    @Override
-    Human getLiving();
-
-    @Override
     Human getEntity();
 }

--- a/src/main/java/org/spongepowered/api/event/entity/player/PlayerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/player/PlayerEvent.java
@@ -26,7 +26,6 @@ package org.spongepowered.api.event.entity.player;
 
 
 import org.spongepowered.api.entity.player.Player;
-import org.spongepowered.api.entity.player.User;
 import org.spongepowered.api.event.entity.living.human.HumanEvent;
 
 /**
@@ -43,5 +42,5 @@ public interface PlayerEvent extends HumanEvent, UserEvent {
     Player getEntity();
 
     @Override
-    User getUser();
+    Player getUser();
 }

--- a/src/main/java/org/spongepowered/api/event/entity/player/PlayerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/player/PlayerEvent.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.event.entity.player;
 
 
 import org.spongepowered.api.entity.player.Player;
+import org.spongepowered.api.entity.player.User;
 import org.spongepowered.api.event.entity.living.human.HumanEvent;
 
 /**
@@ -40,4 +41,7 @@ public interface PlayerEvent extends HumanEvent, UserEvent {
      */
     @Override
     Player getEntity();
+
+    @Override
+    User getUser();
 }

--- a/src/main/java/org/spongepowered/api/event/entity/player/PlayerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/player/PlayerEvent.java
@@ -43,5 +43,5 @@ public interface PlayerEvent extends HumanEvent, UserEvent {
 
     @Override
     Player getUser();
-    
+
 }

--- a/src/main/java/org/spongepowered/api/event/entity/player/PlayerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/player/PlayerEvent.java
@@ -38,18 +38,6 @@ public interface PlayerEvent extends HumanEvent, UserEvent {
      *
      * @return The {@link Player} involved
      */
-    Player getPlayer();
-
-    @Override
-    Player getHuman();
-
-    @Override
-    Player getLiving();
-
     @Override
     Player getEntity();
-
-    @Override
-    Player getUser();
-
 }

--- a/src/main/java/org/spongepowered/api/event/entity/player/PlayerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/player/PlayerEvent.java
@@ -43,4 +43,5 @@ public interface PlayerEvent extends HumanEvent, UserEvent {
 
     @Override
     Player getUser();
+    
 }

--- a/src/main/java/org/spongepowered/api/event/entity/player/UserEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/player/UserEvent.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.event.entity.player;
 
-import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.player.User;
 import org.spongepowered.api.event.GameEvent;
 
 /**
@@ -37,6 +37,6 @@ public interface UserEvent extends GameEvent {
      *
      * @return The user
      */
-    Entity getEntity();
+    User getUser();
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/player/UserEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/player/UserEvent.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.event.entity.player;
 
-import org.spongepowered.api.entity.player.User;
+import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.GameEvent;
 
 /**
@@ -37,6 +37,6 @@ public interface UserEvent extends GameEvent {
      *
      * @return The user
      */
-    User getUser();
+    Entity getEntity();
 
 }


### PR DESCRIPTION
Intended as a potential fix for #641. Guaranteed to be breaking but some form of change like this is needed for sanity purposes. Please do give any feedback possible!

A pr has been created to fix the mixins in the current sponge implementation at https://github.com/SpongePowered/Sponge/pull/264