### PR TITLE
Add MinecartBlockData

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -132,6 +132,7 @@ import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
+import org.spongepowered.api.entity.vehicle.minecart.Minecart;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.merchant.TradeOffer;
@@ -537,6 +538,12 @@ public final class Keys {
     public static final Key<Value<Boolean>> OCCUPIED = null;
 
     /**
+     * Represents the {@link Key} for representing a block's offset when inside
+     * a {@link Minecart}.
+     */
+    public static final Key<Value<Integer>> OFFSET = null;
+
+    /**
      * Represents the {@link Key} for representing the "open" state of
      * various door typed blocks.
      *
@@ -599,6 +606,12 @@ public final class Keys {
      * @see RailDirectionData#type()
      */
     public static final Key<Value<RailDirection>> RAIL_DIRECTION = null;
+
+    /**
+     * Represents the {@link Key} for representing the {@link BlockState}
+     * inside a {@link Minecart}.
+     */
+    public static final Key<Value<BlockState>> REPRESENTED_BLOCK = null;
 
     /**
      * Represents the {@link Key} for representing the {@link BigMushroomType}

--- a/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.data.manipulator.catalog;
 
+import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.DisplayNameData;
@@ -67,6 +68,7 @@ import org.spongepowered.api.data.manipulator.mutable.entity.InvisibilityData;
 import org.spongepowered.api.data.manipulator.mutable.entity.JoinData;
 import org.spongepowered.api.data.manipulator.mutable.entity.KnockbackData;
 import org.spongepowered.api.data.manipulator.mutable.entity.LeashData;
+import org.spongepowered.api.data.manipulator.mutable.entity.MinecartBlockData;
 import org.spongepowered.api.data.manipulator.mutable.entity.OcelotData;
 import org.spongepowered.api.data.manipulator.mutable.entity.PassengerData;
 import org.spongepowered.api.data.manipulator.mutable.entity.PersistingData;
@@ -140,6 +142,7 @@ import org.spongepowered.api.entity.projectile.Arrow;
 import org.spongepowered.api.entity.projectile.EyeOfEnder;
 import org.spongepowered.api.entity.projectile.Firework;
 import org.spongepowered.api.entity.projectile.Projectile;
+import org.spongepowered.api.entity.vehicle.minecart.Minecart;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.merchant.TradeOffer;
@@ -345,6 +348,10 @@ public final class CatalogEntityData {
      * towards. Usually applicable for {@link EyeOfEnder}s.
      */
     public static final Class<TargetedLocationData> LOCATION_DATA = TargetedLocationData.class;
+    /**
+     * Represents a {@link Minecart} with a {@link BlockState} shown inside.
+     */
+    public static final Class<MinecartBlockData> MINECART_BLOCK_DATA = MinecartBlockData.class;
     /**
      * Represents the {@link OcelotType} of an {@link Ocelot}.
      */

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableMinecartBlockData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableMinecartBlockData.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.entity.MinecartBlockData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.entity.vehicle.minecart.Minecart;
+
+public interface ImmutableMinecartBlockData extends ImmutableDataManipulator<ImmutableMinecartBlockData, MinecartBlockData> {
+
+    /**
+     * Gets the {@link BlockState} represented by the {@link Minecart}.
+     * @return The represented block
+     */
+    ImmutableValue<BlockState> block();
+
+    /**
+     * Gets the offset of the represented block, in "pixels".
+     *
+     * <p>Positive values move the block upwards in relation to the minecart,
+     * and negative values move the block downwards.</p>
+     * @return The block offset
+     */
+    ImmutableValue<Integer> offset();
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/MinecartBlockData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/MinecartBlockData.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableMinecartBlockData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.entity.vehicle.minecart.Minecart;
+
+public interface MinecartBlockData extends DataManipulator<MinecartBlockData, ImmutableMinecartBlockData> {
+
+    /**
+     * Gets the {@link BlockState} represented by the {@link Minecart}.
+     * @return The represented block
+     */
+    Value<BlockState> block();
+
+    /**
+     * Gets the offset of the represented block, in "pixels".
+     *
+     * <p>Positive values move the block upwards in relation to the minecart,
+     * and negative values move the block downwards.</p>
+     * @return The block offset
+     */
+    Value<Integer> offset();
+
+}


### PR DESCRIPTION
Implementation: SpongePowered/SpongeCommon#246

Currently there is no way in the API to represent a minecart with a block inside. This fixes that by adding `MinecartBlockData` - which contains a BlockState and offset.

Yep, that's about it!