### PR TITLE
Make FireworkData more broad

### DIFF
--- a/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
@@ -28,7 +28,8 @@ import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.DisplayNameData;
 import org.spongepowered.api.data.manipulator.mutable.DyeableData;
-import org.spongepowered.api.data.manipulator.mutable.FireworkData;
+import org.spongepowered.api.data.manipulator.mutable.FireworkEffectData;
+import org.spongepowered.api.data.manipulator.mutable.FireworkRocketData;
 import org.spongepowered.api.data.manipulator.mutable.PotionEffectData;
 import org.spongepowered.api.data.manipulator.mutable.RepresentedItemData;
 import org.spongepowered.api.data.manipulator.mutable.TargetedLocationData;
@@ -141,6 +142,7 @@ import org.spongepowered.api.entity.projectile.EyeOfEnder;
 import org.spongepowered.api.entity.projectile.Firework;
 import org.spongepowered.api.entity.projectile.Projectile;
 import org.spongepowered.api.item.FireworkEffect;
+import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.merchant.TradeOffer;
 import org.spongepowered.api.potion.PotionEffect;
@@ -273,7 +275,11 @@ public final class CatalogEntityData {
      * Represents the {@link FireworkEffect}s that a {@link Firework} will have
      * upon detonation.
      */
-    public static final Class<FireworkData> FIREWORK_DATA = FireworkData.class;
+    public static final Class<FireworkEffectData> FIREWORK_EFFECT_DATA = FireworkEffectData.class;
+    /**
+     * Represents the flight time of a {@link Firework}.
+     */
+    public static final Class<FireworkRocketData> FIREWORK_ROCKET_DATA = FireworkRocketData.class;
     /**
      * Represents when an entity is considering to be "flying". Applicable for
      * almost all types of {@link Entity}.

--- a/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogItemData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogItemData.java
@@ -30,7 +30,8 @@ import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.ColoredData;
 import org.spongepowered.api.data.manipulator.mutable.DisplayNameData;
 import org.spongepowered.api.data.manipulator.mutable.DyeableData;
-import org.spongepowered.api.data.manipulator.mutable.FireworkData;
+import org.spongepowered.api.data.manipulator.mutable.FireworkEffectData;
+import org.spongepowered.api.data.manipulator.mutable.FireworkRocketData;
 import org.spongepowered.api.data.manipulator.mutable.PotionEffectData;
 import org.spongepowered.api.data.manipulator.mutable.TargetedLocationData;
 import org.spongepowered.api.data.manipulator.mutable.item.BlockItemData;
@@ -118,9 +119,14 @@ public final class CatalogItemData {
      */
     public static final Class<EnchantmentData> ENCHANTMENT_DATA = EnchantmentData.class;
     /**
-     * Represents the {@link FireworkEffect}s of a firework.
+     * Represents the {@link FireworkEffect}s of {@link ItemTypes#FIREWORKS}
+     * or a {@link ItemTypes#FIREWORK_CHARGE}.
      */
-    public static final Class<FireworkData> FIREWORK_DATA = FireworkData.class;
+    public static final Class<FireworkEffectData> FIREWORK_EFFECT_DATA = FireworkEffectData.class;
+    /**
+     * Represents the flight time of {@link ItemTypes#FIREWORKS}.
+     */
+    public static final Class<FireworkRocketData> FIREWORK_ROCKET_DATA = FireworkRocketData.class;
     /**
      * Represents the {@link Fish} type of a {@link ItemTypes#FISH}.
      */

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableFireworkEffectData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableFireworkEffectData.java
@@ -22,38 +22,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.manipulator.mutable;
+package org.spongepowered.api.data.manipulator.immutable;
 
-import org.spongepowered.api.data.manipulator.DataManipulator;
-import org.spongepowered.api.data.manipulator.immutable.ImmutableFireworkData;
-import org.spongepowered.api.data.value.mutable.ListValue;
-import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.FireworkEffectData;
+import org.spongepowered.api.data.value.immutable.ImmutableListValue;
+import org.spongepowered.api.entity.projectile.Firework;
 import org.spongepowered.api.item.FireworkEffect;
-
+import org.spongepowered.api.item.ItemTypes;
+import org.spongepowered.api.item.inventory.ItemStack;
 
 /**
- * Represents data specific to fireworks.
+ * An {@link ImmutableDataManipulator} handling the various
+ * {@link FireworkEffect}s associated with a {@link Firework} and
+ * an {@link ItemStack} that is of the {@link ItemTypes#FIREWORKS} or {@link ItemTypes#FIREWORK_CHARGE}.
  */
-public interface FireworkData extends DataManipulator<FireworkData, ImmutableFireworkData> {
+public interface ImmutableFireworkEffectData extends ImmutableDataManipulator<ImmutableFireworkEffectData, FireworkEffectData> {
 
     /**
-     * Gets the {@link ListValue} of {@link FireworkEffect}s.
+     * Gets the {@link ImmutableListValue} of {@link FireworkEffect}s.
      *
-     * @return The list value of fire work effects
+     * <p>Note that for {@link ItemTypes#FIREWORK_CHARGE} only the first effect
+     * will apply to the charge.</p>
+     *
+     * @return The list value of firework effects
      */
-    ListValue<FireworkEffect> effects();
-
-    /**
-     * Gets the flight modifier for this firework.
-     *
-     * <p>Flight modifiers are tiered ranks of flight duration. Generally,
-     * the modifier is used to calculate the fuse time of a firework when
-     * launched. This can be approximated by multiplying 10 and the modifier,
-     * and adding a random number between 0 and 13. Again, this is a general
-     * approximation of what vanilla Minecraft performs.</p>
-     *
-     * @return The flight modifier
-     */
-    MutableBoundedValue<Integer> flightModifier();
-
+    ImmutableListValue<FireworkEffect> effects();
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableFireworkRocketData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableFireworkRocketData.java
@@ -22,23 +22,31 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.entity.projectile;
+package org.spongepowered.api.data.manipulator.immutable;
 
-import org.spongepowered.api.data.manipulator.mutable.FireworkEffectData;
-import org.spongepowered.api.entity.explosive.FusedExplosive;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.FireworkRocketData;
+import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
+import org.spongepowered.api.entity.projectile.Firework;
+import org.spongepowered.api.item.ItemTypes;
 
 /**
- * Represents a firework.
+ * An {@link ImmutableDataManipulator} representing the flight modifier of a
+ * {@link Firework} or {@link ItemTypes#FIREWORKS} item.
  */
-public interface Firework extends Projectile, FusedExplosive {
+public interface ImmutableFireworkRocketData extends ImmutableDataManipulator<ImmutableFireworkRocketData, FireworkRocketData> {
 
     /**
-     * Gets a copy of the {@link FireworkEffectData} for this firework.
+     * Gets the {@link ImmutableBoundedValue} for the flight modifier.
      *
-     * @return A copy of the firework data
+     * <p>Flight modifiers are tiered ranks of flight duration. Generally,
+     * the modifier is used to calculate the fuse time of a firework when
+     * launched. This can be approximated by multiplying 10 and the modifier,
+     * and adding a random number between 0 and 13. Again, this is a general
+     * approximation of what vanilla Minecraft performs.</p>
+     *
+     * @return The flight modifier
      */
-    default FireworkEffectData getFireworkData() {
-        return get(FireworkEffectData.class).get();
-    }
+    ImmutableBoundedValue<Integer> flightModifier();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/FireworkEffectData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/FireworkEffectData.java
@@ -22,42 +22,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.manipulator.immutable;
+package org.spongepowered.api.data.manipulator.mutable;
 
-import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
-import org.spongepowered.api.data.manipulator.mutable.FireworkData;
-import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
-import org.spongepowered.api.data.value.immutable.ImmutableListValue;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.ImmutableFireworkEffectData;
+import org.spongepowered.api.data.value.mutable.ListValue;
 import org.spongepowered.api.entity.projectile.Firework;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
 
 /**
- * An {@link ImmutableDataManipulator} handling the various
+ * A {@link DataManipulator} handling the various
  * {@link FireworkEffect}s associated with a {@link Firework} and
- * an {@link ItemStack} that is of the {@link ItemTypes#FIREWORKS}.
+ * an {@link ItemStack} that is of the {@link ItemTypes#FIREWORKS} or {@link ItemTypes#FIREWORK_CHARGE}.
  */
-public interface ImmutableFireworkData extends ImmutableDataManipulator<ImmutableFireworkData, FireworkData> {
+public interface FireworkEffectData extends DataManipulator<FireworkEffectData, ImmutableFireworkEffectData> {
 
     /**
-     * Gets the {@link ImmutableListValue} of {@link FireworkEffect}s.
+     * Gets the {@link ListValue} of {@link FireworkEffect}s.
      *
-     * @return The immutable list value of fire work effects
+     * <p>Note that for {@link ItemTypes#FIREWORK_CHARGE} only the first effect
+     * will apply to the charge.</p>
+     *
+     * @return The list value of firework effects
      */
-    ImmutableListValue<FireworkEffect> effects();
-
-    /**
-     * Gets the {@link ImmutableBoundedValue} for the flight modifier.
-     *
-     * <p>Flight modifiers are tiered ranks of flight duration. Generally,
-     * the modifier is used to calculate the fuse time of a firework when
-     * launched. This can be approximated by multiplying 10 and the modifier,
-     * and adding a random number between 0 and 13. Again, this is a general
-     * approximation of what vanilla Minecraft performs.</p>
-     *
-     * @return The flight modifier
-     */
-    ImmutableBoundedValue<Integer> flightModifier();
-
+    ListValue<FireworkEffect> effects();
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/FireworkRocketData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/FireworkRocketData.java
@@ -22,23 +22,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.entity.projectile;
+package org.spongepowered.api.data.manipulator.mutable;
 
-import org.spongepowered.api.data.manipulator.mutable.FireworkEffectData;
-import org.spongepowered.api.entity.explosive.FusedExplosive;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.ImmutableFireworkRocketData;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.entity.projectile.Firework;
+import org.spongepowered.api.item.ItemTypes;
 
 /**
- * Represents a firework.
+ * An {@link DataManipulator} representing the flight modifier of a
+ * {@link Firework} or {@link ItemTypes#FIREWORKS} item.
  */
-public interface Firework extends Projectile, FusedExplosive {
+public interface FireworkRocketData extends DataManipulator<FireworkRocketData, ImmutableFireworkRocketData> {
 
     /**
-     * Gets a copy of the {@link FireworkEffectData} for this firework.
+     * Gets the flight modifier for this firework.
      *
-     * @return A copy of the firework data
+     * <p>Flight modifiers are tiered ranks of flight duration. Generally,
+     * the modifier is used to calculate the fuse time of a firework when
+     * launched. This can be approximated by multiplying 10 and the modifier,
+     * and adding a random number between 0 and 13. Again, this is a general
+     * approximation of what vanilla Minecraft performs.</p>
+     *
+     * @return The flight modifier
      */
-    default FireworkEffectData getFireworkData() {
-        return get(FireworkEffectData.class).get();
-    }
-
+    MutableBoundedValue<Integer> flightModifier();
 }


### PR DESCRIPTION
Currently FireworkData only applies to the firework rocket item and entity. This is because it references the flight modifier, which is only added once the rocket is fully crafted.

This PR changes it so that the modifier is an optional value - this way, we can not only use FireworkData for rockets, but for firework stars as well.

This also updates the API docs to make clear that a star can only have one effect attached to it - the first effect in the list.