### PR TITLE
Fix possible NumberFormatExceptions in Coerce.

### DIFF
--- a/src/main/java/org/spongepowered/api/util/Coerce.java
+++ b/src/main/java/org/spongepowered/api/util/Coerce.java
@@ -402,8 +402,11 @@ public final class Coerce {
             return ((Number) obj).shortValue();
         }
 
-        Short parsed = Short.parseShort(Coerce.sanitiseNumber(obj));
-        return parsed != null ? parsed : (short) 0;
+        try {
+            return Short.parseShort(Coerce.sanitiseNumber(obj));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     /**
@@ -449,8 +452,11 @@ public final class Coerce {
             return ((Number) obj).byteValue();
         }
 
-        Byte parsed = Byte.parseByte(Coerce.sanitiseNumber(obj));
-        return parsed != null ? parsed : 0;
+        try {
+            return Byte.parseByte(Coerce.sanitiseNumber(obj));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     /**
@@ -496,8 +502,11 @@ public final class Coerce {
             return ((Number) obj).shortValue();
         }
 
-        Long parsed = Long.parseLong(Coerce.sanitiseNumber(obj));
-        return parsed != null ? parsed : 0;
+        try {
+            return Long.parseLong(Coerce.sanitiseNumber(obj));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     /**


### PR DESCRIPTION
When parsing `byte`s, `short`s, and `long`s, `Coerce` seems to assume that parsing failures via Java's built in primitive classes will return `null`, while they actually throw `NumberFormatException`s.

The reason only these methods needed to be fixed is that the other methods use Guava methods that return `null` in the case of a parsing failure; however, Guava doesn't provide methods for parsing `byte`s, `short`s, and `long`s.