### PR TITLE
Selectors in command arguments

### DIFF
--- a/src/main/java/org/spongepowered/api/command/CommandSource.java
+++ b/src/main/java/org/spongepowered/api/command/CommandSource.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.command;
 
+import org.spongepowered.api.command.source.ProxySourceTarget;
 import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.text.channel.MessageReceiver;
 import org.spongepowered.api.text.translation.locale.Locales;
@@ -36,7 +37,7 @@ import java.util.Locale;
  * <p>Examples of potential implementations include players, the server console,
  * Rcon clients, web-based clients, command blocks, and so on.</p>
  */
-public interface CommandSource extends MessageReceiver, Subject {
+public interface CommandSource extends MessageReceiver, Subject, ProxySourceTarget {
 
     /**
      * Gets the name identifying this command source.

--- a/src/main/java/org/spongepowered/api/command/args/SelectorCommandElement.java
+++ b/src/main/java/org/spongepowered/api/command/args/SelectorCommandElement.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.args;
+
+import com.google.common.collect.ImmutableList;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.selector.Selector;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+/**
+ * Abstract command element that matches values based on a {@link Selector}.
+ */
+public abstract class SelectorCommandElement extends PatternMatchingCommandElement {
+
+    protected SelectorCommandElement(@Nullable Text key) {
+        super(key);
+    }
+
+    @Nullable
+    @Override
+    protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+        Object state = args.getState();
+        try {
+            return super.parseValue(source, args);
+        } catch (ArgumentParseException e) {
+            args.setState(state);
+            try {
+                return Selector.parse(args.next()).resolve(source);
+            } catch (RuntimeException e1) {
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+        Object state = args.getState();
+        final Optional<String> nextArg = args.nextIfPresent();
+        args.setState(state);
+        if (!nextArg.isPresent()) {
+            return ImmutableList.of();
+        }
+
+        List<String> choices = Selector.complete(nextArg.get());
+        if (choices.isEmpty()) {
+            choices = super.complete(src, args, context);
+        }
+        return choices;
+    }
+}

--- a/src/main/java/org/spongepowered/api/command/source/ProxySource.java
+++ b/src/main/java/org/spongepowered/api/command/source/ProxySource.java
@@ -28,14 +28,21 @@ import org.spongepowered.api.command.CommandSource;
 
 /**
  * Proxy sources are {@link CommandSource}s that are run by one source as a
- * different source.
+ * different object.
  */
-public interface ProxySource extends LocatedSource {
+public interface ProxySource extends CommandSource {
 
     /**
-     * Gets the {@link CommandSource} this source is proxying.
+     * Gets the {@link CommandSource} this source is created by.
      *
      * @return The proxied source
      */
     CommandSource getOriginalSource();
+
+    /**
+     * Get the target of this source.
+     *
+     * @return The target
+     */
+    ProxySourceTarget getTarget();
 }

--- a/src/main/java/org/spongepowered/api/command/source/ProxySourceTarget.java
+++ b/src/main/java/org/spongepowered/api/command/source/ProxySourceTarget.java
@@ -24,20 +24,8 @@
  */
 package org.spongepowered.api.command.source;
 
-import org.spongepowered.api.block.tileentity.Sign;
-import org.spongepowered.api.block.tileentity.TileEntity;
-import org.spongepowered.api.command.CommandSource;
-
 /**
- * Sign sources are {@link CommandSource}s that execute commands when a player
- * clicks a sign. Their location is set to the sign's location.
+ * Represents an object that can be targeted by a {@link ProxySource}.
  */
-public interface SignSource extends LocatedSource, ProxySource {
-
-    /**
-     * Gets the sign {@link TileEntity} that this source has been created for.
-     *
-     * @return The {@link Sign}
-     */
-    Sign getSign();
+public interface ProxySourceTarget {
 }

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -29,7 +29,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.flowpowered.math.vector.Vector3d;
 import org.spongepowered.api.data.DataHolder;
-import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.mutable.TargetedLocationData;
@@ -39,6 +38,7 @@ import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.Identifiable;
 import org.spongepowered.api.util.RelativePositions;
+import org.spongepowered.api.command.source.ProxySourceTarget;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.TeleportHelper;
 import org.spongepowered.api.world.World;
@@ -69,7 +69,7 @@ import javax.annotation.Nullable;
  *
  * <p>Blocks and items (when they are in inventories) are not entities.</p>
  */
-public interface Entity extends Identifiable, DataHolder, DataSerializable, Translatable {
+public interface Entity extends Identifiable, DataHolder, Translatable, ProxySourceTarget {
 
     /**
      * Get the type of entity.

--- a/src/main/java/org/spongepowered/api/text/selector/Selector.java
+++ b/src/main/java/org/spongepowered/api/text/selector/Selector.java
@@ -89,6 +89,16 @@ public interface Selector {
     }
 
     /**
+     * Fetch completions for a selector command argument.
+     * 
+     * @param selector The partial selector
+     * @return Tab completions for the next part of the selector
+     */
+    static List<String> complete(String selector) {
+        return getFactory().complete(selector);
+    }
+
+    /**
      * Returns the type of this {@link Selector}.
      *
      * @return The type of this selector

--- a/src/main/java/org/spongepowered/api/text/selector/SelectorFactory.java
+++ b/src/main/java/org/spongepowered/api/text/selector/SelectorFactory.java
@@ -28,6 +28,7 @@ import org.spongepowered.api.text.selector.ArgumentHolder.Limit;
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -143,5 +144,13 @@ public interface SelectorFactory {
      *         due to invalid format)
      */
     Argument<?> parseArgument(String argument) throws IllegalArgumentException;
+
+    /**
+     * Fetch completions for a selector command argument.
+     * 
+     * @param selector The partial selector
+     * @return Tab completions for the next part of the selector
+     */
+    List<String> complete(String selector);
 
 }


### PR DESCRIPTION
As it stands currently, Sponge commands using `GenericArguments` cannot use selectors without going out of their way. This pull request adds the ability to use selectors in `GenericArguments.player()`. It also adds `GenericArguments.entity()` and `GenericArguments.entityOrSource()`, which are made much easier due to selectors.

Requires SpongePowered/SpongeCommon#110.