### PR TITLE
[WIP] Add Event Filters

### DIFF
--- a/src/main/java/org/spongepowered/api/event/filter/IsCancelled.java
+++ b/src/main/java/org/spongepowered/api/event/filter/IsCancelled.java
@@ -22,39 +22,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event;
+package org.spongepowered.api.event.filter;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.util.Tristate;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotate a method as an {@link EventListener}.
- *
- * <p>The method being targeted must be public and must be in a class that is
- * also public.</p>
+ * Filters out events which do not match the specified cancellation state
+ * (represented by a {@link Tristate}). If the state is set to undefined then
+ * the listener will be called regardless of the cancellation state.
+ * 
+ * <p>If this annotation is not present then the behavior is as normal, which is
+ * to say that the listener is only called if the event is not cancelled.</p>
+ * 
+ * <p> The event type of the annotated event listener <strong>MUST</strong> be
+ * cancellable (eg. must extend {@link Cancellable}). </p>
  */
-@Retention(RUNTIME)
-@Target(METHOD)
-public @interface Listener {
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IsCancelled {
 
     /**
-     * The order this listener should be called in relation to other listeners in
-     * the {@link EventManager}.
-     *
-     * @return The order the listener should be called in
+     * Gets the required cancellation state of the event for the annotated
+     * listener to be called.
+     * 
+     * @return The cancellation state
      */
-    Order order() default Order.DEFAULT;
-
-    /**
-     * Whether this listener should be called before any other server mods, such
-     * as Forge mods. All Sponge event listeners are called after mods, unless
-     * they specify the {@link #beforeModifications()} flag to be true.
-     *
-     * @return If the listener should be fired before other server mods
-     */
-    boolean beforeModifications() default false;
+    Tristate value() default Tristate.TRUE;
 
 }

--- a/src/main/java/org/spongepowered/api/event/filter/cause/All.java
+++ b/src/main/java/org/spongepowered/api/event/filter/cause/All.java
@@ -22,39 +22,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event;
+package org.spongepowered.api.event.filter.cause;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import org.spongepowered.api.event.cause.Cause;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotate a method as an {@link EventListener}.
- *
- * <p>The method being targeted must be public and must be in a class that is
- * also public.</p>
+ * Sets an array parameter to all causes of the array component type in the
+ * cause chain. The type of a parameter annotated with this annotation
+ * <strong>MUST</strong> be an array type.
+ * 
+ * @see Cause#allOf(Class)
  */
-@Retention(RUNTIME)
-@Target(METHOD)
-public @interface Listener {
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface All {
 
     /**
-     * The order this listener should be called in relation to other listeners in
-     * the {@link EventManager}.
-     *
-     * @return The order the listener should be called in
+     * Whether this listener should be skipped if the array would be empty.
+     * 
+     * @return Should ignore if empty
      */
-    Order order() default Order.DEFAULT;
-
-    /**
-     * Whether this listener should be called before any other server mods, such
-     * as Forge mods. All Sponge event listeners are called after mods, unless
-     * they specify the {@link #beforeModifications()} flag to be true.
-     *
-     * @return If the listener should be fired before other server mods
-     */
-    boolean beforeModifications() default false;
-
+    boolean ignoreEmpty() default true;
 }

--- a/src/main/java/org/spongepowered/api/event/filter/cause/First.java
+++ b/src/main/java/org/spongepowered/api/event/filter/cause/First.java
@@ -22,39 +22,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event;
+package org.spongepowered.api.event.filter.cause;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import org.spongepowered.api.event.cause.Cause;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotate a method as an {@link EventListener}.
- *
- * <p>The method being targeted must be public and must be in a class that is
- * also public.</p>
+ * Sets the parameter to the first object in the cause chain of the
+ * parameter type.
+ * 
+ * @see Cause#first(Class)
  */
-@Retention(RUNTIME)
-@Target(METHOD)
-public @interface Listener {
-
-    /**
-     * The order this listener should be called in relation to other listeners in
-     * the {@link EventManager}.
-     *
-     * @return The order the listener should be called in
-     */
-    Order order() default Order.DEFAULT;
-
-    /**
-     * Whether this listener should be called before any other server mods, such
-     * as Forge mods. All Sponge event listeners are called after mods, unless
-     * they specify the {@link #beforeModifications()} flag to be true.
-     *
-     * @return If the listener should be fired before other server mods
-     */
-    boolean beforeModifications() default false;
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface First {
 
 }

--- a/src/main/java/org/spongepowered/api/event/filter/cause/Last.java
+++ b/src/main/java/org/spongepowered/api/event/filter/cause/Last.java
@@ -22,39 +22,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event;
+package org.spongepowered.api.event.filter.cause;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import org.spongepowered.api.event.cause.Cause;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotate a method as an {@link EventListener}.
- *
- * <p>The method being targeted must be public and must be in a class that is
- * also public.</p>
+ * Sets the parameter to the last object in the cause chain of the parameter
+ * type.
+ * 
+ * @see Cause#last(Class)
  */
-@Retention(RUNTIME)
-@Target(METHOD)
-public @interface Listener {
-
-    /**
-     * The order this listener should be called in relation to other listeners in
-     * the {@link EventManager}.
-     *
-     * @return The order the listener should be called in
-     */
-    Order order() default Order.DEFAULT;
-
-    /**
-     * Whether this listener should be called before any other server mods, such
-     * as Forge mods. All Sponge event listeners are called after mods, unless
-     * they specify the {@link #beforeModifications()} flag to be true.
-     *
-     * @return If the listener should be fired before other server mods
-     */
-    boolean beforeModifications() default false;
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Last {
 
 }

--- a/src/main/java/org/spongepowered/api/event/filter/cause/Root.java
+++ b/src/main/java/org/spongepowered/api/event/filter/cause/Root.java
@@ -22,39 +22,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event;
+package org.spongepowered.api.event.filter.cause;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import org.spongepowered.api.event.cause.Cause;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotate a method as an {@link EventListener}.
- *
- * <p>The method being targeted must be public and must be in a class that is
- * also public.</p>
+ * Sets the parameter to the root object in the cause chain, an additional check
+ * is done to ensure that the root object is of the correct type and the filter
+ * fails if this is not the case.
+ * 
+ * @see Cause#root()
  */
-@Retention(RUNTIME)
-@Target(METHOD)
-public @interface Listener {
-
-    /**
-     * The order this listener should be called in relation to other listeners in
-     * the {@link EventManager}.
-     *
-     * @return The order the listener should be called in
-     */
-    Order order() default Order.DEFAULT;
-
-    /**
-     * Whether this listener should be called before any other server mods, such
-     * as Forge mods. All Sponge event listeners are called after mods, unless
-     * they specify the {@link #beforeModifications()} flag to be true.
-     *
-     * @return If the listener should be fired before other server mods
-     */
-    boolean beforeModifications() default false;
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Root {
 
 }

--- a/src/main/java/org/spongepowered/api/event/filter/cause/package-info.java
+++ b/src/main/java/org/spongepowered/api/event/filter/cause/package-info.java
@@ -22,39 +22,4 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event;
-
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
-/**
- * Used to annotate a method as an {@link EventListener}.
- *
- * <p>The method being targeted must be public and must be in a class that is
- * also public.</p>
- */
-@Retention(RUNTIME)
-@Target(METHOD)
-public @interface Listener {
-
-    /**
-     * The order this listener should be called in relation to other listeners in
-     * the {@link EventManager}.
-     *
-     * @return The order the listener should be called in
-     */
-    Order order() default Order.DEFAULT;
-
-    /**
-     * Whether this listener should be called before any other server mods, such
-     * as Forge mods. All Sponge event listeners are called after mods, unless
-     * they specify the {@link #beforeModifications()} flag to be true.
-     *
-     * @return If the listener should be fired before other server mods
-     */
-    boolean beforeModifications() default false;
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.event.filter.cause;

--- a/src/main/java/org/spongepowered/api/event/filter/data/Has.java
+++ b/src/main/java/org/spongepowered/api/event/filter/data/Has.java
@@ -22,39 +22,43 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event;
+package org.spongepowered.api.event.filter.data;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.manipulator.DataManipulator;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotate a method as an {@link EventListener}.
- *
- * <p>The method being targeted must be public and must be in a class that is
- * also public.</p>
+ * Filters out events where the annotated parameter does not have the specified
+ * data manipulator type.
+ * 
+ * <p>The annotated parameter type <strong>MUST</strong> extend
+ * {@link DataHolder}.</p>
+ * 
+ * @see DataHolder#get(Class)
  */
-@Retention(RUNTIME)
-@Target(METHOD)
-public @interface Listener {
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Has {
 
     /**
-     * The order this listener should be called in relation to other listeners in
-     * the {@link EventManager}.
-     *
-     * @return The order the listener should be called in
+     * Gets the {@link DataManipulator} type to test for.
+     * 
+     * @return The manipulator type
      */
-    Order order() default Order.DEFAULT;
+    Class<? extends DataManipulator<?, ?>> value();
 
     /**
-     * Whether this listener should be called before any other server mods, such
-     * as Forge mods. All Sponge event listeners are called after mods, unless
-     * they specify the {@link #beforeModifications()} flag to be true.
-     *
-     * @return If the listener should be fired before other server mods
+     * If true the standard behavior of this filter is reversed and events where
+     * the annotated parameter <string>does have</strong> the specified data
+     * manipulator type are filtered out.
+     * 
+     * @return If the behavior should be reversed
      */
-    boolean beforeModifications() default false;
+    boolean inverse() default false;
 
 }

--- a/src/main/java/org/spongepowered/api/event/filter/data/Supports.java
+++ b/src/main/java/org/spongepowered/api/event/filter/data/Supports.java
@@ -22,39 +22,43 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event;
+package org.spongepowered.api.event.filter.data;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.manipulator.DataManipulator;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotate a method as an {@link EventListener}.
- *
- * <p>The method being targeted must be public and must be in a class that is
- * also public.</p>
+ * Filters out events where the annotated parameter does not support the
+ * specified data manipulator type.
+ * 
+ * <p>The annotated parameter type <strong>MUST</strong> extend
+ * {@link DataHolder}.</p>
+ * 
+ * @see DataHolder#supports(Class)
  */
-@Retention(RUNTIME)
-@Target(METHOD)
-public @interface Listener {
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Supports {
 
     /**
-     * The order this listener should be called in relation to other listeners in
-     * the {@link EventManager}.
-     *
-     * @return The order the listener should be called in
+     * Gets the {@link DataManipulator} type to test for.
+     * 
+     * @return The manipulator type
      */
-    Order order() default Order.DEFAULT;
+    Class<? extends DataManipulator<?, ?>> value();
 
     /**
-     * Whether this listener should be called before any other server mods, such
-     * as Forge mods. All Sponge event listeners are called after mods, unless
-     * they specify the {@link #beforeModifications()} flag to be true.
-     *
-     * @return If the listener should be fired before other server mods
+     * If true the standard behavior of this filter is reversed and events where
+     * the annotated parameter <string>does support</strong> the specified data
+     * manipulator type are filtered out.
+     * 
+     * @return If the behavior should be reversed
      */
-    boolean beforeModifications() default false;
+    boolean inverse() default false;
 
 }

--- a/src/main/java/org/spongepowered/api/event/filter/data/package-info.java
+++ b/src/main/java/org/spongepowered/api/event/filter/data/package-info.java
@@ -22,39 +22,4 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event;
-
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
-/**
- * Used to annotate a method as an {@link EventListener}.
- *
- * <p>The method being targeted must be public and must be in a class that is
- * also public.</p>
- */
-@Retention(RUNTIME)
-@Target(METHOD)
-public @interface Listener {
-
-    /**
-     * The order this listener should be called in relation to other listeners in
-     * the {@link EventManager}.
-     *
-     * @return The order the listener should be called in
-     */
-    Order order() default Order.DEFAULT;
-
-    /**
-     * Whether this listener should be called before any other server mods, such
-     * as Forge mods. All Sponge event listeners are called after mods, unless
-     * they specify the {@link #beforeModifications()} flag to be true.
-     *
-     * @return If the listener should be fired before other server mods
-     */
-    boolean beforeModifications() default false;
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.event.filter.data;

--- a/src/main/java/org/spongepowered/api/event/filter/package-info.java
+++ b/src/main/java/org/spongepowered/api/event/filter/package-info.java
@@ -22,39 +22,4 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event;
-
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
-/**
- * Used to annotate a method as an {@link EventListener}.
- *
- * <p>The method being targeted must be public and must be in a class that is
- * also public.</p>
- */
-@Retention(RUNTIME)
-@Target(METHOD)
-public @interface Listener {
-
-    /**
-     * The order this listener should be called in relation to other listeners in
-     * the {@link EventManager}.
-     *
-     * @return The order the listener should be called in
-     */
-    Order order() default Order.DEFAULT;
-
-    /**
-     * Whether this listener should be called before any other server mods, such
-     * as Forge mods. All Sponge event listeners are called after mods, unless
-     * they specify the {@link #beforeModifications()} flag to be true.
-     *
-     * @return If the listener should be fired before other server mods
-     */
-    boolean beforeModifications() default false;
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.event.filter;

--- a/src/main/java/org/spongepowered/api/event/filter/type/Exclude.java
+++ b/src/main/java/org/spongepowered/api/event/filter/type/Exclude.java
@@ -22,39 +22,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event;
+package org.spongepowered.api.event.filter.type;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import org.spongepowered.api.event.Event;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotate a method as an {@link EventListener}.
- *
- * <p>The method being targeted must be public and must be in a class that is
- * also public.</p>
+ * Filters out all specified event types. This allows listening for a supertype
+ * event and filtering to only receive events not from a specific subset of the
+ * annotated event's subtypes.
+ * 
+ * <p>This annotation cannot be specified in addition to the {@link Include}
+ * annotation.</p>
  */
-@Retention(RUNTIME)
-@Target(METHOD)
-public @interface Listener {
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Exclude {
 
     /**
-     * The order this listener should be called in relation to other listeners in
-     * the {@link EventManager}.
-     *
-     * @return The order the listener should be called in
+     * Gets the event types to exclude.
+     * 
+     * @return The event types
      */
-    Order order() default Order.DEFAULT;
-
-    /**
-     * Whether this listener should be called before any other server mods, such
-     * as Forge mods. All Sponge event listeners are called after mods, unless
-     * they specify the {@link #beforeModifications()} flag to be true.
-     *
-     * @return If the listener should be fired before other server mods
-     */
-    boolean beforeModifications() default false;
+    Class<? extends Event>[] value();
 
 }

--- a/src/main/java/org/spongepowered/api/event/filter/type/Include.java
+++ b/src/main/java/org/spongepowered/api/event/filter/type/Include.java
@@ -22,39 +22,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event;
+package org.spongepowered.api.event.filter.type;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotate a method as an {@link EventListener}.
- *
- * <p>The method being targeted must be public and must be in a class that is
- * also public.</p>
+ * Filters out all event types which are not in the specified array of event
+ * classes. This allows listening for a supertype event and filtering to only
+ * receive events for a specific subset of the annotated event's subtypes.
+ * 
+ * <p>This annotation cannot be specified in addition to the {@link Exclude}
+ * annotation.</p>
  */
-@Retention(RUNTIME)
-@Target(METHOD)
-public @interface Listener {
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Include {
 
     /**
-     * The order this listener should be called in relation to other listeners in
-     * the {@link EventManager}.
-     *
-     * @return The order the listener should be called in
+     * Gets the included event types.
+     * 
+     * @return The event types
      */
-    Order order() default Order.DEFAULT;
-
-    /**
-     * Whether this listener should be called before any other server mods, such
-     * as Forge mods. All Sponge event listeners are called after mods, unless
-     * they specify the {@link #beforeModifications()} flag to be true.
-     *
-     * @return If the listener should be fired before other server mods
-     */
-    boolean beforeModifications() default false;
+    Class<?>[] value();
 
 }

--- a/src/main/java/org/spongepowered/api/event/filter/type/package-info.java
+++ b/src/main/java/org/spongepowered/api/event/filter/type/package-info.java
@@ -22,39 +22,4 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event;
-
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
-/**
- * Used to annotate a method as an {@link EventListener}.
- *
- * <p>The method being targeted must be public and must be in a class that is
- * also public.</p>
- */
-@Retention(RUNTIME)
-@Target(METHOD)
-public @interface Listener {
-
-    /**
-     * The order this listener should be called in relation to other listeners in
-     * the {@link EventManager}.
-     *
-     * @return The order the listener should be called in
-     */
-    Order order() default Order.DEFAULT;
-
-    /**
-     * Whether this listener should be called before any other server mods, such
-     * as Forge mods. All Sponge event listeners are called after mods, unless
-     * they specify the {@link #beforeModifications()} flag to be true.
-     *
-     * @return If the listener should be fired before other server mods
-     */
-    boolean beforeModifications() default false;
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.event.filter.type;


### PR DESCRIPTION
[Impl](https://github.com/SpongePowered/SpongeCommon/pull/274)

#### Event Filtering
This branch adds annotation based event filtering to assist with reducing the amount of boilerplate necessary while writing event listeners.

##### Event type Filters
These filters are applied to the method and apply a range of filters based on the event object.
######  Include
This annotation allows you to listen to a supertype event (such as EntityEvent) and filter it to only receive a specified subset of the event type's subclasses.
```java
    @Listener
    @Include({ InteractBlockEvent.Secondary.class })
    public void include(InteractBlockEvent event) {
        // This listener will only fire if the event is one of the included types
    }
```
######  Exclude
The opposite of include, this allows you to listen to a supertype event and filter it to not receive a specified subset of the event type's subclasses.
```java
    @Listener
    @Exclude({ InteractBlockEvent.Secondary.class })
    public void exclude(InteractBlockEvent event) {
        // This listener will only fire if the event is not one of the excluded types
    }
```
######  IsCancelled
This will filter the event such that your listener will only be called if the event has been cancelled by a previous event listener. This is essentially the opposite of the `ignoreCancelled` flag on the Listener annotation.
```java
    @Listener(order = Order.LATE, ignoreCancelled = false)
    @IsCancelled
    public void cancel(InteractBlockEvent.Secondary event) {
        // This listener will only fire if the event was previously cancelled
    }
```
#####  Parameter Sources
These annotations are applied to additional parameters in the event handler method and specify a source for that parameter. If an object matching the source and type is not found in the cause then your listener is not called.

######  First
This gets the first object from the event `Cause` matching the parameter type.

A fairly typical event listener for a player event will go something like the following
```java
    @Listener
    public void onInteract(InteractBlockEvent.Secondary event) {
        Optional<Player> player = event.getCause().first(Player.class);
        if(player.isPresent()) {
            //do something
        }
    }
```
With the `@First` annotation this can be simplified to the following
```java
    @Listener
    public void first(InteractBlockEvent.Secondary event, @First Player player) {
        // This listener will fire if the event cause has a player
        // The player parameter will be the first player in the cause chain
    }
```
######  Last
Equivalent to `First` except it calls `Cause#last(Class)`.
######  All
The `All` annotation allows you to receive all cause objects of a certain type. It must be applied to an array type and is equivalent to `Cause#allOf(Class)`
```java
    @Listener
    public void all(InteractBlockEvent.Secondary event, @All Player[] players) {
        // This listener will fire if the event cause has at least one player
        // players will contain all players in the cause chain
    }
```
By default your listener will be skipped if the returned array would be empty, this can be disabled however by setting the ignoreEmpty flag to false.
```java
    @Listener
    public void all(InteractBlockEvent.Secondary event, @All(ignoreEmpty = false) BiomeTypes[] players) {
        // This listener will always fire, as even if there are no BiomeTypes
        // objects in the cause chain (and there won't be) its set to not ignore
        // empty and therefore will simply return an empty array
    }
```

#####  Parameter Filters
These filters apply additional conditions to a parameter. These require that the paramter also have a parameter source annotation (see above).

###### Has
This takes a data manipulator type and checks that the annotated data holder has a data manipulator of the specified type. If the object is not a `DataHolder` or does not have a matching manipulator then your listener is not called. Equivalent to `DataHolder#has(Class)`.

###### Supports
Similar to `Has` except the it is only checked that the DataHolder supports the given data manipulator type. Equivalent to `DataHolder#supports(Class)`.


A full example plugin can be found [here](https://gist.github.com/Deamon5550/6d4e4cdec9361ddace93)

TODO:
- [x] Add Root cause annotation
- [ ] remove `ignoreCancelled` from Listener
