### PR TITLE
More formal CatalogType definition

### DIFF
--- a/src/main/java/org/spongepowered/api/CatalogType.java
+++ b/src/main/java/org/spongepowered/api/CatalogType.java
@@ -25,24 +25,40 @@
 package org.spongepowered.api;
 
 /**
- * Represents a type of a catalog that can be used to identify types
- * without using an {@link Enum}.
+ * Represents a type of a catalog that can be used to identify types without
+ * using an {@link Enum}.
+ *
+ * <p>Implementing classes must meet the requirement for all its members that if
+ * any of <code>`a.equals(b)`</code>, <code>`a == b`</code>, or
+ * <code>`a.getId().equalsIgnoreCase(b.getId())`</code> are true then all must
+ * be true. This must also apply to members which are not listed in
+ * the classes listed in the
+ * {@link org.spongepowered.api.util.annotation.CatalogedBy CatalogedBy}
+ * annotation but nevertheless implement this interface.</p>
  */
 public interface CatalogType {
 
     /**
-     * Gets the unique identifier of this {@link CatalogType}. The identifier
-     * can be formatted however needed.
+     * Gets the unique identifier of this {@link CatalogType}. The identifier is
+     * case insensitive, thus there cannot be another instance with a different
+     * character case. The id of this instance must remain the same for the
+     * entire duration of its existence. The identifier can be formatted however
+     * needed.
+     *
+     * <p>A typical id will look like <code>`modId:name`</code> or
+     * <code>`minecraft:name`</code>. However the prefix may be omitted for
+     * default/vanilla minecraft types.</p>
      *
      * @return The unique identifier of this catalog type
      */
     String getId();
 
     /**
-     * Gets the unique human-readable name of this individual
-     * {@link CatalogType}.
+     * Gets the human-readable name of this individual {@link CatalogType}. This
+     * name is not guaranteed to be unique. This value should not be used for
+     * serialization.
      *
-     * @return The uniquely identifiable name of this catalog type
+     * @return The human-readable name of this catalog type
      */
     String getName();
 

--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -87,9 +87,10 @@ public interface GameRegistry {
      * game version changes.</p>
      *
      * @param typeClass The class of the type of {@link CatalogType}
-     * @param id The string id of the catalog type
+     * @param id The case insensitive string id of the catalog type
      * @param <T> The type of catalog type
      * @return The found catalog type, if available
+     * @see CatalogType
      */
     <T extends CatalogType> Optional<T> getType(Class<T> typeClass, String id);
 

--- a/src/main/java/org/spongepowered/api/util/annotation/CatalogedBy.java
+++ b/src/main/java/org/spongepowered/api/util/annotation/CatalogedBy.java
@@ -37,6 +37,26 @@ import javax.annotation.Nonnull;
  * using {@link Enum}. The class marked as {@link CatalogedBy} must have a
  * registrar class that can be queried for all types and subtypes of the
  * catalog.
+ *
+ * <p>All Classes mentioned in the CatalogedBy annotation must meet the
+ * following requirements:</p>
+ * <ul>
+ * <li>The values referenced by catalog classes must remain the same and valid
+ * at all times.</li>
+ * <li>The variables in catalog classes may link to null if the given value is
+ * no longer valid and no appropriate alternative can be found. If no
+ * alternative could be found and if there probably won't be a new one in the
+ * future then the field should be marked as deprecated and should be removed
+ * after a grace period or with the next big release of minecraft, SpongeAPI or
+ * the containing artifact.</li>
+ * <li>It is possible for two or more different variables to link to the same
+ * value. This includes both simple "well known" aliases and features that been
+ * merged together or that were originally very similar and one being removed.
+ * </li>
+ * <li>It is also possible that one or more values are not (yet) listed in the
+ * catalog classes (Especially plugin provided ones).</li>
+ * </ul>
+ * </p>
  */
 @Nonnull
 @Target(ElementType.TYPE)


### PR DESCRIPTION
Solves https://github.com/SpongePowered/SpongeAPI/issues/710

Currently there is only a very unspecific definition what an `CatalogType` is.
This PR try to solves that by adding a very precise definition on what it is and what is connected to that.

**`CatalogType`**

> Represents a type of a catalog that can be used to identify types without using an Enum. 
>
> Implementing classes must meet the following requirements for all its members including those which are not listed in the classes listed in the `CatalogedBy` annotation: 
* Every pair (a, b) that matches ... 
  * `a.equals(b)` must also match `a == b`
  * `a.getId().equalsIgnoreCase(b.getId())` must also match `a == b`

**`CatalogedBy`**

> Represents a class that is intended to represent a type of enum, without using Enum. The class marked as CatalogedBy must have a registrar class that can be queried for all types and subtypes of the catalog. 
>
>All Classes mentioned in the CatalogedBy annotation must meet the following requirements:
* The values referenced by catalog classes must remain the same and valid at all times.
* The variables in catalog classes may link to null if the given value is no longer valid and no appropriate alternative can be found. If no alternative could be found and if there probably won't be a new one in the future then the field should be marked as deprecated and should be removed after a grace period or with the next big release of minecraft, SpongeAPI or the containing artifact.
* It is possible for two or more different variables to link to the same value. This includes both simple "well known" aliases and features that been merged together or that were originally very similar and one being removed. 
* It is also possible that one or more values are not (yet) listed in the catalog classes (Especially plugin provided ones).


This is a very formal definition so if anybody like to reword/rephrase anything feel free to comment.
I tried to cover all cases that needed to be covered and have been discussed in #710, but we may have missed something.

The new definition walks along with the issue exposed in https://github.com/SpongePowered/SpongeAPI/issues/768: 
* `TextColor` shouldn't be a `CatalogType` only `TextColor.Base` should.

It also seems worth discussing the definition of `GameRegistry.getType(Class, String)` in regards to plugin/mod provided type instances and type classes.
* IMO plugin/mod provided instances and type classes should be listed/returned there as well. Due to the impact this might have I haven't added this here yet.
  * `<T extends CatalogType> GameRegistry.registerType(Class<T>, T... type) : void` - 
Which would be sealed after server startup/init phase
