### PR TITLE
Make Optional<Text> returns support subtypes of Text in CommandCallable methods

### DIFF
--- a/src/main/java/org/spongepowered/api/util/command/CommandCallable.java
+++ b/src/main/java/org/spongepowered/api/util/command/CommandCallable.java
@@ -86,7 +86,7 @@ public interface CommandCallable {
      * @param source The source of the help request
      * @return A description
      */
-    Optional<Text> getShortDescription(CommandSource source);
+    Optional<? extends Text> getShortDescription(CommandSource source);
 
     /**
      * Get a longer formatted help message about this command.
@@ -103,7 +103,7 @@ public interface CommandCallable {
      * @param source The source of the help request
      * @return A help text
      */
-    Optional<Text> getHelp(CommandSource source);
+    Optional<? extends Text> getHelp(CommandSource source);
 
     /**
      * Get the usage string of this command.

--- a/src/main/java/org/spongepowered/api/util/command/dispatcher/SimpleDispatcher.java
+++ b/src/main/java/org/spongepowered/api/util/command/dispatcher/SimpleDispatcher.java
@@ -381,7 +381,8 @@ public final class SimpleDispatcher implements Dispatcher {
                 continue;
             }
             CommandMapping mapping = mappingOpt.get();
-            final Optional<Text> description = mapping.getCallable().getShortDescription(source);
+            @SuppressWarnings("unchecked")
+            final Optional<Text> description = (Optional<Text>) mapping.getCallable().getShortDescription(source);
             build.append(Texts.builder(mapping.getPrimaryAlias())
                     .color(TextColors.GREEN)
                     .style(TextStyles.UNDERLINE)


### PR DESCRIPTION
This is a proposed fix to #645.

Since `Optional<T>` is invariant (this is Java, after all), we need to specify a wildcard generic type `Optional<? extends T>` for text methods. I don't know of any other solution, but am unsure that this is the only one which is why I am making such a small PR.

This is probably required for other places, but this is a hotfix for just the scope of the mentioned issue.