### PR TITLE
Add an implementable economy service.

### DIFF
--- a/src/main/java/org/spongepowered/api/service/economy/Account.java
+++ b/src/main/java/org/spongepowered/api/service/economy/Account.java
@@ -29,6 +29,7 @@ import org.spongepowered.api.entity.player.Player;
 import java.util.UUID;
 
 public interface Account {
+
     /**
      * The string that prefixes all custom account names.
      */
@@ -40,33 +41,27 @@ public interface Account {
     public static final String SERVER_ACCOUNT_NAME = "_ESCSV";
 
     /**
-     * Retrieves the string representative of the owner of
-     * this {@link Account}.
+     * Retrieves the string representative of the owner of this {@link Account}.
      * 
-     * <p>The String returned can represent 3 types of
-     * accounts; namely a Player's, the Server's, or a
-     * customly-registered account.</p>
+     * <p>The String returned can represent 3 types of accounts; namely a
+     * Player's, the Server's, or a customly-registered account.</p>
      * 
-     * <p>If the String returned matches the value denoted
-     * by {@link Account#SERVER_ACCOUNT_NAME}, then the
-     * owner of this Account is the server itself.</p>
+     * <p>If the String returned matches the value denoted by
+     * {@link Account#SERVER_ACCOUNT_NAME}, then the owner of this Account is
+     * the server itself.</p>
      * 
-     * <p>If the String returned begins with the value
-     * denoted by {@link Account#CUSTOM_DATA_PREFIX},
-     * then the owner of this Account is a custom owner,
-     * as set by a plugin.</p>
+     * <p>If the String returned begins with the value denoted by
+     * {@link Account#CUSTOM_DATA_PREFIX}, then the owner of this Account is a
+     * custom owner, as set by a plugin.</p>
      * 
-     * <p>If the String returned does not match either of
-     * the above, then it is expected to be the {@link UUID}
-     * of a {@link Player}, in the form given by
+     * <p>If the String returned does not match either of the above, then it is
+     * expected to be the {@link UUID} of a {@link Player}, in the form given by
      * {@link UUID#toString()}.</p>
      * 
-     * <p>Convenience methods should exist within
-     * implementation of the service; it is not necessary to
-     * check the String on your own.</p>
+     * <p>Convenience methods should exist within implementation of the service;
+     * it is not necessary to check the String on your own.</p>
      * 
-     * @return a String representative of the owner of this
-     *         Account
+     * @return a String representative of the owner of this Account
      * 
      * @see UUID
      * @see Player
@@ -77,76 +72,66 @@ public interface Account {
     String getOwner();
 
     /**
-     * Returns whether or not the owner of this
-     * {@link Account} is a {@link Player}.
+     * Returns whether or not the owner of this {@link Account} is a
+     * {@link Player}.
      * 
-     * <p>If this returns true, then
-     * {@link Account#getOwner()} can safely be expected
-     * to return the {@link UUID} of a Player, in the form
-     * given by {@link UUID#toString()}.</p>
+     * <p>If this returns true, then {@link Account#getOwner()} can safely be
+     * expected to return the {@link UUID} of a Player, in the form given by
+     * {@link UUID#toString()}.</p>
      * 
-     * @return true if Account.getOwner() returns a
-     *         Player UUID
+     * @return true if Account.getOwner() returns a Player UUID
      * 
      * @see Account#getOwner()
      */
     boolean isPlayer();
 
     /**
-     * Returns whether or not the owner of this
-     * {@link Account} is the server itself.
+     * Returns whether or not the owner of this {@link Account} is the server
+     * itself.
      * 
-     * <p>If this returns true, then
-     * {@link Account#getOwner()} can safely be expected
-     * to return the value denoted by
+     * <p>If this returns true, then {@link Account#getOwner()} can safely be
+     * expected to return the value denoted by
      * {@link Account#SERVER_ACCOUNT_NAME}.</p>
      * 
-     * @return true if Account.getOwner() returns the
-     *         value of Account.SERVER_ACCOUNT_NAME
+     * @return true if Account.getOwner() returns the value of
+     *         Account.SERVER_ACCOUNT_NAME
      * 
      * @see Account#getOwner()
      */
     boolean isServer();
 
     /**
-     * Returns whether or not the owner of this
-     * {@link Account} is a custom account, as set by
-     * the implementing service.
+     * Returns whether or not the owner of this {@link Account} is a custom
+     * account, as set by the implementing service.
      * 
-     * <p>If this returns true, then
-     * {@link Account#getOwner()} can safely be expected
-     * to return a custom account, of which begins with the
-     * value denoted by {@link Account#CUSTOM_DATA_PREFIX}
-     * .</p>
+     * <p>If this returns true, then {@link Account#getOwner()} can safely be
+     * expected to return a custom account, of which begins with the value
+     * denoted by {@link Account#CUSTOM_DATA_PREFIX} .</p>
      * 
-     * @return true if Account.getOwner() returns a
-     *         value beginning with the String stored in
-     *         Account.CUSTOM_DATA_PREFIX
+     * @return true if Account.getOwner() returns a value beginning with the
+     *         String stored in Account.CUSTOM_DATA_PREFIX
      * 
      * @see Account#getOwner()
      */
     boolean isCustom();
 
     /**
-     * Returns a double representative of the balance stored
-     * within this {@link Account}.
+     * Returns a double representative of the balance stored within this
+     * {@link Account}.
      * 
-     * <p>The double returned is not to exceed two decimal
-     * places. An example would be <pre>129.54</pre>.</p>
+     * <p>The double returned is not to exceed two decimal places. An example
+     * would be <pre>129.54</pre>.</p>
      * 
-     * @return a double value, with two or less decimal
-     *         places
+     * @return a double value, with two or less decimal places
      */
     double getBalance();
 
     /**
-     * Sets the balance stored by this {@link Account} as
-     * the given value.
+     * Sets the balance stored by this {@link Account} as the given value.
      * 
-     * <p>The amount set cannot exceed two decimal places
-     * (e.g. <pre>129.54</pre>); as such, the double passed
-     * as the amount will be rounded up or down if it
-     * violates the former.</p>
+     * <p>The amount set cannot exceed two decimal places (e.g.
+     * <pre>129.54</pre>); as such, the double passed as the amount will be
+     * rounded up or down if it violates the former.</p>
      * 
      * <p>The amount is allowed to be negative.</p>
      * 
@@ -155,51 +140,41 @@ public interface Account {
     void setBalance(double amount);
 
     /**
-     * Pays the target {@link Account} the given amount
-     * of currency by taking the amount from this
-     * Account.
+     * Pays the target {@link Account} the given amount of currency by taking
+     * the amount from this Account.
      * 
-     * <p>If this Account results in holding a negative
-     * balance due to this operation, this will return
-     * true. This does not mean the operation is
+     * <p>If this Account results in holding a negative balance due to this
+     * operation, this will return true. This does not mean the operation is
      * cancelled.</p>
      * 
      * <p>A negative amount parameter will result in an
      * IllegalArgumentException.</p>
      * 
-     * @param target the Account to send the amount of
-     *        money to
-     * @param amount a double representative of the amount
-     *        to give to the target Account
+     * @param target the Account to send the amount of money to
+     * @param amount a double representative of the amount to give to the target
+     *        Account
      * 
-     * @return true if this Account's balance turned
-     *         negative
+     * @return true if this Account's balance turned negative
      * 
-     * @throws IllegalArgumentException if the amount to pay
-     *         is negative
+     * @throws IllegalArgumentException if the amount to pay is negative
      */
     boolean pay(Account target, double amount);
 
     /**
-     * Removes the given sum of currency from this
-     * {@link Account}.
+     * Removes the given sum of currency from this {@link Account}.
      * 
-     * <p>If this Account results in holding a negative
-     * balance due to this operation, this will return
-     * true. This does not mean the operation is
+     * <p>If this Account results in holding a negative balance due to this
+     * operation, this will return true. This does not mean the operation is
      * cancelled.</p>
      * 
      * <p>A negative amount parameter will result in an
      * IllegalArgumentException.</p>
      * 
-     * @param amount a double representing the amount to
-     *        remove from the account
+     * @param amount a double representing the amount to remove from the account
      * 
-     * @return true if this Account's balance turned
-     *         negative
+     * @return true if this Account's balance turned negative
      * 
-     * @throws IllegalArgumentException if the amount to
-     *         remove is negative
+     * @throws IllegalArgumentException if the amount to remove is negative
      */
     boolean elicit(double amount);
 }

--- a/src/main/java/org/spongepowered/api/service/economy/Account.java
+++ b/src/main/java/org/spongepowered/api/service/economy/Account.java
@@ -1,0 +1,228 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.economy;
+
+import org.spongepowered.api.entity.player.Player;
+
+import java.util.UUID;
+
+public interface Account {
+    /**
+     * The string that prefixes all custom account names.
+     */
+    public static final String CUSTOM_DATA_PREFIX = "_ESC-";
+
+    /**
+     * The name of the account belonging to the server.
+     */
+    public static final String SERVER_ACCOUNT_NAME = "_ESCSV";
+
+    /**
+     * Retrieves the string representative of the owner of
+     * this {@link Account}.
+     * 
+     * <p>The String returned can represent 3 types of
+     * accounts; namely a Player's, the Server's, or a
+     * customly-registered account.</p>
+     * 
+     * <p>If the String returned matches the value denoted
+     * by {@link Account#SERVER_ACCOUNT_NAME}, then the
+     * owner of this Account is the server itself.</p>
+     * 
+     * <p>If the String returned begins with the value
+     * denoted by {@link Account#CUSTOM_DATA_PREFIX},
+     * then the owner of this Account is a custom owner,
+     * as set by a plugin.</p>
+     * 
+     * <p>If the String returned does not match either of
+     * the above, then it is expected to be the {@link UUID}
+     * of a {@link Player}, in the form given by
+     * {@link UUID#toString()}.</p>
+     * 
+     * <p>Convenience methods should exist within
+     * implementation of the service; it is not necessary to
+     * check the String on your own.</p>
+     * 
+     * @return a String representative of the owner of this
+     *         Account
+     * 
+     * @see UUID
+     * @see Player
+     * @see Account#isPlayer()
+     * @see Account#isServer()
+     * @see Account#isCustom()
+     */
+    public String getOwner();
+
+    /**
+     * Returns whether or not the owner of this
+     * {@link Account} is a {@link Player}.
+     * 
+     * <p>If this returns true, then
+     * {@link Account#getOwner()} can safely be expected
+     * to return the {@link UUID} of a Player, in the form
+     * given by {@link UUID#toString()}.</p>
+     * 
+     * @return true if Account.getOwner() returns a
+     *         Player UUID
+     * 
+     * @see Account#getOwner()
+     */
+    public boolean isPlayer();
+
+    /**
+     * Returns whether or not the owner of this
+     * {@link Account} is the server itself.
+     * 
+     * <p>If this returns true, then
+     * {@link Account#getOwner()} can safely be expected
+     * to return the value denoted by
+     * {@link Account#SERVER_ACCOUNT_NAME}.</p>
+     * 
+     * @return true if Account.getOwner() returns the
+     *         value of Account.SERVER_ACCOUNT_NAME
+     * 
+     * @see Account#getOwner()
+     */
+    public boolean isServer();
+
+    /**
+     * Returns whether or not the owner of this
+     * {@link Account} is a custom account, as set by
+     * the implementing service.
+     * 
+     * <p>If this returns true, then
+     * {@link Account#getOwner()} can safely be expected
+     * to return a custom account, of which begins with the
+     * value denoted by
+     * {@link Account#CUSTOM_DATA_PREFIX}.</p>
+     * 
+     * @return true if Account.getOwner() returns a
+     *         value beginning with the String stored in
+     *         Account.CUSTOM_DATA_PREFIX
+     * 
+     * @see Account#getOwner()
+     */
+    public boolean isCustom();
+
+    /**
+     * Returns a double representative of the balance stored
+     * within this {@link Account}.
+     * 
+     * <p>The double returned is not to exceed two decimal
+     * places. An example would be <pre>129.54</pre>.</p>
+     * 
+     * @return a double value, with two or less decimal
+     *         places
+     */
+    public double getBalance();
+
+    /**
+     * Sets the balance stored by this {@link Account}
+     * as the given value.
+     * 
+     * <p>The amount set cannot exceed two decimal places
+     * (e.g. <pre>129.54</pre>); as such, the double passed
+     * as the amount will be rounded up or down if it
+     * violates the former.</p>
+     * 
+     * <p>The amount is allowed to be negative.</p>
+     * 
+     * @param amount a double value
+     */
+    public void setBalance(double amount);
+
+    /**
+     * Pays the target {@link Account} the given amount
+     * of currency by taking the amount from this
+     * Account.
+     * 
+     * <p>If this Account results in holding a negative
+     * balance due to this operation, this will return
+     * true.</p>
+     * 
+     * <p>A negative amount parameter will result in an
+     * IllegalArgumentException.</p>
+     * 
+     * @param target the Account to send the amount of
+     *        money to
+     * @param amount a double representative of the amount
+     *        to give to the target Account
+     * 
+     * @return true if this Account's balance turned
+     *         negative
+     * 
+     * @throws IllegalArgumentException if the amount to pay
+     *         is negative
+     */
+    public boolean pay(Account target, double amount);
+
+    /**
+     * Removes the given sum of currency from this
+     * {@link Account}.
+     * 
+     * <p>If this Account results in holding a negative
+     * balance due to this operation, this will return
+     * true.</p>
+     * 
+     * <p>A negative amount parameter will result in an
+     * IllegalArgumentException.</p>
+     * 
+     * @param amount a double representing the amount to
+     *        remove from the account
+     * 
+     * @return true if this Account's balance turned
+     *         negative
+     * 
+     * @throws IllegalArgumentException if the amount to
+     *         remove is negative
+     */
+    public boolean elicit(double amount);
+
+    /**
+     * Removes the given sum of currency from this
+     * {@link Account} and sends it to the destination
+     * Account.
+     * 
+     * <p>If this Account results in holding a negative
+     * balance due to this operation, this will return
+     * true.</p>
+     * 
+     * <p>A negative amount parameter will result in an
+     * IllegalArgumentException.</p>
+     * 
+     * @param destination the Account to send the
+     *        withdrawn currency to
+     * @param amount a double representing the amount to
+     *        withdraw
+     * 
+     * @return true if this Account's balance turned
+     *         negative
+     * 
+     * @throws IllegalArgumentException if the amount to
+     *         remove is negative
+     */
+    public boolean withdraw(Account destination, double amount);
+}

--- a/src/main/java/org/spongepowered/api/service/economy/Account.java
+++ b/src/main/java/org/spongepowered/api/service/economy/Account.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.service.economy;
 
 import org.spongepowered.api.entity.player.Player;
 
+import java.util.Currency;
 import java.util.UUID;
 
 public interface Account {
@@ -119,25 +120,24 @@ public interface Account {
      * Returns a double representative of the balance stored within this
      * {@link Account}.
      * 
-     * <p>The double returned is not to exceed two decimal places. An example
-     * would be <pre>129.54</pre>.</p>
+     * <p>The balance given should follow the rules of the {@link Currency}
+     * denoted by {@link EconomyService#getCurrency()}.</p>
      * 
-     * @return a double value, with two or less decimal places
+     * @return a Number value representative of the Account's balance
      */
-    double getBalance();
+    Number getBalance();
 
     /**
      * Sets the balance stored by this {@link Account} as the given value.
      * 
-     * <p>The amount set cannot exceed two decimal places (e.g.
-     * <pre>129.54</pre>); as such, the double passed as the amount will be
-     * rounded up or down if it violates the former.</p>
+     * <p>The balance set should follow the rules of the {@link Currency}
+     * denoted by {@link EconomyService#getCurrency()}.</p>
      * 
      * <p>The amount is allowed to be negative.</p>
      * 
-     * @param amount a double value
+     * @param amount a Number value representing the Account's new balance
      */
-    void setBalance(double amount);
+    void setBalance(Number amount);
 
     /**
      * Pays the target {@link Account} the given amount of currency by taking
@@ -151,14 +151,14 @@ public interface Account {
      * IllegalArgumentException.</p>
      * 
      * @param target the Account to send the amount of money to
-     * @param amount a double representative of the amount to give to the target
+     * @param amount a Number representative of the amount to give to the target
      *        Account
      * 
      * @return true if this Account's balance turned negative
      * 
      * @throws IllegalArgumentException if the amount to pay is negative
      */
-    boolean pay(Account target, double amount);
+    boolean pay(Account target, Number amount);
 
     /**
      * Removes the given sum of currency from this {@link Account}.
@@ -170,7 +170,7 @@ public interface Account {
      * <p>A negative amount parameter will result in an
      * IllegalArgumentException.</p>
      * 
-     * @param amount a double representing the amount to remove from the account
+     * @param amount a Number representing the amount to remove from the account
      * 
      * @return true if this Account's balance turned negative
      * 

--- a/src/main/java/org/spongepowered/api/service/economy/Account.java
+++ b/src/main/java/org/spongepowered/api/service/economy/Account.java
@@ -74,7 +74,7 @@ public interface Account {
      * @see Account#isServer()
      * @see Account#isCustom()
      */
-    public String getOwner();
+    String getOwner();
 
     /**
      * Returns whether or not the owner of this
@@ -90,7 +90,7 @@ public interface Account {
      * 
      * @see Account#getOwner()
      */
-    public boolean isPlayer();
+    boolean isPlayer();
 
     /**
      * Returns whether or not the owner of this
@@ -106,7 +106,7 @@ public interface Account {
      * 
      * @see Account#getOwner()
      */
-    public boolean isServer();
+    boolean isServer();
 
     /**
      * Returns whether or not the owner of this
@@ -116,8 +116,8 @@ public interface Account {
      * <p>If this returns true, then
      * {@link Account#getOwner()} can safely be expected
      * to return a custom account, of which begins with the
-     * value denoted by
-     * {@link Account#CUSTOM_DATA_PREFIX}.</p>
+     * value denoted by {@link Account#CUSTOM_DATA_PREFIX}
+     * .</p>
      * 
      * @return true if Account.getOwner() returns a
      *         value beginning with the String stored in
@@ -125,7 +125,7 @@ public interface Account {
      * 
      * @see Account#getOwner()
      */
-    public boolean isCustom();
+    boolean isCustom();
 
     /**
      * Returns a double representative of the balance stored
@@ -137,11 +137,11 @@ public interface Account {
      * @return a double value, with two or less decimal
      *         places
      */
-    public double getBalance();
+    double getBalance();
 
     /**
-     * Sets the balance stored by this {@link Account}
-     * as the given value.
+     * Sets the balance stored by this {@link Account} as
+     * the given value.
      * 
      * <p>The amount set cannot exceed two decimal places
      * (e.g. <pre>129.54</pre>); as such, the double passed
@@ -152,7 +152,7 @@ public interface Account {
      * 
      * @param amount a double value
      */
-    public void setBalance(double amount);
+    void setBalance(double amount);
 
     /**
      * Pays the target {@link Account} the given amount
@@ -178,7 +178,7 @@ public interface Account {
      * @throws IllegalArgumentException if the amount to pay
      *         is negative
      */
-    public boolean pay(Account target, double amount);
+    boolean pay(Account target, double amount);
 
     /**
      * Removes the given sum of currency from this
@@ -201,31 +201,5 @@ public interface Account {
      * @throws IllegalArgumentException if the amount to
      *         remove is negative
      */
-    public boolean elicit(double amount);
-
-    /**
-     * Removes the given sum of currency from this
-     * {@link Account} and sends it to the destination
-     * Account.
-     * 
-     * <p>If this Account results in holding a negative
-     * balance due to this operation, this will return
-     * true. This does not mean the operation is
-     * cancelled.</p>
-     * 
-     * <p>A negative amount parameter will result in an
-     * IllegalArgumentException.</p>
-     * 
-     * @param destination the Account to send the
-     *        withdrawn currency to
-     * @param amount a double representing the amount to
-     *        withdraw
-     * 
-     * @return true if this Account's balance turned
-     *         negative
-     * 
-     * @throws IllegalArgumentException if the amount to
-     *         remove is negative
-     */
-    public boolean withdraw(Account destination, double amount);
+    boolean elicit(double amount);
 }

--- a/src/main/java/org/spongepowered/api/service/economy/Account.java
+++ b/src/main/java/org/spongepowered/api/service/economy/Account.java
@@ -161,7 +161,8 @@ public interface Account {
      * 
      * <p>If this Account results in holding a negative
      * balance due to this operation, this will return
-     * true.</p>
+     * true. This does not mean the operation is
+     * cancelled.</p>
      * 
      * <p>A negative amount parameter will result in an
      * IllegalArgumentException.</p>
@@ -185,7 +186,8 @@ public interface Account {
      * 
      * <p>If this Account results in holding a negative
      * balance due to this operation, this will return
-     * true.</p>
+     * true. This does not mean the operation is
+     * cancelled.</p>
      * 
      * <p>A negative amount parameter will result in an
      * IllegalArgumentException.</p>
@@ -208,7 +210,8 @@ public interface Account {
      * 
      * <p>If this Account results in holding a negative
      * balance due to this operation, this will return
-     * true.</p>
+     * true. This does not mean the operation is
+     * cancelled.</p>
      * 
      * <p>A negative amount parameter will result in an
      * IllegalArgumentException.</p>

--- a/src/main/java/org/spongepowered/api/service/economy/Account.java
+++ b/src/main/java/org/spongepowered/api/service/economy/Account.java
@@ -115,6 +115,29 @@ public interface Account {
      * @see Account#getOwner()
      */
     boolean isCustom();
+    
+    /**
+     * Returns the {@link Currency} followed by this {@link Account}.
+     * 
+     * <p>If this Account does not have its own Currency to follow, it should
+     * return the default Currency denoted by
+     * {@link EconomyService#getDefaultCurrency()}.</p>
+     * 
+     * @return a Currency instance
+     * 
+     * @see Currency
+     * @see EconomyService#getDefaultCurrency()
+     */
+    Currency getCurrency();
+    
+    /**
+     * Sets the {@link Currency} followed by this {@link Account}.
+     * 
+     * @param currency the Currency instance to follow
+     * 
+     * @see Currency
+     */
+    void setCurrency(Currency currency);
 
     /**
      * Returns a double representative of the balance stored within this
@@ -140,41 +163,39 @@ public interface Account {
     void setBalance(Number amount);
 
     /**
-     * Pays the target {@link Account} the given amount of currency by taking
-     * the amount from this Account.
-     * 
-     * <p>If this Account results in holding a negative balance due to this
-     * operation, this will return true. This does not mean the operation is
-     * cancelled.</p>
-     * 
-     * <p>A negative amount parameter will result in an
-     * IllegalArgumentException.</p>
+     * Removes the given amount from this {@link Account} and sends it to the
+     * target Account.
      * 
      * @param target the Account to send the amount of money to
      * @param amount a Number representative of the amount to give to the target
      *        Account
      * 
-     * @return true if this Account's balance turned negative
-     * 
-     * @throws IllegalArgumentException if the amount to pay is negative
+     * @return a {@link TransactionResult} representative of the effects of the
+     *         operation
      */
-    boolean pay(Account target, Number amount);
+    TransactionResult deposit(Account target, Number amount);
 
     /**
-     * Removes the given sum of currency from this {@link Account}.
-     * 
-     * <p>If this Account results in holding a negative balance due to this
-     * operation, this will return true. This does not mean the operation is
-     * cancelled.</p>
-     * 
-     * <p>A negative amount parameter will result in an
-     * IllegalArgumentException.</p>
+     * Removes the given sum of currency the target {@link Account} and gives it
+     * to this Account.
      * 
      * @param amount a Number representing the amount to remove from the account
      * 
-     * @return true if this Account's balance turned negative
-     * 
-     * @throws IllegalArgumentException if the amount to remove is negative
+     * @return a {@link TransactionResult} representative of the effects of the
+     *         operation
      */
-    boolean elicit(double amount);
+    TransactionResult withdraw(Account target, Number amount);
+    
+    /**
+     * Transfers the given amount of currency from the source {@link Account} to
+     * the destination Account.
+     * 
+     * @param source the Account to take from
+     * @param destination the Account to send to
+     * @param amount the amount of currency to transfer
+     * 
+     * @return a {@link TransactionResult} representative of the effects of the
+     *         operation
+     */
+    TransactionResult transfer(Account source, Account destination, Number amount);
 }

--- a/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
+++ b/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
@@ -24,13 +24,14 @@
  */
 package org.spongepowered.api.service.economy;
 
-import org.spongepowered.api.entity.player.Player;
-
+import java.util.List;
 import java.util.UUID;
+
+import org.spongepowered.api.entity.player.Player;
 
 import com.google.common.base.Optional;
 
-public interface EconomyService {
+public interface EconomyService {    
     /**
      * Retrieves the {@link Account} denoted by the
      * given owner string.
@@ -91,6 +92,22 @@ public interface EconomyService {
      * @see EconomyService#getAccount(String);
      */
     public Account getServerAccount();
+    
+    /**
+     * Returns an immutable list of all {@link Account}s
+     * belonging to a {@link Player}.
+     * 
+     * @return an immutable List of Accounts
+     */
+    public List<Account> getAllPlayerAccounts();
+    
+    /**
+     * Returns an immutable list of all custom
+     * {@link Account}s made by plugins.
+     * 
+     * @return an immutable List of Accounts
+     */
+    public List<Account> getAllCustomAccounts();
     
     /**
      * Resets the data of the {@link Account} denoted by the

--- a/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
+++ b/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
@@ -1,0 +1,114 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.economy;
+
+import org.spongepowered.api.entity.player.Player;
+
+import java.util.UUID;
+
+import com.google.common.base.Optional;
+
+public interface EconomyService {
+    /**
+     * Retrieves the {@link Account} denoted by the
+     * given owner string.
+     * 
+     * <p>Owner strings are not representative of players
+     * only. See {@link Account#getOwner()} for
+     * reference.</p>
+     * 
+     * @param owner the owner string to search with
+     * 
+     * @return the Account owned by the given owner, or
+     *         Optional.absent() otherwise
+     * 
+     * @see Account#getOwner()
+     */
+    public Optional<Account> getAccount(String owner);
+    
+    /**
+     * Retrieves the {@link Account} denoted by
+     * the given {@link UUID}, belonging to a {@link Player}
+     * , in the form given by {@link UUID#toString()}.
+     * Shortcut method for {@link #getAccount(String)}.
+     * 
+     * @param uuid the UUID of the Player owning the Account
+     * 
+     * @return the Player Account found with the given name,
+     *         or Optional.absent() otherwise
+     * 
+     * @see Account
+     * @see EconomyService#getAccount(String);
+     */
+    public Optional<Account> getPlayerAccount(UUID uuid);
+    
+    /**
+     * Retrieves the {@link Account} denoted by
+     * {@link Account#CUSTOM_DATA_PREFIX} + the given
+     * account name string. Shortcut method for
+     * {@link #getAccount(String)}.
+     * 
+     * @param accountName the name of the custom account
+     * 
+     * @return the custom Account found with the given name,
+     *         or Optional.absent() otherwise
+     * 
+     * @see Account
+     * @see EconomyService#getAccount(String);
+     */
+    public Optional<Account> getCustomAccount(String accountName);
+    
+    /**
+     * Retrieves the {@link Account} assigned to the
+     * server. Shortcut method for
+     * {@link #getAccount(String)}.
+     * 
+     * @return the Account belonging to the server
+     * 
+     * @see Account
+     * @see EconomyService#getAccount(String);
+     */
+    public Account getServerAccount();
+    
+    /**
+     * Resets the data of the {@link Account} denoted by the
+     * given owner string, essentially deleting it.
+     * 
+     * <p>If the Account was reset successfully, this method
+     * will return true. It will return false if the Account
+     * did not exist.</p>
+     * 
+     * <p>Owner strings are not representative of players
+     * only. See {@link Account#getOwner()} for
+     * reference.</p>
+     * 
+     * @param owner the owner string to search with
+     * 
+     * @return true if the Account was found and reset
+     * 
+     * @see Account#getOwner()
+     */
+    public boolean resetAccount(String owner);
+}

--- a/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
+++ b/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
@@ -24,17 +24,19 @@
  */
 package org.spongepowered.api.service.economy;
 
+import com.google.common.base.Optional;
+import org.spongepowered.api.entity.player.Player;
+
 import java.util.List;
 import java.util.UUID;
 
-import org.spongepowered.api.entity.player.Player;
-
-import com.google.common.base.Optional;
-
-public interface EconomyService {    
+public interface EconomyService {
     /**
      * Retrieves the {@link Account} denoted by the
      * given owner string.
+     * 
+     * <p>If the Account does not exist, this method will
+     * return Optional.absent().</p>
      * 
      * <p>Owner strings are not representative of players
      * only. See {@link Account#getOwner()} for
@@ -46,8 +48,35 @@ public interface EconomyService {
      *         Optional.absent() otherwise
      * 
      * @see Account#getOwner()
+     * @see EconomyService#createNewAccount(String)
      */
-    public Optional<Account> getAccount(String owner);
+    Optional<Account> getAccount(String owner);
+    
+    /**
+     * Creates a new {@link Account} and assigns it to the
+     * given owner string.
+     * 
+     * <p>This method cannot override existing Accounts. If
+     * the Account already exists, this method will return
+     * Optional.absent() to indicate that creation has
+     * failed. Existing Accounts should be reset before
+     * they are replaced.</p>
+     * 
+     * <p>Owner strings are not representative of players
+     * only. See {@link Account#getOwner()} for
+     * reference.</p>
+     * 
+     * @param owner the owner string to assign the new
+     *        Account to
+     * 
+     * @return whether or not the Account was created
+     *         successfully
+     * 
+     * @see Account
+     * @see Account#getOwner()
+     * @see EconomyService#resetAccount(String)
+     */
+    Optional<Account> createNewAccount(String owner);
     
     /**
      * Retrieves the {@link Account} denoted by
@@ -63,7 +92,7 @@ public interface EconomyService {
      * @see Account
      * @see EconomyService#getAccount(String);
      */
-    public Optional<Account> getPlayerAccount(UUID uuid);
+    Optional<Account> getPlayerAccount(UUID uuid);
     
     /**
      * Retrieves the {@link Account} denoted by
@@ -79,7 +108,7 @@ public interface EconomyService {
      * @see Account
      * @see EconomyService#getAccount(String);
      */
-    public Optional<Account> getCustomAccount(String accountName);
+    Optional<Account> getCustomAccount(String accountName);
     
     /**
      * Retrieves the {@link Account} assigned to the
@@ -91,23 +120,31 @@ public interface EconomyService {
      * @see Account
      * @see EconomyService#getAccount(String);
      */
-    public Account getServerAccount();
+    Account getServerAccount();
     
     /**
      * Returns an immutable list of all {@link Account}s
      * belonging to a {@link Player}.
      * 
+     * <p>This method should try to return all Accounts
+     * registered belonging to Players; including offline
+     * Players.</p>
+     * 
      * @return an immutable List of Accounts
+     * 
+     * @see Account
      */
-    public List<Account> getAllPlayerAccounts();
+    List<Account> getAllPlayerAccounts();
     
     /**
      * Returns an immutable list of all custom
      * {@link Account}s made by plugins.
      * 
      * @return an immutable List of Accounts
+     * 
+     * @see Account
      */
-    public List<Account> getAllCustomAccounts();
+    List<Account> getAllCustomAccounts();
     
     /**
      * Resets the data of the {@link Account} denoted by the
@@ -127,5 +164,5 @@ public interface EconomyService {
      * 
      * @see Account#getOwner()
      */
-    public boolean resetAccount(String owner);
+    boolean resetAccount(String owner);
 }

--- a/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
+++ b/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
@@ -27,11 +27,53 @@ package org.spongepowered.api.service.economy;
 import com.google.common.base.Optional;
 import org.spongepowered.api.entity.player.Player;
 
+import java.text.NumberFormat;
+import java.util.Currency;
 import java.util.List;
 import java.util.UUID;
 
 public interface EconomyService {
-
+    
+    /**
+     * Retrieves the {@link Currency} to be followed by the
+     * {@link EconomyServce}.
+     * 
+     * <p>This method returning Optional.absent() is representative of an
+     * integer-based system, in which case methods interacting with
+     * balance should not be returning a decimal value.</p>
+     * 
+     * <p>Methods that involve interaction with an {@link Account}'s balance
+     * should take note of this value, and follow its rules accordingly.</p>
+     * 
+     * @return a Currency
+     * 
+     * @see Currency
+     */
+    public Optional<Currency> getCurrency();
+    
+    /**
+     * Sets the {@link Currency} instance to be followed by the
+     * {@link EconomyService}.
+     * 
+     * @param currency the Currency to set
+     * 
+     * @see Currency
+     * @see EconomyService#getCurrency()
+     */
+    public void setCurrency(Currency currency);
+    
+    /**
+     * Retrieves the {@link NumberFormat} instance responsible for formatting
+     * balance values based on the {@link Currency} denoted by
+     * {@link EconomyService#getCurrency()}.
+     * 
+     * @return a NumberFormat instance
+     * 
+     * @see NumberFormat
+     * @see EconomyService#getCurrency()
+     */
+    public NumberFormat getBalanceFormatter();
+    
     /**
      * Retrieves the {@link Account} denoted by the given owner string.
      * 

--- a/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
+++ b/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
@@ -31,88 +31,79 @@ import java.util.List;
 import java.util.UUID;
 
 public interface EconomyService {
+
     /**
-     * Retrieves the {@link Account} denoted by the
-     * given owner string.
+     * Retrieves the {@link Account} denoted by the given owner string.
      * 
-     * <p>If the Account does not exist, this method will
-     * return Optional.absent().</p>
+     * <p>If the Account does not exist, this method will return
+     * Optional.absent().</p>
      * 
-     * <p>Owner strings are not representative of players
-     * only. See {@link Account#getOwner()} for
-     * reference.</p>
+     * <p>Owner strings are not representative of players only. See
+     * {@link Account#getOwner()} for reference.</p>
      * 
      * @param owner the owner string to search with
      * 
-     * @return the Account owned by the given owner, or
-     *         Optional.absent() otherwise
+     * @return the Account owned by the given owner, or Optional.absent()
+     *         otherwise
      * 
      * @see Account#getOwner()
      * @see EconomyService#createNewAccount(String)
      */
     Optional<Account> getAccount(String owner);
-    
+
     /**
-     * Creates a new {@link Account} and assigns it to the
-     * given owner string.
+     * Creates a new {@link Account} and assigns it to the given owner string.
      * 
-     * <p>This method cannot override existing Accounts. If
-     * the Account already exists, this method will return
-     * Optional.absent() to indicate that creation has
-     * failed. Existing Accounts should be reset before
-     * they are replaced.</p>
+     * <p>This method cannot override existing Accounts. If the Account already
+     * exists, this method will return Optional.absent() to indicate that
+     * creation has failed. Existing Accounts should be reset before they are
+     * replaced.</p>
      * 
-     * <p>Owner strings are not representative of players
-     * only. See {@link Account#getOwner()} for
-     * reference.</p>
+     * <p>Owner strings are not representative of players only. See
+     * {@link Account#getOwner()} for reference.</p>
      * 
-     * @param owner the owner string to assign the new
-     *        Account to
+     * @param owner the owner string to assign the new Account to
      * 
-     * @return whether or not the Account was created
-     *         successfully
+     * @return whether or not the Account was created successfully
      * 
      * @see Account
      * @see Account#getOwner()
      * @see EconomyService#resetAccount(String)
      */
     Optional<Account> createNewAccount(String owner);
-    
+
     /**
-     * Retrieves the {@link Account} denoted by
-     * the given {@link UUID}, belonging to a {@link Player}
-     * , in the form given by {@link UUID#toString()}.
-     * Shortcut method for {@link #getAccount(String)}.
+     * Retrieves the {@link Account} denoted by the given {@link UUID},
+     * belonging to a {@link Player} , in the form given by
+     * {@link UUID#toString()}. Shortcut method for {@link #getAccount(String)}.
      * 
      * @param uuid the UUID of the Player owning the Account
      * 
-     * @return the Player Account found with the given name,
-     *         or Optional.absent() otherwise
+     * @return the Player Account found with the given name, or
+     *         Optional.absent() otherwise
      * 
      * @see Account
      * @see EconomyService#getAccount(String);
      */
     Optional<Account> getPlayerAccount(UUID uuid);
-    
+
     /**
      * Retrieves the {@link Account} denoted by
-     * {@link Account#CUSTOM_DATA_PREFIX} + the given
-     * account name string. Shortcut method for
-     * {@link #getAccount(String)}.
+     * {@link Account#CUSTOM_DATA_PREFIX} + the given account name string.
+     * Shortcut method for {@link #getAccount(String)}.
      * 
      * @param accountName the name of the custom account
      * 
-     * @return the custom Account found with the given name,
-     *         or Optional.absent() otherwise
+     * @return the custom Account found with the given name, or
+     *         Optional.absent() otherwise
      * 
      * @see Account
      * @see EconomyService#getAccount(String);
      */
     Optional<Account> getCustomAccount(String accountName);
-    
+
     /**
-     * Retrieves the {@link Account} assigned to the
-     * server. Shortcut method for
+     * Retrieves the {@link Account} assigned to the server. Shortcut method for
      * {@link #getAccount(String)}.
      * 
      * @return the Account belonging to the server
@@ -121,42 +112,38 @@ public interface EconomyService {
      * @see EconomyService#getAccount(String);
      */
     Account getServerAccount();
-    
+
     /**
-     * Returns an immutable list of all {@link Account}s
-     * belonging to a {@link Player}.
+     * Returns an immutable list of all {@link Account}s belonging to a
+     * {@link Player}.
      * 
-     * <p>This method should try to return all Accounts
-     * registered belonging to Players; including offline
-     * Players.</p>
+     * <p>This method should try to return all Accounts registered belonging to
+     * Players; including offline Players.</p>
      * 
      * @return an immutable List of Accounts
      * 
      * @see Account
      */
     List<Account> getAllPlayerAccounts();
-    
+
     /**
-     * Returns an immutable list of all custom
-     * {@link Account}s made by plugins.
+     * Returns an immutable list of all custom {@link Account}s made by plugins.
      * 
      * @return an immutable List of Accounts
      * 
      * @see Account
      */
     List<Account> getAllCustomAccounts();
-    
+
     /**
-     * Resets the data of the {@link Account} denoted by the
-     * given owner string, essentially deleting it.
+     * Resets the data of the {@link Account} denoted by the given owner string,
+     * essentially deleting it.
      * 
-     * <p>If the Account was reset successfully, this method
-     * will return true. It will return false if the Account
-     * did not exist.</p>
+     * <p>If the Account was reset successfully, this method will return true.
+     * It will return false if the Account did not exist.</p>
      * 
-     * <p>Owner strings are not representative of players
-     * only. See {@link Account#getOwner()} for
-     * reference.</p>
+     * <p>Owner strings are not representative of players only. See
+     * {@link Account#getOwner()} for reference.</p>
      * 
      * @param owner the owner string to search with
      * 

--- a/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
+++ b/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
@@ -29,50 +29,52 @@ import org.spongepowered.api.entity.player.Player;
 
 import java.text.NumberFormat;
 import java.util.Currency;
-import java.util.List;
 import java.util.UUID;
 
 public interface EconomyService {
     
     /**
-     * Retrieves the {@link Currency} to be followed by the
-     * {@link EconomyServce}.
+     * Retrieves the default {@link Currency} to be followed by the
+     * {@link EconomyServce} should an {@link Account} not have its
+     * own Currency set.
      * 
      * <p>This method returning Optional.absent() is representative of an
      * integer-based system, in which case methods interacting with
      * balance should not be returning a decimal value.</p>
      * 
-     * <p>Methods that involve interaction with an {@link Account}'s balance
+     * <p>Methods that involve interaction with an Account's balance
      * should take note of this value, and follow its rules accordingly.</p>
      * 
      * @return a Currency
      * 
      * @see Currency
      */
-    public Optional<Currency> getCurrency();
+    public Optional<Currency> getDefaultCurrency();
     
     /**
-     * Sets the {@link Currency} instance to be followed by the
-     * {@link EconomyService}.
+     * Sets the default {@link Currency} instance to be followed by the
+     * {@link EconomyService} should an {@link Account} not have its own
+     * Currency set.
      * 
      * @param currency the Currency to set
      * 
      * @see Currency
      * @see EconomyService#getCurrency()
      */
-    public void setCurrency(Currency currency);
+    public void setDefaultCurrency(Currency currency);
     
     /**
      * Retrieves the {@link NumberFormat} instance responsible for formatting
-     * balance values based on the {@link Currency} denoted by
-     * {@link EconomyService#getCurrency()}.
+     * balance values based on the given {@link Currency}.
+     * 
+     * @param currency the Currency to follow when formatting
      * 
      * @return a NumberFormat instance
      * 
      * @see NumberFormat
      * @see EconomyService#getCurrency()
      */
-    public NumberFormat getBalanceFormatter();
+    public NumberFormat getBalanceFormatter(Currency currency);
     
     /**
      * Retrieves the {@link Account} denoted by the given owner string.
@@ -154,28 +156,6 @@ public interface EconomyService {
      * @see EconomyService#getAccount(String);
      */
     Account getServerAccount();
-
-    /**
-     * Returns an immutable list of all {@link Account}s belonging to a
-     * {@link Player}.
-     * 
-     * <p>This method should try to return all Accounts registered belonging to
-     * Players; including offline Players.</p>
-     * 
-     * @return an immutable List of Accounts
-     * 
-     * @see Account
-     */
-    List<Account> getAllPlayerAccounts();
-
-    /**
-     * Returns an immutable list of all custom {@link Account}s made by plugins.
-     * 
-     * @return an immutable List of Accounts
-     * 
-     * @see Account
-     */
-    List<Account> getAllCustomAccounts();
 
     /**
      * Resets the data of the {@link Account} denoted by the given owner string,

--- a/src/main/java/org/spongepowered/api/service/economy/TransactionResult.java
+++ b/src/main/java/org/spongepowered/api/service/economy/TransactionResult.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.api.service.economy;
 
 public class TransactionResult {

--- a/src/main/java/org/spongepowered/api/service/economy/TransactionResult.java
+++ b/src/main/java/org/spongepowered/api/service/economy/TransactionResult.java
@@ -1,0 +1,5 @@
+package org.spongepowered.api.service.economy;
+
+public class TransactionResult {
+    //TODO this
+}

--- a/src/main/java/org/spongepowered/api/service/economy/package-info.java
+++ b/src/main/java/org/spongepowered/api/service/economy/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.service.economy;


### PR DESCRIPTION
The forums have been /flooded/ with so many economy service providers. To allow server owners to use what they choose instead of the one chosen by most developers, an `EconomyService` has been added for plugins to implement. Developers can instead reference to this service to interact with server economy.