### PR TITLE
Updates to Dispatcher and Disambiguator.

### DIFF
--- a/src/main/java/org/spongepowered/api/service/command/SimpleCommandService.java
+++ b/src/main/java/org/spongepowered/api/service/command/SimpleCommandService.java
@@ -66,6 +66,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 /**
@@ -213,6 +214,11 @@ public class SimpleCommandService implements CommandService {
     @Override
     public Optional<CommandMapping> get(String alias) {
         return this.dispatcher.get(alias);
+    }
+
+    @Override
+    public Optional<? extends CommandMapping> get(String alias, @Nullable CommandSource source) {
+        return this.dispatcher.get(alias, source);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/util/command/dispatcher/Disambiguator.java
+++ b/src/main/java/org/spongepowered/api/util/command/dispatcher/Disambiguator.java
@@ -30,16 +30,18 @@ import org.spongepowered.api.util.command.CommandSource;
 import java.util.List;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 public interface Disambiguator {
 
     /**
      * Disambiguate an alias in cases where there are multiple command mappings registered for a given alias.
      *
-     * @param source The CommandSource executing the command
+     * @param source The CommandSource executing the command, if any
      * @param aliasUsed The alias input by the user
      * @param availableOptions The commands registered to this alias
      * @return The specific command to use
      */
-    Optional<CommandMapping> disambiguate(CommandSource source, String aliasUsed, List<CommandMapping> availableOptions);
+    Optional<CommandMapping> disambiguate(@Nullable CommandSource source, String aliasUsed, List<CommandMapping> availableOptions);
 
 }

--- a/src/main/java/org/spongepowered/api/util/command/dispatcher/Dispatcher.java
+++ b/src/main/java/org/spongepowered/api/util/command/dispatcher/Dispatcher.java
@@ -27,9 +27,12 @@ package org.spongepowered.api.util.command.dispatcher;
 import com.google.common.collect.Multimap;
 import org.spongepowered.api.util.command.CommandCallable;
 import org.spongepowered.api.util.command.CommandMapping;
+import org.spongepowered.api.util.command.CommandSource;
 
 import java.util.Optional;
 import java.util.Set;
+
+import javax.annotation.Nullable;
 
 /**
  * Executes a command based on user input.
@@ -73,7 +76,18 @@ public interface Dispatcher extends CommandCallable {
      * @return The command mapping, if available
      */
     Optional<? extends CommandMapping> get(String alias);
-
+    
+    /**
+     * Get the {@link CommandMapping} associated with an alias in the context
+     * of a given {@link CommandSource}. Returns null if no command is named by
+     * the given alias.
+     *
+     * @param alias The alias to look up
+     * @param source The source this alias is being looked up for
+     * @return The command mapping, if available
+     */
+    Optional<? extends CommandMapping> get(String alias, @Nullable CommandSource source);
+    
     /**
      * Gets all the {@link CommandMapping}s associated with an alias.
      *

--- a/src/main/java/org/spongepowered/api/util/command/dispatcher/SimpleDispatcher.java
+++ b/src/main/java/org/spongepowered/api/util/command/dispatcher/SimpleDispatcher.java
@@ -291,18 +291,12 @@ public final class SimpleDispatcher implements Dispatcher {
         return get(alias, null);
     }
 
-    /**
-     * Get a given command in the context of a certain command source.
-     *
-     * @param alias The alias to look up
-     * @param source The source this alias is being looked up for
-     * @return the command if exactly one matches
-     */
+    @Override
     public synchronized Optional<CommandMapping> get(String alias, @Nullable CommandSource source) {
         List<CommandMapping> results = this.commands.get(alias.toLowerCase());
         if (results.size() == 1) {
             return Optional.of(results.get(0));
-        } else if (results.size() == 0 || source == null) {
+        } else if (results.size() == 0) {
             return Optional.empty();
         } else {
             return this.disambiguatorFunc.disambiguate(source, alias, results);


### PR DESCRIPTION
Add `SimpleDispatcher.get(String, @Nullable CommandSource)` to `Dispatcher`.
Make the `CommandSource` in `Disambiguator` `@Nullable`.

Implementation: SpongePowered/SpongeCommon#179
Addresses SpongePowered/Sponge#320.