### PR TITLE
Add methods to ignore players when skipping the night

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/living/Human.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Human.java
@@ -67,4 +67,26 @@ public interface Human extends Living, ProjectileSource, ArmorEquipable, Tamer, 
      */
     void closeInventory();
 
+    /**
+     * Returns whether this {@link Human} will be ignored when checking whether
+     * to skip the night due to players sleeping. The time in a world will be
+     * advanced to day if all players in it either are sleeping or have this
+     * tag.
+     *
+     * @return Whether this {@link Human} will be ignored when checking whether
+     *         to skip the night
+     */
+    boolean isSleepingIgnored();
+
+    /**
+     * Sets whether this {@link Human} will be ignored when checking whether
+     * to skip the night due to players sleeping. The time in a world will be
+     * advanced to day if all players in it either are sleeping or have this
+     * tag.
+     *
+     * @return Whether this {@link Human} will be ignored when checking whether
+     *         to skip the night
+     */
+    void setSleepingIgnored(boolean sleepingIgnored);
+
 }

--- a/src/main/java/org/spongepowered/api/entity/living/Human.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Human.java
@@ -67,26 +67,4 @@ public interface Human extends Living, ProjectileSource, ArmorEquipable, Tamer, 
      */
     void closeInventory();
 
-    /**
-     * Returns whether this {@link Human} will be ignored when checking whether
-     * to skip the night due to players sleeping. The time in a world will be
-     * advanced to day if all players in it either are sleeping or have this
-     * tag.
-     *
-     * @return Whether this {@link Human} will be ignored when checking whether
-     *         to skip the night
-     */
-    boolean isSleepingIgnored();
-
-    /**
-     * Sets whether this {@link Human} will be ignored when checking whether
-     * to skip the night due to players sleeping. The time in a world will be
-     * advanced to day if all players in it either are sleeping or have this
-     * tag.
-     *
-     * @return Whether this {@link Human} will be ignored when checking whether
-     *         to skip the night
-     */
-    void setSleepingIgnored(boolean sleepingIgnored);
-
 }

--- a/src/main/java/org/spongepowered/api/entity/player/Player.java
+++ b/src/main/java/org/spongepowered/api/entity/player/Player.java
@@ -135,13 +135,13 @@ public interface Player extends Human, User, LocatedSource, RemoteSource, Viewer
     GameModeData getGameModeData();
 
     /**
-     * Returns whether this {@link Player} will be ignored when checking whether
-     * to skip the night due to players sleeping. The time in a world will be
+     * Gets whether this {@link Player} will be ignored when checking whether to
+     * skip the night due to players sleeping. The time in a world will be
      * advanced to day if all players in it either are sleeping or have this
      * tag.
      *
      * @return Whether this {@link Player} will be ignored when checking whether
-     *         to skip the night
+     *     to skip the night
      */
     boolean isSleepingIgnored();
 
@@ -151,8 +151,8 @@ public interface Player extends Human, User, LocatedSource, RemoteSource, Viewer
      * advanced to day if all players in it either are sleeping or have this
      * tag.
      *
-     * @return Whether this {@link Player} will be ignored when checking whether
-     *         to skip the night
+     * @param sleepingIgnored Whether this {@link Player} will be ignored when
+     *     checking whether to skip the night
      */
     void setSleepingIgnored(boolean sleepingIgnored);
 

--- a/src/main/java/org/spongepowered/api/entity/player/Player.java
+++ b/src/main/java/org/spongepowered/api/entity/player/Player.java
@@ -135,23 +135,23 @@ public interface Player extends Human, User, LocatedSource, RemoteSource, Viewer
     GameModeData getGameModeData();
 
     /**
-     * Returns whether this {@link Human} will be ignored when checking whether
+     * Returns whether this {@link Player} will be ignored when checking whether
      * to skip the night due to players sleeping. The time in a world will be
      * advanced to day if all players in it either are sleeping or have this
      * tag.
      *
-     * @return Whether this {@link Human} will be ignored when checking whether
+     * @return Whether this {@link Player} will be ignored when checking whether
      *         to skip the night
      */
     boolean isSleepingIgnored();
 
     /**
-     * Sets whether this {@link Human} will be ignored when checking whether
+     * Sets whether this {@link Player} will be ignored when checking whether
      * to skip the night due to players sleeping. The time in a world will be
      * advanced to day if all players in it either are sleeping or have this
      * tag.
      *
-     * @return Whether this {@link Human} will be ignored when checking whether
+     * @return Whether this {@link Player} will be ignored when checking whether
      *         to skip the night
      */
     void setSleepingIgnored(boolean sleepingIgnored);

--- a/src/main/java/org/spongepowered/api/entity/player/Player.java
+++ b/src/main/java/org/spongepowered/api/entity/player/Player.java
@@ -134,4 +134,26 @@ public interface Player extends Human, User, LocatedSource, RemoteSource, Viewer
      */
     GameModeData getGameModeData();
 
+    /**
+     * Returns whether this {@link Human} will be ignored when checking whether
+     * to skip the night due to players sleeping. The time in a world will be
+     * advanced to day if all players in it either are sleeping or have this
+     * tag.
+     *
+     * @return Whether this {@link Human} will be ignored when checking whether
+     *         to skip the night
+     */
+    boolean isSleepingIgnored();
+
+    /**
+     * Sets whether this {@link Human} will be ignored when checking whether
+     * to skip the night due to players sleeping. The time in a world will be
+     * advanced to day if all players in it either are sleeping or have this
+     * tag.
+     *
+     * @return Whether this {@link Human} will be ignored when checking whether
+     *         to skip the night
+     */
+    void setSleepingIgnored(boolean sleepingIgnored);
+
 }


### PR DESCRIPTION
This PR adds the API methods `isSleepingIgnored()Z` and `setSleepingIgnored(Z)V` to the `Player` interface. When this toggle is set, the `Player` will not be considered when determining whether the night should be skipped due to all players being asleep.

These methods are implemented by [SpongeCommon #74](https://github.com/SpongePowered/SpongeCommon/pull/74).