### PR TITLE
Remove getScheduler() from Game

### DIFF
--- a/src/main/java/org/spongepowered/api/Game.java
+++ b/src/main/java/org/spongepowered/api/Game.java
@@ -84,13 +84,6 @@ public interface Game {
     ServiceManager getServiceManager();
 
     /**
-     * Gets the scheduler used to schedule tasks.
-     *
-     * @return The scheduler
-     */
-    SchedulerService getScheduler();
-
-    /**
      * Get the command dispatcher used for registering and dispatching
      * registered commands.
      *


### PR DESCRIPTION
I don't think there should be access to the `SchedulerService` directly through `Game`. As it is a service, it should be accessible through the `ServiceManager`, and it only bloats `Game` by making it accessible from there.

See SpongePowered/SpongeCommon#97 for the implementation update