### PR TITLE
[WIP] Add ScheduledExecutorService

### DIFF
--- a/src/main/java/org/spongepowered/api/service/scheduler/SchedulerService.java
+++ b/src/main/java/org/spongepowered/api/service/scheduler/SchedulerService.java
@@ -90,7 +90,7 @@ public interface SchedulerService {
      * @return A new executor service that can be used to execute
      *         synchronous tasks
      */
-    SpongeExecutorService syncExecutor(Object plugin);
+    SpongeExecutorService createSyncExecutor(Object plugin);
 
     /**
      * Creates a new ExecutorService that can be used to schedule asynchronous
@@ -99,6 +99,7 @@ public interface SchedulerService {
      * @param plugin The plugin that will own the created tasks
      * @return A new executor service that can be used to execute
      *         asynchronous tasks
+     * @see TaskBuilder#async()
      */
-    SpongeExecutorService asyncExecutor(Object plugin);
+    SpongeExecutorService createAsyncExecutor(Object plugin);
 }

--- a/src/main/java/org/spongepowered/api/service/scheduler/SchedulerService.java
+++ b/src/main/java/org/spongepowered/api/service/scheduler/SchedulerService.java
@@ -81,4 +81,28 @@ public interface SchedulerService {
      * @return A set of scheduled tasks
      */
     Set<Task> getScheduledTasks(Object plugin);
+
+    /**
+     * Creates a new ExecutorService that can be used to schedule synchronous
+     * tasks through the standard Java concurrency interfaces.
+     *
+     * @param plugin The plugin that will own the created tasks
+     * @return A new executor service that can be used to execute
+     *         synchronous tasks
+     */
+    default SpongeExecutorService syncExecutor(Object plugin) {
+        return new SpongeExecutorService(() -> createTaskBuilder(), plugin);
+    }
+
+    /**
+     * Creates a new ExecutorService that can be used to schedule asynchronous
+     * tasks through the standard Java concurrency interfaces.
+     *
+     * @param plugin The plugin that will own the created tasks
+     * @return A new executor service that can be used to execute
+     *         asynchronous tasks
+     */
+    default SpongeExecutorService asyncExecutor(Object plugin) {
+        return new SpongeExecutorService(() -> createTaskBuilder().async(), plugin);
+    }
 }

--- a/src/main/java/org/spongepowered/api/service/scheduler/SchedulerService.java
+++ b/src/main/java/org/spongepowered/api/service/scheduler/SchedulerService.java
@@ -90,9 +90,7 @@ public interface SchedulerService {
      * @return A new executor service that can be used to execute
      *         synchronous tasks
      */
-    default SpongeExecutorService syncExecutor(Object plugin) {
-        return new SpongeExecutorService(() -> createTaskBuilder(), plugin);
-    }
+    SpongeExecutorService syncExecutor(Object plugin);
 
     /**
      * Creates a new ExecutorService that can be used to schedule asynchronous
@@ -102,7 +100,5 @@ public interface SchedulerService {
      * @return A new executor service that can be used to execute
      *         asynchronous tasks
      */
-    default SpongeExecutorService asyncExecutor(Object plugin) {
-        return new SpongeExecutorService(() -> createTaskBuilder().async(), plugin);
-    }
+    SpongeExecutorService asyncExecutor(Object plugin);
 }

--- a/src/main/java/org/spongepowered/api/service/scheduler/SpongeExecutorService.java
+++ b/src/main/java/org/spongepowered/api/service/scheduler/SpongeExecutorService.java
@@ -40,13 +40,17 @@ import java.util.concurrent.TimeUnit;
  */
 public interface SpongeExecutorService extends ScheduledExecutorService {
 
-    @Override SpongeFuture<?> schedule(Runnable command, long delay, TimeUnit unit);
+    @Override
+    SpongeFuture<?> schedule(Runnable command, long delay, TimeUnit unit);
 
-    @Override <V> SpongeFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit);
+    @Override
+    <V> SpongeFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit);
 
-    @Override SpongeFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit);
+    @Override
+    SpongeFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit);
 
-    @Override SpongeFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit);
+    @Override
+    SpongeFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit);
 
     interface SpongeFuture<V> extends RunnableScheduledFuture<V> {
 

--- a/src/main/java/org/spongepowered/api/service/scheduler/SpongeExecutorService.java
+++ b/src/main/java/org/spongepowered/api/service/scheduler/SpongeExecutorService.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.api.service.scheduler;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/src/main/java/org/spongepowered/api/service/scheduler/SpongeExecutorService.java
+++ b/src/main/java/org/spongepowered/api/service/scheduler/SpongeExecutorService.java
@@ -1,0 +1,233 @@
+package org.spongepowered.api.service.scheduler;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableScheduledFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
+/**
+ * A delegating ExecutionService that schedules all its tasks on
+ * Sponge's {@link SchedulerService}.
+ * <p>
+ *     This class can be used to allow any libraries that support the
+ *     standard concurrency interface to schedule their asynchronous
+ *     tasks through Sponge.
+ * </p>
+ * <p>
+ *     This implementation cannot be shut down and does not distinguish
+ *     between fixed-rate / fixed-delay repeating tasks.
+ * </p>
+ */
+public class SpongeExecutorService extends AbstractExecutorService implements ScheduledExecutorService {
+
+    private final Supplier<TaskBuilder> taskBuilderProvider;
+    private final Object plugin;
+
+    protected SpongeExecutorService(final Supplier<TaskBuilder> taskBuilderProvider, final Object plugin) {
+        this.taskBuilderProvider = taskBuilderProvider;
+        this.plugin = checkNotNull(plugin, "plugin");
+    }
+
+    @Override
+    public void shutdown() {
+        //NOOP
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return false;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return false;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        this.createTask(command).submit(this.plugin);
+    }
+
+    @Override
+    public SpongeFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        final FutureTask<?> runnable = new FutureTask<>(command, null);
+
+        final Task task = this.createTask(runnable)
+                .delay(delay, unit)
+                .submit(this.plugin);
+
+        return new SpongeFuture<>(runnable, task);
+    }
+
+    @Override
+    public <V> SpongeFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        final FutureTask<V> runnable = new FutureTask<>(callable);
+
+        final Task task = this.createTask(runnable)
+                .delay(delay, unit)
+                .submit(this.plugin);
+
+        return new SpongeFuture<>(runnable, task);
+    }
+
+    @Override
+    public SpongeFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        final RepeatableFutureTask<?> runnable = new RepeatableFutureTask<>(command);
+
+        final Task task = this.createTask(runnable)
+                .delay(initialDelay, unit)
+                .interval(period, unit)
+                .submit(this.plugin);
+
+        // A repeatable task needs to be able to cancel itself
+        runnable.setTask(task);
+
+        return new SpongeFuture<>(runnable, task);
+    }
+
+    @Override
+    public SpongeFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        //Since we don't have full control over the execution, the contract needs to be a little broken
+        return this.scheduleAtFixedRate(command, initialDelay, delay, unit);
+    }
+
+    private TaskBuilder createTask(final Runnable runnable) {
+        return this.taskBuilderProvider.get().execute(runnable);
+    }
+
+    public static class SpongeFuture<V> implements RunnableScheduledFuture<V> {
+
+        private final long scheduledAt = System.currentTimeMillis();
+        private final FutureTask<V> runnable;
+        private final Task task;
+
+        protected SpongeFuture(FutureTask<V> runnable, Task task) {
+            this.runnable = runnable;
+            this.task = task;
+        }
+
+        /**
+         * @return The {@link SchedulerService} task that is responsible for
+         *         the execution of this future
+         */
+        public Task getTask() {
+            return this.task;
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            return unit.convert(getCurrentDelay(), TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public int compareTo(Delayed other) {
+            // Since getDelay may return different values for each call,
+            // this check is required to correctly implement Comparable
+            if (other == this) {
+                return 0;
+            }
+            return Long.compare(this.getDelay(TimeUnit.MILLISECONDS), other.getDelay(TimeUnit.MILLISECONDS));
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            this.task.cancel(); //Ensure Sponge is not going to try to run a cancelled task.
+            return this.runnable.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return this.runnable.isCancelled();
+        }
+
+        @Override
+        public boolean isDone() {
+            return this.runnable.isDone();
+        }
+
+        @Override
+        public V get() throws InterruptedException, ExecutionException {
+            return this.runnable.get();
+        }
+
+        @Override
+        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return this.runnable.get(timeout, unit);
+        }
+
+        @Override
+        public boolean isPeriodic() {
+            return this.task.getInterval() > 0;
+        }
+
+        @Override
+        public void run() {
+            this.runnable.run();
+        }
+
+        private long getCurrentDelay() {
+            //TODO: this is a hack, probably needs to be partially moved to SpongeCommon if this needs to be accurate
+            long originalDelay = (this.scheduledAt + this.task.getDelay()) - System.currentTimeMillis();
+            if (this.isPeriodic() && originalDelay <= 0) {
+                //Since its periodic, find the first positive delay and report
+                long interval = this.task.getInterval();
+                return originalDelay % interval + interval;
+            } else {
+                return originalDelay;
+            }
+        }
+    }
+
+    /**
+     * An extension of the JREs FutureTask that can be repeatedly executed,
+     * required for scheduling on an interval.
+     */
+    private static class RepeatableFutureTask<V> extends FutureTask<V> {
+
+        @Nullable private Task owningTask = null;
+
+        protected RepeatableFutureTask(Runnable runnable) {
+            super(runnable, null);
+        }
+
+        protected void setTask(Task task) {
+            this.owningTask = task;
+        }
+
+        @Override
+        public void run() {
+            super.runAndReset();
+
+            // A repeating task that is done but hasn't been cancelled has
+            // failed exceptionally. Following the contract of
+            // ScheduledExecutorService, this means the task has to be stopped.
+            if (super.isDone() && !super.isCancelled() && this.owningTask != null) {
+                //TODO: should this be logged?
+                this.owningTask.cancel();
+            }
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/api/service/scheduler/SpongeExecutorService.java
+++ b/src/main/java/org/spongepowered/api/service/scheduler/SpongeExecutorService.java
@@ -24,23 +24,10 @@
  */
 package org.spongepowered.api.service.scheduler;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.common.collect.ImmutableList;
-
-import java.util.List;
-import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.Callable;
-import java.util.concurrent.Delayed;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableScheduledFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Supplier;
-
-import javax.annotation.Nullable;
 
 /**
  * A delegating ExecutionService that schedules all its tasks on
@@ -50,208 +37,23 @@ import javax.annotation.Nullable;
  *     standard concurrency interface to schedule their asynchronous
  *     tasks through Sponge.
  * </p>
- * <p>
- *     This implementation cannot be shut down and does not distinguish
- *     between fixed-rate / fixed-delay repeating tasks.
- * </p>
  */
-public class SpongeExecutorService extends AbstractExecutorService implements ScheduledExecutorService {
+public interface SpongeExecutorService extends ScheduledExecutorService {
 
-    private final Supplier<TaskBuilder> taskBuilderProvider;
-    private final Object plugin;
+    @Override SpongeFuture<?> schedule(Runnable command, long delay, TimeUnit unit);
 
-    protected SpongeExecutorService(final Supplier<TaskBuilder> taskBuilderProvider, final Object plugin) {
-        this.taskBuilderProvider = taskBuilderProvider;
-        this.plugin = checkNotNull(plugin, "plugin");
-    }
+    @Override <V> SpongeFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit);
 
-    @Override
-    public void shutdown() {
-        //NOOP
-    }
+    @Override SpongeFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit);
 
-    @Override
-    public List<Runnable> shutdownNow() {
-        return ImmutableList.of();
-    }
+    @Override SpongeFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit);
 
-    @Override
-    public boolean isShutdown() {
-        return false;
-    }
-
-    @Override
-    public boolean isTerminated() {
-        return false;
-    }
-
-    @Override
-    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        return false;
-    }
-
-    @Override
-    public void execute(Runnable command) {
-        this.createTask(command).submit(this.plugin);
-    }
-
-    @Override
-    public SpongeFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-        final FutureTask<?> runnable = new FutureTask<>(command, null);
-
-        final Task task = this.createTask(runnable)
-                .delay(delay, unit)
-                .submit(this.plugin);
-
-        return new SpongeFuture<>(runnable, task);
-    }
-
-    @Override
-    public <V> SpongeFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-        final FutureTask<V> runnable = new FutureTask<>(callable);
-
-        final Task task = this.createTask(runnable)
-                .delay(delay, unit)
-                .submit(this.plugin);
-
-        return new SpongeFuture<>(runnable, task);
-    }
-
-    @Override
-    public SpongeFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
-        final RepeatableFutureTask<?> runnable = new RepeatableFutureTask<>(command);
-
-        final Task task = this.createTask(runnable)
-                .delay(initialDelay, unit)
-                .interval(period, unit)
-                .submit(this.plugin);
-
-        // A repeatable task needs to be able to cancel itself
-        runnable.setTask(task);
-
-        return new SpongeFuture<>(runnable, task);
-    }
-
-    @Override
-    public SpongeFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
-        //Since we don't have full control over the execution, the contract needs to be a little broken
-        return this.scheduleAtFixedRate(command, initialDelay, delay, unit);
-    }
-
-    private TaskBuilder createTask(final Runnable runnable) {
-        return this.taskBuilderProvider.get().execute(runnable);
-    }
-
-    public static class SpongeFuture<V> implements RunnableScheduledFuture<V> {
-
-        private final long scheduledAt = System.currentTimeMillis();
-        private final FutureTask<V> runnable;
-        private final Task task;
-
-        protected SpongeFuture(FutureTask<V> runnable, Task task) {
-            this.runnable = runnable;
-            this.task = task;
-        }
+    interface SpongeFuture<V> extends RunnableScheduledFuture<V> {
 
         /**
          * @return The {@link SchedulerService} task that is responsible for
          *         the execution of this future
          */
-        public Task getTask() {
-            return this.task;
-        }
-
-        @Override
-        public long getDelay(TimeUnit unit) {
-            return unit.convert(getCurrentDelay(), TimeUnit.MILLISECONDS);
-        }
-
-        @Override
-        public int compareTo(Delayed other) {
-            // Since getDelay may return different values for each call,
-            // this check is required to correctly implement Comparable
-            if (other == this) {
-                return 0;
-            }
-            return Long.compare(this.getDelay(TimeUnit.MILLISECONDS), other.getDelay(TimeUnit.MILLISECONDS));
-        }
-
-        @Override
-        public boolean cancel(boolean mayInterruptIfRunning) {
-            this.task.cancel(); //Ensure Sponge is not going to try to run a cancelled task.
-            return this.runnable.cancel(mayInterruptIfRunning);
-        }
-
-        @Override
-        public boolean isCancelled() {
-            return this.runnable.isCancelled();
-        }
-
-        @Override
-        public boolean isDone() {
-            return this.runnable.isDone();
-        }
-
-        @Override
-        public V get() throws InterruptedException, ExecutionException {
-            return this.runnable.get();
-        }
-
-        @Override
-        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-            return this.runnable.get(timeout, unit);
-        }
-
-        @Override
-        public boolean isPeriodic() {
-            return this.task.getInterval() > 0;
-        }
-
-        @Override
-        public void run() {
-            this.runnable.run();
-        }
-
-        private long getCurrentDelay() {
-            //TODO: this is a hack, probably needs to be partially moved to SpongeCommon if this needs to be accurate
-            long originalDelay = (this.scheduledAt + this.task.getDelay()) - System.currentTimeMillis();
-            if (this.isPeriodic() && originalDelay <= 0) {
-                //Since its periodic, find the first positive delay and report
-                long interval = this.task.getInterval();
-                return originalDelay % interval + interval;
-            } else {
-                return originalDelay;
-            }
-        }
-    }
-
-    /**
-     * An extension of the JREs FutureTask that can be repeatedly executed,
-     * required for scheduling on an interval.
-     */
-    private static class RepeatableFutureTask<V> extends FutureTask<V> {
-
-        @Nullable private Task owningTask = null;
-
-        protected RepeatableFutureTask(Runnable runnable) {
-            super(runnable, null);
-        }
-
-        protected void setTask(Task task) {
-            this.owningTask = task;
-        }
-
-        @Override
-        public void run() {
-            super.runAndReset();
-
-            // A repeating task that is done but hasn't been cancelled has
-            // failed exceptionally. Following the contract of
-            // ScheduledExecutorService, this means the task has to be stopped.
-            if (super.isDone() && !super.isCancelled() && this.owningTask != null) {
-                //TODO: should this be logged?
-                this.owningTask.cancel();
-            }
-        }
+        Task getTask();
     }
 }


### PR DESCRIPTION
@zml2008 has asked if I was willing to contribute my implementation of the standard ExecutorService (Original post: [Sponge forums](https://forums.spongepowered.org/t/executorservice-backed-by-sponges-schedulerservice/8352)) to the project, this implementation delegates the execution of its tasks to the existing SchedulerService.

While most of the implementation is based on the original version ([https://gist.github.com/Kiskae/5c44ea146857ca173170](https://gist.github.com/Kiskae/5c44ea146857ca173170)), I went through the contract of the ScheduledExecutorService again and changed the implementation to be more compliant:
* The `schedule(AtFixedRate|WithFixedDelay)` methods would not execute more than once due to the implementation of FutureTask preventing multiple executions, the private class `RepeatableFutureTask` solves this issue
* The contract of the  `schedule(AtFixedRate|WithFixedDelay)` methods specify that they should stop executing when they encounter an exception. Sponge tasks do not stop when they encounter an exception so the `RepeatableFutureTask` will cancel its parent task if an exception occurs.
  * ~~*TODO* the SchedulerService implementation prints to the log when an exception occurs, should this behaviour be replicated in the `RepeatableFutureTask`. Otherwise it can fail completely silently.~~
* `ScheduledFuture.getDelay(TimeUnit)` specifies that it must return the amount of time UNTIL the next execution, the previous implementation simply returned Sponge's `Task.getDelay()`, which is the original execution delay. The implementation now tries to approximate the delay until the next execution.
  * ~~*TODO* Decide whether the following should be implemented: This could be made more accurate (and less hacky) by moving a part of the SpongeFuture implementation to SpongeCommon, where the `timestamp` value is available.~~

Other changes made to better integrate with Sponge:
* Added `syncExecutor(Object)` and `asyncExecutor(Object)` to the `SchedulerService`, they take a plugin instance and return the ExecutorService
* Removed the ability to customize the task names, given that it is an abstraction over the SchedulerService, the default naming based on creation order makes the most sense anyway.

#### What will this PR allow for?
Through this pull request it is possible to use many of the concurrency frameworks that are available on the JVM, since many use the ExecutorService as basis for the execution of whatever they do.
Known frameworks that support execution through an arbitrary executorservice are:
* [RxJava](http://reactivex.io/RxJava/javadoc/rx/schedulers/Schedulers.html): A custom Scheduler can be used - Schedulers.from(game.getScheduler().syncExecutor(this))
* [Java 8 CompletableFuture]( http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html): All the *Async methods have an overload that accepts an Executor to run on.
* [Scala Futures](http://www.scala-lang.org/files/archive/nightly/docs/library/index.html#scala.concurrent.Future): All futures take an implicit ExecutionContext - ExecutionContext.fromExecutorService(game.getScheduler().syncExecutor(this))

Example of usage:
```java
final Server s = game.getServer();
ExecutorService executor = game.getScheduler().syncExecutor(this);
ObserableFuture<UUID> futurePlayerId = someSource();
futurePlayerId.thenApplyAsync((playerUUID) -> {
    //Any actions performed here are thread-safe!
    final Player p = server.getPlayer(playerUUID).get();
    //Modify the world at the players location
    return player;
}, executor).thenApply((player) -> {
    //Beware, this also runs on the server thread, use another *Async call to move to another thread
      player.kick();
    return player.getName();
}).thenApplyAsync((playerName) -> {
    //This is no longer thread-safe, but will not risk blocking the main thread
    computeNameCoolnessVerySlow(playerName);
});
```