### PR TITLE
Improve Text API

### DIFF
--- a/src/main/java/org/spongepowered/api/text/PlaceholderText.java
+++ b/src/main/java/org/spongepowered/api/text/PlaceholderText.java
@@ -1,0 +1,385 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.text;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.collect.ImmutableList;
+import org.spongepowered.api.text.action.ClickAction;
+import org.spongepowered.api.text.action.HoverAction;
+import org.spongepowered.api.text.action.ShiftClickAction;
+import org.spongepowered.api.text.format.TextColor;
+import org.spongepowered.api.text.format.TextFormat;
+import org.spongepowered.api.text.format.TextStyle;
+import org.spongepowered.api.text.transformer.Transformer;
+import org.spongepowered.api.text.transformer.Transformers;
+import org.spongepowered.api.text.transformer.ValueForKeyTransformer;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents a placeholder {@link Text} that can be replaced with another Text
+ * by {@link Text#format(Text, Function)}.
+ *
+ * @see PlaceholderText.Builder
+ */
+public class PlaceholderText extends Text {
+
+    protected final Transformer<?> transformer;
+    private final Optional<Text> fallback;
+
+    PlaceholderText(String key) {
+        this(key, null);
+    }
+
+    PlaceholderText(String key, @Nullable Text fallback) {
+        this(Transformers.key(key), fallback);
+    }
+
+    PlaceholderText(Transformer<?> transformer) {
+        this(transformer, null);
+    }
+
+    PlaceholderText(Transformer<?> transformer, @Nullable Text fallback) {
+        this.transformer = checkNotNull(transformer, "transformer");
+        this.fallback = Optional.ofNullable(fallback);
+    }
+
+    /**
+     * Constructs a new immutable {@link Builder} for the given plain text
+     * content with the specified formatting and text actions applied.
+     *
+     * @param format The format of the text
+     * @param children The immutable list of children of the text
+     * @param clickAction The click action of the text, or {@code null} for none
+     * @param hoverAction The hover action of the text, or {@code null} for none
+     * @param shiftClickAction The shift click action of the text, or
+     *        {@code null} for none
+     * @param transformer The transformer of the placeholder
+     * @param fallback The fallback text if this does not get replaced
+     */
+    PlaceholderText(TextFormat format, ImmutableList<Text> children, @Nullable ClickAction<?> clickAction,
+            @Nullable HoverAction<?> hoverAction, @Nullable ShiftClickAction<?> shiftClickAction,
+            Transformer<?> transformer, Text fallback) {
+        super(format, children, clickAction, hoverAction, shiftClickAction);
+        this.transformer = checkNotNull(transformer, "transformer");
+        this.fallback = Optional.ofNullable(fallback);
+    }
+
+    /**
+     * This method calculates / generates the replacement for this placeholder
+     * in {@link Text#format(Text, Function)}. It uses the contained
+     * {@link Transformer} to do the necessary transformations. If this method
+     * returns {@link Optional#empty()} then this placeholder should not be
+     * replaced. This is usually the case if not enough context information is
+     * available.
+     *
+     * @param context The context data function passed by
+     *        {@link Text#format(Text, Function)} that should be used to
+     *        calculate/generate a replacement
+     * @return The replacement for this placeholder
+     *
+     * @see Transformer#transform(Function)
+     */
+    public final Optional<?> calculateReplacement(Function<String, ?> context) {
+        return checkNotNull(this.transformer.transform(checkNotNull(context, "context")), "transformer result");
+    }
+
+    /**
+     * Gets the {@link Transformer} that is used to resolve the placeholder's
+     * replacement during the {@link Text#format(Text, Function)} call.
+     *
+     * @return The transformer that is used to resolve the placeholder's
+     *         replacement
+     */
+    public Transformer<?> getTransformer() {
+        return this.transformer;
+    }
+
+    /**
+     * Gets the fallback text that will be used in place if this placeholder has
+     * no value.
+     *
+     * @return The fallback text
+     */
+    public Optional<Text> getFallback() {
+        return this.fallback;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Builder) || !super.equals(o)) {
+            return false;
+        }
+
+        PlaceholderText that = (PlaceholderText) o;
+        return Objects.equal(this.transformer, that.transformer) && Objects.equal(this.fallback, that.fallback);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(super.hashCode(), this.transformer);
+    }
+
+    @Override
+    protected ToStringHelper toStringHelper() {
+        return super.toStringHelper()
+                .add("transformer", this.transformer)
+                .add("fallback", this.fallback.orElse(null))
+                .addValue(super.toString());
+    }
+
+    /**
+     * Represents a {@link Text.Builder} creating immutable {@link PlaceholderText}
+     * instances.
+     *
+     * @see PlaceholderText
+     */
+    public static class Builder extends Text.Builder {
+
+        private Transformer<?> transformer;
+        private Text fallback;
+
+        /**
+         * Constructs a new unformatted {@link Builder} with the given content.
+         *
+         * @param key The none empty replacement key for the placeholder builder
+         */
+        Builder(String key) {
+            key(key);
+        }
+
+        /**
+         * Constructs a new {@link Builder} with the formatting and actions of
+         * the specified {@link Text} and the given content.
+         *
+         * @param text The text to apply the properties from
+         * @param key The none empty replacement key for the placeholder builder
+         */
+        Builder(Text text, String key) {
+            super(text);
+            key(key);
+        }
+
+        /**
+         * Constructs a new unformatted {@link Builder} with the given content.
+         *
+         * @param transformer The transformer for the placeholder builder
+         */
+        Builder(Transformer<?> transformer) {
+            transformer(transformer);
+        }
+
+        /**
+         * Constructs a new {@link Builder} with the formatting and actions of
+         * the specified {@link Text} and the given content.
+         *
+         * @param text The text to apply the properties from
+         * @param transformer The transformer for the placeholder builder
+         */
+        Builder(Text text, Transformer<?> transformer) {
+            super(text);
+            transformer(transformer);
+        }
+
+        /**
+         * Constructs a new {@link Builder} with the formatting, actions and
+         * content of the specified {@link Text.Builder}.
+         *
+         * @param text The text to apply the properties from
+         */
+        Builder(PlaceholderText text) {
+            super(text);
+            this.transformer = text.transformer;
+            if (text.getFallback().isPresent()) {
+                this.fallback = text.getFallback().get();
+            }
+        }
+
+        /**
+         * Returns the current transformer of this builder.
+         *
+         * @return The current transformer
+         *
+         * @see PlaceholderText#getTransformer()
+         */
+        public final Transformer<?> getTransformer() {
+            return this.transformer;
+        }
+
+        /**
+         * Sets the key that is used in {@link Text#format(Text, Function)} to
+         * resolve the replacement for this placeholder.
+         *
+         * @param key The key used to resolve the replacement
+         * @return This text builder
+         * @see ValueForKeyTransformer
+         */
+        public Builder key(String key) {
+            transformer(Transformers.key(key));
+            return this;
+        }
+
+        /**
+         * Sets the {@link Transformer} that is used in
+         * {@link Text#format(Text, Function)} to resolve the replacement for
+         * this placeholder.
+         *
+         * @param transformer The transformer used to resolve the replacement
+         * @return This text builder
+         */
+        public Builder transformer(Transformer<?> transformer) {
+            this.transformer = checkNotNull(transformer, "transformer");
+            return this;
+        }
+
+        /**
+         * Sets the fallback text that will be used if no replacements is
+         * present for this placeholder
+         *
+         * @param fallback The content of this text
+         * @return This text builder
+         * @see PlaceholderText#getFallback()
+         */
+        public Builder fallback(Text fallback) {
+            this.fallback = fallback;
+            return this;
+        }
+
+        @Override
+        public PlaceholderText build() {
+            return new PlaceholderText(
+                    this.format,
+                    ImmutableList.copyOf(this.children),
+                    this.clickAction,
+                    this.hoverAction,
+                    this.shiftClickAction,
+                    this.transformer,
+                    this.fallback);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Builder) || !super.equals(o)) {
+                return false;
+            }
+
+            Builder that = (Builder) o;
+            return Objects.equal(this.transformer, that.transformer) && Objects.equal(this.fallback, that.fallback);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(super.hashCode(), this.fallback);
+        }
+
+        @Override
+        protected ToStringHelper toStringHelper() {
+            return super.toStringHelper()
+                    .add("transformer", this.transformer)
+                    .add("fallback", this.fallback);
+        }
+
+        @Override
+        public Builder color(TextColor color) {
+            return (Builder) super.color(color);
+        }
+
+        @Override
+        public Builder style(TextStyle... styles) {
+            return (Builder) super.style(styles);
+        }
+
+        @Override
+        public Builder onClick(@Nullable ClickAction<?> clickAction) {
+            return (Builder) super.onClick(clickAction);
+        }
+
+        @Override
+        public Builder onHover(@Nullable HoverAction<?> hoverAction) {
+            return (Builder) super.onHover(hoverAction);
+        }
+
+        @Override
+        public Builder onShiftClick(@Nullable ShiftClickAction<?> shiftClickAction) {
+            return (Builder) super.onShiftClick(shiftClickAction);
+        }
+
+        @Override
+        public Builder append(Text... children) {
+            return (Builder) super.append(children);
+        }
+
+        @Override
+        public Builder append(Iterable<? extends Text> children) {
+            return (Builder) super.append(children);
+        }
+
+        @Override
+        public Builder insert(int pos, Text... children) {
+            return (Builder) super.insert(pos, children);
+        }
+
+        @Override
+        public Builder insert(int pos, Iterable<? extends Text> children) {
+            return (Builder) super.insert(pos, children);
+        }
+
+        @Override
+        public Builder remove(Text... children) {
+            return (Builder) super.remove(children);
+        }
+
+        @Override
+        public Builder remove(Iterable<? extends Text> children) {
+            return (Builder) super.remove(children);
+        }
+
+        @Override
+        public Builder removeAll() {
+            return (Builder) super.removeAll();
+        }
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/Text.java
+++ b/src/main/java/org/spongepowered/api/text/Text.java
@@ -83,6 +83,28 @@ public abstract class Text implements TextRepresentable {
      */
     public static final Text EMPTY = LiteralText.EMPTY;
 
+    /**
+     * Format indicator for {@link Text#of(Object...)} to append the following
+     * {@link TextRepresentable}s. This has no effect on none
+     * {@link TextRepresentable} instances.
+     */
+    public static final TextProperty APPEND_TEXTS = new TextProperty() {
+    };
+    /**
+     * Format indicator for {@link Text#of(Object...)} to apply the specified
+     * format to the following {@link Text}s.This has no effect on none
+     * {@link TextRepresentable} instances.
+     */
+    public static final TextProperty FORMAT_TEXTS = new TextProperty() {
+    };
+    /**
+     * Format indicator for {@link Text#of(Object...)} to mark the format as
+     * changed so it will be appended if not followed by a none
+     * {@link TextProperty}.
+     */
+    public static final TextProperty MARK_CHANGED = new TextProperty() {
+    };
+
     static final char NEW_LINE_CHAR = '\n';
     static final String NEW_LINE_STRING = "\n";
 
@@ -825,12 +847,20 @@ public abstract class Text implements TextRepresentable {
         ClickAction<?> clickAction = null;
         ShiftClickAction<?> shiftClickAction = null;
         boolean changedFormat = false;
+        boolean appendTexts = false;
 
         for (Object obj : objects) {
             if (obj instanceof TextProperty) {
                 changedFormat = true;
-                // Text formatting + actions
-                if (obj instanceof TextFormat) {
+                // Format indicators
+                if (obj == APPEND_TEXTS) {
+                    appendTexts = true;
+                } else if (obj == FORMAT_TEXTS) {
+                    appendTexts = false;
+                } else if (obj == MARK_CHANGED) {
+                    // Do nothing, as changedFormat is already true here
+                    // Text formatting + actions
+                } else if (obj instanceof TextFormat) {
                     format = (TextFormat) obj;
                 } else if (obj instanceof TextColor) {
                     format = format.color((TextColor) obj);
@@ -853,6 +883,8 @@ public abstract class Text implements TextRepresentable {
                 } else {
                     // Unsupported TextProperty
                 }
+            } else if (appendTexts && obj instanceof TextRepresentable) {
+                builder.append(((TextRepresentable) obj).toText());
             } else {
                 // Simple content
                 changedFormat = false;

--- a/src/main/java/org/spongepowered/api/text/Text.java
+++ b/src/main/java/org/spongepowered/api/text/Text.java
@@ -29,6 +29,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.spongepowered.api.scoreboard.Score;
 import org.spongepowered.api.text.action.ClickAction;
 import org.spongepowered.api.text.action.HoverAction;
@@ -42,8 +44,12 @@ import org.spongepowered.api.text.format.TextStyle;
 import org.spongepowered.api.text.format.TextStyles;
 import org.spongepowered.api.text.selector.Selector;
 import org.spongepowered.api.text.serializer.TextSerializers;
+import org.spongepowered.api.text.transformer.Transformer;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.text.translation.Translation;
+import org.spongepowered.api.util.Functional;
+import org.spongepowered.api.util.Functions;
+import org.spongepowered.api.util.ResettableBuilder;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,7 +58,13 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import javax.annotation.Nullable;
 
@@ -82,6 +94,8 @@ public abstract class Text implements TextRepresentable {
      * The empty, unformatted {@link Text} instance.
      */
     public static final Text EMPTY = LiteralText.EMPTY;
+
+    public static final Text DEFAULT_SEPARATOR = new LiteralText(", ");
 
     /**
      * Format indicator for {@link Text#of(Object...)} to append the following
@@ -905,6 +919,10 @@ public abstract class Text implements TextRepresentable {
                     childBuilder = builder((Selector) obj);
                 } else if (obj instanceof Score) {
                     childBuilder = builder((Score) obj);
+                } else if (obj instanceof Iterable<?>) {
+                    childBuilder = joinOf(DEFAULT_SEPARATOR, (Iterable<?>) obj).toBuilder();
+                } else if (obj instanceof Object[]) {
+                    childBuilder = joinOf(DEFAULT_SEPARATOR, (Object[]) obj).toBuilder();
                 } else {
                     childBuilder = builder(String.valueOf(obj));
                 }
@@ -919,12 +937,7 @@ public abstract class Text implements TextRepresentable {
             builder.append(applyAndBuild(builder(), format, hoverAction, clickAction, shiftClickAction));
         }
 
-        if (builder.children.size() == 1) {
-            // Single content, reduce Text depth
-            return builder.children.get(0);
-        }
-
-        return builder.build();
+        return simplifyAndBuild(builder);
     }
 
     private static Text applyAndBuild(Builder builder, TextFormat format, HoverAction<?> hoverAction,
@@ -1103,13 +1116,109 @@ public abstract class Text implements TextRepresentable {
     }
 
     /**
+     * Creates a placeholder {@link Text} with the specified key. The created
+     * message won't have any formatting or events configured.
+     *
+     * @param key The key of the placeholder
+     * @return The created text
+     * @see PlaceholderText
+     */
+    public static PlaceholderText placeholder(String key) {
+        return new PlaceholderText(key);
+    }
+
+    /**
+     * Creates a placeholder {@link Text} with the specified key and fallback.
+     * The created message won't have any formatting or events configured.
+     *
+     * @param key The key of the placeholder
+     * @param fallback The fallback of the text if it is not replaced
+     * @return The created text
+     * @see PlaceholderText
+     */
+    public static PlaceholderText placeholder(String key, @Nullable Text fallback) {
+        return new PlaceholderText(key, fallback);
+    }
+
+    /**
+     * Creates a placeholder {@link Text} with the specified {@link Transformer}
+     * . The created message won't have any formatting or events configured.
+     *
+     * @param transformer The transformer of the placeholder
+     * @return The created text
+     * @see PlaceholderText
+     */
+    public static PlaceholderText placeholder(Transformer<?> transformer) {
+        return new PlaceholderText(transformer);
+    }
+
+    /**
+     * Creates a placeholder {@link Text} with the specified {@link Transformer}
+     * and fallback. The created message won't have any formatting or events
+     * configured.
+     *
+     * @param transformer The transformer of the placeholder
+     * @param fallback The fallback of the text if it is not replaced
+     * @return The created text
+     * @see PlaceholderText
+     */
+    public static PlaceholderText placeholder(Transformer<?> transformer, @Nullable Text fallback) {
+        return new PlaceholderText(transformer, fallback);
+    }
+
+    /**
+     * Creates a new unformatted {@link PlaceholderText.Builder} with the
+     * specified key.
+     *
+     * @param key The key of the placeholder
+     * @return The created placeholder builder
+     * @see PlaceholderText
+     * @see PlaceholderText.Builder
+     */
+    public static PlaceholderText.Builder placeholderBuilder(String key) {
+        return new PlaceholderText.Builder(key);
+    }
+
+    /**
+     * Creates a new unformatted {@link PlaceholderText.Builder} with the
+     * specified transformer.
+     *
+     * @param transformer The transformer of the placeholder
+     * @return The created placeholder builder
+     * @see PlaceholderText
+     * @see PlaceholderText.Builder
+     */
+    public static PlaceholderText.Builder placeholderBuilder(Transformer<?> transformer) {
+        return new PlaceholderText.Builder(transformer);
+    }
+
+    /**
+     * If the given builder contains only a single child the child will be
+     * returned otherwise the default {@link Builder#build()} will be called.
+     * This method assumes, that there is no styling or data applied to the
+     * given builder except for children.
+     *
+     * @param builder The builder to simplify or build
+     * @return The simplified or build Text instance
+     */
+    private static Text simplifyAndBuild(Builder builder) {
+        // Children size zero will automatically falls back to Text.EMPTY
+        if (builder.children.size() == 1) {
+            // Single content reduce Text depth
+            return builder.children.get(0);
+        } else {
+            return builder.build();
+        }
+    }
+
+    /**
      * Joins a sequence of text objects together.
      *
      * @param texts The texts to join
      * @return A text object that joins the given text objects
      */
     public static Text join(Text... texts) {
-        return builder().append(texts).build();
+        return simplifyAndBuild(builder().append(texts));
     }
 
     /**
@@ -1119,7 +1228,7 @@ public abstract class Text implements TextRepresentable {
      * @return A text object that joins the given text objects
      */
     public static Text join(Iterable<? extends Text> texts) {
-        return builder().append(texts).build();
+        return simplifyAndBuild(builder().append(texts));
     }
 
     /**
@@ -1129,7 +1238,20 @@ public abstract class Text implements TextRepresentable {
      * @return A text object that joins the given text objects
      */
     public static Text join(Iterator<? extends Text> texts) {
-        return builder().append(texts).build();
+        return simplifyAndBuild(builder().append(texts));
+    }
+
+    /**
+     * Joins a sequence of text objects together along with a separator.
+     *
+     * @param separator The separator
+     * @param texts The texts to join
+     * @return A text object that joins the given text objects
+     */
+    public static Text joinWith(Text separator, Stream<? extends Text> texts) {
+        final Builder builder = builder();
+        texts.forEachOrdered(Functional.joiner(builder::append, separator));
+        return simplifyAndBuild(builder);
     }
 
     /**
@@ -1140,26 +1262,7 @@ public abstract class Text implements TextRepresentable {
      * @return A text object that joins the given text objects
      */
     public static Text joinWith(Text separator, Text... texts) {
-        switch (texts.length) {
-            case 0:
-                return EMPTY;
-            case 1:
-                return texts[0];
-            default:
-                Text.Builder builder = builder();
-                boolean appendSeparator = false;
-                for (Text text : texts) {
-                    if (appendSeparator) {
-                        builder.append(separator);
-                    } else {
-                        appendSeparator = true;
-                    }
-
-                    builder.append(text);
-                }
-
-                return builder.build();
-        }
+        return joinWith(separator, Arrays.stream(texts));
     }
 
     /**
@@ -1170,7 +1273,7 @@ public abstract class Text implements TextRepresentable {
      * @return A text object that joins the given text objects
      */
     public static Text joinWith(Text separator, Iterable<? extends Text> texts) {
-        return joinWith(separator, texts.iterator());
+        return joinWith(separator, StreamSupport.stream(texts.spliterator(), false));
     }
 
     /**
@@ -1181,22 +1284,359 @@ public abstract class Text implements TextRepresentable {
      * @return A text object that joins the given text objects
      */
     public static Text joinWith(Text separator, Iterator<? extends Text> texts) {
-        if (!texts.hasNext()) {
-            return EMPTY;
+        @SuppressWarnings("unchecked")
+        final Iterable<Text> iterable = () -> (Iterator<Text>) texts;
+        return joinWith(separator, iterable);
+    }
+
+    /**
+     * Builds a {@link Text} from a given array of content objects. This method
+     * assumes, that all elements of the array are content and not formatting.
+     *
+     * <p>This will create the correct {@link Text} instance if the input object
+     * is the input for one of the {@link Text} types or convert the object to a
+     * string otherwise.</p>
+     *
+     * @param separator The separator to be inserted between elements
+     * @param objects The array that contains the content
+     * @return The built text object
+     */
+    public static Text joinOf(Text separator, Object... objects) {
+        return joinWith(separator, Arrays.stream(objects).map(Text::of));
+    }
+
+    /**
+     * Builds a {@link Text} from a given {@link Iterable}. This method assumes,
+     * that all elements of the iterable are content and not formatting.
+     *
+     * <p>This will create the correct {@link Text} instance if the input object
+     * is the input for one of the {@link Text} types or convert the object to a
+     * string otherwise.</p>
+     *
+     * @param separator The separator to be inserted between elements
+     * @param contents The iterable that contains the content
+     * @return The built text object
+     */
+    public static Text joinOf(Text separator, Iterable<?> contents) {
+        return joinWith(separator, StreamSupport.stream(contents.spliterator(), false).map(Text::of));
+    }
+
+    /**
+     * Creates a new Text instance with all {@link PlaceholderText}s replaced.
+     * All placeholders without a non-null replacement are ignored. All
+     * replacements will be wrapped in a {@link Text} using
+     * {@link Text#of(Object...)} the color and the style from the placeholder
+     * are transfered to that method as well. Useful for lazy fetching
+     * replacements.
+     *
+     * @param template The template text in which all {@link PlaceholderText}s
+     *        should be replaced
+     * @param context The context data used to calculate the replacements for
+     *        the {@link PlaceholderText}s. It does not have to contain enough
+     *        data to replace all placeholders
+     * @return The text with all possible placeholders replaced
+     */
+    public static Text format(Text template, Function<String, ?> context) {
+        checkNotNull(template, "template");
+        checkNotNull(context, "context values");
+        return formatNoChecks(template, context);
+    }
+
+    /**
+     * Creates a new Text instance with all {@link PlaceholderText}s replaced.
+     * All placeholders without a non-null replacement are ignored. All
+     * replacements will be wrapped in a {@link Text} using
+     * {@link Text#of(Object...)} the color and the style from the placeholder
+     * are transfered to that method as well.
+     *
+     * @param template The template text in which all {@link PlaceholderText}s
+     *        should be replaced
+     * @param context The context data used to calculate the replacements for
+     *        the {@link PlaceholderText}s. It does not have to contain enough
+     *        data to replace all placeholders
+     * @return The text with all possible placeholders replaced
+     */
+    public static Text format(Text template, Map<String, ?> context) {
+        checkNotNull(template, "template");
+        checkNotNull(context, "context values");
+        if (context.isEmpty()) {
+            return template;
+        }
+        return formatNoChecks(template, context::get);
+    }
+
+    /**
+     * Creates a new Text instance with all {@link PlaceholderText}s replaced.
+     * All placeholders with an {@link Optional#empty()} replacement are
+     * ignored. All replacements will be wrapped in a {@link Text} using
+     * {@link Text#of(Object...)} the {@link TextColor}, {@link TextStyle}s and
+     * {@link TextAction}s from the placeholder are transfered to that method as
+     * well.
+     *
+     * @param template The template text in which all {@link PlaceholderText}s
+     *        should be replaced
+     * @param context The context data used to calculate the replacements for
+     *        the {@link PlaceholderText}s. It does not have to contain enough
+     *        data to replace all placeholders
+     * @return The text with all possible placeholders replaced
+     */
+    public static Text format(Text template, Object... context) {
+        checkNotNull(template, "template");
+        checkNotNull(context, "context values");
+        if (context.length == 0) {
+            return template;
+        }
+        final Map<String, Object> contextMap = Maps.newHashMapWithExpectedSize(context.length);
+        int index = 0;
+        for (Object replacement : context) {
+            contextMap.put(Integer.toString(index++), replacement);
+        }
+        return formatNoChecks(template, contextMap::get);
+    }
+
+    private static Text formatNoChecks(Text template, Function<String, ?> context) {
+        // Is this a placeholder that should be replaced?
+        if (template instanceof PlaceholderText) {
+            final Optional<?> replacement = ((PlaceholderText) template).calculateReplacement(context);
+            // Only replace in case a replacement is present
+            if (replacement.isPresent()) {
+                // Copy color, style and text actions from placeholder
+                final List<Object> formats = Lists.newArrayList();
+                formats.add(FORMAT_TEXTS);
+                formats.add(template.getFormat());
+                final Optional<HoverAction<?>> hoverAction = template.getHoverAction();
+                hoverAction.ifPresent(formats::add);
+                final Optional<ClickAction<?>> clickAction = template.getClickAction();
+                clickAction.ifPresent(formats::add);
+                final Optional<ShiftClickAction<?>> shiftClickAction = template.getShiftClickAction();
+                shiftClickAction.ifPresent(formats::add);
+                formats.add(replacement.get());
+
+                return Text.of(formats.toArray());
+            }
+        }
+        // Also check child texts for placeholders
+        Text.Builder builder = null;
+        final List<Text> children = template.getChildren();
+        for (int i = 0; i < children.size(); ++i) {
+            final Text child = children.get(i);
+            final Text formatted = formatNoChecks(child, context);
+            if (builder == null) {
+                if (formatted == child) {
+                    continue;
+                }
+                builder = template.toBuilder();
+                builder.remove(children.subList(i, children.size()));
+            }
+            builder.append(formatted);
+        }
+        return builder == null ? template : builder.build();
+    }
+
+    /**
+     * Creates a new {@link FormatBuilder} that allows chained calls to
+     * configure the format function.
+     *
+     * @return The newly created format builder that can be used to setup the
+     *         formating
+     * @see FormatBuilder
+     */
+    public static FormatBuilder formatBuilder() {
+        return new FormatBuilder();
+    }
+
+    /**
+     * Helper class that allows easier/chained calls to the format method
+     * without extra steps
+     */
+    public static final class FormatBuilder implements Function<Text, Text>, ResettableBuilder<Function<String, Object>, FormatBuilder> {
+
+        private static final Function<String, ?> NO_FALLBACK_FUNCTION = Functions.constantNull();
+
+        private final Map<String, Object> values = Maps.newHashMap();
+        private Function<String, Object> replacerFunction = input -> this.values.get(input);
+        private Function<String, ?> fallbackFunction = NO_FALLBACK_FUNCTION;
+
+        /**
+         * Creates a new format builder that should format the given template.
+         */
+        FormatBuilder() {
         }
 
-        Text first = texts.next();
-        if (!texts.hasNext()) {
-            return first;
+        /**
+         * Set the given replacement for the given keys. Replacements set with
+         * this method will always take precedence over values set by the other
+         * methods. Values set using this method can be set/replaced after the
+         * format execution. This way you can create lots of similar
+         * {@link Text}s by just replacing a single or a few arguments.
+         *
+         * @param key The key used to set the value
+         * @param replacement The replacement to use. Null will unset it
+         * @return This instance for chaining
+         */
+        public FormatBuilder with(String key, @Nullable Object replacement) {
+            checkNotNull(key, "key");
+            this.values.put(key, replacement);
+            return this;
         }
 
-        Text.Builder builder = builder().append(first);
-        do {
-            builder.append(separator);
-            builder.append(texts.next());
-        } while (texts.hasNext());
+        /**
+         * Appends the given replacement {@link Supplier} for the given key.
+         * This method could be used for counters, indexes and stuff alike. If
+         * the supplier returns null the next provider can try to resolve it.
+         *
+         * <p><b>Note:</b>The given {@link Supplier} is only used if no other
+         * previous call provided a replacement for this key.</p>
+         *
+         * @param key The key used to set the supplier
+         * @param supplier The supplier used to get the replacement
+         * @return This instance for chaining
+         * @see Functions#supplied(Supplier)
+         * @see #with(Predicate, Function)
+         */
+        public FormatBuilder with(String key, Supplier<?> supplier) {
+            checkNotNull(key, "key");
+            checkNotNull(supplier, "supplier");
+            return with(input -> key.equals(input), Functions.supplied(supplier));
+        }
 
-        return builder.build();
+        /**
+         * Appends the given replacement {@link Function} for the given key.
+         * This method should be used if only some keys should be resolved the
+         * given function. If the function returns null the next provider can
+         * try to resolve it.
+         *
+         * <p><b>Note:</b>The given {@link Function} is only used if no other
+         * previous call provided a replacement for this key.</p>
+         *
+         * @param filter The filter used to decide whether the given function
+         *        should be used. It will be used if the
+         *        {@link Predicate#test(Object) test} returns true
+         * @param function The function used to calculate the replacement
+         * @return This instance for chaining
+         * @see Functions#conditional(Predicate, Function, Function)
+         * @see #with(Function)
+         */
+        public FormatBuilder with(Predicate<? super String> filter, Function<? super String, ? extends Object> function) {
+            checkNotNull(filter, "filter");
+            checkNotNull(function, "function");
+            return with(Functions.conditional(filter, function, Functions.constantNull()));
+        }
+
+        /**
+         * Appends the given replacement {@link Function} for all keys. Can be
+         * used for both fetching/calculating/returning specific replacements or
+         * parsing the input key to return a generated replacement based on the
+         * input specifications. If the function returns null the next provider
+         * can try to resolve the key.
+         *
+         * <p><b>Note:</b>This given {@link Function} is only used if no other
+         * previous call provided a replacement for the key.</p>
+         *
+         * @param function The function used to calculate the replacement
+         * @return This instance for chaining
+         * @see Functions#nonNullResultOrElse(Function, Function)
+         */
+        public FormatBuilder with(Function<? super String, ? extends Object> function) {
+            checkNotNull(function, "function");
+            this.replacerFunction = Functions.nonNullResultOrElse(this.replacerFunction, function);
+            return this;
+        }
+
+        /**
+         * Set the fallback strategy to use if the key could not be resolved.
+         * The no fallback strategy will omit the placeholder to allow setting
+         * it in a later run.
+         *
+         * @return This instance for chaining
+         * @see #fallback(Function)
+         */
+        public FormatBuilder noFallback() {
+            return fallback(NO_FALLBACK_FUNCTION);
+        }
+
+        /**
+         * Set the fallback strategy to use if the key could not be resolved.
+         * The constant fallback strategy will always return the given constant.
+         * That way you could replace all unresolved {@link PlaceholderText}s
+         * with the empty text.
+         *
+         * @return This instance for chaining
+         * @see #fallback(Function)
+         */
+        public FormatBuilder fallback(Object fallback) {
+            checkNotNull(fallback, "fallback");
+            return fallback(Functions.constant(fallback));
+        }
+
+        /**
+         * Set the fallback strategy to use if the key could not be resolved.
+         * The supplier fallback strategy will get the replacement from the
+         * given {@link Supplier}.
+         *
+         * @return This instance for chaining
+         * @see #fallback(Function)
+         */
+        public FormatBuilder fallback(Supplier<?> supplier) {
+            return fallback(Functions.supplied(supplier));
+        }
+
+        /**
+         * Set the fallback strategy to use if the key could not be resolved.
+         * The throwing fallback strategy will throw an
+         * {@link IllegalStateException} if no replacement for the given key
+         * could be found.
+         *
+         * @return This instance for chaining
+         * @see #fallback(Function)
+         */
+        public FormatBuilder throwingfallback() {
+            return fallback(Functions.exceptionFunction(IllegalStateException::new,
+                    "Missing replacement for placeholder with key: "::concat));
+        }
+
+        /**
+         * Set the fallback strategy to use if the key could not be resolved.
+         * The supplier fallback strategy will get the replacement from the
+         * given {@link Function}.
+         *
+         * @return This instance for chaining
+         */
+        public FormatBuilder fallback(Function<String, ?> function) {
+            checkNotNull(function, "function");
+            this.fallbackFunction = function;
+            return this;
+        }
+
+        @Override
+        public FormatBuilder from(Function<String, Object> function) {
+            reset();
+            return with(function);
+        }
+
+        @Override
+        public FormatBuilder reset() {
+            this.replacerFunction = input -> this.values.get(input);
+            this.values.clear();
+            noFallback();
+            return this;
+        }
+
+        /**
+         * Applies the specified replacements on the given {@link Text}
+         * template. This step is repeatable.
+         *
+         * @param template The {@link Text} template to apply the specified
+         *        formating on
+         * @return The processed with all possible {@link PlaceholderText}s
+         *         replaced
+         * @see #format(Text, Function)
+         */
+        @Override
+        public Text apply(Text template) {
+            return formatNoChecks(template, Functions.nonNullResultOrElse(this.replacerFunction, this.fallbackFunction));
+        }
+
     }
 
 }

--- a/src/main/java/org/spongepowered/api/text/Text.java
+++ b/src/main/java/org/spongepowered/api/text/Text.java
@@ -801,7 +801,7 @@ public abstract class Text implements TextRepresentable {
      * Builds a {@link Text} from a given array of objects.
      *
      * <p>For instance, you can use this like
-     * <code>Texts.of(TextColors.DARK_AQUA, "Hi", TextColors.AQUA, "Bye")</code>
+     * <code>Text.of(TextColors.DARK_AQUA, "Hi", TextColors.AQUA, "Bye")</code>
      * </p>
      *
      * <p>This will create the correct {@link Text} instance if the input object

--- a/src/main/java/org/spongepowered/api/text/action/TextAction.java
+++ b/src/main/java/org/spongepowered/api/text/action/TextAction.java
@@ -28,6 +28,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Objects;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextProperty;
 
 import javax.annotation.Nullable;
 
@@ -40,7 +41,7 @@ import javax.annotation.Nullable;
  * @see HoverAction
  * @see ShiftClickAction
  */
-public abstract class TextAction<R> {
+public abstract class TextAction<R> implements TextProperty {
 
     protected final R result;
 

--- a/src/main/java/org/spongepowered/api/text/action/TextActions.java
+++ b/src/main/java/org/spongepowered/api/text/action/TextActions.java
@@ -42,8 +42,11 @@ import javax.annotation.Nullable;
  */
 public final class TextActions {
 
-    private TextActions() {
-    }
+    /**
+     * Resets all {@link TextAction}s when used in {@link Text#of(Object...)}.
+     */
+    public static final TextAction<?> RESET_ACTIONS = new TextAction<String>("RESET") {
+    };
 
     /**
      * Creates a new {@link ClickAction} that will ask the player to open an URL
@@ -191,6 +194,9 @@ public final class TextActions {
      */
     public static ShiftClickAction.InsertText insertText(String text) {
         return new ShiftClickAction.InsertText(text);
+    }
+
+    private TextActions() {
     }
 
 }

--- a/src/main/java/org/spongepowered/api/text/dictionary/Dictionary.java
+++ b/src/main/java/org/spongepowered/api/text/dictionary/Dictionary.java
@@ -1,0 +1,452 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.text.dictionary;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.Text.FormatBuilder;
+import org.spongepowered.api.text.transformer.Transformer;
+import org.spongepowered.api.text.transformer.Transformers;
+import org.spongepowered.api.text.translation.locale.Locales;
+import org.spongepowered.api.util.BiFunctions;
+import org.spongepowered.api.util.Functions;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
+/**
+ * Utility class to allow plugin developers to easily add multi language support
+ * to their plugins.
+ */
+public class Dictionary implements Function<String, Function<Locale, Text>> {
+
+    /**
+     * Translation fallback that will return any language's translation in case
+     * none has been found before.
+     */
+    private static final BiFunction<Locale, Map<Locale, Text>, Text> TRANSLATION_FALLBACK = (locale, map) -> map.values().iterator().next();
+    /**
+     * Helper function that creates a new {@link Map} on each invocation.
+     */
+    private static final Function<String, Map<Locale, Text>> NEW_TRANSLATION_MAP = Functions.supplied(HashMap::new);
+
+    private final Map<String, Map<Locale, Text>> messages = new HashMap<>();
+    private final BiFunction<Locale, Map<Locale, Text>, Text> translationFallback;
+
+    /**
+     * Creates a new dictionary which uses any locale's translation as fallback
+     * in case the requested language's one could not be found.
+     */
+    public Dictionary() {
+        this.translationFallback = TRANSLATION_FALLBACK;
+    }
+
+    /**
+     * Creates a new dictionary with the given translation fallback.
+     *
+     * @param translationFallback The translation fallback to use if the
+     *        requested there is no translation for the given language, but
+     *        translations for other languages
+     */
+    public Dictionary(BiFunction<Locale, Map<Locale, Text>, Text> translationFallback) {
+        this.translationFallback = BiFunctions.nonNullResultOrElse(
+                checkNotNull(translationFallback, "translationFallback"), TRANSLATION_FALLBACK);
+    }
+
+    /**
+     * Adds the given translation to this dictionary's storage.
+     *
+     * @param translationId The translation id to register the translation for
+     * @param locale The locale to register the translation for
+     * @param translation The translation to register
+     */
+    public void addTranslation(String translationId, Locale locale, Text translation) {
+        checkNotNull(translationId, "translationId");
+        checkNotNull(locale, "locale");
+        checkNotNull(translation, "translation");
+        this.messages.computeIfAbsent(translationId, NEW_TRANSLATION_MAP).put(locale, translation);
+    }
+
+    /**
+     * Helper method to get the map containing the translations for the given
+     * translation id or a fallback in case there is no translation specified
+     * yet.
+     *
+     * @param translationId The translation id to search
+     * @return A map containing the translations for the given translation id
+     */
+    protected Map<Locale, Text> getTranslations(final String translationId) {
+        Map<Locale, Text> translations = this.messages.get(translationId);
+        if (translations == null) {
+            translations = new HashMap<>();
+            translations.put(Locales.DEFAULT, Text.of(translationId));
+        }
+        return translations;
+    }
+
+    /**
+     * Gets the best fitting translation for the given translation id and
+     * locale.
+     *
+     * @param translationId The translation id to look for
+     * @param locale The requested language
+     * @return The best fitting translation for the given translation id and
+     *         locale
+     */
+    public Text getTranslation(String translationId, Locale locale) {
+        final Map<Locale, Text> translations = getTranslations(translationId);
+        final Text result = translations.get(locale);
+        if (result == null) {
+            return this.translationFallback.apply(locale, translations);
+        } else {
+            return result;
+        }
+    }
+
+    /**
+     * Gets a function that will return the best translation for the a given
+     * locale for the given translation id.
+     *
+     * @param translationId The translation id the function should return the
+     *        translations for
+     * @return A function that will return the best translation for the a given
+     *         locale for the given translation id
+     */
+    @Override
+    public Function<Locale, Text> apply(String translationId) {
+        checkNotNull(translationId, "translationId");
+        return locale -> getTranslation(translationId, locale);
+    }
+
+    /**
+     * Gets a caching function that will return the best translation for a given
+     * locale for the given translation id.
+     *
+     * @param translationId The translation id the function should return the
+     *        translations for
+     * @return A function that will return the best matching translation for a
+     *         given locale for the given translation id
+     */
+    public Function<Locale, Text> get(String translationId) {
+        return cache(apply(translationId));
+    }
+
+    /**
+     * Gets a {@link Transformer} containing a caching function that will return
+     * the best translation for a given target (using the target key) for the
+     * given translation id.
+     *
+     * @param translationId The translation id the function should return the
+     *        translations for
+     * @param targetKey The key to get the target from the context later on
+     * @return A transformer containing a function that will return the best
+     *         matching translation for a given locale for the given translation
+     *         id
+     * @see #get(String)
+     * @see Transformers#multiLanguageSupportWithTarget(String, Function)
+     */
+    public Transformer<Text> getWithTarget(String translationId, String targetKey) {
+        return Transformers.multiLanguageSupportWithTarget(targetKey, get(translationId));
+    }
+
+    /**
+     * Gets a {@link Transformer} containing a caching function that will return
+     * the best translation for a given locale (using the locale key) for the
+     * given translation id.
+     *
+     * @param translationId The translation id the function should return the
+     *        translations for
+     * @param localeKey The key to get the locale from the context later on
+     * @return A transformer containing a function that will return the best
+     *         matching translation for a given locale for the given translation
+     *         id
+     * @see #get(String)
+     * @see Transformers#multiLanguageSupportWithLocale(String, Function)
+     */
+    public Transformer<Text> getWithLocale(String translationId, String localeKey) {
+        return Transformers.multiLanguageSupportWithLocale(localeKey, get(translationId));
+    }
+
+    /**
+     * Gets a function that will cache the results of the given function.
+     *
+     * @param resolverFunction The function which results should be cached
+     * @return A function that will cache the results of the given function
+     */
+    protected Function<Locale, Text> cache(Function<Locale, Text> resolverFunction) {
+        checkNotNull(resolverFunction, "resolverFunction");
+        final Map<Locale, Text> map = new HashMap<>();
+        return locale -> map.computeIfAbsent(locale, resolverFunction);
+    }
+
+    /**
+     * Creates a new {@link TranslationPreparator} that can be used to create a
+     * function that will format the {@link Text}s obtained from this dictionary
+     * and apply the configured formating to it and cache the {@link Text} after
+     * that.
+     *
+     * @param translationId The translation id that should be used to get the
+     *        raw translation.
+     * @return Gets a caching function that will return the best matching
+     *         formated translation for a given locale for the given translation
+     *         id
+     */
+    public TranslationPreparator prepare(String translationId) {
+        return new TranslationPreparator(apply(translationId));
+    }
+
+    /**
+     * Helper class to setup the necessary formating steps that must be executed
+     * before the templates can be used.
+     */
+    public class TranslationPreparator {
+
+        private final FormatBuilder formatBuilder = Text.formatBuilder();
+        private final Function<Locale, Text> resolverFunction;
+
+        /**
+         * Creates a new TranslationPreparator that uses the given raw resolver
+         * {@link Function} to create a function that will apply the configured
+         * formating to the returned result.
+         *
+         * @param rawResolverFunction The raw resolver function to use
+         */
+        protected TranslationPreparator(Function<Locale, Text> rawResolverFunction) {
+            checkNotNull(rawResolverFunction, "rawResolverFunction");
+            this.resolverFunction = rawResolverFunction.andThen(this.formatBuilder);
+        }
+
+        /**
+         * Set the given replacement for the given key. Replacements set with
+         * this method will always take precedence over values set by the other
+         * methods. Values set using this method can be set/replaced after the
+         * format execution. This way you can create lots of similar
+         * {@link Text}s by just replacing a single or a few arguments.
+         *
+         * @param key The key used to set the value
+         * @param replacement The replacement to use. Null will unset it
+         * @return This instance for chaining
+         * @see FormatBuilder#with(String, Object)
+         */
+        public TranslationPreparator with(String key, @Nullable Object replacement) {
+            this.formatBuilder.with(key, replacement);
+            return this;
+        }
+
+        /**
+         * Set the given transformer wrapped in a {@link Placeholder} for the
+         * given key. Replacements set with this method will always take
+         * precedence over values set by the other methods. Values set using
+         * this method can be set/replaced after the format execution. This way
+         * you can create lots of similar {@link Text}s by just replacing a
+         * single or a few arguments.
+         *
+         * @param key The key used to set the value
+         * @param transformer {@link Transformer} to use in the placeholder
+         * @return This instance for chaining
+         * @see #with(String, Object)
+         */
+        public TranslationPreparator with(String key, Transformer<?> transformer) {
+            return with(key, Text.placeholder(transformer));
+        }
+
+        /**
+         * Set the given replacement {@link Supplier} for the given key. This
+         * method could be used for counters, indexes and stuff alike. If the
+         * supplier returns null the next provider can try to resolve it.
+         *
+         * <p><b>Note:</b>The given {@link Supplier} is only used if no other
+         * previous call provided a replacement for this key.</p>
+         *
+         * @param key The key used to set the supplier
+         * @param supplier The supplier used to get the replacement
+         * @return This instance for chaining
+         * @see FormatBuilder#with(String,Supplier)
+         */
+        public TranslationPreparator with(String key, Supplier<?> supplier) {
+            this.formatBuilder.with(key, supplier);
+            return this;
+        }
+
+        /**
+         * Set the given replacement {@link Function} for the given key. This
+         * method should be used if only some keys should be resolved the given
+         * function. If the function returns null the next provider can try to
+         * resolve it.
+         *
+         * <p><b>Note:</b>The given {@link Function} is only used if no other
+         * previous call provided a replacement for this key.</p>
+         *
+         * @param filter The filter used to decide whether the given function
+         *        should be used. It will be used if the
+         *        {@link Predicate#test(Object) test} returns true
+         * @param function The function used to calculate the replacement
+         * @return This instance for chaining
+         * @see FormatBuilder#with(Predicate, Function)
+         */
+        public TranslationPreparator with(Predicate<? super String> filter, Function<? super String, ? extends Object> function) {
+            this.formatBuilder.with(filter, function);
+            return this;
+        }
+
+        /**
+         * Set the given replacement {@link Function} for all keys. Can be used
+         * for both fetching/calculating/returning specific replacements or
+         * parsing the input to key to return a generated replacement based on
+         * the input specifications. If the function returns null the next
+         * provider can try to resolve the key.
+         *
+         * <p><b>Note:</b>This given {@link Function} is only used if no other
+         * previous call provided a replacement for the key.</p>
+         *
+         * @param function The function used to calculate the replacement
+         * @return This instance for chaining
+         * @see FormatBuilder#with(Function)
+         */
+        public TranslationPreparator with(Function<? super String, ? extends Object> function) {
+            this.formatBuilder.with(function);
+            return this;
+        }
+
+        /**
+         * Set the fallback strategy to use if the key could not be resolved.
+         * The no fallback strategy will omit the placeholder to allow setting
+         * it in a later run.
+         *
+         * @return This instance for chaining
+         * @see FormatBuilder#noFallback()
+         */
+        public TranslationPreparator noFallback() {
+            this.formatBuilder.noFallback();
+            return this;
+        }
+
+        /**
+         * Set the fallback strategy to use if the key could not be resolved.
+         * The constant fallback strategy will always return the given constant.
+         * That way you could replace all unresolved {@link Placeholder}s with
+         * the empty text.
+         *
+         * @return This instance for chaining
+         * @see FormatBuilder#fallback(Object)
+         */
+        public TranslationPreparator fallback(Object fallback) {
+            this.formatBuilder.fallback(fallback);
+            return this;
+        }
+
+        /**
+         * Set the fallback strategy to use if the key could not be resolved.
+         * The supplier fallback strategy will get the replacement from the
+         * given {@link Supplier}.
+         *
+         * @return This instance for chaining
+         * @see FormatBuilder#fallback(Supplier)
+         */
+        public TranslationPreparator fallback(Supplier<?> supplier) {
+            this.formatBuilder.fallback(supplier);
+            return this;
+        }
+
+        /**
+         * Set the fallback strategy to use if the key could not be resolved.
+         * The throwing fallback strategy will throw an
+         * {@link IllegalStateException} if no replacement for the given key
+         * could be found.
+         *
+         * @return This instance for chaining
+         * @see FormatBuilder#throwingfallback()
+         */
+        public TranslationPreparator throwingfallback() {
+            this.formatBuilder.throwingfallback();
+            return this;
+        }
+
+        /**
+         * Set the fallback strategy to use if the key could not be resolved.
+         * The supplier fallback strategy will get the replacement from the
+         * given {@link Function}.
+         *
+         * @return This instance for chaining
+         * @see FormatBuilder#fallback(java.util.function.Function)
+         */
+        public TranslationPreparator fallback(Function<String, ?> function) {
+            this.formatBuilder.fallback(function);
+            return this;
+        }
+
+        /**
+         * Completes the preparation setup and returns a caching function that
+         * will return the best matching translation for a given locale.
+         *
+         * @return A caching function that will return the best matching
+         *         translation for a given locale
+         */
+        public Function<Locale, Text> done() {
+            return cache(this.resolverFunction);
+        }
+
+        /**
+         * Completes the preparation setup and returns a {@link Transformer}
+         * that will return the best matching translation for a given target
+         * specified via the given target key.
+         *
+         * @param targetKey The key to get the target from the context later on
+         * @return A transformer that will return the best matching translation
+         *         for a given target
+         * @see #done()
+         * @see Transformers#multiLanguageSupportWithTarget(String, Function)
+         */
+        public Transformer<Text> doneWithTarget(String targetKey) {
+            return Transformers.multiLanguageSupportWithTarget(targetKey, done());
+        }
+
+        /**
+         * Completes the preparation setup and returns a {@link Transformer}
+         * that will return the best matching translation for a given locale
+         * specified via the given locale key.
+         *
+         * @param localeKey The key to get the locale from the context later on
+         * @return A transformer that will return the best matching translation
+         *         for a given target
+         * @see #done()
+         * @see Transformers#multiLanguageSupportWithLocale(String, Function)
+         */
+        public Transformer<Text> doneWithLocale(String localeKey) {
+            return Transformers.multiLanguageSupportWithLocale(localeKey, done());
+        }
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/dictionary/package-info.java
+++ b/src/main/java/org/spongepowered/api/text/dictionary/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.api.text.dictionary;

--- a/src/main/java/org/spongepowered/api/text/format/TextFormat.java
+++ b/src/main/java/org/spongepowered/api/text/format/TextFormat.java
@@ -31,7 +31,7 @@ import com.google.common.base.Objects;
 /**
  * Represents a pair of {@link TextStyle} and {@link TextColor}.
  */
-public final class TextFormat {
+public final class TextFormat implements TextProperty {
 
     /**
      * An empty {@link TextFormat} with no {@link TextColor} and no {@link TextStyle}.

--- a/src/main/java/org/spongepowered/api/text/format/TextProperty.java
+++ b/src/main/java/org/spongepowered/api/text/format/TextProperty.java
@@ -22,26 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package org.spongepowered.api.text.format;
 
-import org.spongepowered.api.CatalogType;
-import org.spongepowered.api.text.Text;
-import org.spongepowered.api.util.Color;
-import org.spongepowered.api.util.annotation.CatalogedBy;
-
 /**
- * Represents the color of the text of a {@link Text}.
- *
- * @see TextColors
+ * Parent class for all text formats, styling and actions for easier detection.
  */
-@CatalogedBy(TextColors.class)
-public interface TextColor extends CatalogType, TextProperty {
-
-    /**
-     * Returns the corresponding {@link Color} for this {@link TextColor}.
-     *
-     * @return The RGB color of this text color
-     */
-    Color getColor();
+public interface TextProperty {
 
 }

--- a/src/main/java/org/spongepowered/api/text/format/TextStyle.java
+++ b/src/main/java/org/spongepowered/api/text/format/TextStyle.java
@@ -58,7 +58,7 @@ import javax.annotation.Nullable;
  * @see TextStyles
  */
 @CatalogedBy(TextStyles.class)
-public class TextStyle {
+public class TextStyle implements TextProperty {
 
     /**
      * Whether text where this style is applied is bolded.

--- a/src/main/java/org/spongepowered/api/text/selector/Argument.java
+++ b/src/main/java/org/spongepowered/api/text/selector/Argument.java
@@ -35,6 +35,7 @@ import java.util.Set;
  *
  * @param <T> The type of the value
  */
+@SuppressWarnings("deprecation")
 public interface Argument<T> {
 
     /**

--- a/src/main/java/org/spongepowered/api/text/selector/ArgumentTypes.java
+++ b/src/main/java/org/spongepowered/api/text/selector/ArgumentTypes.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 /**
  * Represents the default {@link ArgumentType}s available in Vanilla Minecraft.
  */
+@SuppressWarnings("deprecation")
 public final class ArgumentTypes {
 
     private ArgumentTypes() {
@@ -132,7 +133,6 @@ public final class ArgumentTypes {
      */
     public static final ArgumentType.Invertible<EntityType> ENTITY_TYPE = null;
 
-    @SuppressWarnings("deprecation")
     static SelectorFactory getFactory() {
         return Sponge.getRegistry().getSelectorFactory();
     }

--- a/src/main/java/org/spongepowered/api/text/selector/Selector.java
+++ b/src/main/java/org/spongepowered/api/text/selector/Selector.java
@@ -67,6 +67,7 @@ import java.util.Set;
  * @see <a href="http://minecraft.gamepedia.com/Selector#Target_selectors">
  *      Target selectors on the Minecraft Wiki</a>
  */
+@SuppressWarnings("deprecation")
 public interface Selector {
 
     /**

--- a/src/main/java/org/spongepowered/api/text/transformer/Transformer.java
+++ b/src/main/java/org/spongepowered/api/text/transformer/Transformer.java
@@ -1,0 +1,299 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.text.transformer;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.text.PlaceholderText;
+import org.spongepowered.api.text.Text;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * The context aware transformer interface represents a function that tries to
+ * convert the passed context data or select from them to dynamically calculate
+ * or generate content suiting the given context best. {@link PlaceholderText}s
+ * use this interface to resolve their replacements for
+ * {@link Text#format(Text, Function)}.
+ *
+ * @param <T> The type returned by this transformer
+ *
+ * @see Text#format(Text, Function)
+ * @see PlaceholderText
+ * @see PlaceholderText#calculateReplacement(Function)
+ */
+public interface Transformer<T> {
+
+    /**
+     * Tries to transform the input context into appropriate content. Other
+     * transformations may take place after this. Implementations should be
+     * aware that sometimes their context data may not be available, in that
+     * case this method should return {@link Optional#empty()}.
+     *
+     * @param context The context function that contains the context data
+     * @return The non-null content for the given context or
+     *         {@link Optional#empty()}
+     *
+     * @see PlaceholderText#calculateReplacement(Function)
+     */
+    Optional<T> transform(Function<String, ?> context);
+
+    /**
+     * Wraps this transformer in another one that will return a fallback value
+     * in case this transformer returns {@link Optional#empty()}.
+     *
+     * @param fallback The fallback to use
+     * @return A newly created transformer with the given fallback
+     */
+    default Transformer<T> orDefault(final T fallback) {
+        checkNotNull(fallback, "fallback");
+        final Optional<T> optFallback = Optional.of(fallback);
+        return context -> {
+            final Optional<T> result = transform(context);
+            if (result.isPresent()) {
+                return result;
+            } else {
+                return optFallback;
+            }
+        };
+    }
+
+    /**
+     * Wraps this transformer in another one that will return a value from the
+     * given {@link Supplier} in case this transformer returns
+     * {@link Optional#empty()}.
+     *
+     * @param fallback The fallback supplier to use. The supplier is allowed to
+     *        return null
+     * @return A newly created transformer with the given fallback supplier
+     */
+    default Transformer<T> orSupplied(final Supplier<? extends T> fallback) {
+        checkNotNull(fallback, "fallback");
+        return context -> {
+            final Optional<T> result = transform(context);
+            if (result.isPresent()) {
+                return result;
+            } else {
+                return Optional.ofNullable(fallback.get());
+            }
+        };
+    }
+
+    /**
+     * Wraps this transformer in another one that will use the given
+     * {@link Transformer} in case this transformer returns
+     * {@link Optional#empty()}.
+     *
+     * @param transformer The fallback transformer to use. The transformer is
+     *        allowed to return empty
+     * @return A newly created transformer with the given fallback transformer
+     */
+    default Transformer<T> orElse(final Transformer<T> transformer) {
+        checkNotNull(transformer, "transformer");
+        return context -> {
+            final Optional<T> result = transform(context);
+            if (result.isPresent()) {
+                return result;
+            } else {
+                return transformer.transform(context);
+            }
+        };
+    }
+
+    /**
+     * Wraps this transformer in another one that will return the
+     * {@link Text#of() empty text} in case this transformer returns
+     * {@link Optional#empty()}. This will effectively remove the param from the
+     * template in case there is no value for it.
+     *
+     * @return A newly created transformer with the empty text fallback
+     */
+    default Transformer<Text> orEmptyText() {
+        return orText(Text.of());
+    }
+
+    /**
+     * Wraps this transformer in another one that will return the given fallback
+     * {@link Text} in case this transformer returns {@link Optional#empty()}.
+     *
+     * @param fallback The fallback text to use
+     * @return A newly created transformer with the given fallback text
+     */
+    default Transformer<Text> orText(final Text fallback) {
+        checkNotNull(fallback, "fallback");
+        return context -> Optional.of(transform(context).map(Text::of).orElse(fallback));
+    }
+
+    /**
+     * Wraps this transformer in another one that will transform the result
+     * using the given function in case the value is present.
+     *
+     * @param function The transform function used to transform the present data
+     * @param <R> The expected result type for the function
+     * @return A newly created transformer with the given transformation
+     *         function
+     * @see Optional#map(Function)
+     */
+    default <R> Transformer<R> map(final Function<? super T, R> function) {
+        checkNotNull(function, "function");
+        return context -> transform(context).map(function);
+    }
+
+    /**
+     * Wraps this transformer in another one that will transform the result
+     * using the given function in case the value is present.
+     *
+     * @param function The transform function used to transform the present data
+     * @param <R> The expected result type for the function
+     * @return A newly created transformer with the given transformation
+     *         function
+     * @see Optional#flatMap(Function)
+     */
+    default <R> Transformer<R> flatMap(final Function<? super T, Optional<R>> function) {
+        checkNotNull(function, "function");
+        return context -> transform(context).flatMap(function);
+    }
+
+    /**
+     * Wraps this transformer in another one that will join a new value to the
+     * result of this one using the given function in case this one's is
+     * present. The created transformer will return {@link Optional#empty()} in
+     * case one of the two values are {@link Optional#empty()}.
+     *
+     * <p>This method is intended to be used to calculate a value based on two
+     * or more context parameters. This could be the distance between two
+     * players or a hostility check.</p>
+     *
+     * @param key The context parameter name to join
+     * @param joinFunction The function used to join both results. The function
+     *        is allowed to return null
+     * @return A newly created transformer with the given join function
+     * @see Transformers#key(String)
+     * @see BiFunction
+     * @see #join(Transformer, BiFunction)
+     */
+    default <U, R> Transformer<R> join(final String key, final BiFunction<T, U, R> joinFunction) {
+        return join(Transformers.key(key), joinFunction);
+    }
+
+    /**
+     * Wraps this transformer in another one that will join a new value to the
+     * result of this one using the given function in case this one's is
+     * present. The created transformer will return {@link Optional#empty()} in
+     * case one of the two values are {@link Optional#empty()}.
+     *
+     * <p>This method is intended to be used to calculate a value based on two
+     * or more context parameters. This could be the distance between two
+     * players or a hostility check.</p>
+     *
+     * @param joined The transformer which results should be used for the join
+     * @param joinFunction The function used to join both results. The function
+     *        is allowed to return null
+     * @return A newly created transformer with the given join function
+     * @see BiFunction
+     */
+    default <U, R> Transformer<R> join(final Transformer<U> joined, final BiFunction<T, U, R> joinFunction) {
+        checkNotNull(joined, "joined");
+        checkNotNull(joinFunction, "function");
+        return context -> {
+            final Optional<T> value = transform(context);
+            if (value.isPresent()) {
+                final Optional<U> value2 = joined.transform(context);
+                if (value2.isPresent()) {
+                    return Optional.ofNullable(joinFunction.apply(value.get(), value2.get()));
+                } else {
+                    return Optional.empty();
+                }
+            } else {
+                return Optional.empty();
+            }
+        };
+    }
+
+    /**
+     * Wraps this transformer in another one that will join a new value to the
+     * result of this one using the given function.
+     *
+     * <p>This method is intended to be used to calculate a value based on two
+     * or more context parameters. This could be the distance between two
+     * players or a hostility check.</p>
+     *
+     * @param key The context parameter name to join
+     * @param joinFunction The function used to join both results. The given
+     *        function must be prepared to deal with null arguments. The
+     *        function is allowed to return null
+     * @return A newly created transformer with the given join function
+     * @see Transformers#key(String)
+     * @see BiFunction
+     * @see #joinNullable(Transformer, BiFunction)
+     * @see #join(String, BiFunction)
+     */
+    default <U, R> Transformer<R> joinNullable(final String key, final BiFunction<T, U, R> joinFunction) {
+        return joinNullable(Transformers.key(key), joinFunction);
+    }
+
+    /**
+     * Wraps this transformer in another one that will join a new value to the
+     * result of this one using the given function.
+     *
+     * <p>This method is intended to be used to calculate a value based on two
+     * or more context parameters. This could be the distance between two
+     * players or a hostility check.</p>
+     *
+     * @param joined The transformer which results should be used for the join
+     * @param joinFunction The function used to join both results. The given
+     *        function must be prepared to deal with null arguments. The
+     *        function is allowed to return null
+     * @return A newly created transformer with the given join function
+     * @see BiFunction
+     * @see #join(Transformer, BiFunction)
+     */
+    default <U, R> Transformer<R> joinNullable(final Transformer<U> joined, final BiFunction<T, U, R> joinFunction) {
+        checkNotNull(joined, "joined");
+        checkNotNull(joinFunction, "function");
+        return context -> {
+            final Optional<T> value = transform(context);
+            final Optional<U> value2 = joined.transform(context);
+            return Optional.ofNullable(joinFunction.apply(value.orElse(null), value2.orElse(null)));
+        };
+    }
+
+    /**
+     * Wraps this transformer in a placeholder to store it in a field or in a
+     * {@link Text} instance. This method is a shortcut for
+     * {@link Text#placeholder(Transformer)}.
+     *
+     * @return A newly created placeholder containing this transformer
+     * @see Text#placeholder(Transformer)
+     */
+    default PlaceholderText asPlaceholder() {
+        return Text.placeholder(this);
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/transformer/Transformers.java
+++ b/src/main/java/org/spongepowered/api/text/transformer/Transformers.java
@@ -1,0 +1,285 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.text.transformer;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.Functions;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * A utility class to generate useful {@link Transformer}s that can be passed to
+ * {@link org.spongepowered.api.text.Text.Placeholder placeholders}.
+ */
+public final class Transformers {
+
+    /**
+     * Creates a new {@link Transformer} that will always return the given
+     * constant.
+     *
+     * @param value The constant to return
+     * @param <T> The type returned by the newly created transformer
+     * @return The newly created {@link Transformer}
+     */
+    public static <T> Transformer<T> constant(final T value) {
+        checkNotNull(value, "value");
+        final Optional<T> optValue = Optional.of(value);
+        return context -> optValue;
+    }
+
+    /**
+     * Creates a new {@link Transformer} that will always return the result of
+     * the given supplier.
+     *
+     * @param supplier The supplier to get the result from
+     * @param <T> The type returned by the newly created transformer
+     * @return The newly created {@link Transformer}
+     */
+    public static <T> Transformer<T> supplied(final Supplier<T> supplier) {
+        checkNotNull(supplier, "supplier");
+        return context -> Optional.ofNullable(supplier.get());
+    }
+
+    /**
+     * Creates a new {@link Transformer} that will return the value for the
+     * given key if it is present and {@link Optional#empty()} otherwise.
+     *
+     * @param key The context key used to get the data
+     * @param <T> The type returned by the newly created transformer
+     * @return The newly created {@link Transformer}
+     */
+    public static <T> Transformer<T> key(final String key) {
+        return new ValueForKeyTransformer<>(key);
+    }
+
+    /**
+     * Creates a new {@link Transformer} that will return the value calculated
+     * using the value for the given key if it is present and return
+     * {@link Optional#empty()} otherwise.
+     *
+     * <p>Note: This is a helper method to avoid having to specify the generic
+     * type in {@link #key(String)} explicitly.</p>
+     *
+     * @param key The context key used to get the data
+     * @param function The transform function used to transform the present data
+     * @return The newly created {@link Transformer}
+     * @param <T> The type of data returned by the context using the given key
+     * @param <R> The type returned by the newly created transformer
+     * @see #key(String)
+     * @see Transformer#map(Function)
+     */
+    public static <T, R> Transformer<R> mappedKey(String key, Function<T, R> function) {
+        return Transformers.<T>key(key).map(function);
+    }
+
+    /**
+     * Creates a new {@link Transformer} that will return the value calculated
+     * using the value for the given key if it is present and return
+     * {@link Optional#empty()} otherwise.
+     *
+     * <p>Note: This is a helper method to avoid having to specify the generic
+     * type in {@link #key(String)} explicitly.</p>
+     *
+     * @param key The context key used to get the data
+     * @param function The transform function used to transform the present data
+     * @return The newly created {@link Transformer}
+     * @param <T> The type of data returned by the context using the given key
+     * @param <R> The type returned by the newly created transformer
+     * @see #key(String)
+     * @see Transformer#flatMap(Function)
+     */
+    public static <T, R> Transformer<R> flatMappedKey(String key, Function<T, Optional<R>> function) {
+        return Transformers.<T>key(key).flatMap(function);
+    }
+
+    /**
+     * Creates a new {@link Transformer} that will return the joined result of
+     * the to values for the given keys if both are present and
+     * {@link Optional#empty()} otherwise. The transformer will use the given
+     * join function to merge the values obtained from both keys into one value.
+     *
+     * <p>Note: This is a helper method to avoid having to specify the generic
+     * type in {@link #key(String)} explicitly.</p>
+     *
+     * @param mainKey The context main key used to get the main data
+     * @param joinKey The context join key used to get the data that should be
+     *        joined
+     * @param joinFunction The function used to join the values returned for the
+     *        two keys.
+     * @param <T> The type of data returned by the context using the main key
+     * @param <U> The type of data returned by the context using the join key
+     * @param <R> The type returned by the newly created transformer
+     * @return The newly created {@link Transformer}
+     * @see Transformers#key(String)
+     * @see Transformer#join(String, BiFunction)
+     */
+    public static <T, U, R> Transformer<R> joinedKeys(final String mainKey, final String joinKey, final BiFunction<T, U, R> joinFunction) {
+        return Transformers.<T>key(mainKey).join(joinKey, joinFunction);
+    }
+
+    /**
+     * Creates a new {@link Transformer} that will return the joined result of
+     * the to values for the given keys. The transformer will use the given join
+     * function to merge the values obtained from both keys into one value.
+     *
+     * <p>Note: This is a helper method to avoid having to specify the generic
+     * type in {@link #key(String)} explicitly.</p>
+     *
+     * @param mainKey The context main key used to get the main data
+     * @param joinKey The context join key used to get the data that should be
+     *        joined
+     * @param joinFunction The function used to join the values returned for the
+     *        two keys.
+     * @param <T> The type of data returned by the context using the main key
+     * @param <U> The type of data returned by the context using the join key
+     * @param <R> The type returned by the newly created transformer
+     * @return The newly created {@link Transformer}
+     * @see Transformers#key(String)
+     * @see Transformer#join(String, BiFunction)
+     */
+    public static <T, U, R> Transformer<R> joinedNullableKeys(final String mainKey, final String joinKey,
+            final BiFunction<T, U, R> joinFunction) {
+        return Transformers.<T>key(mainKey).joinNullable(joinKey, joinFunction);
+    }
+
+    /**
+     * Creates a new utility {@link Transformer} that can be used to resolve the
+     * language based on a context parameter with the given name. The parameter
+     * associated with the given localeKey must be a {@link Locale}.
+     *
+     * @param localeKey The context key used to get the locale
+     * @param function The function used to get the translation {@link Text} for
+     *        the requested locale
+     * @return The newly created multi language support {@link Transformer}
+     */
+    public static Transformer<Text> multiLanguageSupportWithLocale(String localeKey, Function<Locale, Text> function) {
+        checkNotNull(localeKey, "localeKey");
+        return multiLanguageSupport(key(localeKey), function);
+    }
+
+    /**
+     * Creates a new utility {@link Transformer} that can be used to resolve the
+     * language based on a context parameter with the given name. The parameter
+     * associated with the given targetKey must be a {@link CommandSource}.
+     *
+     * @param targetKey The context key used to get the target
+     *        {@link CommandSource}
+     * @param function The function used to get the translation {@link Text} for
+     *        the target's locale
+     * @return The newly created multi language support {@link Transformer}
+     * @see #deepFormater(Transformer)
+     */
+    public static Transformer<Text> multiLanguageSupportWithTarget(String targetKey, Function<Locale, Text> function) {
+        checkNotNull(targetKey, "targetKey");
+        return multiLanguageSupport(mappedKey(targetKey, CommandSource::getLocale), function);
+    }
+
+    /**
+     * Creates a new utility {@link Transformer} that can be used to obtain the
+     * translation using the given locale transformer and the given translation
+     * function.
+     *
+     * @param localeTransformer The transformer used to get the {@link Locale}
+     *        that should be used to get the translation for it
+     * @param function The function used to get the translation {@link Text} for
+     *        the target's locale
+     * @return The newly created multi language support {@link Transformer}
+     * @see #deepFormater(Transformer)
+     */
+    public static Transformer<Text> multiLanguageSupport(Transformer<Locale> localeTransformer, Function<Locale, Text> function) {
+        checkNotNull(localeTransformer, "localeTransformer");
+        checkNotNull(function, "function");
+        return deepFormater(localeTransformer.map(Functions.nonNullResult(function, "missing translation text")));
+    }
+
+    /**
+     * Creates a new {@link Transformer} that will execute
+     * {@link Text#format(Text, Function)} on the result of the given
+     * transformer.
+     *
+     * @param transformer The transformer which results should be formated. The
+     *        transformer must return a none absent/empty value
+     * @return The newly created {@link Transformer}
+     */
+    public static Transformer<Text> deepFormater(Transformer<Text> transformer) {
+        checkNotNull(transformer, "transformer");
+        return context -> Optional.of(Text.format(
+                transformer.transform(context)
+                        .orElseThrow(() -> new IllegalArgumentException(transformer + " returned absent result!")),
+                context));
+    }
+
+    /**
+     * Creates a new {@link Transformer} that will try to get the
+     * {@link BaseValue} from the {@link DataHolder} provided for the given
+     * context {@link Key}.
+     *
+     * @param contextKey The key used to get the {@link DataHolder} from the
+     *        context
+     * @param valueKey The key used to get the data from the {@link DataHolder}
+     * @param <T> The type returned by the newly created transformer
+     * @return The newly created {@link Transformer}
+     * @see #key(String)
+     * @see #dataValueMappedKey(Transformer, Key)
+     */
+    public static <T> Transformer<T> dataValueMappedKey(String contextKey, Key<? extends BaseValue<T>> valueKey) {
+        return dataValueMappedKey(key(contextKey), valueKey);
+    }
+
+    /**
+     * Creates a new {@link Transformer} that will try to get the
+     * {@link BaseValue} from the {@link DataHolder} returned by the given
+     * {@link Transformer}.
+     *
+     * @param transformer The {@link Transformer} used to get the
+     *        {@link DataHolder} from the context
+     * @param valueKey The key used to get the data from the {@link DataHolder}
+     * @param <T> The type returned by the newly created transformer
+     * @return The newly created {@link Transformer}
+     * @see Transformer#flatMap(Function)
+     * @see DataHolder#get(Key)
+     */
+    public static <T> Transformer<T> dataValueMappedKey(Transformer<? extends DataHolder> transformer,
+            final Key<? extends BaseValue<T>> valueKey) {
+        checkNotNull(transformer, "transformer");
+        checkNotNull(valueKey, "valueKey");
+        return transformer.flatMap(input -> input.get(valueKey));
+    }
+
+    private Transformers() {
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/transformer/ValueForKeyTransformer.java
+++ b/src/main/java/org/spongepowered/api/text/transformer/ValueForKeyTransformer.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.text.transformer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Objects;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * This {@link Transformer} will always return the context value for a fixed
+ * key. This class is required for serialization purposes.
+ */
+public final class ValueForKeyTransformer<T> implements Transformer<T> {
+
+    private final String key;
+
+    ValueForKeyTransformer(String key) {
+        checkArgument(!checkNotNull(key, "key").isEmpty(), "key cannot be empty");
+        this.key = key;
+    }
+
+    /**
+     * Gets the key that is used to get a result from the input context. This
+     * method is required for serialization purposes.
+     *
+     * @return The key used to get the data
+     */
+    public String getKey() {
+        return this.key;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Optional<T> transform(Function<String, ?> context) {
+        return Optional.ofNullable((T) context.apply(this.key));
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ValueForKeyTransformer<?> that = (ValueForKeyTransformer<?>) obj;
+        return this.key.equals(that.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.key.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("key", this.key)
+                .toString();
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/transformer/package-info.java
+++ b/src/main/java/org/spongepowered/api/text/transformer/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.text.transformer;

--- a/src/main/java/org/spongepowered/api/text/translation/ResourceBundleTranslation.java
+++ b/src/main/java/org/spongepowered/api/text/translation/ResourceBundleTranslation.java
@@ -49,7 +49,7 @@ import java.util.function.Function;
  *         private TranslationHelper() {} // Prevent instance creation
  *
  *         public static Text t(String key, Object... args) {
- *             return Texts.of(new ResourceBundleTranslation(key, LOOKUP_FUNC), args);
+ *             return Text.of(new ResourceBundleTranslation(key, LOOKUP_FUNC), args);
  *         }
  *     }
  *

--- a/src/main/java/org/spongepowered/api/util/BiFunctions.java
+++ b/src/main/java/org/spongepowered/api/util/BiFunctions.java
@@ -1,0 +1,275 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
+/**
+ * Helper class with some utility methods pertaining {@link BiFunction}s.
+ */
+public final class BiFunctions {
+
+    /**
+     * Creates a {@link BiFunction} that will always return its first input.
+     *
+     * @return The newly created function
+     */
+    public static <T> BiFunction<T, ?, T> first() {
+        return (first, second) -> first;
+    }
+
+    /**
+     * Creates a {@link BiFunction} that will always return its second.
+     *
+     * @return The newly created function
+     */
+    public static <T> BiFunction<?, T, T> second() {
+        return (first, second) -> second;
+    }
+
+    /**
+     * Creates a {@link BiFunction} that will always return the given constant.
+     *
+     * @param value The value to return always
+     * @return The newly created function
+     */
+    public static <T, U, R> BiFunction<T, U, R> constant(R value) {
+        checkNotNull(value, "value");
+        return constantNullable(value);
+    }
+
+    /**
+     * Creates a {@link BiFunction} that will always return null.
+     *
+     * @return The newly created function
+     */
+    public static <T, U, R> BiFunction<T, U, R> constantNull() {
+        return constantNullable(null);
+    }
+
+    /**
+     * Creates a {@link BiFunction} that will always return the given nullable
+     * constant.
+     *
+     * @param value The nullable value to return always
+     * @return The newly created function
+     */
+    public static <T, U, R> BiFunction<T, U, R> constantNullable(final @Nullable R value) {
+        return (first, second) -> value;
+    }
+
+    /**
+     * Creates a {@link BiFunction} that will always return the result of the
+     * given {@link Supplier}.
+     *
+     * @param supplier The supplier to get the result from
+     * @return The newly created function
+     */
+    public static <T, U, R> BiFunction<T, U, R> supplied(final Supplier<? extends R> supplier) {
+        checkNotNull(supplier, "supplier");
+        return (first, second) -> supplier.get();
+    }
+
+    /**
+     * Creates a {@link BiFunction} that will always throw an exception from the
+     * given {@link Supplier}.
+     *
+     * @param exceptionSupplier The supplier for the exception to throw
+     * @return The newly created function
+     */
+    public static <T, U, R> BiFunction<T, U, R> exceptionSupplier(Supplier<? extends RuntimeException> exceptionSupplier) {
+        checkNotNull(exceptionSupplier, "exceptionSupplier");
+        return (first, second) -> {
+            throw checkNotNull(exceptionSupplier.get(), "exception from " + exceptionSupplier);
+        };
+    }
+
+    /**
+     * Creates a {@link BiFunction} that will always throw an exception
+     * calculated by the given {@link BiFunction}.
+     *
+     * @param exceptionFunction The function to calculate the exception to throw
+     * @param messageBiFunction The function to calculate the exception message
+     * @return The newly created function
+     */
+    public static <T, U, R> BiFunction<T, U, R> exceptionBiFunction(Function<String, ? extends RuntimeException> exceptionFunction,
+            BiFunction<T, U, String> messageBiFunction) {
+        checkNotNull(exceptionFunction, "exceptionBiFunction");
+        checkNotNull(messageBiFunction, "messageBiFunction");
+        return exceptionBiFunction(messageBiFunction.andThen(exceptionFunction));
+    }
+
+    /**
+     * Creates a {@link BiFunction} that will always throw an exception
+     * calculated by the given {@link BiFunction}.
+     *
+     * @param exceptionBiFunction The function to calculate the exception to
+     *        throw
+     * @return The newly created function
+     */
+    public static <T, U, R> BiFunction<T, U, R> exceptionBiFunction(BiFunction<T, U, ? extends RuntimeException> exceptionBiFunction) {
+        checkNotNull(exceptionBiFunction, "exceptionBiFunction");
+        return (first, second) -> {
+            throw checkNotNull(exceptionBiFunction.apply(first, second), "exception from " + exceptionBiFunction);
+        };
+    }
+
+    /**
+     * Creates a {@link BiFunction} that will wrap the results of the given
+     * function in an {@link Optional}.
+     *
+     * @param function The function to wrap
+     * @return The newly created function
+     */
+    public static <T, U, R> BiFunction<T, U, Optional<R>> optional(BiFunction<T, U, R> function) {
+        checkNotNull(function, "function");
+        return function.andThen(Optional::ofNullable);
+    }
+
+    /**
+     * Creates a {@link BiFunction} that will unwrap the {@link Optional}
+     * results of the given function.
+     *
+     * @param function The function to unwrap
+     * @return The newly created function
+     * @see Optional#get()
+     */
+    public static <T, U, R> BiFunction<T, U, R> present(BiFunction<T, U, Optional<? extends R>> function) {
+        checkNotNull(function, "function");
+        return function.andThen(Optional::get);
+    }
+
+    /**
+     * Creates a {@link BiFunction} that will wrap the results of the given
+     * function in an {@link Optional} unless it is already an {@link Optional}.
+     *
+     * @param function The function to wrap
+     * @return The newly created function
+     */
+    public static <T, U> BiFunction<T, U, Optional<?>> optionalWrapper(BiFunction<T, U, ?> function) {
+        checkNotNull(function, "function");
+        return (first, second) -> {
+            final Object result = function.apply(first, second);
+            if (result instanceof Optional) {
+                return (Optional<?>) result;
+            } else {
+                return Optional.ofNullable(result);
+            }
+        };
+    }
+
+    /**
+     * Creates a {@link BiFunction} that first try to test the given input using
+     * the given filter and then will either execute the match or dismatch
+     * {@link BiFunction} based on the results of the test.
+     *
+     * @param filter The filter to test the input with
+     * @param match The function that should be executed in case the input does
+     *        match the filter requirements
+     * @param dismatch The function that should be executed in case the input
+     *        does not match the filter requirements
+     * @return The newly created function
+     */
+    public static <T, U, R> BiFunction<T, U, R> conditional(BiPredicate<? super T, ? super U> filter,
+            BiFunction<? super T, ? super U, ? extends R> match, BiFunction<? super T, ? super U, ? extends R> dismatch) {
+        checkNotNull(filter, "filter");
+        checkNotNull(match, "match");
+        checkNotNull(dismatch, "dismatch");
+        return (first, second) -> filter.test(first, second) ? match.apply(first, second) : dismatch.apply(first, second);
+    }
+
+    /**
+     * Creates a {@link BiFunction} that first execute the main
+     * {@link BiFunction} and will then test its result using the given filter.
+     * If the result of the function matches the filter then the result will be
+     * returned. If the filter does not match then the alternative function will
+     * be used to get a different result.
+     *
+     * @param main The function that should be used for the conversion
+     * @param filter The filter to test the main function's result with
+     * @param alternative The function that should be executed in case the
+     *        result does not match the filter requirements
+     * @return The newly created function
+     */
+    public static <T, U, R> BiFunction<T, U, R> resultConditional(BiFunction<? super T, ? super U, ? extends R> main,
+            Predicate<? super R> filter, BiFunction<? super T, ? super U, ? extends R> alternative) {
+        return (first, second) -> {
+            final R result = main.apply(first, second);
+            if (filter.test(result)) {
+                return result;
+            } else {
+                return alternative.apply(first, second);
+            }
+        };
+    }
+
+    /**
+     * Creates a {@link BiFunction} that first execute the main
+     * {@link BiFunction} and will then test its result for being non null. If
+     * the result of the function is not null then it will be returned. If the
+     * result is null then the alternative {@link BiFunction} will be used to
+     * calculate the result.
+     *
+     * @param main The function that should be used for the conversion
+     * @param alternative The function that should be executed in case the
+     *        result of the main function was null
+     * @return The newly created function
+     */
+    public static <T, U, R> BiFunction<T, U, R> nonNullResultOrElse(BiFunction<? super T, ? super U, ? extends R> main,
+            BiFunction<? super T, ? super U, ? extends R> alternative) {
+        return resultConditional(main, Functional.notNull(), alternative);
+    }
+
+    /**
+     * Creates a {@link BiFunction} that first execute the main
+     * {@link BiFunction} and will then test its result for being
+     * {@link Optional#isPresent() present}. If the result of the function is
+     * present then it will be returned. If the result is absent/empty then the
+     * alternative {@link BiFunction} will be used to calculate the result.
+     *
+     * @param main The function that should be used for the conversion
+     * @param alternative The function that should be executed in case the
+     *        result of the main function was absent/empty
+     * @return The newly created function
+     */
+    public static <T, U, R> BiFunction<T, U, Optional<? extends R>> presentResultOrElse(BiFunction<? super T, ? super U, Optional<? extends R>> main,
+            BiFunction<? super T, ? super U, Optional<? extends R>> alternative) {
+        return resultConditional(main, Optional::isPresent, alternative);
+    }
+
+    private BiFunctions() {
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/util/Functions.java
+++ b/src/main/java/org/spongepowered/api/util/Functions.java
@@ -1,0 +1,280 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Preconditions;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
+/**
+ * Helper class with some utility methods pertaining {@link Function}s.
+ */
+public final class Functions {
+
+    /**
+     * Creates a {@link Function} that will always return the given constant.
+     *
+     * @param value The value to return always
+     * @return The newly created function
+     */
+    public static <T, R> Function<T, R> constant(R value) {
+        checkNotNull(value, "value");
+        return constantNullable(value);
+    }
+
+    /**
+     * Creates a {@link Function} that will always return null.
+     *
+     * @return The newly created function
+     */
+    public static <T, R> Function<T, R> constantNull() {
+        return constantNullable(null);
+    }
+
+    /**
+     * Creates a {@link Function} that will always return the given nullable
+     * constant.
+     *
+     * @param value The nullable value to return always
+     * @return The newly created function
+     */
+    public static <T, R> Function<T, R> constantNullable(final @Nullable R value) {
+        return input -> value;
+    }
+
+    /**
+     * Creates a {@link Function} that will always return the result of the
+     * given {@link Supplier}.
+     *
+     * @param supplier The supplier to get the result from
+     * @return The newly created function
+     */
+    public static <T, R> Function<T, R> supplied(final Supplier<? extends R> supplier) {
+        checkNotNull(supplier, "supplier");
+        return input -> supplier.get();
+    }
+
+    /**
+     * Creates a {@link Function} that will always throw an exception from the
+     * given {@link Supplier}.
+     *
+     * @param exceptionSupplier The supplier for the exception to throw
+     * @return The newly created function
+     */
+    public static <T, R> Function<T, R> exceptionSupplier(Supplier<? extends RuntimeException> exceptionSupplier) {
+        checkNotNull(exceptionSupplier, "exceptionSupplier");
+        return input -> {
+            throw checkNotNull(exceptionSupplier.get(), "exception from " + exceptionSupplier);
+        };
+    }
+
+    /**
+     * Creates a {@link Function} that will always throw an exception calculated
+     * by the given {@link Function}.
+     *
+     * @param exceptionFunction The function to calculate the exception to throw
+     * @param messageFunction The function to calculate the exception message
+     * @return The newly created function
+     */
+    public static <T, R> Function<T, R> exceptionFunction(Function<String, ? extends RuntimeException> exceptionFunction,
+            Function<T, String> messageFunction) {
+        checkNotNull(exceptionFunction, "exceptionFunction");
+        checkNotNull(messageFunction, "messageFunction");
+        return exceptionFunction(exceptionFunction.compose(messageFunction));
+    }
+
+    /**
+     * Creates a {@link Function} that will always throw an exception calculated
+     * by the given {@link Function}.
+     *
+     * @param exceptionFunction The function to calculate the exception to throw
+     * @return The newly created function
+     */
+    public static <T, R> Function<T, R> exceptionFunction(Function<T, ? extends RuntimeException> exceptionFunction) {
+        checkNotNull(exceptionFunction, "exceptionFunction");
+        return input -> {
+            throw checkNotNull(exceptionFunction.apply(input), "exception from " + exceptionFunction);
+        };
+    }
+
+    /**
+     * Creates a {@link Function} that will wrap the results of the given
+     * function in an {@link Optional}.
+     *
+     * @param function The function to wrap
+     * @return The newly created function
+     */
+    public static <T, R> Function<T, Optional<R>> optional(Function<T, R> function) {
+        checkNotNull(function, "function");
+        return function.andThen(Optional::ofNullable);
+    }
+
+    /**
+     * Creates a {@link Function} that will unwrap the {@link Optional} results
+     * of the given function.
+     *
+     * @param function The function to unwrap
+     * @return The newly created function
+     * @see Optional#get()
+     */
+    public static <T, R> Function<T, R> present(Function<T, Optional<? extends R>> function) {
+        checkNotNull(function, "function");
+        return function.andThen(Optional::get);
+    }
+
+    /**
+     * Creates a {@link Function} that will wrap the results of the given
+     * function in an {@link Optional} unless it is already an {@link Optional}.
+     *
+     * @param function The function to wrap
+     * @return The newly created function
+     */
+    public static <T> Function<T, Optional<?>> optionalWrapper(Function<T, ?> function) {
+        checkNotNull(function, "function");
+        return input -> {
+            final Object result = function.apply(input);
+            if (result instanceof Optional) {
+                return (Optional<?>) result;
+            } else {
+                return Optional.ofNullable(result);
+            }
+        };
+    }
+
+    /**
+     * Creates a {@link Function} that will check the input for being non-Null.
+     *
+     * @param message The message to show in case the input is null
+     * @return The newly created function
+     * @see Preconditions#checkNotNull(Object, Object)
+     */
+    public static <T> Function<T, T> nonNullIdentity(String message) {
+        checkNotNull(message, "message");
+        return input -> checkNotNull(input, message);
+    }
+
+    /**
+     * Creates a {@link Function} that will check the results of the given
+     * function for being non-Null.
+     *
+     * @param function The function to check for null results
+     * @param message The message to show in case the input is null
+     * @return The newly created function
+     * @see Preconditions#checkNotNull(Object, Object)
+     */
+    public static <T, U> Function<T, U> nonNullResult(Function<T, U> function, String message) {
+        checkNotNull(function, "function");
+        return function.andThen(nonNullIdentity(message));
+    }
+
+    /**
+     * Creates a {@link Function} that first try to test the given input using
+     * the given filter and then will either execute the match or dismatch
+     * {@link Function} based on the results of the test.
+     *
+     * @param filter The filter to test the input with
+     * @param match The function that should be executed in case the input does
+     *        match the filter requirements
+     * @param dismatch The function that should be executed in case the input
+     *        does not match the filter requirements
+     * @return The newly created function
+     */
+    public static <T, R> Function<T, R> conditional(Predicate<? super T> filter,
+            Function<? super T, ? extends R> match, Function<? super T, ? extends R> dismatch) {
+        checkNotNull(filter, "filter");
+        checkNotNull(match, "match");
+        checkNotNull(dismatch, "dismatch");
+        return input -> filter.test(input) ? match.apply(input) : dismatch.apply(input);
+    }
+
+    /**
+     * Creates a {@link Function} that first execute the main {@link Function}
+     * and will then test its result using the given filter. If the result of
+     * the function matches the filter then the result will be returned. If the
+     * filter does not match then the alternative function will be used to get a
+     * different result.
+     *
+     * @param main The function that should be used for the conversion
+     * @param filter The filter to test the main function's result with
+     * @param alternative The function that should be executed in case the
+     *        result does not match the filter requirements
+     * @return The newly created function
+     */
+    public static <T, R> Function<T, R> resultConditional(Function<? super T, ? extends R> main,
+            Predicate<? super R> filter, Function<? super T, ? extends R> alternative) {
+        return input -> {
+            final R result = main.apply(input);
+            if (filter.test(result)) {
+                return result;
+            } else {
+                return alternative.apply(input);
+            }
+        };
+    }
+
+    /**
+     * Creates a {@link Function} that first execute the main {@link Function}
+     * and will then test its result for being non null. If the result of the
+     * function is not null then it will be returned. If the result is null then
+     * the alternative {@link Function} will be used to calculate the result.
+     *
+     * @param main The function that should be used for the conversion
+     * @param alternative The function that should be executed in case the
+     *        result of the main function was null
+     * @return The newly created function
+     */
+    public static <T, R> Function<T, R> nonNullResultOrElse(Function<? super T, ? extends R> main, Function<? super T, ? extends R> alternative) {
+        return resultConditional(main, Functional.notNull(), alternative);
+    }
+
+    /**
+     * Creates a {@link Function} that first execute the main {@link Function}
+     * and will then test its result for being {@link Optional#isPresent()
+     * present}. If the result of the function is present then it will be
+     * returned. If the result is absent/empty then the alternative
+     * {@link Function} will be used to calculate the result.
+     *
+     * @param main The function that should be used for the conversion
+     * @param alternative The function that should be executed in case the
+     *        result of the main function was absent/empty
+     * @return The newly created function
+     */
+    public static <T, R> Function<T, Optional<? extends R>> presentResultOrElse(Function<? super T, Optional<? extends R>> main,
+            Function<? super T, Optional<? extends R>> alternative) {
+        return resultConditional(main, Optional::isPresent, alternative);
+    }
+
+    private Functions() {
+    }
+
+}


### PR DESCRIPTION
This PR improves the changes made in #779.
Implementation: https://github.com/SpongePowered/SpongeCommon/pull/129

## Additions

* `Placeholder`s
  * Placeholders can be used to calculate their replacement using the given context
* `Text.format(Text, Function<String,?>)`
  * Allows lazy fetching/calulcation of replacements used in conjunction with `Placeholder`s
    * Example: Directly fetch player prefixes from a permission plugin without being bound to just `prefix` or similar. `{world}{faction}{foobar}{prefix}{player}: {message}`
  * Also avaiable as `Text.format(Text, Object...)` uses indexes as keys for the map
  * Also avaiable as `Text.format(Text, Map<String,?>)` uses the function impl
* Similarize the behaviour of all `joinX(...)`methods
* `Text#joinOf(Text separator, Object... objects)`
* `Text#joinOf(Text separator, Iterable<?> contents)`
* `Text#formatBuilder()`
  * Utility method to use the format call with named parameters in one row and without having to explicitly create a `Map` for it.
* `Functions` (Optional)
  * Utility class for creating and wrapping `Function`s
* `BiFunctions` (Optional)
  * Utility class for creating and wrapping `BiFunction`s
* `Dictionary` (Optional)
  *  Utility class for multi language support with fully configurable messages.

## Changes

* Better `TextRepresentable` specifications
* `Text.of(Object...)` 
  * added support for `Iterable`s
  * added support for arrays
  * Simplified handling of `TextRepresentable`s

## Test Plugin

[TextFormat.jar](https://dl.dropboxusercontent.com/u/16999313/Sponge/TextFormat.jar) (Plugin)
[TextFormat.zip](https://dl.dropboxusercontent.com/u/16999313/Sponge/TextFormat.zip) (Source)

Try the following commands to see the resutls:
* `/textformat`
* `/textformat PvPMonster`
* `/textformat PvPMonster Innocent`
* `/textformat PvPMonster Innocent &6Stick of Doom`
* `/textformat <YourUsername> Innocent` // Uses the item in hand
* `/texttype <CatalogType/*>`
* `/textjson` - Proves the json (de-)serialization works
* `/textxml` - Proves the xml(de-)serialization works

## Usage

Consider the following situation. You would like to show the following message to your arena participants on a regular basis.
````
Current ranking:
1) MonsterKiller - 42 points (324m away)
2) MunsterHunter - 21 points (123m away)
3) PlayerKiller - 5 points (2m away)
````

Without this PR you have basically four possibilities:
### 1) Using the `Text.Builder`
````java
for (Player player : participants) {
    player.sendMessage(Text.of("Current ranking:"));
    int index = 1;
    for (Player ranked : topRanked) {
        Text.Builder builder = Text.builder();
        builder.append(Text.of(index))
                .append(Text.of(") "))
                .append(Text.of(ranked))
                .append(Text.of(" - "))
                .append(Text.of(arena.getPoints(ranked)))
                .append(Text.of(" points ("))
                .append(Text.of(calcDistance(player, ranked)))
                .append(Text.of("m away)"));
        player.sendMessage(builder.build());
    }
}
````
This is pretty verbose, lets reduce that a little bit.

### 2) Using `Text.of(Object...)`
````java
for (Player player : participants) {
    player.sendMessage(Text.of("Current ranking:"));
    int index = 1;
    for (Player ranked : topRanked) {
        Text text = Text.of(index++, ") ", ranked, " - ", arena.getPoints(ranked), " points (", calcDistance(player, ranked), "m away)");
        player.sendMessage(text);
    }
}
````
This is shorter and easier to read, but you have to create the same `Text`s over and over again. 
Also you cannot use different styles for different languages.

### 3) Using constants
````java
Text MAIN_MESSAGE = Text.of("Current ranking:");
Text STATIC_PART1 = Text.of(") ");
Text STATIC_PART2 = Text.of(" - ");
Text STATIC_PART3 = Text.of(" points (");
Text STATIC_PART4 = Text.of("m away)");
for (Player player : participants) {
    player.sendMessage(MAIN_MESSAGE);
    int index = 1;
    for (Player ranked : topRanked) {
        Text text = Text.of(index++, STATIC_PART1, ranked, STATIC_PART2, arena.getPoints(ranked), STATIC_PART3, calcDistance(player, ranked), STATIC_PART4);
        player.sendMessage(text);
    }
}
````
Well, we don't create the messages over and over again, but this is quite horrible to read and you still cannot use different styles for different languages.
There must be something easier.

### NEW) Using `Text.format(Text, X)` and simple `Placeholder`s
````java
Text MAIN_MESSAGE = Text.of("Current ranking:");
Text RANKING_MESSAGE = Text.of(Text.placeholder("0"), ") ", Text.placeholder("1"), " - ", Text.placeholder("2"), " points (", Text.placeholder("3"), "m away)");

for (Player player : participants) {
    player.sendMessage(MAIN_MESSAGE);
    int index = 1;
    for (Player ranked : topRanked) {
        player.sendMessage(Text.format(RANKING_MESSAGE, index++, ranked, arena.getPoints(ranked), calcDistance(player, ranked)));
    }
}
````
Hell yeah, that looks pretty awesome. We also have multi language support now. We just have to exchange the `RANKING_MESSAGE`. 
But wouldn't it be cool if I could just put the `points` and `distance` calculation inside the Text template? We should also replace the numeric placeholders with named onces to improve readability and simplify configuration.

### NEW + nice) Using `Text.format(Text, X)` and functional `Placeholder`s
Of course we can do that!
````java
Text MAIN_MESSAGE = Text.of("Current ranking:");
Text RAW_RANKING_MESSAGE = Text.of(Text.placeholder("index"), ") ", Text.placeholder("ranked"), " - ", Text.placeholder("points"), " points (", Text.placeholder("distance"), "m away)");

// Prepare once (per arena)
Text RANKING_MESSAGE = Text.formatBuilder()
		.with("points", Transformers.mappedKey("ranked". currentArena::getPoints))
		.with("distance", Transformers.joinedKeys("target", "ranked", ArenaUtil::calcDistance))
		.apply(RAW_RANKING_MESSAGE);

// Send to players infinite times
for (Player player : participants) {
	player.sendMessage(MAIN_MESSAGE);
	FormatBuilder formatter = Text.formatBuilder()
			.with("index", new CountSupplier(0))
			.with("target", player);
	for (Player ranked : topRanked) {
		player.sendMessage(formatter.with("ranked", ranked).apply(RANKING_MESSAGE));
	}
}
````
Yes this looks very straight forward and i probably won't ever have to change the `sendMessage` lines ever again. Only the `Text` message itself and possibly the functions that do the customizations.

Mhh, there is the preparation step that requires me to have the arena there, but I would like to store the template as static field, isn't it possible to provide the arena later as well?

Sure thats possible:

````java
// Prepare once (for all arenas)
static final Text RANKING_MESSAGE = Text.formatBuilder()
		.with("points", Transformers.joinedKeys("arena", "ranked", Arena::getPoints))
		.with("distance", Transformers.joinedKeys("target", "ranked", ArenaUtil::calcDistance))
		.apply(RAW_RANKING_MESSAGE);

// Send to players infinite times
for (Player player : participants) {
	player.sendMessage(MAIN_MESSAGE);
	FormatBuilder formatter = Text.formatBuilder()
			.with("index", new CountSupplier(1))
			.with("arena", currentArena)
			.with("target", player);
	for (Player ranked : topRanked) {
		player.sendMessage(formatter.with("ranked", ranked).apply(RANKING_MESSAGE));
	}
}
````

And I can still replace the `Text` instances if I want to use a different language, but I don't want to create a switch for multiple languages in the code, isn't it possible to push that to the `Placeholder` as well?

### NEW + FANCY) Using `Text.format(Text, X)` and multilingual `Placeholder`s

**Declaration:**
````java
// DictionaryHolder is a plugin private wrapper class statically holding a Dictionary instance
static final Text MAIN_MESSAGE = DictionaryHolder.getWithTarget("MAIN_MESSAGE", "target")
		.asPlaceholder();

static final Text RANKING_MESSAGE = DictionaryHolder.prepare("RANKING_MESSAGE")
		.with("points", Transformers.joinedKeys("arena", "ranked", Arena::getPoints))
		.with("distance", Transformers.joinedKeys("target", "ranked", ArenaUtil::calcDistance))
		.doneWithTarget("target")
		.asPlaceholder();
````
**Usage:**
````java
// Send to players infinite times
for (Player player : participants) {
	FormatBuilder formatter = Text.formatBuilder()
			.with("index", new CountSupplier(1))
			.with("arena", currentArena)
			.with("target", player);
	player.sendMessage(formatter.apply(MAIN_MESSAGE));
	for (Player ranked : topRanked) {
		player.sendMessage(formatter.with("ranked", ranked).apply(RANKING_MESSAGE));
	}
}
````
See here for an example [`DictionaryHolder`](https://gist.github.com/ST-DDT/3565623155e1dc64568f) implementation. This is (except from loading the template `Text`s from a file) the only thing plugin developers have to "implement themselves" to use full multi language support in their plugins.

With these easy changes we have FULL multi language support and we can concentrate on developing our plugin's features and only have to maintain the translation/text files. (And since the translation files are just plain texts even none-developers can create and update them.)

### Configurable prefixes

You want to allow your plugin users/server owner to configure whether you show the player's prefix in the ranking list? Thats quite easy.

````java
DictionaryHolder.prepare("X")
.with(key -> key.startsWith("prefix@"), key -> {
	return Transformers.flatMappedKey(key.substring(7), subject -> ((OptionSubject) subject).getOption("prefix"))
		.orEmptyText()
		.asPlaceholder();
})
[...]
````
Template: `Hi ${prefix@target} ${target}!`

As you can see this setup is not bound to any instance in particular, so you can reuse it across your entire plugin without changes.

Please also note that this only affects the declaration section and will work without any changes to our usage section and without changing the API's default Text parser. And yes you still have multi language support and thus you could show the prefix only to `PIRATE_ENGLISH` users for example (and it won't be calculated it if you don't use it).


Well, you aren't sure whether there will be a permission plugin that supports `OptionSubject` and don't trust the server admin to configure your messages properly (or they are configured that way by default). And you don't want a `ClassCastException` to pop up?

````java
DictionaryHolder.prepare("X")
.with(key -> key.startsWith("prefix@"), key -> {
	return Transformers.flatMappedKey(key.substring(7), Functions.conditional(subject -> subject instanceof OptionSubject,
		subject -> ((OptionSubject) subject).getOption("prefix"), Functions.constantNull()))
		.orEmptyText()
		.asPlaceholder();
})
[...]
````
Template: `Hi ${prefix@target} ${target}!`

If I can support prefixes, why not support everything?
````java
DictionaryHolder.prepare("X")
.with(key -> key.contains("@SUBJECT@"), key -> {
	String[] split = key.split("@SUBJECT@", 2);
	return Transformers.flatMappedKey(split[0], Functions.conditional(subject -> subject instanceof OptionSubject,
		subject -> ((OptionSubject) subject).getOption(split[1]), Functions.constantNull()))
		.orEmptyText()
		.asPlaceholder();
})
[...]
````
Template: `Hi ${target@SUBJECT@prefix}${target@SUBJECT@title} ${target} ${target@SUBJECT@suffix}!`

The format is up to you!

PS: I recommend that such functionalities should be centralized by plugin developers (maybe even pushed inside their `DictionaryHolder`).

--------------------------------------------------

**Any questions left?**

--------------------------------------------------

**Other Suggestions**
(Not part of this PR)
@zml2008 
[MessageEventSuggestion ](https://gist.github.com/ST-DDT/3b337cfa42b1a621e957)
or with the latest additions you will probably add a `FormatBuilder` or a context `Function` to the `MessageEvent` or its associated `MessageSink`