### PR TITLE
[WIP] Added Teammate interface to represent entities that can be added to to teams.

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/player/User.java
+++ b/src/main/java/org/spongepowered/api/entity/player/User.java
@@ -27,21 +27,19 @@ package org.spongepowered.api.entity.player;
 import com.google.common.base.Optional;
 import org.spongepowered.api.GameProfile;
 import org.spongepowered.api.data.DataHolder;
-import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.manipulator.entity.AchievementData;
 import org.spongepowered.api.data.manipulator.entity.BanData;
 import org.spongepowered.api.data.manipulator.entity.StatisticData;
 import org.spongepowered.api.entity.ArmorEquipable;
 import org.spongepowered.api.entity.Tamer;
-import org.spongepowered.api.item.inventory.Carrier;
+import org.spongepowered.api.scoreboard.Teammate;
 import org.spongepowered.api.service.permission.Subject;
-import org.spongepowered.api.util.Identifiable;
 
 /**
  * A User is the data usually associated with a Player that is persisted across server restarts.
  * This is in contrast to Player which represents the ingame entity associated with an online User.
  */
-public interface User extends DataHolder, Identifiable, ArmorEquipable, Tamer, DataSerializable, Subject, Carrier {
+public interface User extends DataHolder, Teammate, ArmorEquipable, Tamer, Subject {
 
     /**
      * Gets the associated {@link GameProfile} of this player.

--- a/src/main/java/org/spongepowered/api/scoreboard/Scoreboard.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Scoreboard.java
@@ -25,15 +25,13 @@
 package org.spongepowered.api.scoreboard;
 
 import com.google.common.base.Optional;
-import org.spongepowered.api.entity.player.User;
 import org.spongepowered.api.scoreboard.critieria.Criterion;
 import org.spongepowered.api.scoreboard.displayslot.DisplaySlot;
 import org.spongepowered.api.scoreboard.objective.Objective;
 import org.spongepowered.api.text.Text;
 
-import java.util.Set;
-
 import javax.annotation.Nullable;
+import java.util.Set;
 
 /**
  * Represents a scoreboard, which contains {@link Team}s and {@link Objective}s.
@@ -124,13 +122,13 @@ public interface Scoreboard {
     void removeScores(Text name);
 
     /**
-     * Gets a {@link User}'s {@link Team} on this scoreboard.
+     * Gets a {@link Teammate}'s {@link Team} on this scoreboard.
      *
-     * @param user The {@link User} to search for
-     * @return The {@link User}'s {@link Team}, or Optional.absent()
+     * @param teammate The {@link Teammate} to search for
+     * @return The {@link Teammate}'s {@link Team}, or Optional.absent()
      *     if the user has no team
      */
-    Optional<Team> getUserTeam(User user);
+    Optional<Team> getTeam(Teammate teammate);
 
     /**
      * Gets a {@link Team} by name on this scoreboard.

--- a/src/main/java/org/spongepowered/api/scoreboard/Scoreboard.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Scoreboard.java
@@ -30,8 +30,9 @@ import org.spongepowered.api.scoreboard.displayslot.DisplaySlot;
 import org.spongepowered.api.scoreboard.objective.Objective;
 import org.spongepowered.api.text.Text;
 
-import javax.annotation.Nullable;
 import java.util.Set;
+
+import javax.annotation.Nullable;
 
 /**
  * Represents a scoreboard, which contains {@link Team}s and {@link Objective}s.

--- a/src/main/java/org/spongepowered/api/scoreboard/Team.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Team.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.scoreboard;
 
 
-import org.spongepowered.api.entity.player.User;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColor;
 
@@ -176,28 +175,28 @@ public interface Team {
     void setDeathTextVisibility(Visibility visibility);
 
     /**
-     * Gets the {@link User}s on the team.
+     * Gets the {@link Teammate}s on the team.
      *
-     * @return The {@link User}s on the team
+     * @return The {@link Teammate}s on the team
      */
-    Set<User> getUsers();
+    Set<Teammate> getTeammates();
 
     /**
-     * Adds the specified {@link User} to this team for the {@link Scoreboard}.
+     * Adds the specified {@link Teammate} to this team for the {@link Scoreboard}.
      *
-     * <p>This will remove the {@link User} from any other team on the {@link Scoreboard}.</p>
+     * <p>This will remove the {@link Teammate} from any other team on the {@link Scoreboard}.</p>
      *
-     * @param user The {@link User} to add
+     * @param teammate The {@link Teammate} to add
      */
-    void addUser(User user);
+    void addTeammate(Teammate teammate);
 
     /**
-     * Removes the specified {@link User} from this team.
+     * Removes the specified {@link Teammate} from this team.
      *
-     * @param user The {@link User} to remove
-     * @return Whether the {@link User} was on this team
+     * @param teammate The {@link Teammate} to remove
+     * @return Whether the {@link Teammate} was on this team
      */
-    boolean removeUser(User user);
+    boolean removeTeammate(Teammate teammate);
 
     /**
      * Returns a {@link Set} of parent {@link Scoreboard}s this {@link Team} is

--- a/src/main/java/org/spongepowered/api/scoreboard/TeamBuilder.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/TeamBuilder.java
@@ -29,6 +29,7 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColor;
 
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Represents a builder tp create {@link Team} instances.
@@ -125,14 +126,14 @@ public interface TeamBuilder {
     TeamBuilder deathTextVisibility(Visibility visibility);
 
     /**
-     * Sets the set of {@link User}s on the {@link Team}.
+     * Sets the set of {@link UUID}s on the {@link UUID}.
      *
      * <p>By default, this is the empty set.</p>
      *
-     * @param users The set of {@link User}s on the {@link Team}
+     * @param uuids The set of {@link User}s on the {@link Team}
      * @return This builder
      */
-    TeamBuilder users(Set<User> users);
+    TeamBuilder UUIDs(Set<UUID> uuids);
 
     /**
      * Resets all information regarding the {@link Team} to be created.

--- a/src/main/java/org/spongepowered/api/scoreboard/TeamBuilder.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/TeamBuilder.java
@@ -126,14 +126,14 @@ public interface TeamBuilder {
     TeamBuilder deathTextVisibility(Visibility visibility);
 
     /**
-     * Sets the set of {@link UUID}s on the {@link UUID}.
+     * Sets the set of {@link Teammate}s on the {@link Teammate}.
      *
      * <p>By default, this is the empty set.</p>
      *
-     * @param uuids The set of {@link User}s on the {@link Team}
+     * @param teammates The set of {@link Teammate}s on the {@link Team}
      * @return This builder
      */
-    TeamBuilder UUIDs(Set<UUID> uuids);
+    TeamBuilder Teammates(Set<Teammate> teammates);
 
     /**
      * Resets all information regarding the {@link Team} to be created.

--- a/src/main/java/org/spongepowered/api/scoreboard/Teammate.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Teammate.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.api.scoreboard;
 
 import org.spongepowered.api.util.Identifiable;

--- a/src/main/java/org/spongepowered/api/scoreboard/Teammate.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Teammate.java
@@ -1,0 +1,9 @@
+package org.spongepowered.api.scoreboard;
+
+import org.spongepowered.api.util.Identifiable;
+
+/**
+ * A marker interface that represents an object that can be added to a team.
+ */
+public interface Teammate extends Identifiable {}
+


### PR DESCRIPTION
This should be considered a work in progress.

Created a Teammate interface that extends identifiable.

Anything identifiable can be added to a scoreboard whether it makes sense or not, entities, entitieLiving, creatures, enemies etc.

I've pointed this out to multiple people in the past, and it resulted in any Text being allowed to be a Score entry, however teams were still restricted to Users only.

The reasoning was that most of the options that apply to teams are currently ignored by entities, but with the announcement that entities being on a team may influence their targeting at Minecon (Shulkers to be precise) confirming that it wasn't an accident on Mojangs behalf that entities could be on teams.

It may now be worthwhile allowing plugins to set entities to teams in order to change their targeting behaviour themselves. 

Should all entities implement Teammate? Living entities? Arrows?