### PR TITLE
Add Platform interface

### DIFF
--- a/src/main/java/org/spongepowered/api/Game.java
+++ b/src/main/java/org/spongepowered/api/Game.java
@@ -40,15 +40,15 @@ import org.spongepowered.api.world.TeleportHelper;
 public interface Game {
 
     /**
-     * Returns the {@link Platform} the implementation
-     * is executing from.
+     * Returns the current platform, or implementation, this {@link Game} is running on.
      *
-     * @return The platform
+     * @return The current implementation
      */
     Platform getPlatform();
 
     /**
      * Gets the {@link Server}.
+     *
      * @return The server
      */
     Server getServer();
@@ -105,27 +105,6 @@ public interface Game {
      * @return The command dispatcher
      */
     CommandService getCommandDispatcher();
-
-    /**
-     * Gets the API version.
-     *
-     * @return The API version
-     */
-    String getApiVersion();
-
-    /**
-     * Gets the implementation version.
-     *
-     * @return The implementation version
-     */
-    String getImplementationVersion();
-
-    /**
-     * Gets the Minecraft version of this game.
-     *
-     * @return The Minecraft version
-     */
-    MinecraftVersion getMinecraftVersion();
 
     /**
      * Gets the {@link TeleportHelper}, used to find safe {@link Location}s.

--- a/src/main/java/org/spongepowered/api/Platform.java
+++ b/src/main/java/org/spongepowered/api/Platform.java
@@ -24,21 +24,114 @@
  */
 package org.spongepowered.api;
 
+import java.util.Map;
+
 /**
- * Effective side platforms.
- *
- * <p>A side is what part of Minecraft this is being run on. The client, or the
- * server. The internal server is also treated like a dedicated server.</p>
+ * Represents a possible platform, or implementation, a {@link Game} could be running on.
  */
-public enum Platform {
+public interface Platform {
 
     /**
-     * The platform of a Minecraft CLIENT is expected.
+     * Retrieves the current {@link Type} this platform is running on.
+     *
+     * @return The current type
      */
-    CLIENT,
+    Type getType();
+
     /**
-     * The platform of a Minecraft SERVER is expected.
+     * Retrieves the current platform name.
+     *
+     * @return The platform name
      */
-    SERVER
+    String getName();
+
+    /**
+     * Retrieves the current platform version.
+     *
+     * <p>This version can be in any format, like a build number or
+     * <a href="http://semver.org/">semantic versioning</a>.</p>
+     *
+     * @return The platform version, as a string
+     */
+    String getVersion();
+
+    /**
+     * Retrieves the current Sponge API version that this platform is implementing.
+     *
+     * @return The API version
+     */
+    String getApiVersion();
+
+    /**
+     * Gets current Minecraft version of this platform.
+     *
+     * @return The Minecraft version
+     */
+    MinecraftVersion getMinecraftVersion();
+
+    /**
+     * Returns this platform instance, as a key-value map.
+     *
+     * <p>The returned map instance is connected directly to this platform instance. Existing
+     * keys like name and version are not modifiable, but new keys are stored in this instance and
+     * are shared between any references to a map obtained through {@link #asMap()}.</p>
+     *
+     * <p>This mechanism allows for platform-specific information like Forge version.</p>
+     *
+     * @return This platform as a map
+     */
+    Map<String, Object> asMap();
+
+    /**
+     * The type of the platform, or where the game is currently running.
+     *
+     * <p>A side is what part of Minecraft this is being run on. The client, or the
+     * server. The internal server is also treated like a dedicated server.</p>
+     */
+    enum Type {
+
+        /**
+         * The platform of a Minecraft CLIENT is expected.
+         */
+        CLIENT,
+
+        /**
+         * The platform of a Minecraft SERVER is expected.
+         */
+        SERVER,
+
+        /**
+         * It is unknown what platform the game is running on.
+         */
+        UNKNOWN;
+
+        /**
+         * Checks for whether the platform is {@link #SERVER}.
+         *
+         * @return True if the platform is {@link #SERVER}, false otherwise
+         */
+        public boolean isServer() {
+            return this == SERVER;
+        }
+
+        /**
+         * Checks for whether the platform is {@link #CLIENT}.
+         *
+         * @return True if the platform is {@link #CLIENT}, false otherwise
+         */
+        public boolean isClient() {
+            return this == CLIENT;
+        }
+
+        /**
+         * Checks for whether the platform is known.
+         *
+         * @return False if the platform is {@link #UNKNOWN}, true otherwise
+         */
+        public boolean isKnown() {
+            return !(this == UNKNOWN);
+        }
+
+    }
 
 }


### PR DESCRIPTION
Intended as a fix for #644.

This PR abstracts away implementation and platform-specific information about the game into a Platform class. It also moves the current Platform enum to Platform.Side. 

I know @Minecrell had some additional ideas for keys.