### PR TITLE
Rename OwnableData to RepresentedPlayerData

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.data.key;
 
 import com.flowpowered.math.vector.Vector3d;
+
 import org.spongepowered.api.GameProfile;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
@@ -174,7 +175,7 @@ public final class Keys {
     public static final Key<MutableBoundedValue<Short>> SPAWNER_SPAWN_RANGE = null;
     public static final Key<MobSpawnerData.NextEntityToSpawnValue> SPAWNER_NEXT_ENTITY_TO_SPAWN = null;
     public static final Key<WeightedEntityCollectionValue> SPAWNER_ENTITIES = null;
-    public static final Key<Value<GameProfile>> OWNED_BY_PROFILE = null;
+    public static final Key<Value<GameProfile>> REPRESENTED_PLAYER = null;
     public static final Key<ListValue<PotionEffect>> POTION_EFFECTS = null;
     public static final Key<Value<ItemStackSnapshot>> REPRESENTED_ITEM = null;
     public static final Key<Value<Rotation>> ROTATION = null;

--- a/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.data.manipulator.catalog;
 
-import org.spongepowered.api.GameProfile;
 import org.spongepowered.api.attribute.Attribute;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.manipulator.DataManipulator;
@@ -32,7 +31,6 @@ import org.spongepowered.api.data.manipulator.mutable.AttributeData;
 import org.spongepowered.api.data.manipulator.mutable.DisplayNameData;
 import org.spongepowered.api.data.manipulator.mutable.DyeableData;
 import org.spongepowered.api.data.manipulator.mutable.FireworkData;
-import org.spongepowered.api.data.manipulator.mutable.OwnableData;
 import org.spongepowered.api.data.manipulator.mutable.PotionEffectData;
 import org.spongepowered.api.data.manipulator.mutable.RepresentedItemData;
 import org.spongepowered.api.data.manipulator.mutable.TargetedLocationData;
@@ -362,11 +360,6 @@ public final class CatalogEntityData {
      * contains.
      */
     public static final Class<ExpOrbData> ORB_DATA = ExpOrbData.class;
-    /**
-     * Signifies that an entity is owned by a {@link GameProfile}. Usually
-     * applicable to {@link Living} entities.
-     */
-    public static final Class<OwnableData> OWNABLE_DATA = OwnableData.class;
     /**
      * Signifies that an entity is a "passenger" riding another {@link Entity}.
      * Usually applicable for all {@link Entity}.

--- a/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogTileEntityData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogTileEntityData.java
@@ -44,7 +44,7 @@ import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.CommandData;
 import org.spongepowered.api.data.manipulator.mutable.DisplayNameData;
 import org.spongepowered.api.data.manipulator.mutable.MobSpawnerData;
-import org.spongepowered.api.data.manipulator.mutable.OwnableData;
+import org.spongepowered.api.data.manipulator.mutable.RepresentedPlayerData;
 import org.spongepowered.api.data.manipulator.mutable.RepresentedItemData;
 import org.spongepowered.api.data.manipulator.mutable.block.ComparatorData;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.BannerData;
@@ -110,7 +110,7 @@ public final class CatalogTileEntityData {
      * Represents data pertaining to a {@link GameProfile} for a tile entity.
      * Usually applicable to {@link Skull}s.
      */
-    public static final Class<OwnableData> OWNABLE_DATA = OwnableData.class;
+    public static final Class<RepresentedPlayerData> REPRESENTED_PLAYER_DATA = RepresentedPlayerData.class;
     /**
      * Represents a {@link TileEntity} that acts on an {@link ItemStack}.
      * Usually applicable to {@link Jukebox}es and {@link FlowerPot}s.

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableRepresentedPlayerData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableRepresentedPlayerData.java
@@ -29,27 +29,22 @@ import org.spongepowered.api.block.tileentity.Skull;
 import org.spongepowered.api.block.tileentity.TileEntity;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
-import org.spongepowered.api.data.manipulator.mutable.OwnableData;
+import org.spongepowered.api.data.manipulator.mutable.RepresentedPlayerData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
-import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.entity.Tamer;
-import org.spongepowered.api.entity.living.animal.Animal;
 
 /**
  * An {@link ImmutableDataManipulator} handling the {@link GameProfile}
- * associated with "owning" an {@link Entity}. Usually applicable to
- * {@link Animal}s that can be tamed by a {@link Tamer}, but sometimes,
- * the {@link DataHolder} providing this ownable data is a
- * {@link Skull} {@link TileEntity}.
+ * represented by this {@link DataHolder}. Applicable to a {@link Skull}
+ * {@link TileEntity} or {@link ItemStack}.
  */
-public interface ImmutableOwnableData extends ImmutableDataManipulator<ImmutableOwnableData, OwnableData> {
+public interface ImmutableRepresentedPlayerData extends ImmutableDataManipulator<ImmutableRepresentedPlayerData, RepresentedPlayerData> {
 
     /**
      * Gets the {@link ImmutableValue} for the {@link GameProfile} that is
-     * marked as "owning" the {@link DataHolder}.
+     * represented by the {@link DataHolder}.
      *
      * @return The immutable value of the game profile
      */
-    ImmutableValue<GameProfile> profile();
+    ImmutableValue<GameProfile> owner();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/RepresentedPlayerData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/RepresentedPlayerData.java
@@ -29,27 +29,22 @@ import org.spongepowered.api.block.tileentity.Skull;
 import org.spongepowered.api.block.tileentity.TileEntity;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.manipulator.DataManipulator;
-import org.spongepowered.api.data.manipulator.immutable.ImmutableOwnableData;
+import org.spongepowered.api.data.manipulator.immutable.ImmutableRepresentedPlayerData;
 import org.spongepowered.api.data.value.mutable.Value;
-import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.entity.Tamer;
-import org.spongepowered.api.entity.living.animal.Animal;
 
 /**
  * An {@link DataManipulator} handling the {@link GameProfile}
- * associated with "owning" an {@link Entity}. Usually applicable to
- * {@link Animal}s that can be tamed by a {@link Tamer}, but sometimes,
- * the {@link DataHolder} providing this ownable data is a
- * {@link Skull} {@link TileEntity}.
+ * represented by this {@link DataHolder}. Applicable to a {@link Skull}
+ * {@link TileEntity} or {@link ItemStack}.
  */
-public interface OwnableData extends DataManipulator<OwnableData, ImmutableOwnableData> {
+public interface RepresentedPlayerData extends DataManipulator<RepresentedPlayerData, ImmutableRepresentedPlayerData> {
 
     /**
-     * Gets the {@link Value} for the {@link GameProfile} that is
-     * marked as "owning" the {@link DataHolder}.
+     * Gets the {@link Value}{@link GameProfile} that is
+     * represented by the {@link DataHolder}.
      *
      * @return The value of the game profile
      */
-    Value<GameProfile> profile();
+    Value<GameProfile> owner();
 
 }


### PR DESCRIPTION
This PR is required by SpongePowered/SpongeCommon#178

rename `OwnableData` to `RepresentedPlayerData` following the discussion on #857 