### PR TITLE
Replace the use of java.awt.Color with our own Color

### DIFF
--- a/src/main/java/org/spongepowered/api/data/Queries.java
+++ b/src/main/java/org/spongepowered/api/data/Queries.java
@@ -63,6 +63,11 @@ public final class Queries {
     public static final DataQuery VARIABLE_VARIANCE = of("Variance");
     public static final DataQuery VARIABLE_AMOUNT = of("Amount");
 
+    // Color
+    public static final DataQuery COLOR_RED = of("Red");
+    public static final DataQuery COLOR_BLUE = of("Blue");
+    public static final DataQuery COLOR_GREEN = of("Green");
+
     private Queries() {
     }
 

--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -140,13 +140,13 @@ import org.spongepowered.api.statistic.Statistic;
 import org.spongepowered.api.statistic.achievement.Achievement;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.Axis;
+import org.spongepowered.api.util.Color;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.util.ban.Ban;
 import org.spongepowered.api.util.rotation.Rotation;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
-import java.awt.Color;
 import java.util.Date;
 import java.util.UUID;
 

--- a/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogItemData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogItemData.java
@@ -63,8 +63,7 @@ import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.effect.potion.PotionEffect;
 import org.spongepowered.api.text.Text;
-
-import java.awt.Color;
+import org.spongepowered.api.util.Color;
 
 /**
  * An enumeration of known {@link DataManipulator}s applicable to

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableColoredData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableColoredData.java
@@ -29,8 +29,7 @@ import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.ColoredData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.item.inventory.ItemStack;
-
-import java.awt.Color;
+import org.spongepowered.api.util.Color;
 
 /**
  * An {@link ImmutableDataManipulator} for handling the {@link Color} of

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/ColoredData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/ColoredData.java
@@ -27,8 +27,7 @@ package org.spongepowered.api.data.manipulator.mutable;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.ImmutableColoredData;
 import org.spongepowered.api.data.value.mutable.Value;
-
-import java.awt.Color;
+import org.spongepowered.api.util.Color;
 
 /**
  * Represents item data that uses colors. Examples may include leather armor,

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/tileentity/BannerData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/tileentity/BannerData.java
@@ -32,8 +32,6 @@ import org.spongepowered.api.data.type.DyeColor;
 import org.spongepowered.api.data.value.mutable.PatternListValue;
 import org.spongepowered.api.data.value.mutable.Value;
 
-import java.awt.Color;
-
 /**
  * An {@link DataManipulator} handling the various information for a
  * {@link Banner} including the {@link PatternLayer}s that customize the
@@ -42,7 +40,7 @@ import java.awt.Color;
 public interface BannerData extends DataManipulator<BannerData, ImmutableBannerData> {
 
     /**
-     * Gets the {@link Value} for the base {@link Color}.
+     * Gets the {@link Value} for the base {@link DyeColor}.
      *
      * @return The value for the base color
      */

--- a/src/main/java/org/spongepowered/api/data/type/DyeColor.java
+++ b/src/main/java/org/spongepowered/api/data/type/DyeColor.java
@@ -25,9 +25,8 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.util.Color;
 import org.spongepowered.api.util.annotation.CatalogedBy;
-
-import java.awt.Color;
 
 /**
  * Represents a color of dye that can be used by various items and blocks.

--- a/src/main/java/org/spongepowered/api/effect/particle/ColoredParticle.java
+++ b/src/main/java/org/spongepowered/api/effect/particle/ColoredParticle.java
@@ -26,8 +26,7 @@ package org.spongepowered.api.effect.particle;
 
 import com.flowpowered.math.vector.Vector3d;
 import org.spongepowered.api.Sponge;
-
-import java.awt.Color;
+import org.spongepowered.api.util.Color;
 
 /**
  * Represents a colored particle effect.

--- a/src/main/java/org/spongepowered/api/effect/particle/ParticleEffect.java
+++ b/src/main/java/org/spongepowered/api/effect/particle/ParticleEffect.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.effect.particle;
 import com.flowpowered.math.vector.Vector3d;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.util.ResettableBuilder;
+import org.spongepowered.api.util.Color;
 
 /**
  * Represents a particle effect that can be send to the Minecraft client.

--- a/src/main/java/org/spongepowered/api/effect/particle/ParticleType.java
+++ b/src/main/java/org/spongepowered/api/effect/particle/ParticleType.java
@@ -26,9 +26,9 @@ package org.spongepowered.api.effect.particle;
 
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.util.Color;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
-import java.awt.Color;
 
 /**
  * Represents a particle that can be sent on a Minecraft client.

--- a/src/main/java/org/spongepowered/api/item/FireworkEffect.java
+++ b/src/main/java/org/spongepowered/api/item/FireworkEffect.java
@@ -26,9 +26,9 @@ package org.spongepowered.api.item;
 
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.DataSerializable;
+import org.spongepowered.api.util.Color;
 import org.spongepowered.api.util.ResettableBuilder;
 
-import java.awt.Color;
 import java.util.List;
 
 /**

--- a/src/main/java/org/spongepowered/api/text/format/TextColor.java
+++ b/src/main/java/org/spongepowered/api/text/format/TextColor.java
@@ -26,9 +26,8 @@ package org.spongepowered.api.text.format;
 
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.Color;
 import org.spongepowered.api.util.annotation.CatalogedBy;
-
-import java.awt.Color;
 
 /**
  * Represents the color of the text of a {@link Text}.

--- a/src/main/java/org/spongepowered/api/text/format/TextColors.java
+++ b/src/main/java/org/spongepowered/api/text/format/TextColors.java
@@ -25,8 +25,7 @@
 package org.spongepowered.api.text.format;
 
 import org.spongepowered.api.text.Text;
-
-import java.awt.Color;
+import org.spongepowered.api.util.Color;
 
 /**
  * TextColors is a list of text colors provided by Vanilla Minecraft.
@@ -43,7 +42,7 @@ public final class TextColors {
      */
     public static final TextColor NONE = new TextColor() {
 
-        private final Color color = new Color(0, 0, 0, 0);
+        private final Color color = Color.BLACK;
 
         @Override
         public String getName() {

--- a/src/main/java/org/spongepowered/api/util/Color.java
+++ b/src/main/java/org/spongepowered/api/util/Color.java
@@ -1,0 +1,245 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.flowpowered.math.vector.Vector3d;
+import com.flowpowered.math.vector.Vector3f;
+import com.flowpowered.math.vector.Vector3i;
+import org.apache.commons.lang3.Validate;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataSerializable;
+import org.spongepowered.api.data.DataView;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.Queries;
+import org.spongepowered.api.data.type.DyeColor;
+import org.spongepowered.api.util.persistence.DataBuilder;
+import org.spongepowered.api.util.persistence.InvalidDataException;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public final class Color implements DataSerializable {
+
+    private static final int MASK = 0xFF;
+
+    public static final Color BLACK = ofRgb(0x000000);
+
+    public static final Color GRAY = ofRgb(0x808080);
+
+    public static final Color WHITE = ofRgb(0xFFFFFF);
+
+    public static final Color BLUE = ofRgb(0x0000FF);
+
+    public static final Color GREEN = ofRgb(0x008000);
+
+    public static final Color LIME = ofRgb(0x00FF00);
+
+    public static final Color RED = ofRgb(0xFF0000);
+
+    public static final Color YELLOW = ofRgb(0xFFFF00);
+
+    public static final Color MAGENTA = ofRgb(0xFF00FF);
+
+    public static final Color PURPLE = ofRgb(0xAA00FF);
+
+    public static final Color DARK_CYAN = ofRgb(0x008B8B);
+
+    public static final Color DARK_GREEN = ofRgb(0x006400);
+
+    public static final Color DARK_MAGENTA = ofRgb(0x8B008B);
+
+    public static final Color CYAN = ofRgb(0x00FFFF);
+
+    public static final Color NAVY = ofRgb(0x000080);
+
+    public static final Color PINK = ofRgb(0xFF00AA);
+
+    public static Color ofRgb(int hex) {
+        return ofRgb((hex >> 0x10) & MASK, (hex >> 0x8) & MASK, hex & MASK);
+    }
+
+    public static Color ofRgb(int red, int green, int blue) {
+        return new Color(red, green, blue);
+    }
+
+    public static Color of(java.awt.Color color) {
+        return new Color(color.getRed(), color.getGreen(), color.getBlue());
+    }
+
+    public static Color of(Vector3i vector3i) {
+        return new Color(vector3i.getX(), vector3i.getY(), vector3i.getZ());
+    }
+
+    public static Color of(Vector3f vector3f) {
+        return new Color(Math.round(vector3f.getX()), Math.round(vector3f.getY()), Math.round(vector3f.getZ()));
+    }
+
+    public static Color of(Vector3d vector3d) {
+        return new Color((int) Math.round(vector3d.getX()), (int) Math.round(vector3d.getY()), (int) Math.round(vector3d.getZ()));
+    }
+
+    public static Color mixDyeColors(DyeColor... colors) {
+        Validate.noNullElements(colors, "No nulls allowed!");
+        final Color[] actualColors = new Color[colors.length];
+        for (int i = 0; i < colors.length; i++) {
+            actualColors[i] = colors[i].getColor();
+        }
+
+        return mixColors(actualColors);
+    }
+
+    public static Color mixColors(Color... colors) {
+        Validate.noNullElements(colors, "No null colors allowed!");
+        checkArgument(colors.length > 0, "Cannot have an empty color array!");
+        if (colors.length == 1) {
+            return colors[0];
+        } else {
+            int red = colors[0].getRed();
+            int green = colors[0].getGreen();
+            int blue = colors[0].getBlue();
+            for (int i = 1; i < colors.length; i++) {
+                red += colors[i].getRed();
+                green += colors[i].getGreen();
+                blue += colors[i].getBlue();
+            }
+            int averageRed = Math.round((float) red / colors.length);
+            int averageGreen = Math.round((float) green / colors.length);
+            int averageBlue = Math.round((float) blue / colors.length);
+            return ofRgb(averageRed, averageGreen, averageBlue);
+        }
+    }
+
+    private final byte red;
+    private final byte green;
+    private final byte blue;
+    private final int rgb;
+
+    private Color(int red, int green, int blue) {
+        this.red = (byte) (red & MASK);
+        this.green = (byte) (green & MASK);
+        this.blue = (byte) (blue & MASK);
+        this.rgb = ((this.red & MASK) << 0x10)
+                   | ((this.green & MASK) << 0x8)
+                   | ((this.blue & MASK) << 0);
+    }
+
+    public int getRed() {
+        return MASK & this.red;
+    }
+
+    public Color withRed(int red) {
+        return ofRgb(red, getGreen(), getBlue());
+    }
+
+    public int getGreen() {
+        return MASK & this.green;
+    }
+
+    public Color withGreen(int green) {
+        return ofRgb(getRed(), green, getBlue());
+    }
+
+    public int getBlue() {
+        return MASK & this.blue;
+    }
+
+    public Color withBlue(int blue) {
+        return ofRgb(getRed(), getGreen(), blue);
+    }
+
+    public java.awt.Color asJavaColor() {
+        return new java.awt.Color(getRed(), getGreen(), getBlue());
+    }
+
+    public int getRgb() {
+        return this.rgb;
+    }
+
+    public Color mixWithColors(Color... colors) {
+        Color[] newColorArray = new Color[colors.length + 1];
+        newColorArray[0] = this;
+        System.arraycopy(colors, 0, newColorArray, 1, colors.length);
+        return mixColors(newColorArray);
+    }
+
+    public Color mixWithDyes(DyeColor... dyeColors) {
+        Color[] newColorArray = new Color[dyeColors.length + 1];
+        newColorArray[0] = this;
+        for (int i = 0; i < dyeColors.length; i++) {
+            newColorArray[i + 1] = dyeColors[i].getColor();
+        }
+        return mixColors(newColorArray);
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return new MemoryDataContainer()
+            .set(Queries.COLOR_RED, this.getRed())
+            .set(Queries.COLOR_GREEN, this.getGreen())
+            .set(Queries.COLOR_BLUE, this.getBlue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(Color.class, this.red, this.green, this.blue);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final Color other = (Color) obj;
+        return this.red == other.red && this.green == other.green && this.blue == other.blue;
+    }
+
+    @Override
+    public String toString() {
+        return com.google.common.base.Objects.toStringHelper(this)
+            .add("red", this.getRed())
+            .add("green", this.getGreen())
+            .add("blue", this.getBlue())
+            .toString();
+    }
+
+    public static final class Builder implements DataBuilder<Color> {
+
+        @Override
+        public Optional<Color> build(DataView container) throws InvalidDataException {
+            if (!container.contains(Queries.COLOR_RED, Queries.COLOR_GREEN, Queries.COLOR_BLUE)) {
+                return Optional.empty();
+            }
+            final int red = container.getInt(Queries.COLOR_RED).get();
+            final int green = container.getInt(Queries.COLOR_GREEN).get();
+            final int blue = container.getInt(Queries.COLOR_BLUE).get();
+            return Optional.of(Color.ofRgb(red, green, blue));
+        }
+    }
+}

--- a/src/test/java/org/spongepowered/api/util/ColorTest.java
+++ b/src/test/java/org/spongepowered/api/util/ColorTest.java
@@ -1,0 +1,154 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.util;
+
+import static org.junit.Assert.assertTrue;
+
+import com.flowpowered.math.vector.Vector3d;
+import com.flowpowered.math.vector.Vector3f;
+import com.flowpowered.math.vector.Vector3i;
+import org.junit.Test;
+import org.spongepowered.api.data.DataContainer;
+
+public class ColorTest {
+
+    @Test
+    public void testOfRgbHex() {
+        final Color colorGray = Color.ofRgb(0x808080);
+        assertTrue(Color.GRAY.equals(colorGray));
+    }
+
+    @Test
+    public void testOfRgbForRedGreenBlue() {
+        final Color colorGray = Color.ofRgb(128, 128, 128);
+        assertTrue(Color.GRAY.equals(colorGray));
+    }
+
+    @Test
+    public void testOfColor() {
+        final Color blueColor = Color.of(java.awt.Color.BLUE);
+        assertTrue(blueColor.equals(Color.BLUE));
+    }
+
+    @Test
+    public void testOfVector3i() {
+        final Vector3i vecGray = new Vector3i(128, 128, 384);
+        final Color colorGray = Color.of(vecGray);
+        assertTrue(Color.GRAY.equals(colorGray));
+    }
+
+    @Test
+    public void testOfVector3f() {
+        final Vector3f vecGray = new Vector3f(128.0, 128.459, 127.5);
+        final Color colorGray = Color.of(vecGray);
+        assertTrue(Color.GRAY.equals(colorGray));
+    }
+
+    @Test
+    public void testOfVector3d() {
+        final Vector3d vecGray = new Vector3d(128.0, 128.459, 127.5);
+        final Color colorGray = Color.of(vecGray);
+        assertTrue(Color.GRAY.equals(colorGray));
+    }
+
+    @Test
+    public void testMixColors() {
+        final Color grey = Color.GRAY;
+        final Color test = Color.WHITE.mixWithColors(Color.BLACK);
+        assertTrue(grey.equals(test));
+    }
+
+    @Test
+    public void testGetRed() {
+        assertTrue(0xFF == Color.RED.getRed());
+    }
+
+    @Test
+    public void testWithRed() {
+        final Color cyan = Color.CYAN;
+        final Color merged = cyan.withRed(0xFF);
+        final int rgb = merged.getRgb();
+        assertTrue(0xFFFFFF == rgb);
+    }
+
+    @Test
+    public void testGetGreen() {
+        assertTrue(0x00FF00 == Color.GREEN.getGreen());
+    }
+
+    @Test
+    public void testWithGreen() {
+        final Color magenta = Color.MAGENTA;
+        final Color merged = magenta.withGreen(0xFF);
+        final int rgb = merged.getRgb();
+        assertTrue(0xFFFFFF == rgb);
+    }
+
+    @Test
+    public void testGetBlue() {
+        assertTrue(0x0000FF == Color.BLUE.getBlue());
+    }
+
+    @Test
+    public void testWithBlue() {
+        final Color yellow = Color.YELLOW;
+        final Color merged = yellow.withBlue(0xFF);
+        final int rgb = merged.getRgb();
+        assertTrue(0xFFFFFF == rgb);
+    }
+
+    @Test
+    public void testAsJavaColor() {
+        final int color = 0xFF00FF;
+        final Color apiColor = Color.ofRgb(color);
+        final java.awt.Color javaColor = apiColor.asJavaColor();
+        final java.awt.Color testColor = new java.awt.Color(color);
+        assertTrue(javaColor.equals(testColor));
+    }
+
+    @Test
+    public void testGetRgb() {
+        final int color = 0x808080;
+        final Color color1 = Color.ofRgb(color);
+        final int rgb = color1.getRgb();
+        assertTrue(color == rgb);
+    }
+
+    @Test
+    public void testToContainer() {
+        final Color colorGray = Color.GRAY;
+        final Color.Builder builder = new Color.Builder();
+        final DataContainer container = colorGray.toContainer();
+        final Color deserialized = builder.build(container).get();
+        assertTrue(colorGray.equals(deserialized));
+    }
+
+    @Test
+    public void testEquals() {
+        assertTrue(Color.GREEN.equals(Color.ofRgb(0x00FF00)));
+        assertTrue(!Color.GREEN.equals(Color.GRAY));
+    }
+
+}


### PR DESCRIPTION
Currently, the API uses `java.awt.Color` due to it's useful capabilities, however, the issue with it is that it's not stable in that it can not be translated to and from various other types of colors that are and will be exposed in the API. This includes `DyeColor` and soon `MapColor`. The benefit of this is that we have a final class `Color` that provides not only some translations between `java.awt.Color`, but also adds some static methods for usability.

