### PR TITLE
Properly generate classes for event using Optional

### DIFF
--- a/src/main/java/org/spongepowered/api/util/event/factory/ClassGenerator.java
+++ b/src/main/java/org/spongepowered/api/util/event/factory/ClassGenerator.java
@@ -47,6 +47,7 @@ import static org.objectweb.asm.Opcodes.IFNULL;
 import static org.objectweb.asm.Opcodes.ILOAD;
 import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
 import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
 import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
 import static org.objectweb.asm.Opcodes.IRETURN;
 import static org.objectweb.asm.Opcodes.ISUB;
@@ -356,6 +357,9 @@ class ClassGenerator {
                 mv.visitCode();
                 mv.visitVarInsn(ALOAD, 0);
                 mv.visitVarInsn(getLoadOpcode(property.getType()), 1);
+                if (property.getAccessor().getReturnType().equals(Optional.class)) {
+                    mv.visitMethodInsn(INVOKESTATIC, "com/google/common/base/Optional", "fromNullable", "(Ljava/lang/Object;)Lcom/google/common/base/Optional;", false);
+                }
                 mv.visitFieldInsn(PUTFIELD, internalName, property.getName(), Type.getDescriptor(property.getType()));
                 mv.visitInsn(RETURN);
                 mv.visitMaxs(0, 0);

--- a/src/main/java/org/spongepowered/api/util/reflect/AccessorFirstStrategy.java
+++ b/src/main/java/org/spongepowered/api/util/reflect/AccessorFirstStrategy.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.util.reflect;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
@@ -34,6 +35,7 @@ import com.google.common.collect.Multimap;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
 import java.util.regex.Matcher;
@@ -66,7 +68,7 @@ public class AccessorFirstStrategy implements PropertySearchStrategy {
 
         for (Method method : candidates) {
             // TODO: Handle supertypes
-            if (method.getParameterTypes()[0] == expectedType) {
+            if (method.getParameterTypes()[0] == expectedType || expectedType == Optional.class) {
                 return method;
             }
         }

--- a/src/test/java/org/spongepowered/api/util/event/factory/ClassGeneratorProviderTest.java
+++ b/src/test/java/org/spongepowered/api/util/event/factory/ClassGeneratorProviderTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.closeTo;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -38,6 +39,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import javax.annotation.Nullable;
 
 public class ClassGeneratorProviderTest {
 
@@ -311,6 +314,34 @@ public class ClassGeneratorProviderTest {
         ClassGeneratorProvider provider = createProvider();
         EventFactory<AbstractImplContainer> factory = provider.create(AbstractImplContainer.class, AbstractImpl.class);
         factory.apply(values);
+    }
+
+    @Test
+    public void testCreate_OptionalGetter() {
+        Map<String, Object> values = Maps.newHashMap();
+        values.put("name", Optional.fromNullable("MyName"));
+
+        ClassGeneratorProvider provider = createProvider();
+        EventFactory<OptionalGetter> factory = provider.create(OptionalGetter.class, Object.class);
+        OptionalGetter getter = factory.apply(values);
+
+        assertThat(getter.getName().isPresent(), is(true));
+        assertThat(getter.getName().get(), is(Matchers.equalTo("MyName")));
+
+        getter.setName(null);
+        assertThat(getter.getName().isPresent(), is(false));
+
+        getter.setName("Aaron");
+
+        assertThat(getter.getName().isPresent(), is(true));
+        assertThat(getter.getName().get(), is(Matchers.equalTo("Aaron")));
+    }
+
+    public interface OptionalGetter {
+
+        Optional<String> getName();
+
+        void setName(@Nullable String name);
     }
 
     public interface PrimitiveContainer {


### PR DESCRIPTION
Currently, events which have a method returning `Optional` don't have said method linked to the corresponding mutator.

This PR ensures that accessors returning Optional are properly linked, and updates the generated setter to call `Optional.fromNullable` before storing the parameter in the generated field.