### PR TITLE
Add API for generating error reports.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ genEventImpl {
             'src/main/java/org/spongepowered/api/event/rcon/',
             'src/main/java/org/spongepowered/api/event/server/',
             'src/main/java/org/spongepowered/api/event/statistic/',
+            'src/main/java/org/spongepowered/api/event/service/',
             'src/main/java/org/spongepowered/api/event/user/',
             'src/main/java/org/spongepowered/api/event/world/',
             'src/main/java/org/spongepowered/api/event/Event.java',

--- a/src/main/java/org/spongepowered/api/Server.java
+++ b/src/main/java/org/spongepowered/api/Server.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.resourcepack.ResourcePack;
 import org.spongepowered.api.service.world.ChunkLoadService;
+import org.spongepowered.api.service.error.Reportable;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.sink.MessageSink;
 import org.spongepowered.api.util.command.source.ConsoleSource;
@@ -47,7 +48,7 @@ import java.util.UUID;
 /**
  * Represents a typical Minecraft Server.
  */
-public interface Server {
+public interface Server extends Reportable {
 
     /**
      * Gets the {@link Player}s currently online.

--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -147,6 +147,7 @@ import org.spongepowered.api.event.network.PardonIpEvent;
 import org.spongepowered.api.event.network.rcon.RconConnectionEvent;
 import org.spongepowered.api.event.server.ClientPingServerEvent;
 import org.spongepowered.api.event.server.query.QueryServerEvent;
+import org.spongepowered.api.event.service.error.ErrorReportEvent;
 import org.spongepowered.api.event.statistic.ChangeStatisticEvent;
 import org.spongepowered.api.event.user.BanUserEvent;
 import org.spongepowered.api.event.user.PardonUserEvent;
@@ -175,6 +176,7 @@ import org.spongepowered.api.item.recipe.Recipe;
 import org.spongepowered.api.network.RemoteConnection;
 import org.spongepowered.api.potion.PotionEffect;
 import org.spongepowered.api.resourcepack.ResourcePack;
+import org.spongepowered.api.service.error.ErrorReport;
 import org.spongepowered.api.service.world.ChunkLoadService;
 import org.spongepowered.api.statistic.Statistic;
 import org.spongepowered.api.statistic.achievement.Achievement;
@@ -4305,6 +4307,20 @@ public class SpongeEventFactory {
         values.put("playerCount", playerCount);
         values.put("size", size);
         return SpongeEventFactoryUtils.createEventImpl(QueryServerEvent.Full.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.service.error.ErrorReportEvent}.
+     * 
+     * @param errorReport The error report
+     * @return A new error report event
+     */
+    public static ErrorReportEvent createErrorReportEvent(ErrorReport errorReport) {
+        Map<String, Object> values = Maps.newHashMap();
+        values.put("errorReport", errorReport);
+        return SpongeEventFactoryUtils.createEventImpl(ErrorReportEvent.class, values);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/event/service/error/ErrorReportEvent.java
+++ b/src/main/java/org/spongepowered/api/event/service/error/ErrorReportEvent.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.service.error;
+
+import org.spongepowered.api.event.Event;
+import org.spongepowered.api.service.error.ErrorReport;
+
+/**
+ * This event is thrown when an error report is generated, after the source of the error report has dispatched it but before it is sent to any
+ * dispatch targets.
+ * When this event is dispatched, the game may be in an inconsistent state. This means that some things that can generally be assumed to be
+ * available *MAY NOT BE*. Keep this in mind, and practice defensive programming to the extreme.
+ */
+public interface ErrorReportEvent extends Event {
+
+    /**
+     * Get the error report being dispatched.
+     *
+     * @return the error report
+     */
+    ErrorReport getErrorReport();
+}

--- a/src/main/java/org/spongepowered/api/service/error/ErrorReport.java
+++ b/src/main/java/org/spongepowered/api/service/error/ErrorReport.java
@@ -1,0 +1,164 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.error;
+
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.command.CommandSource;
+
+import java.net.URL;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An error report. This object is mutable.
+ */
+public interface ErrorReport {
+
+    /**
+     * Get the {@link Throwable} that was responsible for creating this error report, if any is present.
+     *
+     * @return The optional throwable for this error report
+     */
+    Optional<Throwable> getCause();
+
+    /**
+     * Check if this error is the result of a misconfiguration on the user's part, or due to an error in programming.
+     * This defaults to true only if the {@link #getCause()} is a {@link UserErrorException}.
+     *
+     * @return Whether or not this is a user error
+     */
+    boolean isUserError();
+
+    /**
+     * Set whether or not this is user error.
+     *
+     * @param isUserError Whether or not this is a user error
+     * @return this
+     */
+    ErrorReport setUserError(boolean isUserError);
+
+    /**
+     * Get a description of the base cause of this error.
+     *
+     * @return The description of this error's base cause
+     */
+    String getCauseDescription();
+
+    /**
+     * Get a section with the given title, creating and appending to the end of the error report as necessary.
+     *
+     * @param title The title to give the section
+     * @return The correct section
+     */
+    Section appendSection(String title);
+
+    /**
+     * Append a {@link Reportable} to this report. If this {@link Reportable} has already been added, it will not be added again.
+     *
+     * @param reportable The object to append information from
+     * @return this
+     */
+    ErrorReport addReportable(Reportable reportable);
+
+    /**
+     * Dispatch this error as a fatal error. Fatal means that the server will be stopped and a full crash report will be generated.
+     *
+     * An exception will be used to pass the result of this error up the call stack. This exception must be passed on.
+     */
+    void dispatchFatal() throws RuntimeException;
+
+    /**
+     * Dispatch this error to a command source. If this command source is not the console, the error report will additionally be mirrored to the
+     * console.
+     *
+     * @param source The source to send information about the error report to
+     */
+    void dispatchToCommandSource(CommandSource source);
+
+    /**
+     * Dispatch this as a non-fatal error that is sent to the console.
+     */
+    void dispatchToConsole();
+
+    /**
+     * Get the text of this error report.
+     *
+     * @return This error report's text
+     */
+    String toText();
+
+    /**
+     * Takes the text content of this error report and posts it to a pastebin service (implementation-determined).
+     * This allows users to more easily send it to the appropriate target.
+     *
+     * @return a url containing the content of this error report
+     */
+    CompletableFuture<URL> toPastebin();
+
+    interface Section {
+
+        /**
+         * Add an entry to this error report with the given information.
+         *
+         * @param content The content to add to this error report
+         * @return this
+         */
+        Section addEntry(Text content);
+
+        /**
+         * The entry to add.
+         *
+         * @param key The line name
+         * @param value The line value
+         * @return this
+         */
+        Section addEntry(Text key, Text value);
+
+        /**
+         * Add an entry to this section that contains a large block of plaintext information.
+         *
+         * @param key The name of the segment
+         * @param value The block of text to include, with lines separated by \n
+         * @param language The language name to use for syntax highlighting in services where supported
+         * @return this
+         */
+        Section addCodeEntry(Text key, String value, String language);
+
+        /**
+         * Set the exception to be contained within this section.
+         * @param t The exception to be used
+         * @return this
+         */
+        Section setException(Throwable t);
+
+        /**
+         * Get the error report that contains this section.
+         *
+         * @return The report
+         */
+        ErrorReport parent();
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/service/error/ErrorReportService.java
+++ b/src/main/java/org/spongepowered/api/service/error/ErrorReportService.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.error;
+
+import org.spongepowered.api.text.Text;
+
+/**
+ * A service for generating error reports with useful debug information.
+ */
+public interface ErrorReportService {
+
+    /**
+     * Create a report with the provided {@link Throwable} and a message describing the location the error was seen from.
+     *
+     * @param throwable The error causing this report to be generated
+     * @param message The message accompanying this report
+     * @return The report, ready to be dispatched
+     */
+    ErrorReport createReport(Throwable throwable, Text message);
+
+    /**
+     * Create a report describing an error not attached to a specific {@link Throwable}.
+     *
+     * @param message The message for this error
+     * @return The created report
+     */
+    ErrorReport createReport(Text message);
+
+    /**
+     * Create a report describing an error with a throwable and no more details.
+     *
+     * @param throwable The throwable this report is being created in response to
+     * @return The created report
+     */
+    ErrorReport createReport(Throwable throwable);
+}

--- a/src/main/java/org/spongepowered/api/service/error/Reportable.java
+++ b/src/main/java/org/spongepowered/api/service/error/Reportable.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.error;
+
+/**
+ * This interface may be implemented by objects that wish to annotate error reports with useful information.
+ */
+public interface Reportable {
+
+    /**
+     * Decorate an error report with possibly useful information. Keep in mind that this method may be called while the specified object is in an
+     * inconsistent initialization state, so care should be taken when accessing certain resources.
+     *
+     * @param report The report to decorate
+     */
+    void decorateErrorReport(ErrorReport report);
+}

--- a/src/main/java/org/spongepowered/api/service/error/UserErrorException.java
+++ b/src/main/java/org/spongepowered/api/service/error/UserErrorException.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.error;
+
+/**
+ * This is a marker interface for problems that are a result of user error. These are for example errors that are the result of an invalid
+ * configuration or a misconfigured internet connection, that a user is expected to be able to use the information from to be able to resolve issues
+ */
+public interface UserErrorException {
+
+}

--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -29,6 +29,7 @@ import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.effect.Viewer;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.scoreboard.Scoreboard;
+import org.spongepowered.api.service.error.Reportable;
 import org.spongepowered.api.service.permission.context.Contextual;
 import org.spongepowered.api.world.difficulty.Difficulty;
 import org.spongepowered.api.world.explosion.Explosion;
@@ -45,7 +46,7 @@ import java.util.UUID;
 /**
  * A loaded Minecraft world.
  */
-public interface World extends Extent, WeatherUniverse, Viewer, Contextual {
+public interface World extends Extent, WeatherUniverse, Viewer, Contextual, Reportable {
 
     @Override
     default Location<World> getLocation(Vector3i position) {


### PR DESCRIPTION
This service makes it easier for plugins to generate error reports that provide useful information for plugin developers.

[Example error report](https://gist.github.com/anonymous/ae434617c550c176f219)

The implementation wraps Minecraft's CrashReport system, with the changes of:
- Easily allowing sending the error report to a specific player
- Outputting the error report in Markdown format
- Posting the error report to an anonymous gist
- Using Text to allow formatting certain sections

Things to think about:
- [ ] How to pass through fatal exceptions? I currently use MC's ReportedException in the impl, but the SimpleCommandService wraps these in another layer of error reporting. Ways to deal with this are exposing the ReportedException to the API somehow, allowing custom error handlers to pass them through, moving the SimpleCommandService into the implementation and capturing there, or making the ErrorReportService simply reuse the existing error report while allowing the command service to tack on its additional data
- [ ] Should each Reportable be provided the entire error report, or its own section? 
- [ ] Additional pastebin services, authentication support? (would be configurable)