### PR TITLE
Fix return type for Ban.User.getUser()

### DIFF
--- a/src/main/java/org/spongepowered/api/util/ban/Ban.java
+++ b/src/main/java/org/spongepowered/api/util/ban/Ban.java
@@ -88,7 +88,7 @@ public interface Ban {
          *
          * @return The user
          */
-        User getUser();
+        org.spongepowered.api.entity.player.User getUser();
 
     }
 


### PR DESCRIPTION
Currently, the method returns Ban.User rather than User, making the method fairly useless. This corrects the issue, returning the correct User type.