### PR TITLE
[WIP] Cause Enhancements

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -28,6 +28,8 @@ import com.flowpowered.math.vector.Vector3d;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.manipulator.mutable.TargetedLocationData;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
 import org.spongepowered.api.util.Identifiable;
 import org.spongepowered.api.util.RelativePositions;
 import org.spongepowered.api.world.Location;
@@ -277,5 +279,17 @@ public interface Entity extends Identifiable, DataHolder, DataSerializable {
      * within one game tick.
      */
     void remove();
+
+    /**
+     * Damages this {@link Entity} with the given {@link Cause}. It is
+     * imperative that a {@link DamageSource} is included
+     * with the cause for maximum compatibility with plugins and the game
+     * itself.
+     *
+     * @param damage The damage to deal
+     * @param cause The cause of the damage
+     * @return True if damaging the entity was successful
+     */
+    boolean damage(double damage, Cause cause);
 
 }

--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -117,9 +117,9 @@ import org.spongepowered.api.event.entity.player.PlayerPlaceBlockEvent;
 import org.spongepowered.api.event.entity.player.PlayerQuitEvent;
 import org.spongepowered.api.event.entity.player.PlayerRespawnEvent;
 import org.spongepowered.api.event.entity.player.PlayerUpdateEvent;
-import org.spongepowered.api.event.entity.player.fishing.PlayerCastFishingLineEvent;
-import org.spongepowered.api.event.entity.player.fishing.PlayerHookedEntityEvent;
-import org.spongepowered.api.event.entity.player.fishing.PlayerRetractFishingLineEvent;
+import org.spongepowered.api.event.entity.player.PlayerCastFishingLineEvent;
+import org.spongepowered.api.event.entity.player.PlayerHookedEntityEvent;
+import org.spongepowered.api.event.entity.player.PlayerRetractFishingLineEvent;
 import org.spongepowered.api.event.message.CommandEvent;
 import org.spongepowered.api.event.message.CommandSuggestionsEvent;
 import org.spongepowered.api.event.message.MessageEvent;
@@ -273,7 +273,7 @@ public final class SpongeEventFactory {
     public static BlockBreakEvent createBlockBreak(Game game, Cause cause, Location<World> location, BlockSnapshot replacementBlock, int exp) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("location", location);
         values.put("block", location.getBlock());
         values.put("replacementBlock", replacementBlock);
@@ -293,7 +293,7 @@ public final class SpongeEventFactory {
     public static BlockBurnEvent createBlockBurn(Game game, Cause cause, Location<World> location, BlockSnapshot replacementBlock) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("location", location);
         values.put("block", location.getBlock());
         values.put("replacementBlock", replacementBlock);
@@ -312,7 +312,7 @@ public final class SpongeEventFactory {
     public static BlockChangeEvent createBlockChange(Game game, Cause cause, Location<World> location, BlockSnapshot replacementBlock) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("location", location);
         values.put("block", location.getBlock());
         values.put("replacementBlock", replacementBlock);
@@ -332,7 +332,7 @@ public final class SpongeEventFactory {
     public static BlockDispenseEvent createBlockDispense(Game game, Cause cause, Location<World> location, Vector3d velocity, ItemStack dispensedItem) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("location", location);
         values.put("block", location.getBlock());
         values.put("velocity", velocity);
@@ -354,7 +354,7 @@ public final class SpongeEventFactory {
     public static BlockHarvestEvent createBlockHarvest(Game game, Cause cause, Location<World> location, Collection<ItemStack> droppedItems, float dropChance) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("location", location);
         values.put("block", location.getBlock());
         values.put("droppedItems", droppedItems);
@@ -373,7 +373,7 @@ public final class SpongeEventFactory {
     public static BlockIgniteEvent createBlockIgnite(Game game, Cause cause, Location<World> location) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("location", location);
         values.put("block", location.getBlock());
         return createEvent(BlockIgniteEvent.class, values);
@@ -391,7 +391,7 @@ public final class SpongeEventFactory {
     public static BlockInteractEvent createBlockInteract(Game game, Cause cause, Location<World> location, Direction side) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("location", location);
         values.put("block", location.getBlock());
         values.put("side", side);
@@ -409,7 +409,7 @@ public final class SpongeEventFactory {
     public static BlockMoveEvent createBlockMove(Game game, Cause cause, List<Location<World>> locations) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("locations", locations);
         return createEvent(BlockMoveEvent.class, values);
     }
@@ -426,7 +426,7 @@ public final class SpongeEventFactory {
     public static BlockPlaceEvent createBlockPlace(Game game, Cause cause, Location<World> location, BlockSnapshot replacementBlock) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("location", location);
         values.put("block", location.getBlock());
         values.put("replacementBlock", replacementBlock);
@@ -444,7 +444,7 @@ public final class SpongeEventFactory {
     public static BlockRandomTickEvent createBlockRandomTick(Game game, Cause cause, Location<World> location) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("location", location);
         values.put("block", location.getBlock());
         return createEvent(BlockRandomTickEvent.class, values);
@@ -462,7 +462,7 @@ public final class SpongeEventFactory {
     public static BlockUpdateEvent createBlockUpdate(Game game, Cause cause, Location<World> location, List<Location<World>> locations) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("location", location);
         values.put("block", location.getBlock());
         values.put("locations", locations);
@@ -505,7 +505,7 @@ public final class SpongeEventFactory {
     public static FloraGrowEvent createFloraGrow(Game game, Cause cause, Location<World> location, BlockSnapshot replacementBlock) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("location", location);
         values.put("block", location.getBlock());
         values.put("replacementBlock", replacementBlock);
@@ -524,7 +524,7 @@ public final class SpongeEventFactory {
     public static FluidSpreadEvent createFluidSpread(Game game, Cause cause, Location<World> location, List<Location<World>> locations) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("location", location);
         values.put("block", location.getBlock());
         values.put("locations", locations);
@@ -543,7 +543,7 @@ public final class SpongeEventFactory {
     public static LeafDecayEvent createLeafDecay(Game game, Cause cause, Location<World> location, BlockSnapshot replacementBlock) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("location", location);
         values.put("block", location.getBlock());
         values.put("replacementBlock", replacementBlock);
@@ -565,7 +565,7 @@ public final class SpongeEventFactory {
             int exp) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("location", location);
         values.put("block", location.getBlock());
@@ -606,7 +606,7 @@ public final class SpongeEventFactory {
             BlockSnapshot replacementBlock) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("location", location);
         values.put("block", location.getBlock());
@@ -625,7 +625,7 @@ public final class SpongeEventFactory {
     public static EntityCollisionEvent createEntityCollision(Game game, Cause cause, Entity entity) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         return createEvent(EntityCollisionEvent.class, values);
     }
@@ -642,7 +642,7 @@ public final class SpongeEventFactory {
     public static EntityCollisionWithBlockEvent createEntityCollisionWithBlock(Game game, Cause cause, Entity entity, Location<World> location) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("location", location);
         values.put("block", location.getBlock());
@@ -661,7 +661,7 @@ public final class SpongeEventFactory {
     public static EntityCollisionWithEntityEvent createEntityCollisionWithEntity(Game game, Cause cause, Entity entity, Entity collided) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("collided", collided);
         return createEvent(EntityCollisionWithEntityEvent.class, values);
@@ -680,7 +680,7 @@ public final class SpongeEventFactory {
     public static EntityDeathEvent createEntityDeath(Game game, Cause cause, Entity entity, Location<World> location, int exp) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("location", location);
         values.put("exp", exp);
@@ -736,7 +736,7 @@ public final class SpongeEventFactory {
     public static EntityDropItemEvent createEntityDropItem(Game game, Cause cause, Entity entity, Collection<ItemStack> droppedItems) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("droppedItems", droppedItems);
         return createEvent(EntityDropItemEvent.class, values);
@@ -758,7 +758,7 @@ public final class SpongeEventFactory {
             Collection<ItemStack> droppedItems, float dropChance) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("location", location);
         values.put("block", location.getBlock());
@@ -780,7 +780,7 @@ public final class SpongeEventFactory {
     public static EntityInteractBlockEvent createEntityInteractBlock(Game game, Cause cause, Entity entity, Location<World> location, Direction side) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);        
         values.put("location", location);
         values.put("block", location.getBlock());
@@ -919,7 +919,7 @@ public final class SpongeEventFactory {
             BlockSnapshot replacementBlock) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("location", location);
         values.put("block", location.getBlock());
         values.put("entity", entity);
@@ -989,7 +989,7 @@ public final class SpongeEventFactory {
             Vector3d rotation, boolean keepsVelocity) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("oldLocation", oldLocation);
         values.put("newLocation", newLocation);
@@ -1024,7 +1024,7 @@ public final class SpongeEventFactory {
     public static ProjectileLaunchEvent createProjectileLaunch(Game game, Cause cause, Projectile entity, ProjectileSource source) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("launchedProjectile", entity);
         values.put("source", Optional.fromNullable(source));
@@ -1108,7 +1108,7 @@ public final class SpongeEventFactory {
             BlockSnapshot replacementBlock, int exp) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("user", entity);
         values.put("location", location);
@@ -1194,7 +1194,7 @@ public final class SpongeEventFactory {
             BlockSnapshot replacementBlock) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("user", entity);
         values.put("blockFace", blockFace);
@@ -1286,7 +1286,7 @@ public final class SpongeEventFactory {
 
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("source", entity);
         values.put("user", entity);
@@ -1314,7 +1314,7 @@ public final class SpongeEventFactory {
     public static PlayerDropItemEvent createPlayerDropItem(Game game, Player entity, Cause cause, Collection<ItemStack> droppedItems) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("user", entity);
         values.put("droppedItems", droppedItems);
@@ -1338,7 +1338,7 @@ public final class SpongeEventFactory {
             Collection<ItemStack> droppedItems, float dropChance, boolean silkTouch) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("user", entity);
         values.put("location", location);
@@ -1365,7 +1365,7 @@ public final class SpongeEventFactory {
             EntityInteractionType interactionType, @Nullable Vector3d clickedPosition) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("user", entity);
         values.put("location", location);
@@ -1496,7 +1496,7 @@ public final class SpongeEventFactory {
             BlockSnapshot replacementBlock, Direction blockFace) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("entity", entity);
         values.put("user", entity);
         values.put("location", location);
@@ -1861,7 +1861,7 @@ public final class SpongeEventFactory {
             Location<World> location) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("tile", brewingStand);
         values.put("sourceItems", sourceItems);
         values.put("fuelSource", fuelSource);
@@ -1891,7 +1891,7 @@ public final class SpongeEventFactory {
             ItemStack burnedItem, ItemStack remainingFuel, TileEntityInventory<TileEntityCarrier> inventory, Location<World> location) {
             Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("tile", furnace);
         values.put("burnedItem", burnedItem);
         values.put("remainingFuel", Optional.fromNullable(remainingFuel));
@@ -1920,7 +1920,7 @@ public final class SpongeEventFactory {
             cookedItem, ItemStack sourceItem, TileEntityInventory<TileEntityCarrier> inventory, Location<World> location) {
             Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("tile", furnace);
         values.put("cookedItem", cookedItem);
         values.put("sourceItem", sourceItem);
@@ -1944,7 +1944,7 @@ public final class SpongeEventFactory {
     public static SignChangeEvent createSignChange(Game game, Cause cause, Sign sign, ImmutableSignData currentData, SignData newData) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("game", game);
-        values.put("cause", Optional.fromNullable(cause));
+        values.put("cause", cause);
         values.put("tile", sign);
         values.put("currentData", currentData);
         values.put("newData", newData);

--- a/src/main/java/org/spongepowered/api/event/block/BlockDispenseEvent.java
+++ b/src/main/java/org/spongepowered/api/event/block/BlockDispenseEvent.java
@@ -25,12 +25,13 @@
 package org.spongepowered.api.event.block;
 
 import com.flowpowered.math.vector.Vector3d;
+import org.spongepowered.api.event.cause.CauseTracked;
 import org.spongepowered.api.item.inventory.ItemStack;
 
 /**
  * Called when a block is about to dispense an item.
  */
-public interface BlockDispenseEvent extends BlockEvent {
+public interface BlockDispenseEvent extends BlockEvent, CauseTracked {
 
     /**
      * Get the item that is being dispensed.

--- a/src/main/java/org/spongepowered/api/event/cause/Cause.java
+++ b/src/main/java/org/spongepowered/api/event/cause/Cause.java
@@ -26,10 +26,16 @@ package org.spongepowered.api.event.cause;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.event.cause.reason.Reason;
-import org.spongepowered.api.world.Location;
+import org.spongepowered.api.event.Event;
+import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
+import org.spongepowered.api.event.cause.entity.spawn.SpawnCause;
+
+import java.util.Arrays;
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -48,52 +54,366 @@ import javax.annotation.Nullable;
  * some blocks, but tracing this event would be too complicated and thus
  * may not be attempted.</p>
  */
-public class Cause {
+@SuppressWarnings("unchecked")
+public abstract class Cause {
 
-    private final Optional<Cause> parent;
-    private final Object cause;
-    private final Optional<Reason> reason;
-
-    /**
-     * Create a new cause instance.
-     *
-     * @param parent An optional parent
-     * @param cause The causing object (may be a block, entity, etc.)
-     * @param reason An optional reason
-     */
-    public Cause(@Nullable Cause parent, Object cause, @Nullable Reason reason) {
-        checkNotNull(cause, "cause");
-        this.parent = Optional.fromNullable(parent);
-        this.cause = cause;
-        this.reason = Optional.fromNullable(reason);
+    public static Cause empty() {
+        return new EmptyCause();
     }
 
-    /**
-     * Get the parent cause of this cause.
-     *
-     * @return The parent cause
-     */
-    public Optional<Cause> getParent() {
-        return this.parent;
+    public static Cause of(Event event) {
+        return new PresentCause(checkNotNull(event));
     }
 
-    /**
-     * Get the causing object (it may be an {@link Entity}, {@link Location},
-     * etc.).
-     *
-     * @return The cause
-     */
-    public Object getCause() {
-        return this.cause;
+    public static Cause of(List<Event> events, Object... objects) {
+        return new PresentCause(checkNotNull(events), checkNotNull(objects));
     }
 
+    public static Cause fromEvent(Event event, @Nullable Object... objects) {
+        if (objects == null) {
+            return new PresentCause(checkNotNull(event));
+        } else {
+            return new PresentCause(checkNotNull(event), objects);
+        }
+    }
+
+    public static Cause fromNullable(@Nullable List<Event> events, @Nullable Object... objects) {
+        if (objects == null) {
+            if (events == null) {
+                return new EmptyCause();
+            } else {
+                return new PresentCause(events);
+            }
+        } else {
+            if (events == null) {
+                return new PresentCause(objects);
+            } else {
+                return new PresentCause(events, objects);
+            }
+        }
+    }
+
+
+    Cause() {}
+
     /**
-     * Get the reason.
+     * Gets whether this {@link Cause} is empty of any causes or not. An empty
+     * cause may mean the {@link Cause} is not originating from any vanilla
+     * interactions, or it may mean the cause is simply not known.
      *
-     * @return The reason
+     * @return True if this cause is empty, false otherwise
      */
-    public Optional<Reason> getReason() {
-        return this.reason;
+    public abstract boolean isEmpty();
+
+    /**
+     * Gets the root {@link Object} of this cause. The root can be anything,
+     * including but not limited to: {@link DamageSource}, {@link Entity},
+     * {@link SpawnCause}, etc.
+     *
+     * @return The root object cause for this cause
+     */
+    public abstract Optional<?> getRoot();
+
+    /**
+     * Gets the root {@link Event} of this cause. The root event can be any
+     * event that is involved in this {@link Cause} for the event of this
+     * {@link Cause}. The root {@link Event} may not be present, in which
+     * case {@link Optional#absent()} is returned.
+     *
+     * @return The root event cause for this cause
+     */
+    public abstract Optional<Event> getRootEvent();
+
+    /**
+     * Gets the first {@link T} object of this {@link Cause}, if available.
+     *
+     * @param target The class of the target type
+     * @param <T> The type of object being queried for
+     * @return The first element of the type, if available
+     */
+    public abstract <T> Optional<T> getFirst(Class<T> target);
+
+    /**
+     * Gets the last object instance of the {@link Class} of type {@link T}.
+     *
+     * @param target The class of the target type
+     * @param <T> The type of object being queried for
+     * @return The last element of the type, if available
+     */
+    public abstract <T> Optional<T> getLast(Class<T> target);
+
+    /**
+     * Gets an {@link ImmutableList} of all objects that are instances of the
+     * given {@link Class} type {@link T}.
+     *
+     * @param target The class of the target type
+     * @param <T> The type of objects to query for
+     * @return An immutable list of the objects queried
+     */
+    public abstract <T> ImmutableList<T> getAllOf(Class<T> target);
+
+    /**
+     * Gets an {@link ImmutableList} of all causes within this {@link Cause}.
+     *
+     * @return An immutable list of all the causes
+     */
+    public abstract ImmutableList<Object> getAllCauses();
+
+    /**
+     * Gets the first {@link Event} of type <code>E</code> that may be involved
+     * in the {@link Event} chain of causes. The "chain of events" involved in
+     * a {@link Cause} should be considered "immutable" such that any methods
+     * provided by the events themselves may throw
+     * {@link UnsupportedOperationException}s as they should NOT be modified
+     * after they are called and processed. While certain information can be
+     * provided by various
+     * @param target
+     * @param <E>
+     * @return
+     */
+    public abstract <E extends Event> Optional<E> getFirstEvent(Class<E> target);
+
+    public abstract <E extends Event> Optional<E> getLastEvent(Class<E> target);
+
+    public abstract <E extends Event> ImmutableList<E> getAllEventsOf(Class<E> target);
+
+    public abstract ImmutableList<Event> getEventChain();
+
+    /**
+     * Returns {@code true} if {@code object} is a {@code Cause} instance, and either
+     * the contained references are {@linkplain Object#equals equal} to each other or both
+     * are absent.
+     */
+    @Override
+    public abstract boolean equals(@Nullable Object object);
+
+    /**
+     * Returns a hash code for this instance.
+     */
+    @Override
+    public abstract int hashCode();
+
+    private static final class PresentCause extends Cause {
+        private final Object[] cause;
+        private final Event[] events;
+
+        PresentCause(Object... causes) {
+            this.events = new Event[0];
+            for (Object aCause : causes) {
+                checkNotNull(aCause, "Null cause element!");
+            }
+            this.cause = Arrays.copyOf(causes, causes.length);
+        }
+
+        PresentCause(Event event) {
+            checkNotNull(event, "event");
+            this.events = new Event[] { event };
+            this.cause = new Object[0];
+        }
+
+        PresentCause(Event event, Object... causes) {
+            checkNotNull(causes, "cause");
+            checkNotNull(event, "event");
+            this.events = new Event[] { event };
+            for (Object aCause : causes) {
+                checkNotNull(aCause, "Null cause element!");
+            }
+            this.cause = Arrays.copyOf(causes, causes.length);
+        }
+
+        PresentCause(List<Event> events) {
+            checkNotNull(events, "events");
+            for (Event event : events) {
+                checkNotNull(event, "Null event element!");
+            }
+            this.events = events.toArray(new Event[events.size()]);
+            this.cause = new Object[0];
+        }
+
+        PresentCause(List<Event> events, Object... causes) {
+            checkNotNull(causes, "causes");
+            checkNotNull(events, "events");
+            for (Event event : events) {
+                checkNotNull(event, "Null event element!");
+            }
+            this.events = events.toArray(new Event[events.size()]);
+            for (Object aCause : causes) {
+                checkNotNull(aCause, "Null cause element!");
+            }
+            this.cause = Arrays.copyOf(causes, causes.length);
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public Optional<?> getRoot() {
+            return Optional.of(this.cause[0]);
+        }
+
+        @Override
+        public Optional<Event> getRootEvent() {
+            return null;
+        }
+
+        @Override
+        public <T> Optional<T> getFirst(Class<T> target) {
+            for (Object aCause : this.cause) {
+                if (target.isInstance(aCause)) {
+                    return Optional.of((T) aCause);
+                }
+            }
+            return Optional.absent();
+        }
+
+        @Override
+        public <T> ImmutableList<T> getAllOf(Class<T> target) {
+            ImmutableList.Builder<T> builder = ImmutableList.builder();
+            for (Object aCause : this.cause) {
+                if (target.isInstance(aCause)) {
+                    builder.add((T) aCause);
+                }
+            }
+            return builder.build();
+        }
+
+        @Override
+        public <T> Optional<T> getLast(Class<T> target) {
+            for (int i = this.cause.length - 1; i >= 0; i--) {
+                if (target.isInstance(this.cause[i])) {
+                    return Optional.of((T) this.cause[i]);
+                }
+            }
+            return Optional.absent();
+        }
+
+        @Override
+        public ImmutableList<Object> getAllCauses() {
+            return ImmutableList.copyOf(this.cause);
+        }
+
+        @Override
+        public <E extends Event> Optional<E> getFirstEvent(Class<E> target) {
+            for (Event anEvent : this.events) {
+                if (target.isInstance(anEvent)) {
+                    return Optional.of((E) anEvent);
+                }
+            }
+            return Optional.absent();
+        }
+
+        @Override
+        public <E extends Event> Optional<E> getLastEvent(Class<E> target) {
+            for (int i = this.events.length - 1; i >= 0; i--) {
+                if (target.isInstance(this.events[i])) {
+                    return Optional.of((E) this.cause[i]);
+                }
+            }
+            return Optional.absent();
+        }
+
+        @Override
+        public <E extends Event> ImmutableList<E> getAllEventsOf(Class<E> target) {
+            ImmutableList.Builder<E> builder = ImmutableList.builder();
+            for (Event anEvent : this.events) {
+                if (target.isInstance(anEvent)) {
+                    builder.add((E) anEvent);
+                }
+            }
+            return builder.build();
+        }
+
+        @Override
+        public ImmutableList<Event> getEventChain() {
+            return ImmutableList.copyOf(this.events);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object object) {
+            if (object instanceof PresentCause) {
+                PresentCause cause = ((PresentCause) object);
+                return Arrays.equals(this.cause, cause.cause);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(this.cause);
+        }
+    }
+
+    private static final class EmptyCause extends Cause {
+
+        EmptyCause() {
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
+
+        @Override
+        public Optional<?> getRoot() {
+            return Optional.absent();
+        }
+
+        @Override
+        public Optional<Event> getRootEvent() {
+            return Optional.absent();
+        }
+
+        @Override
+        public <T> Optional<T> getFirst(Class<T> target) {
+            return Optional.absent();
+        }
+
+        @Override
+        public <T> Optional<T> getLast(Class<T> target) {
+            return Optional.absent();
+        }
+
+        @Override
+        public <T> ImmutableList<T> getAllOf(Class<T> target) {
+            return ImmutableList.of();
+        }
+
+        @Override
+        public ImmutableList<Object> getAllCauses() {
+            return ImmutableList.of();
+        }
+
+        @Override
+        public <E extends Event> Optional<E> getFirstEvent(Class<E> target) {
+            return Optional.absent();
+        }
+
+        @Override
+        public <E extends Event> Optional<E> getLastEvent(Class<E> target) {
+            return Optional.absent();
+        }
+
+        @Override
+        public <E extends Event> ImmutableList<E> getAllEventsOf(Class<E> target) {
+            return ImmutableList.of();
+        }
+
+        @Override
+        public ImmutableList<Event> getEventChain() {
+            return ImmutableList.of();
+        }
+
+        @Override
+        public boolean equals(@Nullable Object object) {
+            return object == this;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0x39e8a5b;
+        }
     }
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/CauseTracked.java
+++ b/src/main/java/org/spongepowered/api/event/cause/CauseTracked.java
@@ -24,21 +24,16 @@
  */
 package org.spongepowered.api.event.cause;
 
-import com.google.common.base.Optional;
-
 /**
  * Something that keeps track of the cause.
  */
 public interface CauseTracked {
 
     /**
-     * Get the last cause.
-     *
-     * <p>Parent causes, including possibly the root cause, can be
-     * retrieved using {@link Cause#getParent()}.</p>
+     * Get the cause for the event.
      *
      * @return The last cause
      */
-    Optional<Cause> getCause();
+    Cause getCause();
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/Motive.java
+++ b/src/main/java/org/spongepowered/api/event/cause/Motive.java
@@ -22,40 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import java.util.UUID;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface Motive {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    UUID getEventUniqueId();
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
@@ -22,40 +22,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.damage;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import com.google.common.base.Function;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
+ * Represents a modifier that will apply a function on a damage value to
+ * deal towards an entity such that the raw damage is the input of a
+ * {@link Function} such that the output will be the final damage applied
+ * to the {@link Entity}.
  */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface DamageModifier {
 
     /**
-     * Gets the old health data of the {@link Living}.
+     * Gets the cause of this {@link DamageModifier}.
      *
-     * @return The old health data.
+     * @return The cause of this damage modifier
      */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    Cause getCause();
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifiers.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifiers.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.cause.entity.damage;
+
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.cause.entity.damage.source.FallingBlockDamageSource;
+import org.spongepowered.api.item.Enchantment;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.potion.PotionEffect;
+import org.spongepowered.api.potion.PotionEffectTypes;
+
+/**
+ * An index of known vanilla {@link DamageModifier}s that can be applied by
+ * an {@link Entity}.
+ */
+public final class DamageModifiers {
+
+    private DamageModifiers() {
+    }
+
+    /**
+     * Represents the {@link DamageModifier} that will modify damage from
+     * an {@link Enchantment} on an equipped {@link ItemStack}.
+     */
+    public static final DamageModifier WEAPON_ENCHANTMENT = null;
+    /**
+     * Represents the {@link DamageModifier} that will increase damage from
+     * a {@link PotionEffect} affecting the attacker.
+     */
+    public static final DamageModifier OFFENSIVE_POTION_EFFECT = null;
+    /**
+     * Represents the {@link DamageModifier} that will modify damage from
+     * a {@link FallingBlockDamageSource}.
+     */
+    public static final DamageModifier HARD_HAT = null;
+    /**
+     * Represents a {@link DamageModifier} that will reduce damage due to
+     * an attempt at blocking.
+     */
+    public static final DamageModifier BLOCKING = null;
+    /**
+     * Represents a {@link DamageModifier} that will reduce damage based on
+     * the armor {@link ItemStack}s.
+     */
+    public static final DamageModifier ARMOR = null;
+    /**
+     * Represents a {@link DamageModifier} that will reduce damage based on
+     * the {@link PotionEffectTypes#RESISTANCE}.
+     */
+    public static final DamageModifier DEFENSIVE_POTION_EFFECT = null;
+    /**
+     * Represents a {@link DamageModifier} that will modify damage based on
+     * magic.
+     */
+    public static final DamageModifier MAGIC = null;
+    /**
+     * Represents a {@link DamageModifier} that "absorbs" damage based on
+     * the {@link PotionEffectTypes#ABSORPTION} level on the
+     * {@link Entity}.
+     */
+    public static final DamageModifier ABSORPTION = null;
+
+}

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageType.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageType.java
@@ -22,40 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.damage;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
-
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+@CatalogedBy(DamageTypes.class)
+public interface DamageType extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageTypes.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageTypes.java
@@ -22,40 +22,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.damage;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public final class DamageTypes {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
+    public static final DamageType CONTACT = null;
+    public static final DamageType EXPLOSIVE = null;
+    public static final DamageType FIRE = null;
+    public static final DamageType MAGIC = null;
+    public static final DamageType PROJECTILE = null;
+    public static final DamageType PLUGIN = null;
 
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    private DamageTypes() {}
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/package-info.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/package-info.java
@@ -22,40 +22,4 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
-
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
-
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
-
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.event.cause.entity.damage;

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/BlockDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/BlockDamageSource.java
@@ -22,40 +22,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.damage.source;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.world.Location;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface BlockDamageSource extends DamageSource {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
+    Location getLocation();
 
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    BlockState getBlockState();
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/BlockDamageSourceBuilder.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/BlockDamageSourceBuilder.java
@@ -22,4 +22,42 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.event.cause.reason;
+package org.spongepowered.api.event.cause.entity.damage.source;
+
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.event.cause.entity.damage.DamageType;
+import org.spongepowered.api.world.Location;
+
+public interface BlockDamageSourceBuilder extends DamageSourceBuilder {
+
+    @Override
+    BlockDamageSourceBuilder affectsCreativeMode();
+
+    @Override
+    BlockDamageSourceBuilder scalesWithDifficulty();
+
+    @Override
+    BlockDamageSourceBuilder bypassesArmor();
+
+    @Override
+    BlockDamageSourceBuilder blockable();
+
+    @Override
+    BlockDamageSourceBuilder explosion();
+
+    @Override
+    BlockDamageSourceBuilder absolute();
+
+    @Override
+    BlockDamageSourceBuilder magical();
+
+    @Override
+    BlockDamageSourceBuilder type(DamageType damageType);
+
+    BlockDamageSourceBuilder block(Location location);
+
+    BlockDamageSourceBuilder block(BlockState blockState);
+
+    @Override
+    BlockDamageSource build() throws IllegalStateException;
+}

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSource.java
@@ -1,0 +1,102 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.cause.entity.damage.source;
+
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.Motive;
+import org.spongepowered.api.event.cause.entity.damage.DamageType;
+import org.spongepowered.api.world.difficulty.Difficulty;
+
+/**
+ * Represents a {@link Cause} for damage on the {@link Entity} being
+ * damaged. Usually the {@link DamageSource} will have different properties
+ * based on the source of damage, such as {@link EntityDamageSource}s,
+ * {@link BlockDamageSource}s, and {@link FallingBlockDamageSource}s.
+ *
+ * <p>Almost always, the {@link DamageSource} will be the first element in
+ * the {@link Cause} of the event. Any additional modifiers that "aid" the
+ * {@link Cause} of the event will be listed subsequently.</p>
+ */
+public interface DamageSource extends Motive {
+
+    DamageType getDamageType();
+
+    /**
+     * Gets whether this {@link DamageSource} is blockable by weapon
+     * blocking.
+     *
+     * @return True if the source can be blocked
+     */
+    boolean isBlockable();
+
+    /**
+     * Gets whether this {@link DamageSource} can not be modified and the
+     * damage is absolute.
+     *
+     * @return If this damage source deals absolute damage
+     */
+    boolean isAbsolute();
+
+    /**
+     * Gets whether this {@link DamageSource} will deal damage that
+     * bypasses any armor.
+     *
+     * @return True if this damage source bypasses armor
+     */
+    boolean isBypassingArmor();
+
+    /**
+     * Gets whether this {@link DamageSource}'s damage is scaled by
+     * {@link Difficulty}.
+     *
+     * @return True if the damage from this source is scaled
+     */
+    boolean isDifficultyScaled();
+
+    /**
+     * Gets whether this {@link DamageSource} is an explosion.
+     *
+     * @return True if this damage source is an explosion
+     */
+    boolean isExplosion();
+
+    /**
+     * Gets whether this {@link DamageSource} is starvation based, and
+     * therefor should be considered to bypass armor and other resistances.
+     *
+     * @return If this damage is starvation based
+     */
+    boolean isStarvationBased();
+
+    /**
+     * Gets whether this {@link DamageSource} is considered to be magical
+     * damage, such as potions, or other sources.
+     *
+     * @return If this damage is magic based
+     */
+    boolean isMagic();
+
+}

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSourceBuilder.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSourceBuilder.java
@@ -22,40 +22,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.damage.source;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.event.cause.entity.damage.DamageType;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface DamageSourceBuilder {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
+    DamageSourceBuilder affectsCreativeMode();
 
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
+    DamageSourceBuilder scalesWithDifficulty();
 
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    DamageSourceBuilder bypassesArmor();
+
+    DamageSourceBuilder blockable();
+
+    DamageSourceBuilder explosion();
+
+    DamageSourceBuilder absolute();
+
+    DamageSourceBuilder magical();
+
+    DamageSourceBuilder type(DamageType damageType);
+
+    DamageSource build() throws IllegalStateException;
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSources.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSources.java
@@ -22,40 +22,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.damage.source;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+public final class DamageSources {
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
-
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    public static final DamageSource POISON = null;
+    public static final DamageSource EXPLOSION = null;
+    public static final DamageSource MELTING = null;
+    public static final DamageSource IN_FIRE = null;
+    public static final DamageSource LIGHTNING = null;
+    public static final DamageSource FIRE_TICK = null;
+    public static final BlockDamageSource LAVA = null;
+    public static final BlockDamageSource IN_WALL = null;
+    public static final DamageSource DROWNING = null;
+    public static final EntityDamageSource STARVATION = null;
+    public static final BlockDamageSource CONTACT = null;
+    public static final DamageSource FALLING = null;
+    public static final DamageSource VOID = null;
+    public static final DamageSource GENERIC = null;
+    public static final DamageSource MAGIC = null;
+    public static final DamageSource WITHER = null;
+    public static final EntityDamageSource ANVIL = null;
+    public static final FallingBlockDamageSource FALLING_BLOCK = null;
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/EntityDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/EntityDamageSource.java
@@ -22,15 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.player.fishing;
+package org.spongepowered.api.event.cause.entity.damage.source;
 
-import org.spongepowered.api.event.entity.living.human.fishing.HumanFishEvent;
-import org.spongepowered.api.event.entity.player.PlayerEvent;
+import org.spongepowered.api.entity.Entity;
 
-/**
- * Called when a {@link org.spongepowered.api.entity.player.Player} performs
- * a fishing-related action
- */
-public interface PlayerFishEvent extends HumanFishEvent, PlayerEvent {
+public interface EntityDamageSource extends DamageSource {
+
+    Entity getSource();
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/EntityDamageSourceBuilder.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/EntityDamageSourceBuilder.java
@@ -22,40 +22,40 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.damage.source;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.cause.entity.damage.DamageType;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface EntityDamageSourceBuilder extends DamageSourceBuilder {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
+    @Override
+    EntityDamageSourceBuilder affectsCreativeMode();
 
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
+    @Override
+    EntityDamageSourceBuilder scalesWithDifficulty();
 
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    @Override
+    EntityDamageSourceBuilder bypassesArmor();
+
+    @Override
+    EntityDamageSourceBuilder blockable();
+
+    @Override
+    EntityDamageSourceBuilder explosion();
+
+    @Override
+    EntityDamageSourceBuilder absolute();
+
+    @Override
+    EntityDamageSourceBuilder magical();
+
+    @Override
+    EntityDamageSourceBuilder type(DamageType damageType);
+
+    EntityDamageSourceBuilder entity(Entity entity);
+
+    @Override
+    EntityDamageSource build() throws IllegalStateException;
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/FallingBlockDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/FallingBlockDamageSource.java
@@ -22,40 +22,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.damage.source;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableFallingBlockData;
+import org.spongepowered.api.entity.FallingBlock;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface FallingBlockDamageSource extends EntityDamageSource {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
+    @Override
+    FallingBlock getSource();
 
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
-
+    ImmutableFallingBlockData getFallingBlockData();
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/FallingBlockDamageSourceBuilder.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/FallingBlockDamageSourceBuilder.java
@@ -22,40 +22,43 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.damage.source;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.FallingBlock;
+import org.spongepowered.api.event.cause.entity.damage.DamageType;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface FallingBlockDamageSourceBuilder extends EntityDamageSourceBuilder {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
+    @Override
+    FallingBlockDamageSourceBuilder scalesWithDifficulty();
 
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
+    @Override
+    FallingBlockDamageSourceBuilder bypassesArmor();
 
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    @Override
+    FallingBlockDamageSourceBuilder blockable();
 
+    @Override
+    FallingBlockDamageSourceBuilder explosion();
+
+    @Override
+    FallingBlockDamageSourceBuilder absolute();
+
+    @Override
+    FallingBlockDamageSourceBuilder magical();
+
+    @Override
+    FallingBlockDamageSourceBuilder entity(Entity entity);
+
+    @Override
+    FallingBlockDamageSourceBuilder affectsCreativeMode();
+
+    @Override
+    FallingBlockDamageSourceBuilder type(DamageType damageType);
+
+    FallingBlockDamageSourceBuilder fallingBlock(FallingBlock fallingBlock);
+
+    @Override
+    FallingBlockDamageSource build() throws IllegalStateException;
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/ProjectileDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/ProjectileDamageSource.java
@@ -22,40 +22,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.damage.source;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.entity.projectile.Projectile;
+import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface ProjectileDamageSource extends EntityDamageSource {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
+    @Override
+    Projectile getSource();
 
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    ProjectileSource getShooter();
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/ProjectileDamageSourceBuilder.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/ProjectileDamageSourceBuilder.java
@@ -22,40 +22,44 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.damage.source;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.projectile.Projectile;
+import org.spongepowered.api.event.cause.entity.damage.DamageType;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface ProjectileDamageSourceBuilder extends EntityDamageSourceBuilder {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
+    @Override
+    ProjectileDamageSourceBuilder affectsCreativeMode();
 
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
+    @Override
+    ProjectileDamageSourceBuilder scalesWithDifficulty();
 
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    @Override
+    ProjectileDamageSourceBuilder bypassesArmor();
+
+    @Override
+    ProjectileDamageSourceBuilder blockable();
+
+    @Override
+    ProjectileDamageSourceBuilder explosion();
+
+    @Override
+    ProjectileDamageSourceBuilder absolute();
+
+    @Override
+    ProjectileDamageSourceBuilder magical();
+
+    @Override
+    ProjectileDamageSourceBuilder entity(Entity entity);
+
+    @Override
+    ProjectileDamageSourceBuilder type(DamageType damageType);
+
+    ProjectileDamageSourceBuilder projectile(Projectile projectile);
+
+    @Override
+    ProjectileDamageSource build() throws IllegalStateException;
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/package-info.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/package-info.java
@@ -22,40 +22,4 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
-
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
-
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
-
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.event.cause.entity.damage.source;

--- a/src/main/java/org/spongepowered/api/event/cause/entity/package-info.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/package-info.java
@@ -22,40 +22,4 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
-
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
-
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
-
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.event.cause.entity;

--- a/src/main/java/org/spongepowered/api/event/cause/entity/spawn/BlockSpawnCause.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/spawn/BlockSpawnCause.java
@@ -22,40 +22,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.spawn;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.world.Location;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface BlockSpawnCause extends SpawnCause {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
+    Location getLocation();
 
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    BlockState getBlockState();
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/spawn/BreedingSpawnCause.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/spawn/BreedingSpawnCause.java
@@ -22,40 +22,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.spawn;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.entity.Entity;
 
 /**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
+ * A {@link SpawnCause} that involves two entities that "mate" to breed a new
+ * {@link Entity}.
  */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface BreedingSpawnCause extends EntitySpawnCause {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    Entity getMate();
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/spawn/EntitySpawnCause.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/spawn/EntitySpawnCause.java
@@ -22,40 +22,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.spawn;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.cause.Motive;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface EntitySpawnCause extends SpawnCause, Motive {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    Entity getEntity();
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/spawn/MobSpawnerSpawnCause.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/spawn/MobSpawnerSpawnCause.java
@@ -22,4 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living.human.fishing;
+package org.spongepowered.api.event.cause.entity.spawn;
+
+import org.spongepowered.api.data.manipulator.immutable.ImmutableMobSpawnerData;
+
+public interface MobSpawnerSpawnCause extends SpawnCause {
+
+    ImmutableMobSpawnerData getMobSpawnerData();
+
+}

--- a/src/main/java/org/spongepowered/api/event/cause/entity/spawn/SpawnCause.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/spawn/SpawnCause.java
@@ -22,40 +22,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.spawn;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.data.manipulator.mutable.MobSpawnerData;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.entity.EntitySpawnEvent;
 
 /**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
+ * Represents a specific cause for an {@link EntitySpawnEvent} such that
+ * the cause has more information relevant to the "reason" for an entity spawn,
+ * such as {@link MobSpawnerSpawnCause} linking to the {@link MobSpawnerData}
+ * related to spawning the {@link Entity}.
  */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface SpawnCause {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    SpawnType getType();
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/spawn/SpawnType.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/spawn/SpawnType.java
@@ -22,31 +22,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living.human.fishing;
+package org.spongepowered.api.event.cause.entity.spawn;
 
-import com.google.common.base.Optional;
-import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.event.entity.living.human.HumanEvent;
+import org.spongepowered.api.CatalogType;
 
-import javax.annotation.Nullable;
 
-/**
- * Called when a {@link org.spongepowered.api.entity.living.Human} hooks an
- * {@link Entity} with a fishing rod.
- */
-public interface HumanHookedEntityEvent extends HumanFishEvent, HumanEvent {
+public interface SpawnType extends CatalogType {
 
-    /**
-     * Gets the {@link Entity} hooked, if available.
-     *
-     * @return The hooked {@link Entity}
-     */
-    Optional<Entity> getCaughtEntity();
-
-    /**
-     * Sets the {@link Entity} hooked, if available.
-     *
-     * @param entity The hooked {@link Entity} to set
-     */
-    void setCaughtEntity(@Nullable Entity entity);
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/spawn/SpawnTypes.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/spawn/SpawnTypes.java
@@ -22,14 +22,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.cause.reason;
+package org.spongepowered.api.event.cause.entity.spawn;
 
-import org.spongepowered.api.event.cause.Cause;
+public final class SpawnTypes {
 
-/**
- * A reason explains a {@link Cause}. For example, a cause might be a fire
- * block, and the reason would be fire spread.
- */
-public interface Reason {
+    private SpawnTypes() {}
+
+    public static final SpawnType BLOCK_SPAWNING = null;
+    public static final SpawnType BREEDING = null;
+    public static final SpawnType DISPENSE = null;
+    public static final SpawnType DROPPED_ITEM = null;
+    public static final SpawnType EXPERIENCE = null;
+    public static final SpawnType FALLING_BLOCK = null;
+    public static final SpawnType MOB_SPAWNER = null;
+    public static final SpawnType PASSIVE = null;
+    public static final SpawnType PLACEMENT = null;
+    public static final SpawnType PROJECTILE = null;
+    public static final SpawnType SPAWN_EGG = null;
+    public static final SpawnType STRUCTURE = null;
+    public static final SpawnType TNT_IGNITE = null;
+    public static final SpawnType WEATHER = null;
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/spawn/WeatherSpawnCause.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/spawn/WeatherSpawnCause.java
@@ -22,5 +22,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.player.fishing;
+package org.spongepowered.api.event.cause.entity.spawn;
 
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.world.weather.Weather;
+
+/**
+ * Signifies that a spawn was caused by a specific {@link Weather} state.
+ */
+public interface WeatherSpawnCause extends SpawnCause {
+
+    /**
+     * Gets the current {@link Weather} state that caused the {@link Entity} to
+     * spawn.
+     *
+     * @return The weather state causing the spawn
+     */
+    Weather getWeather();
+
+}

--- a/src/main/java/org/spongepowered/api/event/cause/entity/spawn/package-info.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/spawn/package-info.java
@@ -22,14 +22,4 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.player.fishing;
-
-import org.spongepowered.api.event.entity.living.human.fishing.HumanRetractFishingLineEvent;
-
-/**
- * Called when a {@link org.spongepowered.api.entity.player.Player} retracts
- * a fishing line.
- */
-public interface PlayerRetractFishingLineEvent extends HumanRetractFishingLineEvent, PlayerFishEvent {
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.event.cause.entity.spawn;

--- a/src/main/java/org/spongepowered/api/event/cause/entity/teleport/EntityTeleportCause.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/teleport/EntityTeleportCause.java
@@ -22,40 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.teleport;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.entity.Entity;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface EntityTeleportCause extends TeleportCause {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    Entity getTeleporter();
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/teleport/TeleportCause.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/teleport/TeleportCause.java
@@ -22,12 +22,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living.human.fishing;
+package org.spongepowered.api.event.cause.entity.teleport;
+
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.monster.Enderman;
+import org.spongepowered.api.event.entity.EntityTeleportEvent;
 
 /**
- * Called when a {@link org.spongepowered.api.entity.living.Human} casts
- * a fishing line.
+ * Represents a cause for a {@link EntityTeleportEvent} such that there is an
+ * associated {@link TeleportType} and possibly, an object associated with the
+ * type.
+ *
+ * Examples may include {@link EntityTeleportCause} for an {@link Enderman}
+ * teleporting away from rain, or a {@link Entity} entering a nether portal.
  */
-public interface HumanCastFishingLineEvent extends HumanFishEvent {
+public interface TeleportCause {
+
+    /**
+     * Gets the type of the teleport.
+     *
+     * @return The type of teleport
+     */
+    TeleportType getTeleportType();
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/teleport/TeleportType.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/teleport/TeleportType.java
@@ -22,40 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.teleport;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
-
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+@CatalogedBy(TeleportTypes.class)
+public interface TeleportType extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/teleport/TeleportTypes.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/teleport/TeleportTypes.java
@@ -22,40 +22,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.teleport;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+public final class TeleportTypes {
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+    public static final TeleportType COMMAND = null;
+    public static final TeleportType PLUGIN = null;
+    public static final TeleportType NETHER_PORTAL = null;
+    public static final TeleportType END_PORTAL = null;
+    public static final TeleportType ENDER_PEARL = null;
+    public static final TeleportType ENTITY_TELEPORT = null;
+    public static final TeleportType UNKNOWN = null;
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    private TeleportTypes() {}
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/teleport/TeleporterTeleportCause.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/teleport/TeleporterTeleportCause.java
@@ -22,40 +22,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.cause.entity.teleport;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+public interface TeleporterTeleportCause extends TeleportCause {
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
-
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    //Teleporter getTeleporter(); // todo when we make Teleporters!0
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/EntityDamageEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityDamageEvent.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.entity;
+
+import com.google.common.base.Function;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.cause.CauseTracked;
+import org.spongepowered.api.event.cause.entity.damage.DamageModifier;
+import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
+import org.spongepowered.api.util.Tuple;
+
+import java.util.List;
+/**
+ * An event that is fired when raw damage is being applied to an
+ * {@link Entity}. Since the event is processed when the entity is being
+ * damaged, all the available {@link DamageModifier}s provided are originating
+ * from the {@link Entity} being damaged, not from the {@link DamageSource}.
+ * Any
+ */
+public interface EntityDamageEvent extends EntityEvent, CauseTracked, Cancellable {
+
+    /**
+     * Gets the old health of the {@link Entity}.
+     *
+     * @return The old health.
+     */
+    double getOriginalDamage();
+
+    double getBaseDamage();
+
+    void setBaseDamage(double baseDamage);
+
+    /**
+     * Gets the new health of the {@link Entity}.
+     *
+     * @return The new health.
+     */
+    double getFinalDamage();
+
+    /**
+     * Sets the new health of the {@link Entity}.
+     *
+     * @param newHealth The new health
+     */
+    void setDamage(double newHealth);
+
+    double getOriginalDamage(DamageModifier damageModifier);
+
+    double getDamage(DamageModifier damageModifier);
+
+    void setDamage(DamageModifier damageModifier, double damage);
+
+    void setDamageFunction(DamageModifier damageFunction, Function<? super Double, Double> function);
+
+    /**
+     * Gets a list of simple {@link Tuple}s of {@link DamageModifier} keyed to
+     * their representative {@link Function}s. All {@link DamageModifier}s are
+     * applicable to the entity based on the {@link DamageSource} and any
+     * possible invulnerabilities due to the {@link DamageSource}.
+     *
+     * @return A list of damage modifiers to functions
+     */
+    List<Tuple<DamageModifier, Function<? super Double, Double>>> getModifiers();
+
+    void setModifierFunctions(List<Tuple<DamageModifier, Function<? super Double, Double>>> functions);
+
+
+}

--- a/src/main/java/org/spongepowered/api/event/entity/EntityHealEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityHealEvent.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of SpongeAPI, licensed under the MIT License (MIT).
  *
- * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
  * Copyright (c) contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,40 +22,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
+package org.spongepowered.api.event.entity;
+
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface EntityHealEvent extends EntityEvent, CauseTracked, Cancellable {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
+    double getOriginalHealAmount();
 
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
+    double getBaseHealAmount();
 
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    void setBaseHealAmount(double healAmount);
+
+    double getFinalHealAmount();
+
+    void setHealAmount(double healAmount);
+
+
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/EntityPreDamageEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/EntityPreDamageEvent.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.entity;
+
+import com.google.common.base.Function;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.cause.CauseTracked;
+import org.spongepowered.api.event.cause.entity.damage.DamageModifier;
+import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
+import org.spongepowered.api.item.Enchantment;
+import org.spongepowered.api.potion.PotionEffect;
+import org.spongepowered.api.util.Tuple;
+
+import java.util.List;
+
+/**
+ * An event that is specifically called prior to the {@link EntityDamageEvent}
+ * such that the damage that will be dealt is modified based on various
+ * {@link DamageModifier}s.
+ *
+ * <p>Examples of when this event is used: A skeleton's arrow hitting an
+ * {@link Entity}, A player attacking another {@link Entity}.</p>
+ *
+ * <p>With this event, all {@link DamageModifier}s are modifying the damage
+ * being dealt by the attacker, examples include: {@link Enchantment}s,
+ * {@link PotionEffect}s, etc.</p>
+ */
+public interface EntityPreDamageEvent extends EntityEvent, CauseTracked, Cancellable {
+
+    double getOriginalDamage();
+
+    double getBaseDamage();
+
+    void setBaseDamage(double baseDamage);
+
+    /**
+     * Gets the final damage that will be passed in to the
+     * {@link EntityDamageEvent}.
+     *
+     * @return The new health.
+     */
+    double getFinalDamage();
+
+    /**
+     * Sets the new health of the {@link Entity}.
+     *
+     * @param newHealth The new health
+     */
+    void setDamage(double newHealth);
+
+    double getOriginalDamage(DamageModifier damageModifier);
+
+    double getDamage(DamageModifier damageModifier);
+
+    void setDamage(DamageModifier damageModifier, double damage);
+
+    void setDamageFunction(DamageModifier damageFunction, Function<? super Double, Double> function);
+
+    /**
+     * Gets a list of simple {@link Tuple}s of {@link DamageModifier} keyed to
+     * their representative {@link Function}s. All {@link DamageModifier}s are
+     * applicable to the entity based on the {@link DamageSource} and any
+     * possible invulnerabilities due to the {@link DamageSource}.
+     *
+     * @return A list of damage modifiers to functions
+     */
+    List<Tuple<DamageModifier, Function<? super Double, Double>>> getModifiers();
+
+    void setModifierFunctions(List<Tuple<DamageModifier, Function<? super Double, Double>>> functions);
+
+
+}

--- a/src/main/java/org/spongepowered/api/event/entity/living/LivingDamageEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/LivingDamageEvent.java
@@ -24,38 +24,8 @@
  */
 package org.spongepowered.api.event.entity.living;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
 import org.spongepowered.api.event.entity.EntityDamageEvent;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
-
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+public interface LivingDamageEvent extends LivingEvent, EntityDamageEvent {
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/living/human/HumanCastFishingLineEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/human/HumanCastFishingLineEvent.java
@@ -22,40 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
-
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+package org.spongepowered.api.event.entity.living.human;
 
 /**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
+ * Called when a {@link org.spongepowered.api.entity.living.Human} casts
+ * a fishing line.
  */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
-
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+public interface HumanCastFishingLineEvent extends HumanFishEvent {
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/living/human/HumanDamageEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/human/HumanDamageEvent.java
@@ -22,40 +22,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.entity.living.human;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.event.entity.living.LivingDamageEvent;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
-
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+public interface HumanDamageEvent extends HumanEvent, LivingDamageEvent {
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/living/human/HumanFishEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/human/HumanFishEvent.java
@@ -22,46 +22,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living.human.fishing;
+package org.spongepowered.api.event.entity.living.human;
 
-import com.google.common.base.Optional;
-import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.event.ExperienceEvent;
-import org.spongepowered.api.item.inventory.ItemStack;
-
-import javax.annotation.Nullable;
+import org.spongepowered.api.entity.projectile.FishHook;
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.entity.living.human.HumanEvent;
 
 /**
- * Called when a {@link org.spongepowered.api.entity.living.Human} retracts
- * a fishing line.
+ * Called when a {@link org.spongepowered.api.entity.living.Human} performs
+ * a fishing-related action.
  */
-public interface HumanRetractFishingLineEvent extends HumanFishEvent, ExperienceEvent {
+public interface HumanFishEvent extends HumanEvent, Cancellable {
 
     /**
-     * Gets the {@link ItemStack} that will be given, if available.
+     * Gets the {@link FishHook} used in this event.
      *
-     * @return The {@link ItemStack} that will be given
+     * @return The {@link FishHook used} in this event
      */
-    Optional<ItemStack> getCaughtItem();
-
-    /**
-     * Sets the {@link ItemStack} that will be given, if available.
-     *
-     * @param item The {@link ItemStack} to set
-     */
-    void setCaughtItem(@Nullable ItemStack item);
-
-    /**
-     * Gets the {@link Entity} hooked, if available.
-     *
-     * @return The hooked {@link Entity}
-     */
-    Optional<Entity> getCaughtEntity();
-
-    /**
-     * Sets the {@link Entity} hooked, if available.
-     *
-     * @param entity The hooked {@link Entity} to set
-     */
-    void setCaughtEntity(@Nullable Entity entity);
+    FishHook getFishHook();
 }

--- a/src/main/java/org/spongepowered/api/event/entity/living/human/HumanHookedEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/human/HumanHookedEntityEvent.java
@@ -22,40 +22,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.entity.living.human;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import com.google.common.base.Optional;
+import org.spongepowered.api.entity.Entity;
+
+import javax.annotation.Nullable;
 
 /**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
+ * Called when a {@link org.spongepowered.api.entity.living.Human} hooks an
+ * {@link Entity} with a fishing rod.
  */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface HumanHookedEntityEvent extends HumanFishEvent, HumanEvent {
 
     /**
-     * Gets the old health data of the {@link Living}.
+     * Gets the {@link Entity} hooked, if available.
      *
-     * @return The old health data.
+     * @return The hooked {@link Entity}
      */
-    HealthData getOldData();
+    Optional<Entity> getCaughtEntity();
 
     /**
-     * Gets the new health data of the {@link Living}.
+     * Sets the {@link Entity} hooked, if available.
      *
-     * @return The new health data.
+     * @param entity The hooked {@link Entity} to set
      */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
-
+    void setCaughtEntity(@Nullable Entity entity);
 }

--- a/src/main/java/org/spongepowered/api/event/entity/living/human/HumanRetractFishingLineEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/human/HumanRetractFishingLineEvent.java
@@ -22,40 +22,46 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.entity.living.human;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import com.google.common.base.Optional;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.ExperienceEvent;
+import org.spongepowered.api.item.inventory.ItemStack;
+
+import javax.annotation.Nullable;
 
 /**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
+ * Called when a {@link org.spongepowered.api.entity.living.Human} retracts
+ * a fishing line.
  */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public interface HumanRetractFishingLineEvent extends HumanFishEvent, ExperienceEvent {
 
     /**
-     * Gets the old health data of the {@link Living}.
+     * Gets the {@link ItemStack} that will be given, if available.
      *
-     * @return The old health data.
+     * @return The {@link ItemStack} that will be given
      */
-    HealthData getOldData();
+    Optional<ItemStack> getCaughtItem();
 
     /**
-     * Gets the new health data of the {@link Living}.
+     * Sets the {@link ItemStack} that will be given, if available.
      *
-     * @return The new health data.
+     * @param item The {@link ItemStack} to set
      */
-    HealthData getNewData();
+    void setCaughtItem(@Nullable ItemStack item);
 
     /**
-     * Sets the new health data of the {@link Living}.
+     * Gets the {@link Entity} hooked, if available.
      *
-     * @param newData The new health data
+     * @return The hooked {@link Entity}
      */
-    void setNewData(HealthData newData);
+    Optional<Entity> getCaughtEntity();
 
+    /**
+     * Sets the {@link Entity} hooked, if available.
+     *
+     * @param entity The hooked {@link Entity} to set
+     */
+    void setCaughtEntity(@Nullable Entity entity);
 }

--- a/src/main/java/org/spongepowered/api/event/entity/player/PlayerCastFishingLineEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/player/PlayerCastFishingLineEvent.java
@@ -22,9 +22,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.player.fishing;
+package org.spongepowered.api.event.entity.player;
 
-import org.spongepowered.api.event.entity.living.human.fishing.HumanCastFishingLineEvent;
+import org.spongepowered.api.event.entity.living.human.HumanCastFishingLineEvent;
 
 /**
  * Called when a {@link org.spongepowered.api.entity.player.Player} casts

--- a/src/main/java/org/spongepowered/api/event/entity/player/PlayerDamageEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/player/PlayerDamageEvent.java
@@ -22,40 +22,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.entity.player;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.event.entity.living.human.HumanDamageEvent;
 
-/**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
- */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
-
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+public interface PlayerDamageEvent extends PlayerEvent, HumanDamageEvent {
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/player/PlayerFishEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/player/PlayerFishEvent.java
@@ -22,22 +22,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living.human.fishing;
+package org.spongepowered.api.event.entity.player;
 
-import org.spongepowered.api.entity.projectile.FishHook;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.entity.living.human.HumanEvent;
+import org.spongepowered.api.event.entity.living.human.HumanFishEvent;
+import org.spongepowered.api.event.entity.player.PlayerEvent;
 
 /**
- * Called when a {@link org.spongepowered.api.entity.living.Human} performs
- * a fishing-related action.
+ * Called when a {@link org.spongepowered.api.entity.player.Player} performs
+ * a fishing-related action
  */
-public interface HumanFishEvent extends HumanEvent, Cancellable {
+public interface PlayerFishEvent extends HumanFishEvent, PlayerEvent {
 
-    /**
-     * Gets the {@link FishHook} used in this event.
-     *
-     * @return The {@link FishHook used} in this event
-     */
-    FishHook getFishHook();
 }

--- a/src/main/java/org/spongepowered/api/event/entity/player/PlayerHookedEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/player/PlayerHookedEntityEvent.java
@@ -22,9 +22,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.player.fishing;
+package org.spongepowered.api.event.entity.player;
 
-import org.spongepowered.api.event.entity.living.human.fishing.HumanHookedEntityEvent;
+import org.spongepowered.api.event.entity.living.human.HumanHookedEntityEvent;
 
 /**
  * Called when a {@link org.spongepowered.api.entity.player.Player} hooks an

--- a/src/main/java/org/spongepowered/api/event/entity/player/PlayerRetractFishingLineEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/player/PlayerRetractFishingLineEvent.java
@@ -22,40 +22,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.event.entity.player;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import org.spongepowered.api.event.entity.living.human.HumanRetractFishingLineEvent;
 
 /**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
+ * Called when a {@link org.spongepowered.api.entity.player.Player} retracts
+ * a fishing line.
  */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
-
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
-
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
-
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+public interface PlayerRetractFishingLineEvent extends HumanRetractFishingLineEvent, PlayerFishEvent {
 
 }

--- a/src/main/java/org/spongepowered/api/util/Tuple.java
+++ b/src/main/java/org/spongepowered/api/util/Tuple.java
@@ -22,40 +22,52 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.entity.living;
+package org.spongepowered.api.util;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
-import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.CauseTracked;
-import org.spongepowered.api.event.entity.EntityDamageEvent;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Objects;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
- * An event that is processed after any {@link EntityDamageEvent}s or when the
- * {@link Living} entity is healed. This is a post event after all damage has been
- * calculated.
+ * A tuple of objects. This can be considered a {@link Pair}
+ * @param <K> 
+ * @param <V>
  */
-public interface LivingChangeHealthEvent extends LivingEvent, CauseTracked, Cancellable {
+public class Tuple<K, V> {
 
-    /**
-     * Gets the old health data of the {@link Living}.
-     *
-     * @return The old health data.
-     */
-    HealthData getOldData();
+    private final K first;
+    private final V second;
 
-    /**
-     * Gets the new health data of the {@link Living}.
-     *
-     * @return The new health data.
-     */
-    HealthData getNewData();
+    public Tuple(K first, V second) {
+        this.first = checkNotNull(first);
+        this.second = checkNotNull(second);
+    }
 
-    /**
-     * Sets the new health data of the {@link Living}.
-     *
-     * @param newData The new health data
-     */
-    void setNewData(HealthData newData);
+    public K getFirst() {
+        return this.first;
+    }
 
+    public V getSecond() {
+        return this.second;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.first, this.second);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final Tuple other = (Tuple) obj;
+        return Objects.equal(this.first, other.first)
+                && Objects.equal(this.second, other.second);
+    }
 }


### PR DESCRIPTION
So far, [`Cause`](https://github.com/SpongePowered/SpongeAPI/blob/master/src/main/java/org/spongepowered/api/event/cause/Cause.java) as it stands is somewhat confusing with the inclusion of [`Reason`](https://github.com/SpongePowered/SpongeAPI/blob/master/src/main/java/org/spongepowered/api/event/cause/reason/Reason.java) such that it isn't clear as to what should be considered a `Cause` and what should be considered a `Reason`.

This PR aims to achieve the following:
- `Cause` becomes a container object of all related objects associated with the cause for a `CauseTracked` event
- "Reasons" or additional causes aiding the direct cause for an event are included in `Cause`, the closer the association to the direct cause, the lower the index that object will be
- Include `EntityDamageEvent` and `DamageSource`s while keeping in line with the primary `Cause` goal. Any additional associated objects aiding the direct `DamageSource` are included in the `Cause` associated with the `EntityDamageEvent`
- Introduce `EntityPreDamageEvent` where the damage calculations for modifying the raw damage are included, this is primarily used for modifying the outgoing damage BEFORE the `EntityDamageEvent` is fired, this is equivalent to having an event to modify the damage a `Player` will output when using an `ItemStack` of `ItemTypes.DIAMOND_SWORD` such that all modifiers are included (such as the enchantments on the sword, the potion effects, and any other `AttributeModifier`s or alternative `DamageModifier`s relating to the final raw damage output from the `Player`
- For many `CauseTrack`ed events, the `Cause` now is always available, but a `Cause.empty()` may be included


#### So what does this really mean for `CauseTracked` events?

What this means is that a vanilla interaction throwing a `CauseTracked` event will have as much information as possible within the `Cause`. With the following addition to `Cause`:

```java
<T> Optional<T> getFirst(Class<T>);

<T> Optional<T> getLast(Class<T>);
```

a plugin is easily able to determine whether a `BlockState` was the cause for an event, a `Player`, or if a `TileEntity` was part of the mix. 

The one issue with `Cause` previously was that it was always optional. Passing in a null to the [`SpongeEventFactory`](https://github.com/SpongePowered/SpongeAPI/blob/master/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java#L341) is that the `Cause` is always optional, even when it should not be.  In the PR, I change this to where `Cause` can be "empty". Some might think: *Wait! Isn't that making `Cause` just become a similar object to `Optional`?* To which the answer is yes. The one issue with `Optional` however is that  `Optional` can only hold a single value. There is no way to hold multiple values, except if the `Optional` is declared like so: `Optional<Object[]>`, which eliminates any utility methods provided by `getFirst(Class<T>)` and `getAllOf(Class<T>)` from `Cause`.

#### Ok, so where does this come into play with actual events? I want to know the cause for a `BlockChangeEvent`!

Well, see, this is where the uniqueness comes into play. Since we always have a `Cause`, we can always call `getFirst(Player.class)` which will return a present `Player` if and only if a `Player` was involved in the `BlockChangeEvent`. How the objects are ordered in the `Cause` is simple: The direct cause of the event comes first, any additional "helpers" that aid the *root cause* are indexed afterwards.

I'll give an example here of how a `BlockChangeEvent` could have the order of objects in the cause, for the case of a `Player` placing a `ItemTypes.SAPPLING`.

First, the `Player` is the root cause, because the player is right clicking with the `ItemStack`.
Second, the `ItemStack` follows because the `ItemStack` is a part of the "reason" why the `BlockChangeEvent` is being called.

#### Now, what I haven't seen is how this affects something like `EntityDamageEvent`, care to elaborate?

Of course! With an `EntityDamageEvent`, I'll have to pull the same description from #707 


> Skeleton shoots bow launching an arrow hitting a Player.
>
>This is pretty plain and simple to understand what happens, but we need to look at it much deeper to fully understand what the final damage comes out to:

>I'll give an order of how the damage is calculated:
1) Skeleton is shooting the arrow, by default it will apply say 3 damage to the Arrow
2) The bow, if enchanted applies a bonus amount of damage to the arrow, say 1.5 additional damage
The final raw damage of the arrow is now 4.5.

>Now here comes the fun part:
The Player is hit with the arrow
1) The damage is modified based on the game difficulty, in this case, it's on `HARD` difficulty, so the damage is multiplied by 1.5 (damage is now 6.75)
2) Armor calculations are factored in, Say that the player has full iron armor, and the iron armor reduces the damage by 2 (damage is now at 4.75)
3) Potion effects add to resistances, so damage is reduced by multiplying damage by 20 and dividing by 25 (damage is now at 3.8)
4) Armor Enchantments reduce the damage by 20% for example (the damage is now at 3.04)
5) The Absorption potion effect is now factored in to find out how much actual health is removed from the entity, say we have an additional 2 health from absorption, (damage is now at 1.04)

>The end result is a damage value of 1.04 damage dealt directly to the entity, where 4.5 damage originated.

>The reason why I walked you through all of this is the following: I've been contemplating that we should have a LivingPreAttackEntityEvent of which we can trace the modifiers for the damage being dealt to the entity (in the case of the skeleton shooting, there's the modifier of the bow and the modifier base damage of the skeleton). After that event, we'd need a proper `WeightedCollection` to store the `DamageModifier`s and their `Function`s being applied to the incoming damage for an `EntityDamageEvent`. Considering the limitless possibilities of being able to identify the `DamageModifier`s and the `Cause` for each modifier, I do believe this would make an excellent change with Causes PR in the near future.

What HAS been achieved however, is slightly different. Instead of just including the associated `Entity` as a *root* to the `Cause`, a `DamageSource` is now the *root* cause. A `DamageSource` is essentially a wrapper around any object with a descriptive `DamageType` with various *attributes* of the `DamageSource` including whether the damage is *absolute*, *ignores armor*, *magical*, *explosive*, or even *scaled with difficulty*. The included `DamageSource`s in this PR facilitate understanding the *type* of damage being dealt, and the parties involved in the `DamageSource`.

#### I'm a little confused about `DamageSource`, can you give me an example?

Of course! Say you have an `EntityPreDamageEvent`:

The `DamageSource` in this case is actually a `ProjectileDamageSource`, where the `Projectile` is an `Arrow`, and the `ProjectileSource` is a `Skeleton`. Given that the `ProjectileDamageSource` is the *root* cause to the `EntityPreDamageEvent`, we can then use this information to know that the `Cause` should have a related `ItemStack` used as a *bow* to shoot the *Arrow*. With the *bow*, we know that it can have no `Enchantment`s or it can have some `Enchantment`s. Of course, with these objects in the `Cause`, it makes it plain and clear to use them:

```java
@Subscribe
public void cancelAnvils(EntityPreDamageEvent event) {
    if (event.getCause().isEmpty()) {
        return;
    }
    final Cause cause = event.getCause();
    final Optional<BlockDamageSource> damageSource = cause.getFirst(BlockDamageSource.class);
    if (damageSource.isPresent()) {
        if (damageSource.get().getBlockState().getType() == BlockTypes.ANVIL) {
            event.setCancelled(true);
        }
    }
}

@Subscribe
public void skeletonArrows(EntityPreDamageEvent event) {
    if (event.getCause().isEmpty()) {
        return;
    }
    final Cause cause = event.getCause();
    final Optional<ProjectileDamageSource> projectileDamageSource = cause.getFirst(ProjectileDamageSource.class);
    if (projectileDamageSource.isPresent()) {
        final ProjectileSource source = projectileDamageSource.get().getShooter();
        if (source instanceof Skeleton) {
            final SkeletonType skeletonType = ((Skeleton) source).getData(SkeletonData.class).get().getValue();
            if (skeletonType == SkeletonTypes.WITHER) {
                event.setDamageFunction(new MyDamageModifier(Cause.of(source, this)), new Function<Double, Double>() {
                    @Nullable
                    @Override
                    public Double apply(Double input) {
                        return input * 3 / 2;
                    }
                });
            } else if (skeletonType == SkeletonTypes.NORMAL) {
                event.setDamageFunction(new MyDamageModifier(Cause.of(source, this)), new Function<Double, Double>() {
                    @Nullable
                    @Override
                    public Double apply(Double input) {
                        return input * 3 / 4;
                    }
                });
            }
        }
    }
    for (final Tuple<DamageModifier, Function<? super Double, Double>> damageModifier : event.getModifiers()) {
        if (damageModifier.getFirst().getCause().getFirst(ItemStack.class).isPresent()) {
            // We know that we have an ItemStack that was used in the DamageModifier cause, we can suspect that
            // the ItemStack has some sort of enchantments, or not
            final ItemStack itemStack = damageModifier.getFirst().getCause().getFirst(ItemStack.class).get();
            final Optional<EnchantmentData> dataOptional = itemStack.getData(EnchantmentData.class);
            if (dataOptional.isPresent() && dataOptional.get().get(Enchantments.POWER).isPresent()) {
                event.setDamageFunction(damageModifier.getFirst(), new Function<Double, Double>() {
                    @Nullable
                    @Override
                    public Double apply(@Nullable Double input) {
                        return input * 1.25 * dataOptional.get().get(Enchantments.POWER).get().doubleValue();
                    }
                });
            }
        }
    }
}

public final class MyDamageModifier implements DamageModifier {
    private Cause cause;

    public MyDamageModifier(Cause cause) {
        this.cause = checkNotNull(cause);
    }

    @Override
    public Cause getCause() {
        return this.cause;
    }

    @Override
    public String getId() {
        return "com.gabizou.MyDamageModifier";
    }

    @Override
    public String getName() {
        return "MyDamageModifier";
    }
}
``` 

#### Holy cow batman! Why so complicated?!

Unfortunately, there is A LOT that goes into an `EntityDamageEvent`, even more so if you want to be able to manipulate the damage *coming in*, essentially the `EntityPreDamageEvent`. To fully unlock the power available with this, the possibilities to associate new `DamageModifier`s with a damage event are nigh limitless. Since we can expose the underlying functions, as they placed in order from vanilla mechanics, we can successfully interpret that an `EntityPreDamageEvent` is augmented not only by the `Skeleton`, but also that the `ItemStack` used by the `Skeleton` affects the total damage applied onto the `Arrow`. With that in mind, we can also assume that we can interpret the following `EntityDamageEvent` with similar processing for `DamageModifier`s when an `Entity` is being *damaged*, dictating the *final* damage actually being *applied* to the `Entity`, and not just interpret the *raw* incoming damage.

Of course, there are so many factors that can go into the `EntityDamageEvent` that I can't possibly explain it all in a simple code snippet, but I can explain in layman terms here.

With the `EntityDamageEvent` being fired only while the `Entity` is being damaged, we can gather all `DamageModifier`s that would further process the raw incoming damage, such as `ItemStack`s that are considered to be *armor*, `PotionEffect`s that are absorbing damage, heck, we can even apply our own custom `DamageModifier`s if we had a party plugin that had a "reducing damage" effect based on the number of players joined in the party! All of this is as extensible as possible.

#### Ok... well, it's clear that you've given a lot of thought about `EntityDamageEvent`, but what about other `CauseTracked` events?

Similar to the `EntityDamageEvent` and `EntityPreDamageEvent`, we can safely say that most `CauseTracked` events are going to receive similar treatment with regards to adding additional *sources*/*causes*/*reasons* whatever you want to call them. So far, I've only been able to seriously work on the damage events, however, my thought process is that with `EntitySpawnEvent`, it is very easy to apply the same idea of having the following:

`EntitySpawnEvent`:
 - `SpawnCause` : An abstract *root cause* that aids in helping further understand the `Cause` for why an `Entity` is being spawned
 - `SpawnType` : Another `CatalogType` that aims to further simplify the *type* of `SpawnCause`, more specifically, when an `Entity` is spawned by a `MobSpawner`, the `SpawnCause` would be an instance of a `MobSpawnerSpawnCause` with the associated `MobSpawnerData` that defined the `Entity` to be spawned

`EntityTeleportEvent`:
- `TeleportType` : Yet again, a helper `CatalogType` that aims to make it understandable why an `Entity` is being teleported
- `TeleportCause` : Another *root cause* for the `Entity` to be teleporting, can range from `EntityTeleportCause` (an `Enderman` teleporting due to rain), `TeleporterTeleportCause` (a portal performing the teleport as per vanilla mechanics)

The list will grow as the PR is worked on and time goes on.

#### So, will this make it easy for me to know if a `BlockChangeEvent` was caused by a `Player` using some bonemeal on a sapling?

In a short answer: yes. 
The long answer: The `Cause` would indeed have a `Player` object, and the secondary `cause` would be the `ItemStack` that "aided" in the cause for the `BlockChangeEvent` to take place. What is better is that with the knowledge of the `Player`, the `ItemStack`, and any other objects placed into the `Cause`, it becomes very simple for you to decide on changing the `BlockChangeEvent` for whatever purpose.

#### How about throwing custom events? I don't really understand what I'm supposed to do here if I want to allow plugins to hook into my custom `EntityTeleportEvent`.

To be honest, that is why I simplified `Cause` to replicate `Optional`. When you are wanting to teleport an `Entity` with a `Cause`, you can include the *root* cause, say the `Entity` called a `Command`, and the `Command` was entered through a `Sign`, you now have *two* objects to include in your `Cause`. However, let's say you wanted to expand and provide some custom `TeleportCause`s, you could extend `TeleportCause` and provide the extended `Cause` to be the `Sign`, and likewise you could include your own custom marker object so that in the event you have a listener for `EntityTeleportEvent`, you can safely ignore the event if your custom marker object is included.

#### How about X event?

Well, as I said before, the PR is still a work in progress, so I haven't finished designing the `Cause` for every `CauseTracked` event.