### PR TITLE
Add Text methods for working with Teams

### DIFF
--- a/src/main/java/org/spongepowered/api/scoreboard/Team.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Team.java
@@ -200,6 +200,38 @@ public interface Team {
     boolean removeUser(User user);
 
     /**
+     * Gets the {@link Text}s on the team.
+     *
+     * <p>Text-based methods on {@link Team} are usually used for "fake player" entries on the
+     * scoreboard.</p>
+     *
+     * @return The {@link Text}s on the team
+     */
+    Set<Text> getTexts();
+
+    /**
+     * Adds the specified {@link Text} to this team for the {@link Scoreboard}.
+     *
+     * <p>Text-based methods on {@link Team} are usually used for "fake player" entries on the
+     * scoreboard.</p>
+     * <p>This will remove the {@link Text} from any other team on the {@link Scoreboard}.</p>
+     *
+     * @param text The {@link Text} to add
+     */
+    void addText(Text text);
+
+    /**
+     * Removes the specified {@link Text} from this team.
+     *
+     * <p>Text-based methods on {@link Team} are usually used for "fake player" entries on the
+     * scoreboard.</p>
+     *
+     * @param text The {@link Text} to remove
+     * @return Whether the {@link Text} was on this team
+     */
+    boolean removeText(Text text);
+
+    /**
      * Returns a {@link Set} of parent {@link Scoreboard}s this {@link Team} is
      * registered to.
      *


### PR DESCRIPTION
This adds `Text` methods to `Team` for adding "fake players" to a scoreboard team. This is helpful when [using `Text` scores](https://github.com/SpongePowered/SpongeAPI/blob/master/src/main/java/org/spongepowered/api/scoreboard/Scoreboard.java#L109-L124).

See https://github.com/SpongePowered/SpongeAPI/pull/739#issuecomment-116238966 for a more detailed explanation.

*(...and the worst PR description award goes to...)*