### PR TITLE
Allow getting the duration from WeatherChangeEvent

### DIFF
--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -1517,15 +1517,17 @@ public final class SpongeEventFactory {
      * @param weatherUniverse The volume the weather changed in
      * @param initialWeather The previous weather
      * @param resultingWeather The weather to change to
+     * @param duration The lenfth of the resulting weather, in ticks
      * @return A new instance of the event
      */
     public static WeatherChangeEvent createWeatherChange(Game game, WeatherUniverse weatherUniverse, Weather initialWeather,
-            Weather resultingWeather) {
+            Weather resultingWeather, int duration) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
         values.put("initialWeather", initialWeather);
         values.put("weatherUniverse", weatherUniverse);
         values.put("resultingWeather", resultingWeather);
+        values.put("duration", duration);
         return createEvent(WeatherChangeEvent.class, values);
     }
 

--- a/src/main/java/org/spongepowered/api/event/weather/WeatherChangeEvent.java
+++ b/src/main/java/org/spongepowered/api/event/weather/WeatherChangeEvent.java
@@ -53,11 +53,16 @@ public interface WeatherChangeEvent extends WeatherEvent {
     void setResultingWeather(Weather weather);
 
     /**
-     * Sets what the new {@link Weather} should be with a given duration.
+     * Sets the duration of the {@link Weather}.
      *
-     * @param weather The new {@link Weather}
+     * @return The duration of the weather in ticks
+     */
+    int getDuration();
+
+    /**
+     * Sets the duration of the {@link Weather}.
+     *
      * @param duration The duration of the weather in ticks
      */
-    void setResultingWeather(Weather weather, int duration);
-
+    void setDuration(int duration);
 }


### PR DESCRIPTION
Currently, `WeatherChangeEvent` allows setting the duration of the resulting weather, but not getting it. This PR splits the resulting weather duration into a separate getter and setter.

Duration is also required when creating the event through the event factory.