### PR TITLE
Bump version to 3.0-SNAPSHOT.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 }
 
-version = '2.1-SNAPSHOT'
+version = '3.0-SNAPSHOT'
 
 ext.api = project
 apply from: 'gradle/java.gradle'


### PR DESCRIPTION
There's various caching issues that gradle isn't picking up for some reason, and I do believe we did decide to bump the snapshot version to 3.0-SNAPSHOT with the Java 8 update.

