### PR TITLE
Support for the resource pack implementation

### DIFF
--- a/src/main/java/org/spongepowered/api/Server.java
+++ b/src/main/java/org/spongepowered/api/Server.java
@@ -30,6 +30,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.network.ChannelRegistrar;
+import org.spongepowered.api.resourcepack.ResourcePack;
 import org.spongepowered.api.service.world.ChunkLoadService;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.sink.MessageSink;
@@ -366,4 +367,12 @@ public interface Server extends ChannelRegistrar {
      * @return The current ticks per second
      */
     double getTicksPerSecond();
+
+    /**
+     * Gets the default resource pack. The default resource pack is sent to
+     * players when they join the server.
+     * 
+     * @return The default resource pack
+     */
+    Optional<ResourcePack> getDefaultResourcePack();
 }

--- a/src/main/java/org/spongepowered/api/event/entity/living/player/ResourcePackStatusEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/player/ResourcePackStatusEvent.java
@@ -69,12 +69,12 @@ public interface ResourcePackStatusEvent extends GameEvent {
         DECLINED(false),
 
         /**
-         * The pack was not a .zip file.
+         * The client failed to download the resource pack.
          */
-        PACK_FILE_FORMAT_NOT_RECOGNIZED(false),
+        FAILED(false),
 
         /**
-         * The pack URL was successfully loaded. This does not mean that pack
+         * The pack URI was successfully loaded. This does not mean that pack
          * was loaded, as the vanilla client sends this even when encountering a
          * 404 or similar.
          */

--- a/src/main/java/org/spongepowered/api/resourcepack/ResourcePack.java
+++ b/src/main/java/org/spongepowered/api/resourcepack/ResourcePack.java
@@ -26,7 +26,7 @@ package org.spongepowered.api.resourcepack;
 
 import com.google.common.base.Optional;
 
-import java.net.URL;
+import java.net.URI;
 
 /**
  * Represents a resource pack that can be sent to the client.
@@ -34,11 +34,11 @@ import java.net.URL;
 public interface ResourcePack {
 
     /**
-     * Gets the URL associated with this ResourcePack.
+     * Gets the URI associated with this ResourcePack.
      *
-     * @return The URL associated with this ResourcePack
+     * @return The URI associated with this ResourcePack
      */
-    URL getUrl();
+    URI getUri();
 
     /**
      * Gets the name of this resource pack. This is the filename of the pack
@@ -60,7 +60,7 @@ public interface ResourcePack {
 
     /**
      * If this resource pack was initialized through
-     * {@link ResourcePackFactory#fromUrl(URL)}, the hash, as calculated with
+     * {@link ResourcePackFactory#fromUri(URI)}, the hash, as calculated with
      * <code>com.google.common.hash.Hashing.sha1().hashBytes(com.google.common.io.Files.toByteArray(resourcepackfile)).toString();</code>
      *
      * @return The hash of this pack, if present

--- a/src/main/java/org/spongepowered/api/resourcepack/ResourcePackFactory.java
+++ b/src/main/java/org/spongepowered/api/resourcepack/ResourcePackFactory.java
@@ -25,7 +25,7 @@
 package org.spongepowered.api.resourcepack;
 
 import java.io.FileNotFoundException;
-import java.net.URL;
+import java.net.URI;
 
 /**
  * A factory for creating {@link ResourcePack}s.
@@ -33,22 +33,22 @@ import java.net.URL;
 public interface ResourcePackFactory {
 
     /**
-     * Creates a {@link ResourcePack} from a URL and tries to download and hash
+     * Creates a {@link ResourcePack} from a URI and tries to download and hash
      * it.
      *
-     * @param url The URL to look in
-     * @return A ResourcePack with the specified URL
+     * @param uri The URI to look in
+     * @return A ResourcePack with the specified URI
      * @throws FileNotFoundException If a valid resourcepack could not be
-     *         downloaded from the URL
+     *         downloaded from the URI
      */
-    ResourcePack fromUrl(URL url) throws FileNotFoundException;
+    ResourcePack fromUri(URI uri) throws FileNotFoundException;
 
     /**
-     * Creates a {@link ResourcePack} from a URL.
+     * Creates a {@link ResourcePack} from a URI.
      *
-     * @param url The URL to look in
-     * @return A ResourcePack with the specified URL
+     * @param uri The URI to look in
+     * @return A ResourcePack with the specified URI
      */
-    ResourcePack fromUrlUnchecked(URL url);
+    ResourcePack fromUriUnchecked(URI uri);
 
 }

--- a/src/main/java/org/spongepowered/api/resourcepack/ResourcePacks.java
+++ b/src/main/java/org/spongepowered/api/resourcepack/ResourcePacks.java
@@ -25,7 +25,7 @@
 package org.spongepowered.api.resourcepack;
 
 import java.io.FileNotFoundException;
-import java.net.URL;
+import java.net.URI;
 
 /**
  * A class for creating {@link ResourcePack}s.
@@ -35,26 +35,26 @@ public final class ResourcePacks {
     private static final ResourcePackFactory factory = null;
 
     /**
-     * Creates a {@link ResourcePack} from a URL and tries to download and hash
+     * Creates a {@link ResourcePack} from a URI and tries to download and hash
      * it.
      *
-     * @param url The URL to look in
-     * @return A ResourcePack with the specified URL
+     * @param uri The URI to look in
+     * @return A ResourcePack with the specified URI
      * @throws FileNotFoundException If a valid resourcepack could not be
-     *         downloaded from the URL
+     *         downloaded from the URI
      */
-    public static ResourcePack fromUrl(URL url) throws FileNotFoundException {
-        return factory.fromUrl(url);
+    public static ResourcePack fromUri(URI uri) throws FileNotFoundException {
+        return factory.fromUri(uri);
     }
 
     /**
-     * Creates a {@link ResourcePack} from a URL, without checking ("unchecked")
-     * if there is a valid pack at the URL.
+     * Creates a {@link ResourcePack} from a URI, without checking ("unchecked")
+     * if there is a valid pack at the URI.
      *
-     * @param url The URL to look in
-     * @return A ResourcePack with the specified URL
+     * @param uri The URI to look in
+     * @return A ResourcePack with the specified URI
      */
-    public static ResourcePack fromUrlUnchecked(URL url) {
-        return factory.fromUrlUnchecked(url);
+    public static ResourcePack fromUriUnchecked(URI uri) {
+        return factory.fromUriUnchecked(uri);
     }
 }


### PR DESCRIPTION
This PR:
- ~~Adds `PlayerResourcePackStatusEvent` to the event factory.~~ This was taken care of with the events refactor.
- Replaces `URL` with `URI`. This allows Minecraft's `level://` resource packs (used for `resources.zip` insode a world) to be represented using Sponge (as `java.net.URL` does not support unknown protocols, e.g. `level://`).
- Renames `ResourcePackStatus.PACK_FILE_FORMAT_NOT_RECOGNIZED` to `FAILED`.
- Adds `Server.getDefaultResourcePack()`.

Implemented by SpongePowered/SpongeCommon#100.