### PR TITLE
Add methods to work with XML-format text messages.

### DIFF
--- a/extra/text_xml_schema.xsd
+++ b/extra/text_xml_schema.xsd
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xs:schema version="1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!-- Declarations of various elements -->
+  <xs:element name="a" type="a"/>
+  <xs:element name="b" type="b"/>
+  <xs:element name="c" type="color"/>
+  <xs:element name="color" type="color"/>
+  <xs:element name="i" type="i"/>
+  <xs:element name="o" type="obfuscated"/>
+  <xs:element name="obfuscated" type="obfuscated"/>
+  <xs:element name="s" type="strikethrough"/>
+  <xs:element name="span" type="span"/>
+  <xs:element name="strikethrough" type="strikethrough"/>
+  <xs:element name="tr" type="tr"/>
+  <xs:element name="u" type="u"/>
+
+  <!-- Actual type definitions for individual elements (some elements are aliases/can share types with others) -->
+  <xs:complexType name="element" abstract="true" mixed="true">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="a"/>
+        <xs:element ref="b"/>
+        <xs:element ref="color"/>
+        <xs:element ref="c"/>
+        <xs:element ref="i"/>
+        <xs:element ref="obfuscated"/>
+        <xs:element ref="o"/>
+        <xs:element ref="strikethrough"/>
+        <xs:element ref="s"/>
+        <xs:element ref="span"/>
+        <xs:element ref="tr"/>
+        <xs:element ref="u"/>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="onClick" type="xs:string"/>
+    <xs:attribute name="onShiftClick" type="xs:string"/>
+    <xs:attribute name="onHover" type="xs:string"/>
+  </xs:complexType>
+  
+  <xs:complexType name="a">
+    <xs:complexContent>
+      <xs:extension base="element">
+        <xs:sequence/>
+        <xs:attribute name="href" type="xs:anyURI" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="b">
+    <xs:complexContent>
+      <xs:extension base="element">
+        <xs:sequence/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="color">
+    <xs:complexContent>
+      <xs:extension base="element">
+        <xs:sequence/>
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="n" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="i">
+    <xs:complexContent>
+      <xs:extension base="element">
+        <xs:sequence/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="obfuscated">
+    <xs:complexContent>
+      <xs:extension base="element">
+        <xs:sequence/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="strikethrough">
+    <xs:complexContent>
+      <xs:extension base="element">
+        <xs:sequence/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="span">
+    <xs:complexContent>
+      <xs:extension base="element">
+        <xs:sequence/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="tr">
+    <xs:complexContent>
+      <xs:extension base="element">
+        <xs:sequence/>
+        <xs:attribute name="key" type="xs:string" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="u">
+    <xs:complexContent>
+      <xs:extension base="element">
+        <xs:sequence/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:schema>

--- a/src/main/java/org/spongepowered/api/text/TextFactory.java
+++ b/src/main/java/org/spongepowered/api/text/TextFactory.java
@@ -33,24 +33,6 @@ import java.util.Locale;
 public interface TextFactory {
 
     /**
-     * Parses the specified JSON text and returns the parsed result.
-     *
-     * @param json The valid JSON text
-     * @return The parsed text
-     * @throws IllegalArgumentException If the JSON is invalid
-     */
-    Text parseJson(String json) throws IllegalArgumentException;
-
-    /**
-     * Parses the specified JSON text leniently and returns the parsed result.
-     *
-     * @param json The JSON text
-     * @return The parsed text
-     * @throws IllegalArgumentException If the JSON couldn't be parsed
-     */
-    Text parseJsonLenient(String json) throws IllegalArgumentException;
-
-    /**
      * Returns a plain text representation of the {@link Text} without any
      * formattings.
      *
@@ -70,39 +52,18 @@ public interface TextFactory {
     String toPlain(Text text, Locale locale);
 
     /**
-     * Returns a JSON representation of the {@link Text} as used in commands.
+     * Get a {@link TextRepresentation} for the Mojangson representation of a {@link Text} object.
      *
-     * @param text The text to convert
-     * @return The text converted to JSON
+     * @return The json serializer
      */
-    String toJson(Text text);
+    TextRepresentation json();
 
     /**
-     * Returns a JSON representation of the {@link Text} as used in commands in the specified language.
+     * Get a {@link TextRepresentation} for the TextXML representation of a {@link Text} object.
      *
-     * @param text The text to convert
-     * @param locale The language to get the json in
-     * @return The text converted to JSON
+     * @return The xml text serializer
      */
-    String toJson(Text text, Locale locale);
-
-    /**
-     * Parses the provided XML-formatted message to a Text object.
-     *
-     * @param input The input string to parse
-     * @return The parsed {@link Text}
-     */
-    Text parseXml(String input);
-
-    /**
-     * Returns an xml representation of the {@link Text} for usage in configurations.
-     *
-     * @param input The input to use
-     * @param locale The locale to dump to
-     * @return The text as xml
-     */
-    String toXml(Text input, Locale locale);
-
+    TextRepresentation xml();
     /**
      * Returns the default legacy formatting character.
      *
@@ -111,13 +72,13 @@ public interface TextFactory {
     char getLegacyChar();
 
     /**
-     * Creates a Message from a legacy string, given a color character.
+     * Return a representation that accepts and outputs legacy color codes, using the provided legacy character.
      *
-     * @param text The text to be converted as a String
-     * @param code The color character to be replaced
-     * @return The converted Message
+     * @param legacyChar The legacy character to parse and output using
+     * @return The appropriate legacy representation handler
      */
-    Text.Literal parseLegacyMessage(String text, char code);
+    TextRepresentation legacy(char legacyChar);
+
 
     /**
      * Removes the legacy formatting character from a legacy string.
@@ -138,26 +99,4 @@ public interface TextFactory {
      * @return The replaced text
      */
     String replaceLegacyCodes(String text, char from, char to);
-
-    /**
-     * Returns a representation of the {@link Text} using the legacy color
-     * codes.
-     *
-     * @param text The text to convert
-     * @param code The legacy char to use for the message
-     * @return The text converted to the old color codes
-     */
-    String toLegacy(Text text, char code);
-
-    /**
-     * Returns a representation of the {@link Text} using the legacy color
-     * codes in the given Locale.
-     *
-     * @param text The text to convert
-     * @param code The legacy char to use for the message
-     * @param locale The language to translate into
-     * @return The text converted to the old color codes
-     */
-    String toLegacy(Text text, char code, Locale locale);
-
 }

--- a/src/main/java/org/spongepowered/api/text/TextFactory.java
+++ b/src/main/java/org/spongepowered/api/text/TextFactory.java
@@ -87,6 +87,23 @@ public interface TextFactory {
     String toJson(Text text, Locale locale);
 
     /**
+     * Parses the provided XML-formatted message to a Text object.
+     *
+     * @param input The input string to parse
+     * @return The parsed {@link Text}
+     */
+    Text parseXml(String input);
+
+    /**
+     * Returns an xml representation of the {@link Text} for usage in configurations.
+     *
+     * @param input The input to use
+     * @param locale The locale to dump to
+     * @return The text as xml
+     */
+    String toXml(Text input, Locale locale);
+
+    /**
      * Returns the default legacy formatting character.
      *
      * @return The legacy formatting character

--- a/src/main/java/org/spongepowered/api/text/TextRepresentation.java
+++ b/src/main/java/org/spongepowered/api/text/TextRepresentation.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.text;
+
+import org.spongepowered.api.util.TextMessageException;
+
+import java.util.Locale;
+
+/**
+ * Interface for a certain representation of a Text object.
+ */
+public interface TextRepresentation {
+
+    /**
+     * Return a string representation of the provided text in a format that will be accepted by this serializer's {@link #from(String)} (String)}
+     * method.
+     *
+     * @param text The text to convert to a string representation
+     * @return An appropriate string representation of this text
+     */
+    String to(Text text);
+
+    /**
+     * Return a string representation of the provided text in a format that will be accepted by this serializer's {@link #from(String)} (String)}
+     * method and is appropriate for the given locale.
+     *
+     * @param text The text to serialize
+     * @param locale The locale to serialize this text in
+     * @return An appropriate string representation of this text
+     */
+    String to(Text text, Locale locale);
+
+    /**
+     * Return a {@link Text} instance from an appropriately formatted string.
+     *
+     * @param input The raw input to parse into a text
+     * @return An appropriate {@link Text} object from the input string
+     * @throws TextMessageException if an error occurs while parsing the input
+     */
+    Text from(String input) throws TextMessageException;
+
+    /**
+     * Tries to return a {@link Text} instance from the provided input string. However, if the input string is not of a valid format, the returned
+     * {@link Text} object will be of the raw input, rather than throwing an exception.
+     *
+     * @param input The raw input to try to parse into a text
+     * @return An appropriate {@link Text} object from the input string, or the raw input
+     */
+    Text fromUnchecked(String input);
+}

--- a/src/main/java/org/spongepowered/api/text/Texts.java
+++ b/src/main/java/org/spongepowered/api/text/Texts.java
@@ -435,6 +435,29 @@ public final class Texts {
     public static String toJson(Text text, Locale locale) {
         return factory.toJson(text, locale);
     }
+
+    /**
+     * Parses the provided XML-formatted message to a Text object.
+     *
+     * @param input The input string to parse
+     * @return The parsed {@link Text}
+     */
+    public static Text parseXml(String input) {
+        return factory.parseXml(input);
+    }
+
+    /**
+     * Returns an xml representation of the {@link Text} for usage in configurations.
+     * TODO: Does Locale make sense here?
+     *
+     * @param input The input to use
+     * @param locale The locale to dump to
+     * @return The text as xml
+     */
+    public static String toXml(Text input, Locale locale) {
+        return factory.toXml(input, locale);
+    }
+
     /**
      * Returns the default legacy formatting character.
      *

--- a/src/main/java/org/spongepowered/api/text/Texts.java
+++ b/src/main/java/org/spongepowered/api/text/Texts.java
@@ -370,31 +370,6 @@ public final class Texts {
     }
 
     /**
-     * Parses the specified JSON text and returns the parsed result.
-     *
-     * @param json The valid JSON text
-     * @return The parsed text
-     * @throws IllegalArgumentException If the JSON is invalid
-     */
-    public static Text parseJson(String json) throws IllegalArgumentException {
-        return factory.parseJson(json);
-    }
-
-    /**
-     * Parses the specified JSON text and returns the parsed result.
-     *
-     * <p>Unlike {@link #parseJson(String)} this will ignore some formatting
-     * errors and parse the JSON data more leniently.</p>
-     *
-     * @param json The JSON text
-     * @return The parsed text
-     * @throws IllegalArgumentException If the JSON couldn't be parsed
-     */
-    public static Text parseJsonLenient(String json) throws IllegalArgumentException {
-        return factory.parseJsonLenient(json);
-    }
-
-    /**
      * Returns a plain text representation of the {@link Text} without any
      * formatting.
      *
@@ -403,16 +378,6 @@ public final class Texts {
      */
     public static String toPlain(Text text) {
         return factory.toPlain(text);
-    }
-
-    /**
-     * Returns a JSON representation of the {@link Text} as used in commands.
-     *
-     * @param text The text to convert
-     * @return The text converted to JSON
-     */
-    public static String toJson(Text text) {
-        return factory.toJson(text);
     }
 
     /**
@@ -427,35 +392,22 @@ public final class Texts {
     }
 
     /**
-     * Returns a JSON representation of the {@link Text} as used in commands.
+     * Get a {@link TextRepresentation} for the Mojangson representation of a {@link Text} object.
      *
-     * @param text The text to convert
-     * @return The text converted to JSON
+     *
+     * @return The json serializer
      */
-    public static String toJson(Text text, Locale locale) {
-        return factory.toJson(text, locale);
+    public static TextRepresentation json() {
+        return factory.json();
     }
 
     /**
-     * Parses the provided XML-formatted message to a Text object.
+     * Get a {@link TextRepresentation} for the TextXML representation of a {@link Text} object.
      *
-     * @param input The input string to parse
-     * @return The parsed {@link Text}
+     * @return The xml text serializer
      */
-    public static Text parseXml(String input) {
-        return factory.parseXml(input);
-    }
-
-    /**
-     * Returns an xml representation of the {@link Text} for usage in configurations.
-     * TODO: Does Locale make sense here?
-     *
-     * @param input The input to use
-     * @param locale The locale to dump to
-     * @return The text as xml
-     */
-    public static String toXml(Text input, Locale locale) {
-        return factory.toXml(input, locale);
+    public static TextRepresentation xml() {
+        return factory.xml();
     }
 
     /**
@@ -470,29 +422,25 @@ public final class Texts {
     }
 
     /**
-     * Creates a Message from a legacy string using the default legacy.
+     * Return a representation that accepts and outputs legacy color codes, using the default legacy char {{@link #getLegacyChar()}}.
      *
-     * @param text The text to be converted as a String
-     * @return The converted Message
-     * @deprecated Legacy formatting codes are being phased out of Minecraft
+     * @return The appropriate legacy representation handler
      */
     @Deprecated
     @SuppressWarnings("deprecation")
-    public static Text.Literal fromLegacy(String text) {
-        return fromLegacy(text, getLegacyChar());
+    public static TextRepresentation legacy() {
+        return legacy(getLegacyChar());
     }
 
     /**
-     * Creates a Message from a legacy string, given a color character.
+     * Return a representation that accepts and outputs legacy color codes, using the provided legacy character.
      *
-     * @param text The text to be converted as a String
-     * @param color The color character to be replaced
-     * @return The converted Message
-     * @deprecated Legacy formatting codes are being phased out of Minecraft
+     * @param legacyChar The legacy character to parse and output using
+     * @return The appropriate legacy representation handler
      */
     @Deprecated
-    public static Text.Literal fromLegacy(String text, char color) {
-        return factory.parseLegacyMessage(text, color);
+    public static TextRepresentation legacy(char legacyChar) {
+        return factory.legacy(legacyChar);
     }
 
     /**
@@ -550,48 +498,4 @@ public final class Texts {
     public static String replaceCodes(String text, char from, char to) {
         return factory.replaceLegacyCodes(text, from, to);
     }
-
-    /**
-     * Returns a representation of the {@link Text} using the legacy color
-     * codes.
-     *
-     * @param text The text to convert
-     * @return The text converted to the old color codes
-     * @deprecated Legacy formatting codes are being phased out of Minecraft
-     */
-    @Deprecated
-    @SuppressWarnings("deprecation")
-    public static String toLegacy(Text text) {
-        return toLegacy(text, getLegacyChar());
-    }
-
-    /**
-     * Returns a representation of the {@link Text} using the legacy color
-     * codes.
-     *
-     * @param text The text to convert
-     * @param code The legacy char to use for the message
-     * @return The text converted to the old color codes
-     * @deprecated Legacy formatting codes are being phased out of Minecraft
-     */
-    @Deprecated
-    public static String toLegacy(Text text, char code) {
-        return factory.toLegacy(text, code);
-    }
-
-    /**
-     * Returns a representation of the {@link Text} using the legacy color
-     * codes.
-     *
-     * @param text The text to convert
-     * @param code The legacy char to use for the message
-     * @param locale The language to return this representation in
-     * @return The text converted to the old color codes
-     * @deprecated Legacy formatting codes are being phased out of Minecraft
-     */
-    @Deprecated
-    public static String toLegacy(Text text, char code, Locale locale) {
-        return factory.toLegacy(text, code, locale);
-    }
-
 }


### PR DESCRIPTION
This PR proposes the integration of @TomyLobo's XML format for chat styling into the Text API through the addition of new methods in Texts to go to and from XML.

The XML format vastly improves usability of plugins wishing to have user-configurable formatted text by providing a less verbose method for specifying formatting, with similarities to HTML. The tags handled are as follows:

### HTML-compatible

- `b`: bold text
- `i`: italic text
- `u`: underlined text
- `<a href="url">`: create a link
- `<span>`: Does nothing to the text inside, useful to apply text actions though

### Custom
- `<o>` or `<obfuscated>`: obfuscated text
- `<color n="red">` or `<c n="red">` or `<color name="red">`: specify the color of text
- `<s>` or `<strikethrough>`: Strikethrough
- `<tr key="mc-key">`: Translation key. Each child element is an argument


### Text Actions
Any tag can take one of the attributes onClick, onHover, or onShiftClick. Each attribute has a value of the form type('value'), for example `<span onClick="run_command('/say hi')">Greet the server!</span>`
