### PR TITLE
Fix missing or invalid Translatables

### DIFF
--- a/src/main/java/org/spongepowered/api/data/type/BodyPart.java
+++ b/src/main/java/org/spongepowered/api/data/type/BodyPart.java
@@ -25,9 +25,10 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 @CatalogedBy(BodyParts.class)
-public interface BodyPart extends CatalogType {
+public interface BodyPart extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/BrickType.java
+++ b/src/main/java/org/spongepowered/api/data/type/BrickType.java
@@ -25,12 +25,13 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a type of "brick".
  */
 @CatalogedBy(BrickTypes.class)
-public interface BrickType extends CatalogType {
+public interface BrickType extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/CoalType.java
+++ b/src/main/java/org/spongepowered/api/data/type/CoalType.java
@@ -25,12 +25,13 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents the type of coal.
  */
 @CatalogedBy(CoalTypes.class)
-public interface CoalType extends CatalogType {
+public interface CoalType extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/CookedFish.java
+++ b/src/main/java/org/spongepowered/api/data/type/CookedFish.java
@@ -25,13 +25,14 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a type of cooked fish.
  */
 @CatalogedBy(CookedFishes.class)
-public interface CookedFish extends CatalogType {
+public interface CookedFish extends CatalogType, Translatable {
 
     /**
      * Gets this cooked fish type's corresponding {@link Fish} type.

--- a/src/main/java/org/spongepowered/api/data/type/DirtType.java
+++ b/src/main/java/org/spongepowered/api/data/type/DirtType.java
@@ -26,12 +26,13 @@ package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents the {@link DirtType} of a {@link BlockTypes#DIRT}.
  */
 @CatalogedBy(DirtTypes.class)
-public interface DirtType extends CatalogType {
+public interface DirtType extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/DoublePlantType.java
+++ b/src/main/java/org/spongepowered/api/data/type/DoublePlantType.java
@@ -25,12 +25,13 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a type of double plant.
  */
 @CatalogedBy(DoublePlantTypes.class)
-public interface DoublePlantType extends CatalogType {
+public interface DoublePlantType extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/DyeColor.java
+++ b/src/main/java/org/spongepowered/api/data/type/DyeColor.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.Color;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -32,7 +33,7 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * Represents a color of dye that can be used by various items and blocks.
  */
 @CatalogedBy(DyeColors.class)
-public interface DyeColor extends CatalogType {
+public interface DyeColor extends CatalogType, Translatable {
 
     /**
      * Gets this dye color as a {@link Color} for easy translation.

--- a/src/main/java/org/spongepowered/api/data/type/Fish.java
+++ b/src/main/java/org/spongepowered/api/data/type/Fish.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 import java.util.Optional;
@@ -33,7 +34,7 @@ import java.util.Optional;
  * Represents a type of raw fish item.
  */
 @CatalogedBy(Fishes.class)
-public interface Fish extends CatalogType {
+public interface Fish extends CatalogType, Translatable {
 
     /**
      * Gets this raw fish type's corresponding {@link CookedFish} type.

--- a/src/main/java/org/spongepowered/api/data/type/PistonType.java
+++ b/src/main/java/org/spongepowered/api/data/type/PistonType.java
@@ -25,12 +25,13 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a "type" of piston.
  */
 @CatalogedBy(PistonTypes.class)
-public interface PistonType extends CatalogType {
+public interface PistonType extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/PlantType.java
+++ b/src/main/java/org/spongepowered/api/data/type/PlantType.java
@@ -25,9 +25,10 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 @CatalogedBy(PlantTypes.class)
-public interface PlantType extends CatalogType {
+public interface PlantType extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/PrismarineType.java
+++ b/src/main/java/org/spongepowered/api/data/type/PrismarineType.java
@@ -25,9 +25,10 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 @CatalogedBy(PrismarineTypes.class)
-public interface PrismarineType extends CatalogType {
+public interface PrismarineType extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/Profession.java
+++ b/src/main/java/org/spongepowered/api/data/type/Profession.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
-import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 import java.util.Collection;
@@ -35,7 +34,7 @@ import java.util.Collection;
  * trade offers a villager may offer to a player.
  */
 @CatalogedBy(Professions.class)
-public interface Profession extends CatalogType, Translatable {
+public interface Profession extends CatalogType {
 
     /**
      * Gets the collection of available {@link Career}s.

--- a/src/main/java/org/spongepowered/api/data/type/QuartzType.java
+++ b/src/main/java/org/spongepowered/api/data/type/QuartzType.java
@@ -25,9 +25,10 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 @CatalogedBy(QuartzTypes.class)
-public interface QuartzType extends CatalogType {
+public interface QuartzType extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/SandType.java
+++ b/src/main/java/org/spongepowered/api/data/type/SandType.java
@@ -25,12 +25,13 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents a type of "sand".
  */
 @CatalogedBy(SandTypes.class)
-public interface SandType extends CatalogType {
+public interface SandType extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/SandstoneType.java
+++ b/src/main/java/org/spongepowered/api/data/type/SandstoneType.java
@@ -25,9 +25,10 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 @CatalogedBy(SandstoneTypes.class)
-public interface SandstoneType extends CatalogType {
+public interface SandstoneType extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/ShrubType.java
+++ b/src/main/java/org/spongepowered/api/data/type/ShrubType.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
@@ -33,6 +34,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * {@link BlockTypes#TALLGRASS}.
  */
 @CatalogedBy(ShrubTypes.class)
-public interface ShrubType extends CatalogType {
+public interface ShrubType extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/SlabType.java
+++ b/src/main/java/org/spongepowered/api/data/type/SlabType.java
@@ -25,9 +25,10 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 @CatalogedBy(SlabTypes.class)
-public interface SlabType extends CatalogType {
+public interface SlabType extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/StoneType.java
+++ b/src/main/java/org/spongepowered/api/data/type/StoneType.java
@@ -25,9 +25,10 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 @CatalogedBy(StoneTypes.class)
-public interface StoneType extends CatalogType {
+public interface StoneType extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/TreeType.java
+++ b/src/main/java/org/spongepowered/api/data/type/TreeType.java
@@ -25,9 +25,10 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 @CatalogedBy(TreeTypes.class)
-public interface TreeType extends CatalogType {
+public interface TreeType extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/effect/potion/PotionEffectType.java
+++ b/src/main/java/org/spongepowered/api/effect/potion/PotionEffectType.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.effect.potion;
 
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.text.translation.Translatable;
+import org.spongepowered.api.text.translation.Translation;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
@@ -35,10 +36,18 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
 public interface PotionEffectType extends CatalogType, Translatable {
 
     /**
-     * Gets whether this potion effect is applied
-     * instantly or over time.
+     * Gets whether this potion effect is applied instantly or over time.
      *
      * @return If applied instantly.
      */
     boolean isInstant();
+
+    /**
+     * Gets the {@link Translation} for this potion effect type as a potion
+     * name.
+     *
+     * @return The translation representing this effect as potion
+     */
+    Translation getPotionTranslation();
+
 }

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -31,7 +31,8 @@ import org.spongepowered.api.data.manipulator.mutable.TargetedLocationData;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
-import org.spongepowered.api.event.entity.DamageEntityEvent;
+import org.spongepowered.api.text.TextRepresentable;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.Identifiable;
 import org.spongepowered.api.util.RelativePositions;
 import org.spongepowered.api.world.Location;
@@ -59,7 +60,7 @@ import java.util.UUID;
  *
  * <p>Blocks and items (when they are in inventories) are not entities.</p>
  */
-public interface Entity extends Identifiable, DataHolder, DataSerializable {
+public interface Entity extends Identifiable, DataHolder, DataSerializable, Translatable, TextRepresentable {
 
     /**
      * Get the type of entity.

--- a/src/main/java/org/spongepowered/api/entity/living/player/User.java
+++ b/src/main/java/org/spongepowered/api/entity/living/player/User.java
@@ -33,6 +33,7 @@ import org.spongepowered.api.entity.ArmorEquipable;
 import org.spongepowered.api.entity.Tamer;
 import org.spongepowered.api.item.inventory.Carrier;
 import org.spongepowered.api.service.permission.Subject;
+import org.spongepowered.api.text.TextRepresentable;
 import org.spongepowered.api.util.Identifiable;
 
 import java.util.Optional;
@@ -41,7 +42,7 @@ import java.util.Optional;
  * A User is the data usually associated with a Player that is persisted across server restarts.
  * This is in contrast to Player which represents the ingame entity associated with an online User.
  */
-public interface User extends DataHolder, Identifiable, ArmorEquipable, Tamer, DataSerializable, Subject, Carrier {
+public interface User extends DataHolder, Identifiable, ArmorEquipable, Tamer, DataSerializable, Subject, Carrier, TextRepresentable {
 
     /**
      * Gets the associated {@link GameProfile} of this player.

--- a/src/main/java/org/spongepowered/api/world/difficulty/Difficulty.java
+++ b/src/main/java/org/spongepowered/api/world/difficulty/Difficulty.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.world.difficulty;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
@@ -33,6 +34,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * @see Difficulties
  */
 @CatalogedBy(Difficulties.class)
-public interface Difficulty extends CatalogType {
+public interface Difficulty extends CatalogType, Translatable {
 
 }


### PR DESCRIPTION
Implementation: https://github.com/SpongePowered/SpongeCommon/pull/155

Previously this was contained in https://github.com/SpongePowered/SpongeAPI/pull/808

This PR adds the missing `Translatable` and `TextRepresentable` interfaces to a couple of types.
Removed `Translatable` from `Profession` since there are no translations available.

- A lot of `CatalogType`s extend `Translatable`
- `Entity` extends `Translatable` + `TextRepresentable`
- `User` extends `TextRepresentable`

**[Current API TextRepresentables](https://github.com/SpongePowered/SpongeAPI/blob/master/src/main/java/org/spongepowered/api/text/TextRepresentable.java)**
- `Achievement`
- `Entity`
- `ItemStack`
- `Player`
- `User`

If I have missed something with a special text representation like `ItemStack` or `Achievement` please post a comment.