### PR TITLE
Extend platform API

### DIFF
--- a/src/main/java/org/spongepowered/api/Platform.java
+++ b/src/main/java/org/spongepowered/api/Platform.java
@@ -24,10 +24,12 @@
  */
 package org.spongepowered.api;
 
+import org.spongepowered.api.plugin.PluginContainer;
+
 import java.util.Map;
 
 /**
- * Represents a possible platform, or implementation, a {@link Game} could be
+ * Represents a possible platform or implementation a {@link Game} could be
  * running on.
  */
 public interface Platform {
@@ -51,32 +53,21 @@ public interface Platform {
     Type getExecutionType();
 
     /**
-     * Retrieves the current platform name.
+     * Returns the current API plugin container.
      *
-     * @return The platform name
+     * @return The API plugin container
      */
-    String getName();
+    PluginContainer getApi();
 
     /**
-     * Retrieves the current platform version.
+     * Returns the current implementation plugin container.
      *
-     * <p>This version can be in any format, like a build number or
-     * <a href="http://semver.org/">semantic versioning</a>.</p>
-     *
-     * @return The platform version, as a string
+     * @return The implementation plugin container
      */
-    String getVersion();
+    PluginContainer getImplementation();
 
     /**
-     * Retrieves the current Sponge API version that this platform is
-     * implementing.
-     *
-     * @return The API version
-     */
-    String getApiVersion();
-
-    /**
-     * Gets current Minecraft version of this platform.
+     * Gets the current Minecraft version of this platform.
      *
      * @return The Minecraft version
      */
@@ -145,7 +136,7 @@ public interface Platform {
          * @return False if the platform is {@link #UNKNOWN}, true otherwise
          */
         public boolean isKnown() {
-            return !(this == UNKNOWN);
+            return this != UNKNOWN;
         }
 
     }

--- a/src/main/java/org/spongepowered/api/plugin/PluginContainer.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginContainer.java
@@ -24,6 +24,11 @@
  */
 package org.spongepowered.api.plugin;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
 /**
  * A wrapper around a class marked with an {@link Plugin} annotation to retrieve
  * information from the annotation for easier use.
@@ -52,10 +57,19 @@ public interface PluginContainer {
     String getVersion();
 
     /**
-     * Returns the created instance of {@link Plugin}.
+     * Returns the assigned logger to this {@link Plugin}.
      *
-     * @return The instance
+     * @return The assigned logger
      */
-    Object getInstance();
+    default Logger getLogger() {
+        return LoggerFactory.getLogger(getId());
+    }
+
+    /**
+     * Returns the created instance of {@link Plugin} if it is available.
+     *
+     * @return The instance if available
+     */
+    Optional<Object> getInstance();
 
 }


### PR DESCRIPTION
This extends the Platform API by replacing specific methods like `getName()` or `getApiVersion()` with an exposed `PluginContainer` for the API and the implementation, which provides all of these methods and possibly more in the future (as soon we have added more [plugin metadata](https://github.com/SpongePowered/SpongeAPI/issues/822)).

This also matches the current design in SpongeVanilla and Forge where the components of the implementation (e.g. Minecraft, Forge, SpongeForge) are all represented as separate plugins, even though they aren't standalone plugins.

SpongeCommon PR: https://github.com/SpongePowered/SpongeCommon/pull/277
SpongeVanilla PR: https://github.com/SpongePowered/SpongeVanilla/pull/187
SpongeForge PR: https://github.com/SpongePowered/SpongeForge/pull/423