### PR TITLE
Add PermissionDescription API

### DIFF
--- a/src/main/java/org/spongepowered/api/service/permission/PermissionDescription.java
+++ b/src/main/java/org/spongepowered/api/service/permission/PermissionDescription.java
@@ -114,7 +114,8 @@ public interface PermissionDescription {
     /**
      * Gets an immutable {@link Set} of {@link Subject}s that have set a none
      * default value for this permission (true and false). This may include
-     * permissions that are directly related to this permission.
+     * permissions that are directly related to this permission. This may not
+     * include subjects that inherit the none default value.
      *
      * <p>If you want to know to which role-templates this permission is
      * assigned use {@link PermissionService#SUBJECTS_ROLE_TEMPLATE}.</p>

--- a/src/main/java/org/spongepowered/api/service/permission/PermissionDescription.java
+++ b/src/main/java/org/spongepowered/api/service/permission/PermissionDescription.java
@@ -73,14 +73,38 @@ public interface PermissionDescription {
     static final String RANK_ADMIN = "admin";
     /**
      * A permission with this rank should normally not granted to anybody. This
-     * usually applies to debug permissions.
+     * usually applies to debug permissions or specializations of permissions
+     * that would already be granted.
+     *
+     * <p>Examples can be show debug messages or myPlugin.give.type.DIRT where
+     * myPlugin.give.type is already granted.</p>
      */
     static final String RANK_NOBODY = "nobody";
 
     /**
-     * Gets the permission id this description belongs too. May include
-     * placeholders {@code "<SomeParameter>"} such as in
-     * {@code "pluginId.give.item.<ItemType>"}.
+     * Gets the permission id this description belongs too.
+     *
+     * <p>The permission id must be of the specified format as specified using
+     * EBNF:
+     * <ul>
+     * <li>CHARACTER  = "A" - "Z" | "a" - "z" | "0" - "9" | "_" | "-"</li>
+     * <li>NAME       = CHARACTER , { CHARACTER }</li>
+     * <li>TEMPLATE   = "&lt" , NAME , "&gt"</li>
+     * <li>PART       = NAME | TEMPLATE</li>
+     * <li>PERMISSION = NAME , { "." , PART }</li>
+     * </ul>
+     * </p>
+     *
+     * <p>Examples:
+     * <ul>
+     * <li>"myPlugin.give.type" - Grants all ItemTypes</li>
+     * <li>"myPlugin.give.type.&ltItemType&gt" - A template should not be granted to anybody</li>
+     * <li>"myPlugin.give.type.DIAMOND" - Only grants DIAMOND</li>
+     * </ul>
+     * </p>
+     *
+     * <p><b>Note:</b> Permission ids are case insensitive! Permission ids should
+     * start with the owning plugin's id.</p>
      *
      * @return The permission id
      */
@@ -118,9 +142,8 @@ public interface PermissionDescription {
     interface Builder {
 
         /**
-         * Sets the permission id for the description this builder creates. May
-         * include placeholders {@code "<SomeParameter>"} such as in
-         * {@code "pluginId.give.item.<ItemType>"}.
+         * Sets the permission id for the description this builder creates. See
+         * {@link PermissionDescription#getId()} for format specifications.
          *
          * @param permissionId The permission id
          * @return This builder for chaining

--- a/src/main/java/org/spongepowered/api/service/permission/PermissionDescription.java
+++ b/src/main/java/org/spongepowered/api/service/permission/PermissionDescription.java
@@ -1,0 +1,170 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.service.permission;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.text.Text;
+
+import javax.annotation.Nullable;
+
+/**
+ * A description object for permissions. The description is meant to provide
+ * human readable descriptions and meta data for a permission. Instances should
+ * be registered at the {@link PermissionService}, but the registration does not
+ * have any impact on the results of the permission checks of the service.
+ */
+public interface PermissionDescription {
+
+    /**
+     * A permission with this rank can be granted to anybody including the
+     * untrusted guests. For most servers there is no difference between
+     * {@link #RANK_GUEST} and {@link #RANK_USER}.
+     *
+     * <p>Examples can be chat, MotD receive.</p>
+     */
+    static final String RANK_GUEST = "guest";
+    /**
+     * A permission with this rank can be granted to anybody that should have
+     * default user access. For most servers there is no difference between
+     * {@link #RANK_GUEST} and {@link #RANK_USER}.
+     *
+     * <p>Examples can be claim city plot, access to games and public warps.</p>
+     */
+    static final String RANK_USER = "user";
+    /**
+     * A permission with this rank should only be granted to known server staff.
+     * The permission's impact on the server is quite low.
+     *
+     * <p>Examples can be give items, teleport other players, access to support
+     * commands, globally mute other players.</p>
+     */
+    static final String RANK_STAFF = "staff";
+    /**
+     * A permission with this rank should only be granted to fully trusted
+     * server administrators. The permission's impact on the server may be high.
+     *
+     * <p>Examples can be create/delete worlds, grant permissions, restart
+     * server.</p>
+     */
+    static final String RANK_ADMIN = "admin";
+    /**
+     * A permission with this rank should normally not granted to anybody. This
+     * usually applies to debug permissions.
+     */
+    static final String RANK_NOBODY = "nobody";
+
+    /**
+     * Gets the permission id this description belongs too. May include
+     * placeholders {@code "<SomeParameter>"} such as in
+     * {@code "pluginId.give.item.<ItemType>"}.
+     *
+     * @return The permission id
+     */
+    String getId();
+
+    /**
+     * Gets a short description of the linked permission. May include a link to
+     * a more detailed description on the plugin's web page.
+     *
+     * @return A short description of the linked permission
+     */
+    Text getDescription();
+
+    /**
+     * Gets the human readable <b>suggested</b> rank the players should have
+     * before they should have access to this permission.
+     *
+     * <p><b>Note:</b> This is a suggestion for server owners and does not have
+     * any impact on the results of the permission checks.</p>
+     *
+     * @return The suggested player rank the permission should be granted to
+     */
+    Optional<String> getSuggestedRank();
+
+    /**
+     * Gets the owning plugin the permission belongs to.
+     *
+     * @return The owning plugin the permission belongs to
+     */
+    PluginContainer getOwner();
+
+    /**
+     * A builder for permission descriptions.
+     */
+    interface Builder {
+
+        /**
+         * Sets the permission id for the description this builder creates. May
+         * include placeholders {@code "<SomeParameter>"} such as in
+         * {@code "pluginId.give.item.<ItemType>"}.
+         *
+         * @param permissionId The permission id
+         * @return This builder for chaining
+         */
+        Builder id(String permissionId);
+
+        /**
+         * Sets the short description to use. May include a link to a more
+         * detailed description on the plugin's web page.
+         *
+         * @param description The short description to use
+         * @return This builder for chaining
+         */
+        Builder description(Text description);
+
+        /**
+         * Sets the suggested rank players should have before being able to
+         * access this permission. Setting this is optional although
+         * recommended.
+         *
+         * @param rank The suggested rank to have
+         * @return This builder for chaining
+         */
+        Builder suggestedRank(@Nullable String rank);
+
+        /**
+         * Creates and registers a new {@link PermissionDescription} instance
+         * with the given settings.
+         *
+         * @return The newly created permission description instance
+         * @throws IllegalStateException If there are any settings left unset or
+         *         a description with the given permission id was already
+         *         registered and the {@link PermissionService} does not support
+         *         overwriting descriptions
+         */
+        PermissionDescription register() throws IllegalStateException;
+
+        /**
+         * Resets this builder to its default settings.
+         *
+         * @return This builder for chaining
+         */
+        Builder reset();
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/service/permission/PermissionDescription.java
+++ b/src/main/java/org/spongepowered/api/service/permission/PermissionDescription.java
@@ -115,7 +115,8 @@ public interface PermissionDescription {
      * Gets an immutable {@link Set} of {@link Subject}s that have set a none
      * default value for this permission (true and false). This may include
      * permissions that are directly related to this permission. This may not
-     * include subjects that inherit the none default value.
+     * include subjects that inherit the none default value. This method assumes
+     * a global context.
      *
      * <p>If you want to know to which role-templates this permission is
      * assigned use {@link PermissionService#SUBJECTS_ROLE_TEMPLATE}.</p>
@@ -123,6 +124,7 @@ public interface PermissionDescription {
      * @param identifier The subject type identifier to use
      * @return An immutable set of subjects that have an none default value for
      *         this or a directly related permission
+     * @see SubjectCollection#getAllWithPermission(String)
      */
     Set<Subject> getAssignedSubjects(String identifier);
 

--- a/src/main/java/org/spongepowered/api/service/permission/PermissionDescription.java
+++ b/src/main/java/org/spongepowered/api/service/permission/PermissionDescription.java
@@ -161,13 +161,14 @@ public interface PermissionDescription {
          * If the given subject does not exist it will be created. It is
          * recommended, but not necessary to use the role suggestions provided
          * by this class. It is also recommended to prefix the role template
-         * with the plugin name to make the assignment of the template groups to
-         * real groups more differentiated. Example: "myPlugin.user". Please do
-         * not assign a permission to user, staff and admin at the same time but
-         * solve this with subject inheritance if possible.
+         * with the plugin's name to make the assignment of the template groups
+         * to real groups more differentiated. Example: "myPlugin.user". Please
+         * do not assign a permission to user, staff and admin at the same time
+         * but solve this with subject inheritance if possible.
          *
          * <p><b>Note:</b> The permissions are only assigned during
-         * {@link #register()}.</p>
+         * {@link #register()}. Permission templates should not be assigned to
+         * anyone.</p>
          *
          * @param role The role-template to assign the permission to
          * @param value The value to to assign

--- a/src/main/java/org/spongepowered/api/service/permission/PermissionService.java
+++ b/src/main/java/org/spongepowered/api/service/permission/PermissionService.java
@@ -42,6 +42,7 @@ public interface PermissionService {
     String SUBJECTS_GROUP = "group";
     String SUBJECTS_SYSTEM = "system";
     String SUBJECTS_COMMAND_BLOCK = "commandblock";
+    String SUBJECTS_ROLE_TEMPLATE = "role-template";
 
     /**
      * Returns the permissions level that describes users. User identifiers are

--- a/src/main/java/org/spongepowered/api/service/permission/PermissionService.java
+++ b/src/main/java/org/spongepowered/api/service/permission/PermissionService.java
@@ -24,8 +24,11 @@
  */
 package org.spongepowered.api.service.permission;
 
+import com.google.common.base.Optional;
+import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.service.permission.context.ContextCalculator;
 
+import java.util.Collection;
 import java.util.Map;
 
 
@@ -87,4 +90,34 @@ public interface PermissionService {
      * @param calculator The context calculator to register
      */
     void registerContextCalculator(ContextCalculator calculator);
+
+    /**
+     * Creates a new description builder for the given plugin's permission. May
+     * return {@link Optional#absent()} if the service does not support
+     * {@link PermissionDescription}s.
+     *
+     * @param plugin The plugin to create permission descriptions for
+     * @return The newly created permission description builder, if supported
+     */
+    Optional<PermissionDescription.Builder> newDescriptionBuilder(PluginContainer plugin);
+
+    /**
+     * Gets the registered or generated {@link PermissionDescription} for the
+     * given permission if available.
+     *
+     * @param permission The permission to get the description for
+     * @return The description for the given permission or
+     *         {@link Optional#absent()}
+     */
+    Optional<PermissionDescription> getDescription(String permission);
+
+    /**
+     * Gets a immutable collection containing all registered or generated
+     * {@link PermissionDescription}s.
+     *
+     * @return An immutable collection contain all registered or generated
+     *         descriptions
+     */
+    Collection<PermissionDescription> getDescriptions();
+
 }

--- a/src/main/java/org/spongepowered/api/service/permission/PermissionService.java
+++ b/src/main/java/org/spongepowered/api/service/permission/PermissionService.java
@@ -104,7 +104,8 @@ public interface PermissionService {
 
     /**
      * Gets the registered or generated {@link PermissionDescription} for the
-     * given permission if available.
+     * given permission if available. If the given permission is not defined
+     * itself this might also return the associated permission template.
      *
      * @param permission The permission to get the description for
      * @return The description for the given permission or


### PR DESCRIPTION
Adds https://github.com/SpongePowered/SpongeAPI/issues/601 (low priority)
Implemented in https://github.com/SpongePowered/SpongeCommon/pull/84

This adds `PermissionDescription` to the `PermissionService`.

`PermissionDescription`s should help server owners manage the registered permissions more easyly.

Some facts about `PermissionDescription`s:
* Registration is optional
* Registration may not be supported by all impls
* Registration has **NO** impact on the default value in general
  - Permission Plugins may offer util commands/options to import the defaults (per plugin)
  - The `role-templates` can be assigned to groups (manually) to allow changing the defaults
* Contains of
  - Owning plugin
  - PermissionId (`String`)
    - May include placeholders `myPlugin.command.give.<ItemType>`
  - Description `Text`
    - May include a link to a more detailed description page
  - `Role-emplate` assignment
     - `User`, `Staff`, `Admin`, custom values
     - This can be used to group permissions and allow server admins to add them to groups more easily.

The discussion and a short explanation why i have chosen this properties can be found [here](https://github.com/SpongePowered/SpongeAPI/issues/601#issuecomment-116326563)

**This PR does NOT contain**
* Annotations to automatically create and register permissions
  - Just too messy if it should contain useful info/descriptions
* File specifications for permission data files
  - I thought about that, but i think this should be done in a more general way.
    - This should be done similar to json/config->object parsing, which maps to the keys to method names. If you like this i can write some example code. (NOT part of this PR)
* Commands to get the registered descriptions
  - This is up to the permission plugins, since the storing of the descriptions has great influence on the possibilities, however a basic (`/sponge` sub-) command could be added nevertheless.

**TBD**
* Explicit `PermissionReference`s (maybe as `String`)
  - `CHILD`/ `PARENT` - Basic inheritance
  - `REFERENCE` - "See also"
  - `BASE`/`SPECIFICATION` - Base permission `myPlugin.command.give.<ItemType>` of `myPlugin.command.give.DIRT` or `myPlugin.command.give.*`
  - `EXAMPLE` - Opposite of `BASE`/`SPECIFICATION`

Anything i missed?