### PR TITLE
[WIP] Add API's for additional world management operations

### DIFF
--- a/src/main/java/org/spongepowered/api/Server.java
+++ b/src/main/java/org/spongepowered/api/Server.java
@@ -207,12 +207,27 @@ public interface Server extends ChannelRegistrar {
 
     /**
      * Creates a copy of the provided world under the new name given and returns
-     * the new copy if the copy was possible
+     * the new copy if the copy was possible. 
      *
      * @param originalWorld The original world instance to copy
      * @param copyName The name that should be used in the duplicated entry instead of the originalWorld's name.
      */
-    Optional<World> copyWorld(World originalWorld, String copyName);
+    Optional<WorldProperties> copyWorld(WorldProperties originalWorld, String copyName);
+
+    /**
+     * Allows the copy to be made while the world is still loaded by forcing a save
+     * first, this could cause changes to be missed if made after that save. By
+     * using this method the developer is assumed to properly respect that large worlds
+     * will likely take a long enough period to copy that a reasonable number of changes are
+     * missed.
+     *
+     * A {@link World} instance is used here because unloaded worlds should not be copied
+     * using this method, and instead should be copied using {@link #copyWorld(WorldProperties,String)}.
+     *
+     * @param originalWorld The original world instance to copy
+     * @param copyName The name for the copy that is made
+     */
+    Optional<WorldProperties> copyLoadedWorld(World originalWorld, String copyName);
 
     /**
      * Persists the given {@link WorldProperties} to the world storage for it,

--- a/src/main/java/org/spongepowered/api/Server.java
+++ b/src/main/java/org/spongepowered/api/Server.java
@@ -232,7 +232,17 @@ public interface Server extends ChannelRegistrar {
     Optional<WorldProperties> copyLoadedWorld(World originalWorld, String copyName);
 
     /**
+     * Renames an unloaded world.
+     *
+     * @param worldProperties The world instance to rename
+     * @param newName The name that should be used as a replacement for the current world name
+     * @return An {@link Optional} containing the new {@link WorldProperties} if the rename was successful
+     */
+    Optional<WorldProperties> renameWorld(WorldProperties worldProperties, String newName);
+
+    /**
      * Deletes the provided world's files from the disk.
+     *
      * @param worldProperties The world instance to delete
      * @return True if the deletion was successful.
      */

--- a/src/main/java/org/spongepowered/api/Server.java
+++ b/src/main/java/org/spongepowered/api/Server.java
@@ -206,6 +206,15 @@ public interface Server extends ChannelRegistrar {
     Optional<WorldProperties> createWorld(WorldCreationSettings settings);
 
     /**
+     * Creates a copy of the provided world under the new name given and returns
+     * the new copy if the copy was possible
+     *
+     * @param originalWorld The original world instance to copy
+     * @param copyName The name that should be used in the duplicated entry instead of the originalWorld's name.
+     */
+    Optional<World> copyWorld(World originalWorld, String copyName);
+
+    /**
      * Persists the given {@link WorldProperties} to the world storage for it,
      * updating any modified values.
      *

--- a/src/main/java/org/spongepowered/api/Server.java
+++ b/src/main/java/org/spongepowered/api/Server.java
@@ -210,7 +210,8 @@ public interface Server extends ChannelRegistrar {
      * the new copy if the copy was possible. 
      *
      * @param originalWorld The original world instance to copy
-     * @param copyName The name that should be used in the duplicated entry instead of the originalWorld's name.
+     * @param copyName The name that should be used in the duplicated entry instead of the originalWorld's name
+     * @return An {@link Optional} containing the properties of the new world instance, if the copy was successful
      */
     Optional<WorldProperties> copyWorld(WorldProperties originalWorld, String copyName);
 
@@ -226,8 +227,16 @@ public interface Server extends ChannelRegistrar {
      *
      * @param originalWorld The original world instance to copy
      * @param copyName The name for the copy that is made
+     * @return An {@link Optional} containing the properties of the new world instance, if the copy was successful
      */
     Optional<WorldProperties> copyLoadedWorld(World originalWorld, String copyName);
+
+    /**
+     * Deletes the provided world's files from the disk.
+     * @param worldProperties The world instance to delete
+     * @return True if the deletion was successful.
+     */
+    boolean deleteWorld(WorldProperties worldProperties);
 
     /**
      * Persists the given {@link WorldProperties} to the world storage for it,

--- a/src/main/java/org/spongepowered/api/world/storage/WorldProperties.java
+++ b/src/main/java/org/spongepowered/api/world/storage/WorldProperties.java
@@ -106,13 +106,6 @@ public interface WorldProperties extends DataSerializable {
     String getWorldName();
 
     /**
-     * Gets the directory the files for this world are located.
-     *
-     * @return The directory the files are located in
-     */
-    File getWorldDirectory();
-
-    /**
      * Gets the {@link UUID} of the world.
      * 
      * @return The unique Id

--- a/src/main/java/org/spongepowered/api/world/storage/WorldProperties.java
+++ b/src/main/java/org/spongepowered/api/world/storage/WorldProperties.java
@@ -39,6 +39,7 @@ import org.spongepowered.api.world.WorldBorder;
 import org.spongepowered.api.world.difficulty.Difficulty;
 import org.spongepowered.api.world.gen.WorldGeneratorModifier;
 
+import java.io.File;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
@@ -103,6 +104,13 @@ public interface WorldProperties extends DataSerializable {
      * @return The name
      */
     String getWorldName();
+
+    /**
+     * Gets the directory the files for this world are located.
+     *
+     * @return The directory the files are located in
+     */
+    File getWorldDirectory();
 
     /**
      * Gets the {@link UUID} of the world.

--- a/src/main/java/org/spongepowered/api/world/storage/WorldProperties.java
+++ b/src/main/java/org/spongepowered/api/world/storage/WorldProperties.java
@@ -39,7 +39,6 @@ import org.spongepowered.api.world.WorldBorder;
 import org.spongepowered.api.world.difficulty.Difficulty;
 import org.spongepowered.api.world.gen.WorldGeneratorModifier;
 
-import java.io.File;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;


### PR DESCRIPTION
This pull request introduces an API where worlds that exist can be copied and loaded as a new world with a different name. 

This pretty much needs an API because of the uuid added for Sponge's worlds. Fixing this would require plugins to copy the world, then load up the NBT and change the name, dimension id and UUID in the file manually, which is prone to breaking and also likely impossible, because plugins shouldn't have access to a way to get the next open dimension ID.

Solves https://github.com/SpongePowered/SpongeAPI/issues/750

Feature list:
- [X] Support the ability to copy an existing world and load it as a duplicate with the same name.
- [X] ~~Support the ability to get the world directory from the API to allow plugins to store data with the worlds.~~
- [X]  Add ability to delete existing worlds from the disk (after being unloaded first)
- [ ] Add the ability to fully rename an existing world, including folder or other stored name.

Todo:
- [X] Determine if world copying should only be allowed after unloading a world **(It should)**