### PR TITLE
Add ClientConnectEvent, for when a player initially connects to the server

### DIFF
--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -32,6 +32,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Maps;
 import org.spongepowered.api.Game;
+import org.spongepowered.api.GameProfile;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.tileentity.Sign;
 import org.spongepowered.api.block.tileentity.carrier.BrewingStand;
@@ -45,7 +46,6 @@ import org.spongepowered.api.entity.EntityInteractionType;
 import org.spongepowered.api.entity.Tamer;
 import org.spongepowered.api.entity.living.Ageable;
 import org.spongepowered.api.entity.player.Player;
-import org.spongepowered.api.entity.player.User;
 import org.spongepowered.api.entity.player.gamemode.GameMode;
 import org.spongepowered.api.entity.projectile.FishHook;
 import org.spongepowered.api.entity.projectile.Projectile;
@@ -109,11 +109,9 @@ import org.spongepowered.api.event.entity.player.PlayerInteractBlockEvent;
 import org.spongepowered.api.event.entity.player.PlayerInteractEntityEvent;
 import org.spongepowered.api.event.entity.player.PlayerInteractEvent;
 import org.spongepowered.api.event.entity.player.PlayerJoinEvent;
-import org.spongepowered.api.event.entity.player.PlayerLoginEvent;
 import org.spongepowered.api.event.entity.player.PlayerMoveEvent;
 import org.spongepowered.api.event.entity.player.PlayerPickUpItemEvent;
 import org.spongepowered.api.event.entity.player.PlayerPlaceBlockEvent;
-import org.spongepowered.api.event.entity.player.PlayerPreLoginEvent;
 import org.spongepowered.api.event.entity.player.PlayerQuitEvent;
 import org.spongepowered.api.event.entity.player.PlayerRespawnEvent;
 import org.spongepowered.api.event.entity.player.PlayerUpdateEvent;
@@ -123,6 +121,8 @@ import org.spongepowered.api.event.entity.player.fishing.PlayerRetractFishingLin
 import org.spongepowered.api.event.message.CommandEvent;
 import org.spongepowered.api.event.message.CommandSuggestionsEvent;
 import org.spongepowered.api.event.message.MessageEvent;
+import org.spongepowered.api.event.network.GameClientAuthEvent;
+import org.spongepowered.api.event.network.GameClientConnectEvent;
 import org.spongepowered.api.event.rcon.RconLoginEvent;
 import org.spongepowered.api.event.rcon.RconQuitEvent;
 import org.spongepowered.api.event.server.StatusPingEvent;
@@ -176,7 +176,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import javax.annotation.Nullable;
 
@@ -1947,41 +1946,47 @@ public final class SpongeEventFactory {
     }
 
     /**
-     * Create a new {@link PlayerPreLoginEvent}.
+     * Creates a new {@link GameClientConnectEvent}.
      *
      * @param game The game instance for this {@link GameEvent}
-     * @param user The stored data for the player attempting to connect
-     * @param name The name of the player attempting to connect
-     * @param uniqueId The unique ID of the player attempting to connect
-     * @param connection The connection in progress
+     * @param connection The connection info of the client
+     * @param profile The profile of the client attempting to connect
+     * @param disconnectMessage The message to show to the client if the event
+     *        is cancelled
+     * @param disconnectCause The cause for disconnected if the event is cancelled
      * @return A new instance of the event
      */
-    public static PlayerPreLoginEvent createPlayerPreLogin(Game game, User user, String name, UUID uniqueId, RemoteConnection connection) {
+    public static GameClientConnectEvent createClientConnect(Game game, RemoteConnection connection, GameProfile profile,
+            @Nullable Text disconnectMessage, @Nullable Cause disconnectCause) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("user", user);
-        values.put("name", name);
-        values.put("uniqueId", uniqueId);
         values.put("connection", connection);
-        return createEvent(PlayerPreLoginEvent.class, values);
+        values.put("profile", profile);
+        values.put("disconnectMessage", Optional.fromNullable(disconnectMessage));
+        values.put("disconnectCause", Optional.fromNullable(disconnectCause));
+        return createEvent(GameClientConnectEvent.class, values);
     }
 
     /**
-     * Create a new {@link PlayerLoginEvent}.
+     * Creates a new {@link GameClientAuthEvent}.
      *
      * @param game The game instance for this {@link GameEvent}
-     * @param player The player logging in
-     * @param cause The reason this player would be kicked, if present
-     * @param kickMessage The kick message for the player, if present
+     * @param connection The connection info of the client
+     * @param profile The profile of the client attempting to connect
+     * @param disconnectMessage The message to show to the client if the event
+     *        is cancelled
+     * @param disconnectCause The cause for disconnected if the event is cancelled
      * @return A new instance of the event
      */
-    public static PlayerLoginEvent createPlayerLogin(Game game, Player player, @Nullable Cause cause, @Nullable Text kickMessage) {
+    public static GameClientAuthEvent createClientAuth(Game game, RemoteConnection connection, GameProfile profile,
+            @Nullable Text disconnectMessage, @Nullable Cause disconnectCause) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("user", player);
-        values.put("entity", player);
-        values.put("cause", Optional.fromNullable(cause));
-        values.put("kickMessage", Optional.fromNullable(kickMessage));
-        return createEvent(PlayerLoginEvent.class, values);
+        values.put("connection", connection);
+        values.put("profile", profile);
+        values.put("disconnectMessage", Optional.fromNullable(disconnectMessage));
+        values.put("disconnectCause", Optional.fromNullable(disconnectCause));
+        return createEvent(GameClientAuthEvent.class, values);
     }
+
 }

--- a/src/main/java/org/spongepowered/api/event/network/ConnectEvent.java
+++ b/src/main/java/org/spongepowered/api/event/network/ConnectEvent.java
@@ -22,39 +22,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.player;
 
-import com.google.common.base.Optional;
+package org.spongepowered.api.event.network;
+
 import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.Cause;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.text.Text;
+import org.spongepowered.api.event.GameEvent;
 
 /**
- * This event is called after a player object has been created but before it is placed in any sort of location.
+ * Represents a remote connection trying to connect.
  *
- * <p>This is the best event to use when determining if a player should be kicked because of being banned, unwhitelisted, etc, as well as
- * performing player state initialization.
+ * <p>Cancelling the event will prevent the source from connecting.</p>
  */
-public interface PlayerLoginEvent extends PlayerEvent, Cancellable, CauseTracked {
+public interface ConnectEvent extends GameEvent, Cancellable {
 
-    /**
-     * Get the message that will be sent to the player logging in.
-     * @return The
-     */
-    Optional<Text> getKickMessage();
-
-    /**
-     * Set the message to kick this event's player with. If the event is not already cancelled, calling this method will cancel the event.
-     *
-     * @param message The message to kick the player with
-     */
-    void setKickMessage(Text message);
-
-    /**
-     * Set the cause for this event being cancelled. If the event is not already cancelled, calling this method will cancel the event.
-     *
-     * @param cause The cause to set
-     */
-    void setCause(Cause cause);
 }

--- a/src/main/java/org/spongepowered/api/event/network/DisconnectEvent.java
+++ b/src/main/java/org/spongepowered/api/event/network/DisconnectEvent.java
@@ -22,13 +22,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.player;
 
-import org.spongepowered.api.entity.player.Player;
-import org.spongepowered.api.event.network.DisconnectEvent;
+package org.spongepowered.api.event.network;
+
+import org.spongepowered.api.event.GameEvent;
 
 /**
- * Called when a {@link Player} quit the game.
+ * Represents a remote connection disconnecting. The remote connection may have
+ * hung up or the server may have disconnected it.
  */
-public interface PlayerQuitEvent extends PlayerMessageEvent, DisconnectEvent {
+public interface DisconnectEvent extends GameEvent {
+
 }

--- a/src/main/java/org/spongepowered/api/event/network/GameClientAuthEvent.java
+++ b/src/main/java/org/spongepowered/api/event/network/GameClientAuthEvent.java
@@ -22,13 +22,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.player;
-
-import org.spongepowered.api.entity.player.Player;
-import org.spongepowered.api.event.network.DisconnectEvent;
+package org.spongepowered.api.event.network;
 
 /**
- * Called when a {@link Player} quit the game.
+ * Fired when a game client has authenticated with the server.
+ *
+ * <p>This event is fired asynchronously, i.e. not in the main thread.</p>
+ *
+ * <p>After the event is fired, the login state switches to
+ * {@code READY_TO_ACCEPT} and the thread dies. (The main thread then
+ * acknowledges the {@code READY_TO_ACCEPT} state and proceeds to firing
+ * {@link GameClientConnectEvent}). The event is triggered after the encryption
+ * response is sent from the client, see
+ * http://wiki.vg/Protocol#Encryption_Response for more info.</p>
+ *
+ * <p>Cancelling the event will prevent the client from joining and show
+ * {@link #getDisconnectMessage} to the client.</p>
+ *
+ * @see GameClientConnectEvent
  */
-public interface PlayerQuitEvent extends PlayerMessageEvent, DisconnectEvent {
+public interface GameClientAuthEvent extends GameClientLoginEvent {
 }

--- a/src/main/java/org/spongepowered/api/event/network/GameClientConnectEvent.java
+++ b/src/main/java/org/spongepowered/api/event/network/GameClientConnectEvent.java
@@ -22,42 +22,31 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.player;
+package org.spongepowered.api.event.network;
 
-
-import org.spongepowered.api.entity.player.Player;
-import org.spongepowered.api.network.RemoteConnection;
-
-import java.util.UUID;
+import org.spongepowered.api.event.entity.player.PlayerJoinEvent;
 
 /**
- * This event is called asynchronously immediately after a player has been authenticated. This event is primarily useful for performing
- * asynchronous caching of player data, since it is primarily immutable
+ * Fired when a game client attempts to connect to the server.
  *
- * <p>Because a {@link Player} object has not been constructed yet at this point in the login process, this event only contains some relevant
- * information
+ * <p>This event is fired after {@link GameClientAuthEvent}, and in the main
+ * thread.</p>
  *
+ * <p>This event fires during the login process when the login state is
+ * {@code READY_TO_ACCEPT} - after the token has been verified but before the
+ * connection state switches to 'play'. See
+ * http://wiki.vg/Protocol#Login_Success for the protocol info.</p>
+ *
+ * <p>The server may have cancelled the event if the client's profile or IP is
+ * banned or not on the whitelist (if these features are enabled). Be sure to
+ * set {@code ignoreCancelled = false} in the {@code @Subscribe} annotation to
+ * receive the event in this case.</p>
+ *
+ * <p>Cancelling the event will prevent the client from joining and show
+ * {@link #getDisconnectMessage} to the client.</p>
+ *
+ * @see GameClientAuthEvent
+ * @see PlayerJoinEvent
  */
-public interface PlayerPreLoginEvent extends UserEvent {
-
-    /**
-     * The name of the player connecting.
-     *
-     * @return The name of the player connecting.
-     */
-    String getName();
-
-    /**
-     * Thee {@link UUID} of the player connecting. This is determined by Mojang unless the server is in offline mode.
-     *
-     * @return The unique id
-     */
-    UUID getUniqueId();
-
-    /**
-     * Get the connection information related to the player in the process of connecting.
-     *
-     * @return The player's connection
-     */
-    RemoteConnection getConnection();
+public interface GameClientConnectEvent extends GameClientLoginEvent {
 }

--- a/src/main/java/org/spongepowered/api/event/network/GameClientLoginEvent.java
+++ b/src/main/java/org/spongepowered/api/event/network/GameClientLoginEvent.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.network;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.GameProfile;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.network.RemoteConnection;
+import org.spongepowered.api.text.Text;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents an event fired during the login process.
+ *
+ * @see GameClientAuthEvent
+ * @see GameClientConnectEvent
+ */
+public interface GameClientLoginEvent extends ConnectEvent {
+
+    /**
+     * Gets the {@link RemoteConnection} representing the client connection.
+     *
+     * @return The remote connection
+     */
+    RemoteConnection getConnection();
+
+    /**
+     * Gets the profile of the client attempting to connect.
+     *
+     * @return The client's profile
+     */
+    GameProfile getProfile();
+
+    /**
+     * Gets the disconnect message that will show to the client if the event is
+     * cancelled.
+     *
+     * @return The disconnect message
+     */
+    Optional<Text> getDisconnectMessage();
+
+    /**
+     * Sets the disconnect message that will show to the client if the event is
+     * cancelled. Passing null will will result in the message being set by the
+     * server if the event is cancelled.
+     *
+     * @param message The disconnect message
+     */
+    void setDisconnectMessage(@Nullable Text message);
+
+    /**
+     * Gets the currently set reason why the client will be disconnected if the
+     * event is cancelled.
+     *
+     * @return The reason for disconnecting, if set
+     */
+    Optional<Cause> getDisconnectCause();
+
+    /**
+     * Sets the cause for disconnecting the client if the event is cancelled.
+     * Passing null will result in the cause being set by the server if the
+     * event is cancelled.
+     *
+     * @param cause The cause
+     */
+    void setDisconnectCause(@Nullable Cause cause);
+}

--- a/src/main/java/org/spongepowered/api/event/rcon/RconLoginEvent.java
+++ b/src/main/java/org/spongepowered/api/event/rcon/RconLoginEvent.java
@@ -24,10 +24,10 @@
  */
 package org.spongepowered.api.event.rcon;
 
-import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.network.ConnectEvent;
 
 /**
  * An event when an Rcon source logs in to the server.
  */
-public interface RconLoginEvent extends RconEvent, Cancellable {
+public interface RconLoginEvent extends RconEvent, ConnectEvent {
 }

--- a/src/main/java/org/spongepowered/api/event/rcon/RconQuitEvent.java
+++ b/src/main/java/org/spongepowered/api/event/rcon/RconQuitEvent.java
@@ -24,9 +24,11 @@
  */
 package org.spongepowered.api.event.rcon;
 
+import org.spongepowered.api.event.network.DisconnectEvent;
+
 /**
  * This event is called when a rcon client disconnects from the server.
  */
-public interface RconQuitEvent extends RconEvent {
+public interface RconQuitEvent extends RconEvent, DisconnectEvent {
 
 }


### PR DESCRIPTION
Fired before `PlayerJoinEvent`, other players will not know the player attempted to join if the event is cancelled.

No longer modelling around `FMLNetworkEvent.ServerConnectionFromClientEvent`, `PlayerConnectEvent` will occur before FML initializes it's handshake.

Renamed to `ClientConnectEvent`