### PR TITLE
Add FallDistanceData to API

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -75,6 +75,7 @@ import org.spongepowered.api.data.manipulator.mutable.block.SuspendedData;
 import org.spongepowered.api.data.manipulator.mutable.block.TreeData;
 import org.spongepowered.api.data.manipulator.mutable.block.WallData;
 import org.spongepowered.api.data.manipulator.mutable.block.WireAttachmentData;
+import org.spongepowered.api.data.manipulator.mutable.entity.FallDistanceData;
 import org.spongepowered.api.data.meta.ItemEnchantment;
 import org.spongepowered.api.data.type.Art;
 import org.spongepowered.api.data.type.BigMushroomType;
@@ -454,6 +455,14 @@ public final class Keys {
      * @see ExtendedData#extended()
      */
     public static final Key<Value<Boolean>> EXTENDED = null;
+
+    /**
+     * Represents the {@link Key} for representing the distance an entity has
+     * fallen.
+     *
+     * @see FallDistanceData#fallDistance()
+     */
+    public static final Key<Value<Integer>> FALL_DISTANCE = null;
 
     /**
      * Represents the {@link Key} for representing the {@link BigMushroomType}

--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -462,7 +462,7 @@ public final class Keys {
      *
      * @see FallDistanceData#fallDistance()
      */
-    public static final Key<Value<Integer>> FALL_DISTANCE = null;
+    public static final Key<MutableBoundedValue<Float>> FALL_DISTANCE = null;
 
     /**
      * Represents the {@link Key} for representing the {@link BigMushroomType}

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableFallDistanceData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableFallDistanceData.java
@@ -2,6 +2,7 @@ package org.spongepowered.api.data.manipulator.immutable.entity;
 
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.entity.FallDistanceData;
+import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 
 /**
@@ -15,6 +16,6 @@ public interface ImmutableFallDistanceData extends ImmutableDataManipulator<Immu
      * Gets the {@link ImmutableValue} for the current fall distance.
      * @return The value for the fall distance
      */
-    ImmutableValue<Integer> fallDistance();
+    ImmutableBoundedValue<Float> fallDistance();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableFallDistanceData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableFallDistanceData.java
@@ -1,0 +1,20 @@
+package org.spongepowered.api.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.entity.FallDistanceData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+
+/**
+ * A {@link ImmutableDataManipulator} that represents the distance an entity has fallen
+ * in the world. Usually the higher this value, the more damage that inflicted
+ * when the entity reaches the ground.
+ */
+public interface ImmutableFallDistanceData extends ImmutableDataManipulator<ImmutableFallDistanceData, FallDistanceData> {
+
+    /**
+     * Gets the {@link ImmutableValue} for the current fall distance.
+     * @return The value for the fall distance
+     */
+    ImmutableValue<Integer> fallDistance();
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableFallDistanceData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableFallDistanceData.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.api.data.manipulator.immutable.entity;
 
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/FallDistanceData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/FallDistanceData.java
@@ -1,0 +1,20 @@
+package org.spongepowered.api.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableFallDistanceData;
+import org.spongepowered.api.data.value.mutable.Value;
+
+/**
+ * A {@link DataManipulator} that represents the distance an entity has fallen
+ * in the world. Usually the higher this value, the more damage that inflicted
+ * when the entity reaches the ground.
+ */
+public interface FallDistanceData extends DataManipulator<FallDistanceData, ImmutableFallDistanceData> {
+
+    /**
+     * Gets the {@link Value} for the current fall distance.
+     * @return The value for the fall distance
+     */
+    Value<Integer> fallDistance();
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/FallDistanceData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/FallDistanceData.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.api.data.manipulator.mutable.entity;
 
 import org.spongepowered.api.data.manipulator.DataManipulator;

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/FallDistanceData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/FallDistanceData.java
@@ -2,6 +2,7 @@ package org.spongepowered.api.data.manipulator.mutable.entity;
 
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableFallDistanceData;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.api.data.value.mutable.Value;
 
 /**
@@ -15,6 +16,6 @@ public interface FallDistanceData extends DataManipulator<FallDistanceData, Immu
      * Gets the {@link Value} for the current fall distance.
      * @return The value for the fall distance
      */
-    Value<Integer> fallDistance();
+    MutableBoundedValue<Float> fallDistance();
 
 }


### PR DESCRIPTION
SpongePowered/SpongeCommon#233

Currently there isn't a way for plugins to query the distance that an entity has fallen. This is important, for example, for plugins that want to affect gravity (like [here](https://forums.spongepowered.org/t/how-to-reset-fall-damage/9726/5)), or maybe send a message when a player falls 20 blocks.

While this can be discovered by listening for player movement and recording changes in location this is not always accurate, especially when you need to consider other circumstances like flying, mods, etc.

This PR adds the key, mutable and immutable data to get and alter an entity's fall distance.