### PR TITLE
Added CommandReceiveEvent

### DIFF
--- a/src/main/java/org/spongepowered/api/event/message/CommandReceiveEvent.java
+++ b/src/main/java/org/spongepowered/api/event/message/CommandReceiveEvent.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.message;
+
+/**
+ * Fired when a command has been received by the server, but before it has been passed into any handlers.
+ */
+public interface CommandReceiveEvent extends CommandEvent {
+
+    /**
+     * Set the command string, without any prefix.
+     *
+     * <p>For example, if the command being set was {@code /example bob 3 -f}, then
+     * the parameter would be {@code example}.</p>
+     *
+     * @param command The command
+     */
+    void setCommand(String command);
+
+    /**
+     * Set the arguments string.
+     *
+     * <p>For example, if the command being set was {@code /example bob 3 -f}, then
+     * the parameter would be {@code bob 3 -f}.</p>
+     *
+     * @param arguments The arguments
+     */
+    void setArguments(String arguments);
+
+}


### PR DESCRIPTION
This event exists to fill the feature-set of Bukkit's CommandPreProcessEvent and subsequent events. The word Receive has been used instead of PreProcess, because I personally don't like words that would generally be hyphenated to be inside a class name.

The reasoning for including such an event is not, 'because bukkit did it', but instead to allow plugins such as CraftBook with the variables feature, to replace variables in the command with the values. I had many discussions with Bukkit staff back in the day about making this event 'generic' to all CommandSources, but they declined on the as they did not want to keep the event at all.

I propose that with Sponge, we include this event and allow it to filter any commands from any CommandSources.