### PR TITLE
[WIP] Allow transforming the result of an event method

### DIFF
--- a/src/main/java/org/spongepowered/api/block/BlockSnapshot.java
+++ b/src/main/java/org/spongepowered/api/block/BlockSnapshot.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.block;
 
 import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.data.DataSerializable;
+import org.spongepowered.api.util.annotation.TransformWith;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.extent.Extent;
 
@@ -75,6 +76,7 @@ public interface BlockSnapshot extends DataSerializable {
      * Copies the snapshot.
      * @return The copied snapshot
      */
+    @TransformWith
     BlockSnapshot copy();
 
 }

--- a/src/main/java/org/spongepowered/api/data/DataManipulator.java
+++ b/src/main/java/org/spongepowered/api/data/DataManipulator.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.data;
 
 import com.google.common.base.Optional;
+import org.spongepowered.api.util.annotation.TransformWith;
 
 /**
  * Represents a changelist of data that can be applied to a {@link DataHolder}.
@@ -95,6 +96,7 @@ public interface DataManipulator<T extends DataManipulator<T>> extends Comparabl
      *
      * @return The new copy of this manipulator with all data copied
      */
+    @TransformWith
     T copy();
 
 }

--- a/src/main/java/org/spongepowered/api/event/AbstractEvent.java
+++ b/src/main/java/org/spongepowered/api/event/AbstractEvent.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.event;
 
+import org.spongepowered.api.util.annotation.SetField;
 import org.spongepowered.api.util.event.callback.CallbackList;
 
 /**
@@ -32,7 +33,8 @@ import org.spongepowered.api.util.event.callback.CallbackList;
  */
 public abstract class AbstractEvent implements Event {
 
-    private final CallbackList callbacks = new CallbackList();
+    @SetField
+    protected final CallbackList callbacks = new CallbackList();
 
     @Override
     public CallbackList getCallbacks() {

--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -37,6 +37,7 @@ import org.spongepowered.api.block.tile.Sign;
 import org.spongepowered.api.block.tile.carrier.BrewingStand;
 import org.spongepowered.api.block.tile.carrier.Furnace;
 import org.spongepowered.api.block.tile.carrier.TileEntityCarrier;
+import org.spongepowered.api.data.DataManipulator;
 import org.spongepowered.api.data.manipulators.tileentities.BrewingData;
 import org.spongepowered.api.data.manipulators.tileentities.FurnaceData;
 import org.spongepowered.api.data.manipulators.tileentities.SignData;
@@ -67,6 +68,7 @@ import org.spongepowered.api.event.block.tile.BrewingStandBrewEvent;
 import org.spongepowered.api.event.block.tile.FurnaceConsumeFuelEvent;
 import org.spongepowered.api.event.block.tile.FurnaceSmeltItemEvent;
 import org.spongepowered.api.event.block.tile.SignChangeEvent;
+import org.spongepowered.api.event.block.tile.TileEntityEvent;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.entity.EntityBreakBlockEvent;
 import org.spongepowered.api.event.entity.EntityChangeBlockEvent;
@@ -146,7 +148,8 @@ import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.util.command.CommandResult;
 import org.spongepowered.api.util.command.CommandSource;
 import org.spongepowered.api.util.command.source.RconSource;
-import org.spongepowered.api.util.event.factory.AnnotationEventFactoryPlugin;
+import org.spongepowered.api.util.event.factory.plugin.AccessorModifierEventFactoryPlugin;
+import org.spongepowered.api.util.event.factory.plugin.AnnotationEventFactoryPlugin;
 import org.spongepowered.api.util.event.factory.ClassGeneratorProvider;
 import org.spongepowered.api.util.event.factory.EventFactory;
 import org.spongepowered.api.util.event.factory.EventFactoryPlugin;
@@ -162,13 +165,11 @@ import org.spongepowered.api.world.storage.WorldProperties;
 import org.spongepowered.api.world.weather.Weather;
 import org.spongepowered.api.world.weather.WeatherUniverse;
 
-import java.util.ArrayDeque;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Deque;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 
 import javax.annotation.Nullable;
 
@@ -177,7 +178,7 @@ import javax.annotation.Nullable;
  */
 public final class SpongeEventFactory {
 
-    private static final FactoryProvider factoryProvider;
+    private static final ClassGeneratorProvider factoryProvider;
     private static final LoadingCache<Class<?>, EventFactory<?>> factories;
     private static final List<EventFactoryPlugin> plugins = new ArrayList<EventFactoryPlugin>();
 
@@ -187,6 +188,7 @@ public final class SpongeEventFactory {
 
         plugins.add(0, new AnnotationEventFactoryPlugin());
 
+        plugins.add(0, new AccessorModifierEventFactoryPlugin("org.spongepowered.api.event.impl.base"));
         factories = CacheBuilder.newBuilder()
                 .build(
                         new CacheLoader<Class<?>, EventFactory<?>>() {
@@ -203,7 +205,7 @@ public final class SpongeEventFactory {
     private static Class<?> getBaseClass(Class<?> event) {
         Class<?> superClass = null;
         for (EventFactoryPlugin plugin: plugins) {
-            superClass = plugin.resolveSuperClassFor(event, superClass);
+            superClass = plugin.resolveSuperClassFor(event, superClass, factoryProvider.getClassLoader());
         }
         return superClass;
     }

--- a/src/main/java/org/spongepowered/api/event/block/BlockChangeEvent.java
+++ b/src/main/java/org/spongepowered/api/event/block/BlockChangeEvent.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.event.block;
 
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.util.annotation.TransformResult;
 
 /**
  * Dispatched when a block is in the process of changing, before
@@ -38,6 +39,7 @@ public interface BlockChangeEvent extends BlockEvent, Cancellable {
      *
      * @return The block that will replace
      */
+    @TransformResult
     BlockSnapshot getReplacementBlock();
 
 }

--- a/src/main/java/org/spongepowered/api/event/block/tile/TileEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/block/tile/TileEntityEvent.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.event.block.tile;
 import org.spongepowered.api.block.tile.TileEntity;
 import org.spongepowered.api.data.DataManipulator;
 import org.spongepowered.api.event.GameEvent;
+import org.spongepowered.api.util.annotation.TransformResult;
 
 /**
  * An event that involves a {@link TileEntity}.
@@ -46,6 +47,7 @@ public interface TileEntityEvent extends GameEvent {
      *
      * @return The snapshot of the current tile entity data
      */
+    @TransformResult
     DataManipulator<?> getCurrentData();
 
 }

--- a/src/main/java/org/spongepowered/api/util/annotation/SetField.java
+++ b/src/main/java/org/spongepowered/api/util/annotation/SetField.java
@@ -22,29 +22,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.util.event.factory;
+package org.spongepowered.api.util.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- ** Represents a class which modifies the behavior of an event generator.
+ * Used to mark fields which should be set by the class generator, despite
+ * the abstract class having an implementation of the property
  */
-public interface EventFactoryPlugin {
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface SetField {
 
     /**
-     * Gets the superclass to use for class generated for the specified
-     * event interface.
+     * Indicates whether having the annotated field is required to be passed in.
      *
-     * <p>All of the registered plugins have this method called in a chain, which each plugin receiving
-     * the return value of the previous plugin as the {@param superClass} parameter.
-     * The first plugin in the chain is passed <code>null</code> as its {@param superClass}.
-     *
-     * If a plugin is able to determine a superclass for an event interface, it should return it.
-     * Otherwise, it should return the value it received as {@param superClass}.
-     *
-     * @param eventClass The interface to determine the superclass for
-     * @param superClass The current superclass of the event interface
-     * @param classLoader The classloader used to load the generated event class
-     * @return The class to use as the event interface's superclass
+     * <p>Setting this to <code>true</code> will require the null check in the event constructor</p>
+     * @return
      */
-    Class<?> resolveSuperClassFor(Class<?> eventClass, Class<?> superClass, ClassGeneratorProvider.LocalClassLoader classLoader);
-
+    boolean isRequired() default false;
 }

--- a/src/main/java/org/spongepowered/api/util/annotation/TransformResult.java
+++ b/src/main/java/org/spongepowered/api/util/annotation/TransformResult.java
@@ -22,29 +22,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.util.event.factory;
+package org.spongepowered.api.util.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- ** Represents a class which modifies the behavior of an event generator.
+ * Used to indicate that the return type of a method should be transformed
+ * by calling a method on it, indicated by the {@link TransformWith} annotation.
+ *
+ * This annotation should be placed on the method with the least specific return
+ * type, if covariant return types are used.
+ *
+ * The return type of the annotation, or a superclass/superinterface of it,
+ * must have a method annotated with {@link TransformWith}, with a matching {@link #name()}.
  */
-public interface EventFactoryPlugin {
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface TransformResult {
 
     /**
-     * Gets the superclass to use for class generated for the specified
-     * event interface.
+     * Gets the name used to match this annotation to a {@link TransformWith} annotation.
      *
-     * <p>All of the registered plugins have this method called in a chain, which each plugin receiving
-     * the return value of the previous plugin as the {@param superClass} parameter.
-     * The first plugin in the chain is passed <code>null</code> as its {@param superClass}.
+     * <p>Changing this is only necessary when multiple {@link TransformWith} annotations
+     * are present in the annotated method's return type's class.</p>
      *
-     * If a plugin is able to determine a superclass for an event interface, it should return it.
-     * Otherwise, it should return the value it received as {@param superClass}.
-     *
-     * @param eventClass The interface to determine the superclass for
-     * @param superClass The current superclass of the event interface
-     * @param classLoader The classloader used to load the generated event class
-     * @return The class to use as the event interface's superclass
+     * @return The name to use
      */
-    Class<?> resolveSuperClassFor(Class<?> eventClass, Class<?> superClass, ClassGeneratorProvider.LocalClassLoader classLoader);
-
+    String value() default "";
 }

--- a/src/main/java/org/spongepowered/api/util/annotation/TransformWith.java
+++ b/src/main/java/org/spongepowered/api/util/annotation/TransformWith.java
@@ -22,29 +22,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.util.event.factory;
+package org.spongepowered.api.util.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- ** Represents a class which modifies the behavior of an event generator.
+ * Used to indicate a method that will be called from
+ * the method with the corresponding {@link TransformResult} annotation.
+ *
+ * This annotation should be placed on the method with the least specific return
+ * type, if covariant return types are used.
+ *
+ * The method annotated with this annotation <bold>must</bold> either return
+ * an instance of the method's class, or Object (for compatibility with generics).
  */
-public interface EventFactoryPlugin {
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface TransformWith {
 
     /**
-     * Gets the superclass to use for class generated for the specified
-     * event interface.
+     * Gets the name used to match this annotation to a {@link TransformResult} annotation.
      *
-     * <p>All of the registered plugins have this method called in a chain, which each plugin receiving
-     * the return value of the previous plugin as the {@param superClass} parameter.
-     * The first plugin in the chain is passed <code>null</code> as its {@param superClass}.
+     * <p>Changing this is only necessary when this annotation is present on multiple
+     * methods in a class, or its superinterfaces/superclass.
      *
-     * If a plugin is able to determine a superclass for an event interface, it should return it.
-     * Otherwise, it should return the value it received as {@param superClass}.
-     *
-     * @param eventClass The interface to determine the superclass for
-     * @param superClass The current superclass of the event interface
-     * @param classLoader The classloader used to load the generated event class
-     * @return The class to use as the event interface's superclass
+     * @return The name to use
      */
-    Class<?> resolveSuperClassFor(Class<?> eventClass, Class<?> superClass, ClassGeneratorProvider.LocalClassLoader classLoader);
+    String value() default "";
 
 }

--- a/src/main/java/org/spongepowered/api/util/event/factory/ClassGeneratorProvider.java
+++ b/src/main/java/org/spongepowered/api/util/event/factory/ClassGeneratorProvider.java
@@ -86,9 +86,18 @@ public class ClassGeneratorProvider implements FactoryProvider {
     }
 
     /**
+     * Gets the {@link LocalClassLoader} used to load generated event classes.
+     *
+     * @return The {@link LocalClassLoader}
+     */
+    public LocalClassLoader getClassLoader() {
+        return this.classLoader;
+    }
+
+    /**
      * Class loader to use to call {@link #defineClass(String, byte[])}.
      */
-    private static class LocalClassLoader extends ClassLoader {
+    public static class LocalClassLoader extends ClassLoader {
 
         public LocalClassLoader(ClassLoader parent) {
             super(parent);

--- a/src/main/java/org/spongepowered/api/util/event/factory/plugin/AccessorModifierEventFactoryPlugin.java
+++ b/src/main/java/org/spongepowered/api/util/event/factory/plugin/AccessorModifierEventFactoryPlugin.java
@@ -1,0 +1,238 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.util.event.factory.plugin;
+
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_SUPER;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.GETFIELD;
+import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.V1_6;
+import static org.objectweb.asm.Opcodes.ACC_PROTECTED;
+
+import com.google.common.base.Optional;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+import org.spongepowered.api.event.AbstractEvent;
+import org.spongepowered.api.util.annotation.SetField;
+import org.spongepowered.api.util.annotation.TransformResult;
+import org.spongepowered.api.util.annotation.TransformWith;
+import org.spongepowered.api.util.event.factory.ClassGenerator;
+import org.spongepowered.api.util.event.factory.ClassGeneratorProvider;
+import org.spongepowered.api.util.event.factory.EventFactoryPlugin;
+import org.spongepowered.api.util.reflect.AccessorFirstStrategy;
+import org.spongepowered.api.util.reflect.Property;
+import org.spongepowered.api.util.reflect.PropertySearchStrategy;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * An event factory plugin to modify the return type of an accessor
+ * by calling one of its methods.
+ */
+public class AccessorModifierEventFactoryPlugin implements EventFactoryPlugin {
+
+    private static final PropertySearchStrategy propertySearch = new AccessorFirstStrategy();
+
+    private final LoadingCache<Class<?>, Class<?>> superclasses = CacheBuilder.newBuilder()
+            .build(
+                    new CacheLoader<Class<?>, Class<?>>() {
+                        @Override
+                        public Class<?> load(Class<?> type) {
+                            return generateSuperclass(type);
+                        }
+                    });
+
+
+    private final String targetPackage;
+
+    private ClassGeneratorProvider.LocalClassLoader classLoader;
+    private Class<?> superClass;
+
+    public AccessorModifierEventFactoryPlugin(String targetPackage) {
+        this.targetPackage = targetPackage;
+    }
+
+    private boolean canGenerate(Class<?> eventClass) {
+        final ImmutableSet<? extends Property> properties = propertySearch.findProperties(eventClass);
+        Collection<MethodPair> pairs = this.getLinkedFields(properties);
+        return !pairs.isEmpty();
+    }
+
+    private Class<?> generateSuperclass(Class<?> eventClass) {
+        // MAGIC
+        String name = this.targetPackage + "." + "Abstract" + eventClass.getSimpleName();
+        String internalName = name.replace('.', '/');
+
+        final ImmutableSet<? extends Property> properties = propertySearch.findProperties(eventClass);
+        Collection<MethodPair> pairs = this.getLinkedFields(properties);
+        if (pairs.isEmpty()) {
+            return this.superClass;
+        }
+
+        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+        cw.visit(V1_6, ACC_PUBLIC + ACC_SUPER, internalName, null, Type.getInternalName(AbstractEvent.class),
+                 new String[]{Type.getInternalName(eventClass)});
+
+        {
+            MethodVisitor mv =
+                    cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+            mv.visitCode();
+
+            // super()
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKESPECIAL, Type.getInternalName(AbstractEvent.class), "<init>", "()V", false);
+
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(0, 0);
+            mv.visitEnd();
+        }
+
+        for (MethodPair pair: pairs) {
+            Property property = pair.getProperty();
+            Method accessor = property.getAccessor();
+            Method transformerMethod = pair.getTransfomrerMethod();
+
+            if (property.isLeastSpecificType()) {
+                FieldVisitor fv = cw.visitField(ACC_PROTECTED, property.getName(), Type.getDescriptor(property.getLeastSpecificType()), null, null);
+                AnnotationVisitor visitor = fv.visitAnnotation(Type.getDescriptor(SetField.class), true);
+                visitor.visit("isRequired", true);
+                visitor.visitEnd();
+                fv.visitEnd();
+            }
+
+
+            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, accessor.getName(), Type.getMethodDescriptor(accessor), null, null);
+            mv.visitCode();
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitFieldInsn(GETFIELD, internalName, property.getName(), Type.getDescriptor(property.getLeastSpecificType()));
+
+            int opcode = INVOKESPECIAL;
+            if (accessor.getReturnType().isInterface()) {
+                opcode = INVOKEINTERFACE;
+            }
+
+
+            mv.visitMethodInsn(opcode, Type.getInternalName(accessor.getReturnType()), transformerMethod.getName(), Type.getMethodDescriptor(transformerMethod), opcode == INVOKESPECIAL ? false : true);
+
+            mv.visitInsn(ClassGenerator.getReturnOpcode(property.getType()));
+            mv.visitMaxs(0, 0);
+            mv.visitEnd();
+        }
+        cw.visitEnd();
+        return this.classLoader.defineClass(name, cw.toByteArray());
+    }
+
+    private Collection<MethodPair> getLinkedFields(Set<? extends Property> properties) {
+        Map<Property, Map<String, MethodPair>> methodPairs = Maps.newHashMap();
+        for (Property property: properties) {
+            if (!methodPairs.containsKey(property)) {
+                methodPairs.put(property, new HashMap<String, MethodPair>());
+            }
+
+            Method leastSpecificMethod = property.getLeastSpecificMethod();
+            TransformResult result;
+            TransformWith transformWith;
+
+            if ((result = leastSpecificMethod.getAnnotation(TransformResult.class)) != null) {
+                String name = result.value();
+                // Since we that the modifier method (the one annotated with TransformWith) doesn't
+                // use covariant types, we can call getMethods on the more specific version,
+                // allowing the annotation to be present on a method defined there, as well as in
+                // the least specific type.
+                for (Method method: property.getAccessor().getReturnType().getMethods()) {
+                    if ((transformWith = method.getAnnotation(TransformWith.class)) != null && transformWith.value().equals(name)) {
+                        if (methodPairs.get(property).containsKey(name)) {
+                            throw new RuntimeException("Multiple @TransformResult annotations were found with the name " +
+                                                       name + ". One of them needs to be changed!");
+                        }
+                        methodPairs.get(property).put(name, new MethodPair(name, leastSpecificMethod, method, property));
+                        break;
+                    }
+                }
+                if (!methodPairs.get(property).containsKey(name)) {
+                    throw new RuntimeException("Unable to locate a matching @TransformWith annotation with the name " +
+                                              name + " for the method" + property.getAccessor());
+                }
+            }
+        }
+        Set<MethodPair> pairs = Sets.newHashSet();
+        for (Map<String, MethodPair> map: methodPairs.values()) {
+            pairs.addAll(map.values());
+        }
+        return pairs;
+    }
+
+    @Override
+    public Class<?> resolveSuperClassFor(Class<?> eventClass, Class<?> superClass, ClassGeneratorProvider.LocalClassLoader classLoader) {
+        this.classLoader = classLoader;
+        this.superClass = superClass;
+        return this.canGenerate(eventClass) ? this.superclasses.getUnchecked(eventClass) : null;
+    }
+
+    private static final class MethodPair {
+
+        private final String name;
+
+        private Method callerMethod;
+        private Method transformerMethod;
+
+        private Property property;
+
+        public MethodPair(String name, Method callerMethod, Method transformerMethod, Property property) {
+            this.name = name;
+            this.callerMethod = callerMethod;
+            this.transformerMethod = transformerMethod;
+            this.property = property;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Method getTransfomrerMethod() {
+            return transformerMethod;
+        }
+
+        public Property getProperty() {
+            return this.property;
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/api/util/event/factory/plugin/AnnotationEventFactoryPlugin.java
+++ b/src/main/java/org/spongepowered/api/util/event/factory/plugin/AnnotationEventFactoryPlugin.java
@@ -22,10 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.util.event.factory;
+package org.spongepowered.api.util.event.factory.plugin;
 
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.util.annotation.ImplementedBy;
+import org.spongepowered.api.util.event.factory.ClassGeneratorProvider;
+import org.spongepowered.api.util.event.factory.EventFactoryPlugin;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
@@ -41,7 +43,7 @@ import java.util.Queue;
 public class AnnotationEventFactoryPlugin implements EventFactoryPlugin {
 
     @Override
-    public Class<?> resolveSuperClassFor(Class<?> eventClass, Class<?> superClass) {
+    public Class<?> resolveSuperClassFor(Class<?> eventClass, Class<?> superClass, ClassGeneratorProvider.LocalClassLoader classLoader) {
         if (superClass != null) {
             return superClass;
         }

--- a/src/main/java/org/spongepowered/api/util/event/factory/plugin/package-info.java
+++ b/src/main/java/org/spongepowered/api/util/event/factory/plugin/package-info.java
@@ -22,29 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.util.event.factory;
-
 /**
- ** Represents a class which modifies the behavior of an event generator.
+ * Created by aaron on 5/11/15.
  */
-public interface EventFactoryPlugin {
-
-    /**
-     * Gets the superclass to use for class generated for the specified
-     * event interface.
-     *
-     * <p>All of the registered plugins have this method called in a chain, which each plugin receiving
-     * the return value of the previous plugin as the {@param superClass} parameter.
-     * The first plugin in the chain is passed <code>null</code> as its {@param superClass}.
-     *
-     * If a plugin is able to determine a superclass for an event interface, it should return it.
-     * Otherwise, it should return the value it received as {@param superClass}.
-     *
-     * @param eventClass The interface to determine the superclass for
-     * @param superClass The current superclass of the event interface
-     * @param classLoader The classloader used to load the generated event class
-     * @return The class to use as the event interface's superclass
-     */
-    Class<?> resolveSuperClassFor(Class<?> eventClass, Class<?> superClass, ClassGeneratorProvider.LocalClassLoader classLoader);
-
-}
+package org.spongepowered.api.util.event.factory.plugin;

--- a/src/main/java/org/spongepowered/api/util/event/superclasses/AbstractBulkBlockEvent.java
+++ b/src/main/java/org/spongepowered/api/util/event/superclasses/AbstractBulkBlockEvent.java
@@ -28,6 +28,7 @@ import com.google.common.base.Predicate;
 import org.spongepowered.api.event.AbstractEvent;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.block.BulkBlockEvent;
+import org.spongepowered.api.util.event.callback.CallbackList;
 import org.spongepowered.api.world.Location;
 
 import java.util.Iterator;

--- a/src/main/java/org/spongepowered/api/util/reflect/AccessorFirstStrategy.java
+++ b/src/main/java/org/spongepowered/api/util/reflect/AccessorFirstStrategy.java
@@ -144,7 +144,7 @@ public class AccessorFirstStrategy implements PropertySearchStrategy {
         final Multimap<String, Method> accessors = HashMultimap.create();
         final Multimap<String, Method> mutators = HashMultimap.create();
         final Queue<Class<?>> queue = new NonNullUniqueQueue<Class<?>>();
-        final Map<String, Class<?>> accessorHierarchyBottoms = new HashMap<String, Class<?>>();
+        final Map<String, Method> accessorHierarchyBottoms = new HashMap<String, Method>();
 
         queue.add(type); // Start off with our target type
 
@@ -153,10 +153,11 @@ public class AccessorFirstStrategy implements PropertySearchStrategy {
             for (Method method : scannedType.getMethods()) {
                 String name;
 
-                if ((name = getAccessorName(method)) != null && accessorHierarchyBottoms.get(name) != method.getReturnType()) {
+                Method leastSpecificMethod;
+                if ((name = getAccessorName(method)) != null && ((leastSpecificMethod = accessorHierarchyBottoms.get(name)) == null || leastSpecificMethod.getReturnType() != method.getReturnType())) {
                     accessors.put(name, method);
-                    if (accessorHierarchyBottoms.get(name) == null || method.getReturnType().isAssignableFrom(accessorHierarchyBottoms.get(name))) {
-                        accessorHierarchyBottoms.put(name, method.getReturnType());
+                    if (accessorHierarchyBottoms.get(name) == null || method.getReturnType().isAssignableFrom(accessorHierarchyBottoms.get(name).getReturnType())) {
+                        accessorHierarchyBottoms.put(name, method);
                     }
                 } else if ((name = getMutatorName(method)) != null) {
                     mutators.put(name, method);

--- a/src/main/java/org/spongepowered/api/util/reflect/NonNullUniqueQueue.java
+++ b/src/main/java/org/spongepowered/api/util/reflect/NonNullUniqueQueue.java
@@ -37,7 +37,7 @@ import java.util.Set;
  *
  * @param <E> The contained type
  */
-class NonNullUniqueQueue<E> extends AbstractQueue<E> implements Queue<E> {
+public class NonNullUniqueQueue<E> extends AbstractQueue<E> implements Queue<E> {
 
     private final Queue<E> queue = new ArrayDeque<E>();
     private final Set<E> set = new HashSet<E>();

--- a/src/main/java/org/spongepowered/api/util/reflect/Property.java
+++ b/src/main/java/org/spongepowered/api/util/reflect/Property.java
@@ -40,7 +40,7 @@ public final class Property {
 
     private final String name;
     private final Class<?> type;
-    private final Class<?> leastSpecificType;
+    private final Method leastSpecificMethod;
     private final Method accessor;
     private final Optional<Method> mutator;
 
@@ -52,14 +52,14 @@ public final class Property {
      * @param accessor The accessor
      * @param mutator The mutator
      */
-    public Property(String name, Class<?> type, Class<?> leastSpecificType, Method accessor, @Nullable Method mutator) {
+    public Property(String name, Class<?> type, Method leastSpecificMethod, Method accessor, @Nullable Method mutator) {
         checkNotNull(name, "name");
         checkNotNull(type, "type");
-        checkNotNull(leastSpecificType, "leastSpecificType");
+        checkNotNull(leastSpecificMethod, "leastSpecificMethod");
         checkNotNull(accessor, "accessor");
         this.name = name;
         this.type = type;
-        this.leastSpecificType = leastSpecificType;
+        this.leastSpecificMethod = leastSpecificMethod;
         this.accessor = accessor;
         this.mutator = Optional.fromNullable(mutator);
     }
@@ -83,6 +83,15 @@ public final class Property {
     }
 
     /**
+     * Gets the least specific version of the accessor used.
+     *
+     * @return The least specific accessor
+     */
+    public Method getLeastSpecificMethod() {
+        return this.leastSpecificMethod;
+    }
+
+    /**
      * Gets the least specific version of the type used
      *
      * <p>This is used for the type of the generated field used to hold the value.</p>
@@ -90,7 +99,7 @@ public final class Property {
      * @return The type
      */
     public Class<?> getLeastSpecificType() {
-        return this.leastSpecificType;
+        return this.leastSpecificMethod.getReturnType();
     }
 
     /**
@@ -138,7 +147,7 @@ public final class Property {
      * @return True if tis property's type is the least specific
      */
     public boolean isLeastSpecificType() {
-        return this.type == this.leastSpecificType;
+        return this.type == this.leastSpecificMethod.getReturnType();
     }
 
 }

--- a/src/test/java/org/spongepowered/api/event/SpongeEventFactoryTest.java
+++ b/src/test/java/org/spongepowered/api/event/SpongeEventFactoryTest.java
@@ -27,6 +27,14 @@ package org.spongepowered.api.event;
 import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockSettings;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.spongepowered.api.block.BlockSnapshot;
+import org.spongepowered.api.data.DataManipulator;
+import org.spongepowered.api.event.block.BlockChangeEvent;
+import org.spongepowered.api.event.block.tile.TileEntityEvent;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 import org.spongepowered.api.util.event.factory.EventFactory;
@@ -34,6 +42,7 @@ import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.extent.Extent;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -72,7 +81,7 @@ public class SpongeEventFactoryTest {
                             }
 
                             if (eventMethod.getReturnType() != void.class) {
-                                assertNotNull("The return type of " + eventMethod + "was null!", eventMethod.invoke(event, params));
+                                assertNotNull("The return type of " + eventMethod + " was null!", eventMethod.invoke(event, params));
                             }
 
                         } catch (Exception e) {
@@ -125,7 +134,7 @@ public class SpongeEventFactoryTest {
         }
     }
 
-    private Object mockParam(Class<?> paramType) {
+    private Object mockParam(final Class<?> paramType) {
         if (paramType == byte.class) {
             return (byte) 0;
         } else if (paramType == short.class) {
@@ -150,6 +159,30 @@ public class SpongeEventFactoryTest {
             return new Location(mock(Extent.class), 0, 0, 0);
         } else if (paramType == Text[].class) {
             return new Text[] {};
+        } else if (BlockSnapshot.class.isAssignableFrom(paramType)) {
+            BlockSnapshot mock = (BlockSnapshot) mock(paramType);
+
+            final Answer answer = new Answer<Object>() {
+                @Override
+                public Object answer(InvocationOnMock invocation) throws Throwable {
+                    return mock(paramType);
+                }
+            };
+
+            when(mock.copy()).thenAnswer(answer);
+            return mock;
+        } else if (DataManipulator.class.isAssignableFrom(paramType)) {
+            DataManipulator mock = (DataManipulator) mock(paramType);
+
+            final Answer answer = new Answer<Object>() {
+                @Override
+                public Object answer(InvocationOnMock invocation) throws Throwable {
+                    return mock(paramType);
+                }
+            };
+            when(mock.copy()).thenAnswer(answer);
+
+            return mock;
         } else {
             return mock(paramType);
         }

--- a/src/test/java/org/spongepowered/api/util/event/factory/ClassGeneratorProviderTest.java
+++ b/src/test/java/org/spongepowered/api/util/event/factory/ClassGeneratorProviderTest.java
@@ -28,12 +28,20 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.closeTo;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.api.scoreboard.objective.Objective;
+import org.spongepowered.api.util.annotation.TransformResult;
+import org.spongepowered.api.util.annotation.TransformWith;
+
+import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -48,6 +56,19 @@ public class ClassGeneratorProviderTest {
 
     private ClassGeneratorProvider createProvider() {
         return new ClassGeneratorProvider("org.spongepowered.test");
+    }
+
+    @Test
+    public void testCreate_ModifierMethodInterface() throws Exception {
+        ClassGeneratorProvider provider = createProvider();
+        EventFactory<ModifiedMethodInterface> factory = provider.create(ModifiedMethodInterface.class, Object.class);
+
+        Map<String, Object> values = Maps.newHashMap();
+
+        ModifiedMethodInterface result = factory.apply(values);
+
+        assertNotSame(result.getNewModifierClass(), result);
+        assertNotSame(result.getOtherModifierClass(), result);
     }
 
     @Test
@@ -537,6 +558,29 @@ public class ClassGeneratorProviderTest {
 
         public boolean isCool() {
             return true;
+        }
+    }
+
+    public interface ModifiedMethodInterface {
+
+        @TransformResult
+        ModifierClass getNewModifierClass();
+
+        @TransformResult("foo")
+        ModifierClass getOtherModifierClass();
+
+    }
+
+    public class ModifierClass {
+
+        @TransformWith
+        public ModifierClass copy() {
+            return new ModifierClass();
+        }
+
+        @TransformWith("foo")
+        public ModifierClass copy2() {
+            return new ModifierClass();
         }
     }
 


### PR DESCRIPTION
This PR allows event interfaces to specify that they want the return value of a method transformed (by calling a method on) before it's returned. Both `TileEntityEvent` and `BlockChangeEvent` require this, in order to prevent plugins that modify certain mutable objects (`DataManipulator` and `BlockSnapshot`, respectively) from affecting other plugins.

I'm going to be cleaning this up significantly, as the code is quite messy from the extensive debugging I had to do. However, everything should work, so feel free to test that it works as intended in the meantime.

Regarding the `TransformResult` and `TransformWith` annotations: I'm completely open to suggestions for better names (I chose those mainly because I couldn't think of anything better at the time).