### PR TITLE
Supply Abstract Data implementations for Plugin usability

### DIFF
--- a/src/main/java/org/spongepowered/api/data/DataTransactionResult.java
+++ b/src/main/java/org/spongepowered/api/data/DataTransactionResult.java
@@ -88,6 +88,15 @@ public interface DataTransactionResult {
     Type getType();
 
     /**
+     * Gets whether this {@link DataTransactionResult} was successful or not.
+     *
+     * @return True if this result was successful
+     */
+    default boolean isSuccessful() {
+        return getType() == Type.SUCCESS;
+    }
+
+    /**
      * If any {@link BaseValue}s applied onto a {@link CompositeValueStore} were
      * successful, they'll be stored in the given list.
      *

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/AbstractImmutableBooleanData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/AbstractImmutableBooleanData.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.common;
+
+import com.google.common.collect.ComparisonChain;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+
+/**
+ * An abstract implementation of an {@link ImmutableDataManipulator} handling
+ * specifically a {@code boolean} value. Technically these can be cached since
+ * their values are immutable.
+ *
+ * @param <I> The immutable manipulator type
+ * @param <M> The mutable manipulator type
+ */
+public abstract class AbstractImmutableBooleanData<I extends ImmutableDataManipulator<I, M>, M extends DataManipulator<M, I>> extends
+        AbstractImmutableSingleData<Boolean, I, M> {
+
+    private final boolean defaultValue;
+    private final ImmutableValue<Boolean> immutableValue;
+
+    public AbstractImmutableBooleanData(boolean value, Key<Value<Boolean>> usedKey, boolean defaultValue) {
+        super(value, usedKey);
+        this.defaultValue = defaultValue;
+        this.immutableValue = Sponge.getRegistry().getValueFactory().createValue(usedKey, defaultValue, value).asImmutable();
+    }
+
+    @Override
+    protected final ImmutableValue<Boolean> getValueGetter() {
+        return this.immutableValue;
+    }
+
+    @Override
+    public int compareTo(I o) {
+        return ComparisonChain.start()
+            .compare(o.get(this.usedKey).get(), this.getValue())
+            .result();
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/AbstractImmutableBoundedComparableData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/AbstractImmutableBoundedComparableData.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.common;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.data.value.mutable.Value;
+
+import java.util.Comparator;
+
+/**
+ * An abstracted {@link ImmutableDataManipulator} that focuses solely on an
+ * {@link ImmutableBoundedValue} as it's {@link Value} return type.
+ *
+ * @param <T> The type of comparable element
+ * @param <I> The immutable data manipulator type
+ * @param <M> The mutable data manipulator type
+ */
+public abstract class AbstractImmutableBoundedComparableData<T extends Comparable<T>, I extends ImmutableDataManipulator<I, M>,
+    M extends DataManipulator<M, I>> extends AbstractImmutableSingleData<T, I, M> {
+
+    protected final Comparator<T> comparator;
+    protected final T lowerBound;
+    protected final T upperBound;
+    protected final T defaultValue;
+    private final ImmutableBoundedValue<T> immutableBoundedValue;
+
+    @SuppressWarnings("unchecked")
+    protected AbstractImmutableBoundedComparableData(T value, Key<MutableBoundedValue<T>> usedKey,
+                                                     Comparator<T> comparator, T lowerBound,
+                                                     T upperBound, T defaultValue) {
+        super(value, usedKey);
+        this.comparator = comparator;
+        this.lowerBound = lowerBound;
+        this.upperBound = upperBound;
+        this.defaultValue = defaultValue;
+        this.immutableBoundedValue = Sponge.getRegistry().getValueFactory()
+            .createBoundedValueBuilder((Key<MutableBoundedValue<T>>) this.usedKey)
+            .defaultValue(this.defaultValue)
+            .actualValue(this.value)
+            .minimum(this.lowerBound)
+            .maximum(this.upperBound)
+            .comparator(this.comparator)
+            .build()
+            .asImmutable();
+    }
+
+    @Override
+    protected final ImmutableBoundedValue<T> getValueGetter() {
+        return this.immutableBoundedValue;
+    }
+
+    @Override
+    public int compareTo(I o) {
+        return this.comparator.compare(o.get(this.usedKey).get(), this.value);
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/AbstractImmutableData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/AbstractImmutableData.java
@@ -1,0 +1,159 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.common;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * An abstract implementation of an {@link ImmutableDataManipulator} such that
+ * all fields are declared {@code final} and remain "immutable".
+ *
+ * @param <I> The immutable data manipulator type
+ * @param <M> The mutable manipulator type
+ */
+@SuppressWarnings("unchecked")
+public abstract class AbstractImmutableData<I extends ImmutableDataManipulator<I, M>, M extends DataManipulator<M, I>> implements ImmutableDataManipulator<I, M> {
+
+
+    private final Map<Key<?>, Supplier<ImmutableValue<?>>> keyValueMap = Maps.newHashMap();
+    private final Map<Key<?>, Supplier<?>> keyFieldGetterMap = Maps.newHashMap();
+
+    protected AbstractImmutableData() {
+    }
+
+    /**
+     * Simple registration method for the keys to value return methods.
+     *
+     * <p>Note that this is still usable with Java 8 method references. Referencing
+     * {@code this::getfoo()} is recommended.</p>
+     *
+     * @param key The key for the value return type
+     * @param function The function for getting the value
+     */
+    protected final void registerKeyValue(Key<?> key, Supplier<ImmutableValue<?>> function) {
+        this.keyValueMap.put(checkNotNull(key), checkNotNull(function));
+    }
+
+    /**
+     * Simple registration method for the keys to field getter methods.
+     *
+     * <p>Note that this is still usable with Java 8 method references. Referencing
+     * {@code this::getfoo()} is recommended.</p>
+     *
+     * @param key The key for the value return type
+     * @param function The function for getting the field
+     */
+    protected final void registerFieldGetter(Key<?> key, Supplier<?> function) {
+        this.keyFieldGetterMap.put(checkNotNull(key), checkNotNull(function));
+    }
+
+    protected abstract void registerGetters();
+
+    @Override
+    public final I copy() {
+        return (I) this;
+    }
+
+    // Beyond this point is involving keyFieldGetters or keyValueGetters. No external
+    // implementation required.
+
+    @Override
+    public <E> Optional<E> get(Key<? extends BaseValue<E>> key) {
+        if (!supports(key)) {
+            return Optional.empty();
+        }
+        return Optional.of((E) this.keyFieldGetterMap.get(key).get());
+    }
+
+    @Override
+    public <E, V extends BaseValue<E>> Optional<V> getValue(Key<V> key) {
+        if (!this.keyValueMap.containsKey(key)) {
+            return Optional.empty();
+        }
+        return Optional.of((V) checkNotNull(this.keyValueMap.get(key).get()));
+    }
+
+    @Override
+    public boolean supports(Key<?> key) {
+        return this.keyFieldGetterMap.containsKey(checkNotNull(key));
+    }
+
+    @Override
+    public Set<Key<?>> getKeys() {
+        return ImmutableSet.copyOf(this.keyValueMap.keySet());
+    }
+
+    @Override
+    public Set<ImmutableValue<?>> getValues() {
+        ImmutableSet.Builder<ImmutableValue<?>> builder = ImmutableSet.builder();
+        for (Supplier<ImmutableValue<?>> function : this.keyValueMap.values()) {
+            builder.add(checkNotNull(function.get()));
+        }
+        return builder.build();
+    }
+
+    // Then finally traditional java stuff.
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.keyFieldGetterMap.values().stream()
+                                    .map(Supplier::get)
+                                    .collect(Collectors.toList()));
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final AbstractImmutableData other = (AbstractImmutableData) obj;
+        return Objects.equals(this.keyFieldGetterMap.values().stream()
+                                 .map(Supplier::get)
+                                 .collect(Collectors.toList()),
+                              ((Map<Key<?>, Supplier<?>>) other.keyFieldGetterMap).values().stream()
+                                 .map(Supplier::get)
+                                 .collect(Collectors.toList()));
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/AbstractImmutableSingleCatalogData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/AbstractImmutableSingleCatalogData.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.common;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.immutable.ImmutableVariantData;
+import org.spongepowered.api.data.manipulator.mutable.VariantData;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+
+/**
+ * An abstract implementation of an {@link ImmutableVariantData} extending
+ * {@link AbstractImmutableSingleData} such that the values are immutable.
+ *
+ * @param <E> The type of catalog type
+ * @param <I> The type of immutable manipulator
+ * @param <M> The type of mutable manipulator
+ */
+public abstract class AbstractImmutableSingleCatalogData<E extends CatalogType, I extends ImmutableVariantData<E, I, M>,
+        M extends VariantData<E, M, I>> extends AbstractImmutableSingleData<E, I, M> implements ImmutableVariantData<E, I, M> {
+
+    private final E defaultValue;
+    private final ImmutableValue<E> immutableValue;
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public AbstractImmutableSingleCatalogData(E value, E defaultValue, Key<? extends BaseValue<E>> usedKey) {
+        super(value, usedKey);
+        this.defaultValue = checkNotNull(defaultValue, "The default value was null! This is unacceptable! Maybe the value was not registered?");
+        this.immutableValue = Sponge.getRegistry().getValueFactory().createValue((Key<Value<E>>) (Key) this.usedKey, this.defaultValue, this.value).asImmutable();
+
+    }
+
+    @Override
+    public int compareTo(I o) {
+        return o.get(this.usedKey).get().getId().compareToIgnoreCase(this.getValue().getId());
+    }
+
+    @Override
+    protected ImmutableValue<E> getValueGetter() {
+        return this.immutableValue;
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return super.toContainer().set(this.usedKey.getQuery(), this.value.getId());
+    }
+
+    @Override
+    public ImmutableValue<E> type() {
+        return this.immutableValue;
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/AbstractImmutableSingleData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/AbstractImmutableSingleData.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.common;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableSet;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * An abstract implementation of an {@link ImmutableDataManipulator} that
+ * specificaly deals with a single value.
+ *
+ * @param <T> The type of value
+ * @param <I> The type of immutable manipulator
+ * @param <M> The type of mutable manipulator
+ */
+public abstract class AbstractImmutableSingleData<T, I extends ImmutableDataManipulator<I, M>, M extends DataManipulator<M, I>>
+        extends AbstractImmutableData<I, M> {
+
+    protected final Key<? extends BaseValue<T>> usedKey;
+    protected final T value;
+
+    protected AbstractImmutableSingleData(T value, Key<? extends BaseValue<T>> usedKey) {
+        super();
+        this.value = checkNotNull(value);
+        this.usedKey = checkNotNull(usedKey, "Hey, the key provided is null! Please make sure it is registered!");
+        registerGetters();
+    }
+
+    protected abstract ImmutableValue<?> getValueGetter();
+
+    protected final T getValue() {
+        return this.value;
+    }
+
+    @Override
+    public abstract M asMutable();
+
+    @Override
+    public DataContainer toContainer() {
+        return new MemoryDataContainer();
+    }
+
+    @Override
+    protected final void registerGetters() {
+        registerFieldGetter(this.usedKey, AbstractImmutableSingleData.this::getValue);
+        registerKeyValue(this.usedKey, AbstractImmutableSingleData.this::getValueGetter);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <E> Optional<E> get(Key<? extends BaseValue<E>> key) {
+        return checkNotNull(key).equals(this.usedKey) ? Optional.of((E) this.value) : Optional.<E>empty();
+    }
+
+    @Override
+    public boolean supports(Key<?> key) {
+        return checkNotNull(key) == this.usedKey;
+    }
+
+    @Override
+    public Set<Key<?>> getKeys() {
+        return ImmutableSet.<Key<?>>of(this.usedKey);
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/AbstractImmutableSingleEnumData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/AbstractImmutableSingleEnumData.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.common;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+
+/**
+ * An abstract implementation of an {@link ImmutableDataManipulator} dealing
+ * specifically with an {@link Enum} value. Note that due to the limitations
+ * of adding new values to an {@code Enum}, these may be cached.
+ *
+ * @param <E> The enum type
+ * @param <I> The immutable manipulator type
+ * @param <M> The mutable manipulator type
+ */
+public abstract class AbstractImmutableSingleEnumData<E extends Enum<E>, I extends ImmutableDataManipulator<I, M>, M extends DataManipulator<M, I>> extends
+        AbstractImmutableSingleData<E, I, M> {
+
+    private final E defaultValue;
+    private final ImmutableValue<E> cachedValue;
+
+    protected AbstractImmutableSingleEnumData(E value, E defaultValue, Key<Value<E>> usedKey) {
+        super(value, usedKey);
+        this.defaultValue = defaultValue;
+        this.cachedValue = Sponge.getRegistry().getValueFactory().createValue(usedKey, this.defaultValue, this.value).asImmutable();
+    }
+
+    public final ImmutableValue<E> type() {
+        return this.cachedValue;
+    }
+
+    @Override
+    protected final ImmutableValue<E> getValueGetter() {
+        return this.cachedValue;
+    }
+
+    @Override
+    public int compareTo(I o) {
+        return o.get(this.usedKey).get().ordinal() - this.value.ordinal();
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return super.toContainer().set(this.usedKey.getQuery(), this.value.name());
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/collection/AbstractImmutableSingleListData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/collection/AbstractImmutableSingleListData.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.common.collection;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.common.AbstractImmutableSingleData;
+import org.spongepowered.api.data.value.immutable.ImmutableListValue;
+import org.spongepowered.api.data.value.mutable.ListValue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class AbstractImmutableSingleListData<E, I extends ImmutableDataManipulator<I, M>, M extends DataManipulator<M, I>>
+    extends AbstractImmutableSingleData<List<E>, I, M> {
+
+    private final ImmutableListValue<E> listValue;
+
+    protected AbstractImmutableSingleListData(List<E> value, Key<ListValue<E>> usedKey) {
+        super(new ArrayList<>(value), usedKey);
+        this.listValue = Sponge.getRegistry().getValueFactory().createListValue(usedKey, value).asImmutable();
+    }
+
+    @Override
+    protected final ImmutableListValue<E> getValueGetter() {
+        return this.listValue;
+    }
+
+    @Override
+    public int compareTo(I o) {
+        final List<E> list = o.get(this.usedKey).get();
+        return Boolean.compare(list.containsAll(this.getValue()), this.getValue().containsAll(list));
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/collection/AbstractImmutableSingleMapData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/collection/AbstractImmutableSingleMapData.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.common.collection;
+
+import com.google.common.collect.ImmutableMap;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.common.AbstractImmutableSingleData;
+import org.spongepowered.api.data.value.immutable.ImmutableMapValue;
+import org.spongepowered.api.data.value.mutable.MapValue;
+
+import java.util.Map;
+
+public abstract class AbstractImmutableSingleMapData<K, V, M extends DataManipulator<M, I>, I extends ImmutableDataManipulator<I, M>>
+    extends AbstractImmutableSingleData<Map<K, V>, I, M> {
+
+    private final ImmutableMapValue<K, V> mapValue;
+
+    public AbstractImmutableSingleMapData(Map<K, V> value, Key<MapValue<K, V>> usedKey) {
+        super(ImmutableMap.copyOf(value), usedKey);
+        this.mapValue = Sponge.getRegistry().getValueFactory()
+            .createMapValue(usedKey, this.value)
+            .asImmutable();
+    }
+
+    @Override
+    protected final ImmutableMapValue<K, V> getValueGetter() {
+        return this.mapValue;
+    }
+
+    @Override
+    public int compareTo(I o) {
+        return 0;
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/collection/AbstractImmutableSingleSetData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/collection/AbstractImmutableSingleSetData.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.common.collection;
+
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.ImmutableSet;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.common.AbstractImmutableSingleData;
+import org.spongepowered.api.data.value.immutable.ImmutableSetValue;
+import org.spongepowered.api.data.value.mutable.SetValue;
+
+import java.util.Set;
+
+public abstract class AbstractImmutableSingleSetData<E, I extends ImmutableDataManipulator<I, M>, M extends DataManipulator<M, I>>
+    extends AbstractImmutableSingleData<Set<E>, I, M> {
+
+    private final ImmutableSetValue<E> setValue;
+
+    public AbstractImmutableSingleSetData(Set<E> value, Key<SetValue<E>> usedKey) {
+        super(ImmutableSet.copyOf(value), usedKey);
+        this.setValue = Sponge.getRegistry().getValueFactory().createSetValue(usedKey, this.value).asImmutable();
+    }
+
+    @Override
+    protected ImmutableSetValue<E> getValueGetter() {
+        return this.setValue;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public int compareTo(I o) {
+        return ComparisonChain.start()
+            .compare(o.getValue((Key<SetValue<E>>) (Key) this.usedKey).get().get().containsAll(this.getValue()),
+                     this.getValue().containsAll(o.getValue((Key<SetValue<E>>) (Key) this.usedKey).get().get()))
+            .result();
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/collection/package-info.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/collection/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.data.manipulator.immutable.common.collection;

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/package-info.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/common/package-info.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+/**
+ * A common abstract implementation of several types of
+ * {@link org.spongepowered.api.data.manipulator.ImmutableDataManipulator}s
+ * for simpler use with plugins. Common implementations of manipulators that
+ * deal with single values can easily utilize
+ * {@link org.spongepowered.api.data.manipulator.immutable.common.AbstractImmutableSingleData}
+ * without having to implement all the required methods of a manipulator.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.data.manipulator.immutable.common;

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractBooleanData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractBooleanData.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.common;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ComparisonChain;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.mutable.Value;
+
+/**
+ * An abstract {@link DataManipulator} dealing specifically with a
+ * {@code boolean} value type.
+ *
+ * @param <M> The manipulator type
+ * @param <I> The immutable manipulator type
+ */
+public abstract class AbstractBooleanData<M extends DataManipulator<M, I>, I extends ImmutableDataManipulator<I, M>> extends
+        AbstractSingleData<Boolean, M, I> {
+
+    private final boolean defaultValue;
+
+    protected AbstractBooleanData(boolean value, Key<? extends BaseValue<Boolean>> usedKey, boolean defaultValue) {
+        super(value, usedKey);
+        this.defaultValue = checkNotNull(defaultValue);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Value<Boolean> getValueGetter() {
+        return Sponge.getRegistry().getValueFactory().createValue((Key<Value<Boolean>>) this.usedKey, this.getValue(), this.defaultValue);
+    }
+
+    @Override
+    public int compareTo(M o) {
+        return ComparisonChain.start()
+            .compare(o.get(this.usedKey).get(), this.getValue())
+            .result();
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return new MemoryDataContainer().set(this.usedKey.getQuery(), getValue());
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractBoundedComparableData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractBoundedComparableData.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.common;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+
+import java.util.Comparator;
+
+/**
+ * An abstract implementation of a {@link DataManipulator} that deals
+ * specifically with a {@link MutableBoundedValue}. Similar to
+ * {@link AbstractSingleData} in that it focuses on a single value,
+ * it adds the certainty that the value can only accept values of which
+ * the bounds are met.
+ *
+ * @param <T> The type of comparable
+ * @param <M> The API datamanipulator
+ * @param <I> The API immutable data manipulator
+ */
+public abstract class AbstractBoundedComparableData<T extends Comparable<T>, M extends DataManipulator<M, I>, I extends ImmutableDataManipulator<I, M>>
+    extends AbstractSingleData<T, M, I> {
+
+    protected final Comparator<T> comparator;
+    protected final T lowerBound;
+    protected final T upperBound;
+    protected final T defaultValue;
+
+    protected AbstractBoundedComparableData(T value, Key<MutableBoundedValue<T>> usedKey, Comparator<T> comparator, T lowerBound, T upperBound,
+                                            T defaultValue) {
+        super(value, usedKey);
+        this.comparator = checkNotNull(comparator);
+        this.lowerBound = checkNotNull(lowerBound);
+        this.upperBound = checkNotNull(upperBound);
+        this.defaultValue = checkNotNull(defaultValue);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected MutableBoundedValue<T> getValueGetter() {
+        return Sponge.getRegistry().getValueFactory()
+            .createBoundedValueBuilder((Key<MutableBoundedValue<T>>) this.usedKey)
+            .defaultValue(this.defaultValue)
+            .comparator(this.comparator)
+            .minimum(this.lowerBound)
+            .maximum(this.upperBound)
+            .actualValue(this.getValue())
+            .build();
+    }
+
+    @Override
+    public int compareTo(M o) {
+        return this.comparator.compare(o.get(this.usedKey).get(), this.getValue());
+    }
+
+    @Override
+    public M setValue(T value) {
+        checkArgument(this.comparator.compare(this.lowerBound, value) >= 0);
+        checkArgument(this.comparator.compare(this.upperBound, value) <= 0);
+        return super.setValue(value);
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return new MemoryDataContainer().set(this.usedKey.getQuery(), this.getValue());
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractData.java
@@ -1,0 +1,207 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.common;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * A base abstract layer for implementing a {@link DataManipulator}. This
+ * provides all the otherwise "redundant" code dealing with various methods
+ * such as {@link #get(Key)} or {@link #supports(Key)} etc. The root of this
+ * implementation relies on a pseudo registration of
+ * {@link #registerFieldGetter(Key, Supplier)},
+ * {@link #registerFieldSetter(Key, Consumer)},
+ * and {@link #registerKeyValue(Key, Supplier)} of which supply and consume
+ * values otherwise accessible by fields.
+ *
+ * @param <M> The generic of the DataManipulator from the API
+ * @param <I> The type of the ImmutableDatAManipulator from the API
+ */
+@SuppressWarnings("unchecked")
+public abstract class AbstractData<M extends DataManipulator<M, I>, I extends ImmutableDataManipulator<I, M>> implements DataManipulator<M, I> {
+
+
+    // Ok, so, you're probably asking "Why the hell are you doing this type of hackery?"
+    // Answer: Because I'd rather have these abstract functions (read method references)
+    // to get and set field values according to the key, and get values based on key
+    // instead of using a Value/Data Processor. The advantage of course is that
+    // in Java 8, this would all be done with lambda expressions, but since we
+    // target Java 6, we can't quite do that... so, this is the compromise.
+    //
+    // There was a possibility for using annotations, but I (gabizou) decided against
+    // it since there's a lot of magic that goes on with it, and there is very little
+    // customization when it comes to the method calls for setting/getting the values.
+    // The largest issue was implementation. Since most fields are simple to get and
+    // set, other values, such as ItemStacks require a bit of finer tuning.
+    //
+    private final Map<Key<?>, Supplier<Value<?>>> keyValueMap = Maps.newHashMap();
+    private final Map<Key<?>, Supplier<?>> keyFieldGetterMap = Maps.newHashMap();
+    private final Map<Key<?>, Consumer<Object>> keyFieldSetterMap = Maps.newHashMap();
+
+    protected AbstractData() {
+    }
+
+    /**
+     * Simple registration method for the keys to value return methods.
+     *
+     * <p>Note that this is still usable with Java 8 method references. Referencing
+     * {@code this::getfoo()} is recommended.</p>
+     *
+     * @param key The key for the value return type
+     * @param function The function for getting the value
+     */
+    protected final void registerKeyValue(Key<?> key, Supplier<Value<?>> function) {
+        this.keyValueMap.put(checkNotNull(key), checkNotNull(function));
+    }
+
+    /**
+     * Simple registration method for the keys to field getter methods.
+     *
+     * <p>Note that this is still usable with Java 8 method references. Referencing
+     * {@code this::getfoo()} is recommended.</p>
+     *
+     * @param key The key for the value return type
+     * @param function The function for getting the field
+     */
+    protected final void registerFieldGetter(Key<?> key, Supplier<?> function) {
+        this.keyFieldGetterMap.put(checkNotNull(key, "The key cannot be null"), checkNotNull(function, "The function cannot be null"));
+    }
+
+    /**
+     * Simple registration method for the keys to field setter methods.
+     *
+     * <p>Note that this is still usable with Java 8 method references. Referencing
+     * {@code this::setFoo(something)} is recommended.</p>
+     *
+     * @param key The key for the value return type
+     * @param function The function for setting the field
+     */
+    @SuppressWarnings("rawtypes")
+    protected final <E> void registerFieldSetter(Key<? extends BaseValue<E>> key, Consumer<E> function) {
+        this.keyFieldSetterMap.put(checkNotNull(key), checkNotNull((Consumer) function));
+    }
+
+    /**
+     * A required registration method for registering the various fields and
+     * value getters. It's suggested that if multipl fields are used, each field
+     * can be represented as a {@link Value} such that there is an associated
+     * {@link Key} to "get" that field value.
+     */
+    protected abstract void registerGettersAndSetters();
+
+    // Beyond this point is all implementation with the getter/setter functions!
+
+    @Override
+    public <E> M set(Key<? extends BaseValue<E>> key, E value) {
+        checkArgument(supports(key), "This data manipulator doesn't support the following key: " + key.toString());
+        this.keyFieldSetterMap.get(key).accept(value);
+        return (M) this;
+    }
+
+    @Override
+    public <E> M transform(Key<? extends BaseValue<E>> key, Function<E, E> function) {
+        checkArgument(supports(key));
+        this.keyFieldSetterMap.get(key).accept(checkNotNull(function.apply((E) this.keyFieldGetterMap.get(key).get())));
+        return (M) this;
+    }
+
+    @Override
+    public <E> Optional<E> get(Key<? extends BaseValue<E>> key) {
+        if (!supports(key)) {
+            return Optional.empty();
+        }
+        return Optional.of((E) this.keyFieldGetterMap.get(key).get());
+    }
+
+    @Override
+    public <E, V extends BaseValue<E>> Optional<V> getValue(Key<V> key) {
+        if (!this.keyValueMap.containsKey(key)) {
+            return Optional.empty();
+        }
+        return Optional.of((V) checkNotNull(this.keyValueMap.get(key).get()));
+    }
+
+    @Override
+    public boolean supports(Key<?> key) {
+        return this.keyFieldSetterMap.containsKey(checkNotNull(key));
+    }
+
+    @Override
+    public Set<Key<?>> getKeys() {
+        return ImmutableSet.copyOf(this.keyFieldSetterMap.keySet());
+    }
+
+    @Override
+    public Set<ImmutableValue<?>> getValues() {
+        ImmutableSet.Builder<ImmutableValue<?>> builder = ImmutableSet.builder();
+        for (Supplier<Value<?>> function : this.keyValueMap.values()) {
+            builder.add(checkNotNull(function.get()).asImmutable());
+        }
+        return builder.build();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.keyFieldGetterMap, this.keyFieldSetterMap, this.keyValueMap);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final AbstractData other = (AbstractData) obj;
+        return Objects.equals(this.keyFieldGetterMap.values().stream()
+                                 .map(Supplier::get)
+                                 .collect(Collectors.toList()),
+                             ((Map<Key<?>, Supplier<?>>) other.keyFieldGetterMap).values().stream()
+                                 .map(Supplier::get)
+                                 .collect(Collectors.toList()));
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractIntData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractIntData.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.common;
+
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.BaseValue;
+
+/**
+ * An abstract {@link DataManipulator} specifically dealing with {@code int}
+ * values.
+ *
+ * @param <M> The manipulator type
+ * @param <I> The immutable manipulator type
+ */
+public abstract class AbstractIntData<M extends DataManipulator<M, I>, I extends ImmutableDataManipulator<I, M>>
+    extends AbstractSingleData<Integer, M, I> {
+
+    protected AbstractIntData(int value, Key<? extends BaseValue<Integer>> usedKey) {
+        super(value, usedKey);
+    }
+
+    @Override
+    public int compareTo(M o) {
+        return Integer.compare(o.get(this.usedKey).get(), this.getValue());
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractSingleCatalogData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractSingleCatalogData.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.common;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.immutable.ImmutableVariantData;
+import org.spongepowered.api.data.manipulator.mutable.VariantData;
+import org.spongepowered.api.data.value.mutable.Value;
+
+/**
+ * An abstract {@link VariantData} implementation providing all implementation
+ * requirements, except {@link #asImmutable()}.
+ *
+ * @param <T> The type of catalog type
+ * @param <M> The manipulator type
+ * @param <I> The immutable manipulator type
+ */
+public abstract class AbstractSingleCatalogData<T extends CatalogType, M extends VariantData<T, M, I>, I extends ImmutableVariantData<T, I, M>>
+        extends AbstractSingleData<T, M, I> implements VariantData<T, M, I> {
+
+    protected AbstractSingleCatalogData(T value, Key<Value<T>> usedKey) {
+        super(value, usedKey);
+    }
+
+    @Override
+    protected Value<?> getValueGetter() {
+        return type();
+    }
+
+    @Override
+    public int compareTo(M o) {
+        return o.get(this.usedKey).get().getId().compareToIgnoreCase(this.getValue().getId());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Value<T> type() {
+        return Sponge.getRegistry().getValueFactory().createValue((Key<Value<T>>) this.usedKey, getValue(), getValue());
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return new MemoryDataContainer().set(this.usedKey.getQuery(), this.getValue().getId());
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractSingleData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractSingleData.java
@@ -1,0 +1,142 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.common;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Objects;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.mutable.Value;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * An abstraction for the various {@link DataManipulator}s that handle a single
+ * value, adding the provided {@link #getValue()} and {@link #setValue(Object)}
+ * methods for easy manipulation. This as well simplifies handling various
+ * other common implementations, such as {@link #hashCode()} and
+ * {@link #equals(Object)}.
+ *
+ * @param <T> The type of single value this will hold
+ * @param <M> The type of {@link DataManipulator}
+ * @param <I> The type of {@link ImmutableDataManipulator}
+ */
+@SuppressWarnings("unchecked")
+public abstract class AbstractSingleData<T, M extends DataManipulator<M, I>, I extends ImmutableDataManipulator<I, M>>
+        extends AbstractData<M, I> {
+
+    protected final Key<? extends BaseValue<T>> usedKey;
+    private T value;
+
+    protected AbstractSingleData(T value, Key<? extends BaseValue<T>> usedKey) {
+        this.value = checkNotNull(value);
+        this.usedKey = checkNotNull(usedKey);
+        registerGettersAndSetters();
+    }
+
+    @Override
+    protected final void registerGettersAndSetters() {
+        registerFieldGetter(this.usedKey, AbstractSingleData.this::getValue);
+        registerFieldSetter(this.usedKey, this::setValue);
+        registerKeyValue(this.usedKey, AbstractSingleData.this::getValueGetter);
+    }
+
+    /**
+     * Gets the {@link Value} as a method since this manipulator only focuses
+     * on a single value.
+     *
+     * @return The constructed value
+     */
+    protected abstract Value<?> getValueGetter();
+
+    @Override
+    public <E> Optional<E> get(Key<? extends BaseValue<E>> key) {
+        // we can delegate this since we have a direct value check as this is
+        // a Single value.
+        return key == this.usedKey ? Optional.of((E) this.value) : super.get(key);
+    }
+
+    @Override
+    public boolean supports(Key<?> key) {
+        return checkNotNull(key) == this.usedKey;
+    }
+
+    // We have to have this abstract to properly override for generics.
+    @Override
+    public abstract I asImmutable();
+
+    // Again, overriding for generics
+    @Override
+    public abstract int compareTo(M o);
+
+    /**
+     * A simple getter for usage with a {@link Supplier} for
+     * the {@link #registerFieldGetter(Key, Supplier)} method.
+     *
+     * @return The value
+     */
+    protected T getValue() {
+        return this.value;
+    }
+
+    /**
+     * A simple setter for usage with a {@link Consumer} for
+     * the {@link #registerFieldSetter(Key, Consumer)} method.
+     *
+     * @param value The value
+     * @return This manipulator
+     */
+    protected M setValue(T value) {
+        this.value = checkNotNull(value);
+        // double casting due to jdk 6 type inference
+        return (M) this;
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * super.hashCode() + Objects.hashCode(this.value);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        final AbstractSingleData other = (AbstractSingleData) obj;
+        return Objects.equal(this.value, other.value);
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractSingleEnumData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractSingleEnumData.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.common;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.mutable.Value;
+
+/**
+ * Another abstract helper class further simplifying implementing various
+ * single value enum based {@link DataManipulator}s.
+ *
+ * @param <E> The type of enum value
+ * @param <M> The manipulator type
+ * @param <I> The immutable manipulator type
+ */
+public abstract class AbstractSingleEnumData<E extends Enum<E>, M extends DataManipulator<M, I>, I extends ImmutableDataManipulator<I, M>>
+        extends AbstractSingleData<E, M, I> {
+
+    private final E defaultValue;
+
+    protected AbstractSingleEnumData(E value, Key<? extends BaseValue<E>> usedKey, E defaultValue) {
+        super(value, usedKey);
+        this.defaultValue = checkNotNull(defaultValue);
+    }
+
+    @Override
+    public int compareTo(M o) {
+        return o.get(this.usedKey).get().ordinal() - this.getValue().ordinal();
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return new MemoryDataContainer().set(this.usedKey.getQuery(), this.getValue().name());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Value<E> getValueGetter() {
+        return Sponge.getRegistry().getValueFactory().createValue((Key<Value<E>>) this.usedKey, this.getValue(), this.defaultValue);
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/collection/AbstractSingleListData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/collection/AbstractSingleListData.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.common.collection;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.common.AbstractSingleData;
+import org.spongepowered.api.data.value.mutable.ListValue;
+
+import java.util.List;
+
+/**
+ * An abstract {@link DataManipulator} focusing on a single value that is
+ * represented as a {@link List}.
+ *
+ * @param <E> The type of element
+ * @param <M> The manipulator class
+ * @param <I> The immutable manipulator class
+ */
+public abstract class AbstractSingleListData<E, M extends DataManipulator<M, I>, I extends ImmutableDataManipulator<I, M>>
+    extends AbstractSingleData<List<E>, M, I> {
+
+    protected AbstractSingleListData(List<E> value, Key<ListValue<E>> usedKey) {
+        super(Lists.newArrayList(value), usedKey);
+    }
+
+    @Override
+    protected List<E> getValue() {
+        return Lists.newArrayList(super.getValue());
+    }
+
+    @Override
+    public M setValue(List<E> value) {
+        checkNotNull(value).forEach(Preconditions::checkNotNull);
+        return super.setValue(Lists.newArrayList(value));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected ListValue<E> getValueGetter() {
+        return Sponge.getRegistry().getValueFactory().createListValue((Key<ListValue<E>>) this.usedKey, getValue());
+    }
+
+    @Override
+    public int compareTo(M o) {
+        final List<E> list = o.get(this.usedKey).get();
+        return Boolean.compare(list.containsAll(this.getValue()), this.getValue().containsAll(list));
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/collection/AbstractSingleMapData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/collection/AbstractSingleMapData.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.common.collection;
+
+import com.google.common.collect.Maps;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.common.AbstractSingleData;
+import org.spongepowered.api.data.value.mutable.MapValue;
+import org.spongepowered.api.data.value.mutable.Value;
+
+import java.util.Map;
+
+/**
+ * An abstract implementation of a {@link DataManipulator} that deals with a
+ * {@link Map} value.
+ *
+ * @param <K> The key type of the map
+ * @param <V> The value type of the map
+ * @param <M> The manipulator type
+ * @param <I> The immutable manipulator type
+ */
+public abstract class AbstractSingleMapData<K, V, M extends DataManipulator<M, I>, I extends ImmutableDataManipulator<I, M>>
+    extends AbstractSingleData<Map<K, V>, M, I> {
+
+    protected AbstractSingleMapData(Map<K, V> value, Key<MapValue<K, V>> usedKey) {
+        super(Maps.newHashMap(value), usedKey);
+    }
+
+    @Override
+    protected Map<K, V> getValue() {
+        return Maps.newHashMap(super.getValue());
+    }
+
+    @Override
+    protected M setValue(Map<K, V> value) {
+        return super.setValue(Maps.newHashMap(value));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Value<?> getValueGetter() {
+        return Sponge.getRegistry().getValueFactory().createMapValue((Key<MapValue<K, V>>) this.usedKey, this.getValue());
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/collection/AbstractSingleSetData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/collection/AbstractSingleSetData.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.common.collection;
+
+import com.google.common.collect.Sets;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.common.AbstractSingleData;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.mutable.SetValue;
+import org.spongepowered.api.data.value.mutable.Value;
+
+import java.util.Set;
+
+/**
+ * An abstract {@link DataManipulator} specifically dealing with a {@link Set}
+ * type value.
+ *
+ * @param <E> The type of element within the set
+ * @param <M> The manipulator type
+ * @param <I> The immutable manipulator type
+ */
+public abstract class AbstractSingleSetData<E, M extends DataManipulator<M, I>, I extends ImmutableDataManipulator<I, M>>
+    extends AbstractSingleData<Set<E>, M, I> {
+
+
+    public AbstractSingleSetData(Set<E> value, Key<? extends BaseValue<Set<E>>> usedKey) {
+        super(Sets.newHashSet(value), usedKey);
+    }
+
+    @Override
+    protected Set<E> getValue() {
+        return Sets.newHashSet(super.getValue());
+    }
+
+    @Override
+    protected M setValue(Set<E> value) {
+        return super.setValue(Sets.newHashSet(value));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Value<?> getValueGetter() {
+        return Sponge.getRegistry().getValueFactory().createSetValue((Key<SetValue<E>>) this.usedKey, this.getValue());
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/collection/package-info.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/collection/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.data.manipulator.mutable.common.collection;

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/package-info.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.data.manipulator.mutable.common;


### PR DESCRIPTION
With the stability of abstract `DataManipulator` implementation in SpongeCommon, I feel it's safe to now supply these abstractions for plugin usage. Little should change at this point.