### PR TITLE
Add checks for interactable objects.

### DIFF
--- a/src/main/java/org/spongepowered/api/block/BlockType.java
+++ b/src/main/java/org/spongepowered/api/block/BlockType.java
@@ -113,7 +113,16 @@ public interface BlockType extends CatalogType, Translatable {
      * @return Is affected by gravity
      */
     boolean isAffectedByGravity();
-
+    
+    /**
+     * Gets whether or not this block will cause a reaction when
+     * right-clicked.
+     * 
+     * <p>This includes blocks that open GUIs and switch their own states
+     * when right-clicked, e.g. opening/closing a door or opening a chest.</p>
+     */
+    boolean isInteractable();
+    
     /**
      * Gets if a block should be counted for statistics gathering.
      *

--- a/src/main/java/org/spongepowered/api/block/BlockType.java
+++ b/src/main/java/org/spongepowered/api/block/BlockType.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.block;
 import com.google.common.base.Optional;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.entity.living.Human;
 import org.spongepowered.api.item.ItemBlock;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
@@ -115,13 +116,14 @@ public interface BlockType extends CatalogType, Translatable {
     boolean isAffectedByGravity();
     
     /**
-     * Gets whether or not this block will cause a reaction when
-     * right-clicked.
+     * Gets whether or not this block will cause a reaction when right-clicked
+     * by the given {@link Human} entity.
      * 
-     * <p>This includes blocks that open GUIs and switch their own states
-     * when right-clicked, e.g. opening/closing a door or opening a chest.</p>
+     * <p>This includes blocks that open GUIs and switch their own states when
+     * right-clicked, e.g. opening/closing a door or opening a chest. Mod
+     * objects may make this value vary based on the given Human.</p>
      */
-    boolean isInteractable();
+    boolean isInteractable(Human cause);
     
     /**
      * Gets if a block should be counted for statistics gathering.

--- a/src/main/java/org/spongepowered/api/item/ItemType.java
+++ b/src/main/java/org/spongepowered/api/item/ItemType.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.item;
 import com.google.common.base.Optional;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.data.Property;
+import org.spongepowered.api.entity.living.Human;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
@@ -57,14 +58,15 @@ public interface ItemType extends CatalogType, Translatable {
     int getMaxStackQuantity();
     
     /**
-     * Gets whether or not this item will cause a reaction when
-     * right-clicked.
+     * Gets whether or not this item will cause a reaction when right-clicked by
+     * the given {@link Human} entity.
      * 
-     * <p>This includes items that open GUIs or switch their own states
-     * when right-clicked in hand, e.g. opening a Written Book to view its
-     * contents or drinking a Potion.</p>
+     * <p>This includes items that open GUIs or switch their own states when
+     * right-clicked in hand, e.g. opening a Written Book to view its contents
+     * or drinking a Potion. Mod objects may make this value vary based on the
+     * given Human.</p>
      */
-    boolean isInteractable();
+    boolean isInteractable(Human cause);
 
     /**
      * Gets the default {@link Property} of this {@link ItemType}.

--- a/src/main/java/org/spongepowered/api/item/ItemType.java
+++ b/src/main/java/org/spongepowered/api/item/ItemType.java
@@ -55,6 +55,16 @@ public interface ItemType extends CatalogType, Translatable {
      * @return Max stack quantity
      */
     int getMaxStackQuantity();
+    
+    /**
+     * Gets whether or not this item will cause a reaction when
+     * right-clicked.
+     * 
+     * <p>This includes items that open GUIs or switch their own states
+     * when right-clicked in hand, e.g. opening a Written Book to view its
+     * contents or drinking a Potion.</p>
+     */
+    boolean isInteractable();
 
     /**
      * Gets the default {@link Property} of this {@link ItemType}.


### PR DESCRIPTION
_enhancement, low priority_

Previously, when registering an interaction event one must always consider the item in hand, as well as the block the player is targetting. In order for normal gameplay to not be interrupted, a blacklist of objects must be checked to make sure the player isn't intending to do something other than the plugin's function. This usually includes blocks like doors or chests, which do things within the world when you right-click them.

These two methods will eliminate having to have a blacklist of blocks and items to check with, and replace the former with a simple call checking whether or not the item/block has a reaction to being right-clicked.