### PR TITLE
Enforce setting the correct type in generated event methods

### DIFF
--- a/src/test/java/org/spongepowered/api/event/SpongeEventFactoryTest.java
+++ b/src/test/java/org/spongepowered/api/event/SpongeEventFactoryTest.java
@@ -157,7 +157,7 @@ public class SpongeEventFactoryTest {
         } else if (BlockSnapshot.class.isAssignableFrom(paramType)) {
             BlockSnapshot mock = (BlockSnapshot) mock(paramType);
 
-            final Answer answer = new Answer<Object>() {
+            final Answer<Object> answer = new Answer<Object>() {
                 @Override
                 public Object answer(InvocationOnMock invocation) throws Throwable {
                     return mock(paramType);
@@ -167,9 +167,9 @@ public class SpongeEventFactoryTest {
             when(mock.copy()).thenAnswer(answer);
             return mock;
         } else if (DataManipulator.class.isAssignableFrom(paramType)) {
-            DataManipulator mock = (DataManipulator) mock(paramType);
+            DataManipulator<?> mock = (DataManipulator) mock(paramType);
 
-            final Answer answer = new Answer<Object>() {
+            final Answer<Object> answer = new Answer<Object>() {
                 @Override
                 public Object answer(InvocationOnMock invocation) throws Throwable {
                     return mock(paramType);

--- a/src/test/java/org/spongepowered/api/util/event/factory/ClassGeneratorProviderTest.java
+++ b/src/test/java/org/spongepowered/api/util/event/factory/ClassGeneratorProviderTest.java
@@ -358,6 +358,18 @@ public class ClassGeneratorProviderTest {
         assertThat(getter.getName().get(), is(Matchers.equalTo("Aaron")));
     }
 
+    @Test(expected = RuntimeException.class)
+    public void testCreate_OverloadedSetter() {
+        Map<String, Object> values = Maps.newHashMap();
+        values.put("object", "");
+
+        ClassGeneratorProvider provider = createProvider();
+        EventFactory<CovariantMethodOverrideInterface> factory = provider.create(CovariantMethodOverrideInterface.class, Object.class);
+        CovariantMethodOverrideInterface overriden = factory.apply(values);
+
+        overriden.setObject(new Object());
+    }
+
     public interface OptionalGetter {
 
         Optional<String> getName();
@@ -582,6 +594,21 @@ public class ClassGeneratorProviderTest {
         public ModifierClass copy2() {
             return new ModifierClass();
         }
+    }
+
+    public interface CovariantMethodInterface {
+
+        Object getObject();
+
+        void setObject(Object object);
+    }
+
+    public interface CovariantMethodOverrideInterface extends CovariantMethodInterface {
+
+        @Override
+        String getObject();
+
+        void setObject(String object);
     }
 
 }


### PR DESCRIPTION
Many event interfaces in the API provide getters which are overridden in subinterfaces, using covariant types. An example of this is `TileEntityChangeEvent`, which has a method `getNewData`, returning a `DataManiuplator`. In `SignChangeEvent`, this is overridden to return `SignData`.

If corresponding setters are provided in both interfaces, then there's currently no mechanism to verify that a setter is being called with the most specific type. For example:

Again, look at `TileEntityChangeEvent`, which, in addition to the methods mentioned above, has a `setNewData` method, which takes a `DataManipulator` as a parameter. Should a plugin call this method with some generic `DataManipulator`, it may turn out that the parameter type used is incompatible with the overriden getter method, should the event turn out to be an instance of the subinterface.

In the above example, if a plugin were to call `setNewData(DataManipulator manipulator)` on an event which is actually a `SignChangeEvent`, no exception would be thrown. However, the next time the overriden getter - `getNewData` in `SignChangeEvent` - was called, a cast exception would be thrown, due to the set `DataManipulator` not being a `SignData`.

This PR ensures that the generated setter methods check the type of the passed in parameter, and determine whether it's compatible with the actual instance of the event.