### PR TITLE
Improve PlayerChatEvent for better plugin interop

### DIFF
--- a/src/main/java/org/spongepowered/api/event/entity/player/PlayerChatEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/player/PlayerChatEvent.java
@@ -34,10 +34,35 @@ import org.spongepowered.api.text.Text;
 public interface PlayerChatEvent extends PlayerMessageEvent, Cancellable {
 
     /**
+     * The placeholder key that will be replaced with the player's name
+     */
+    String PLACEHOLDER_NAME = "name";
+
+    /**
+     * The placeholder key that will be replaced with the output of {@link #getUnformattedMessage()}
+     */
+    String PLACEHOLDER_MESSAGE = "message";
+
+    /**
      * Returns the message as the player provided it, without being formatted with the player's name or any other decorations.
      *
      * @return The unformatted message
      */
     Text getUnformattedMessage();
 
+    /**
+     * Set the unformatted message that will be provided for this event
+     *
+     * @param message The message to set
+     */
+    void setUnformattedMessage(Text message);
+
+    /**
+     * Set the new message to be used in this event. The placeholders {@code name} and {@code message} will be replaced with the sender's display
+     * name and {@link #getUnformattedMessage()} in the provided text.
+     *
+     * @param message The new message
+     */
+    @Override
+    void setNewMessage(Text message);
 }


### PR DESCRIPTION
This change makes use of placeholders to have an api-exposed method of
interoperability for chat messages. The unformatted message is also
made mutable so that plugins can change the player's message without
having to be concerned with formatting.

These changes have been made to make it easier for multiple plugins to
have a say in the final message sent by a player.

@mbaxter @mmonkey would love to get your opinion on this