### PR TITLE
Implement decimal (double) parsing. Resolves #937

### DIFF
--- a/src/main/java/org/spongepowered/api/util/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/util/command/args/GenericArguments.java
@@ -691,6 +691,34 @@ public final class GenericArguments {
         }
     }
 
+    /**
+     * Require an argument to be an double-precision floating point number.
+     * Gives values of type {@link Double}
+     *
+     * @param key The key to store the parsed argument under
+     * @return the element to match the input
+     */
+    public static CommandElement decimal(Text key) {
+        return new DecimalElement(key);
+    }
+
+    private static class DecimalElement extends KeyElement {
+
+        private IntegerElement(Text key) {
+            super(key);
+        }
+
+        @Override
+        public Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+            final String input = args.next();
+            try {
+                return Double.parseDouble(input);
+            } catch (NumberFormatException ex) {
+                throw args.createError(t("Expected an decimal, but input '%s' was not", input));
+            }
+        }
+    }
+
     private static final Map<String, Boolean> BOOLEAN_CHOICES = ImmutableMap.<String, Boolean>builder()
             .put("true", true)
             .put("t", true)

--- a/src/main/java/org/spongepowered/api/util/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/util/command/args/GenericArguments.java
@@ -704,7 +704,7 @@ public final class GenericArguments {
 
     private static class DecimalElement extends KeyElement {
 
-        private IntegerElement(Text key) {
+        private DecimalElement(Text key) {
             super(key);
         }
 

--- a/src/main/java/org/spongepowered/api/util/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/util/command/args/GenericArguments.java
@@ -714,7 +714,7 @@ public final class GenericArguments {
             try {
                 return Double.parseDouble(input);
             } catch (NumberFormatException ex) {
-                throw args.createError(t("Expected an decimal, but input '%s' was not", input));
+                throw args.createError(t("Expected a decimal, but input '%s' was not", input));
             }
         }
     }

--- a/src/main/java/org/spongepowered/api/util/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/util/command/args/GenericArguments.java
@@ -698,13 +698,13 @@ public final class GenericArguments {
      * @param key The key to store the parsed argument under
      * @return the element to match the input
      */
-    public static CommandElement decimal(Text key) {
-        return new DecimalElement(key);
+    public static CommandElement doubleNum(Text key) {
+        return new DoubleNumElement(key);
     }
 
-    private static class DecimalElement extends KeyElement {
+    private static class DoubleNumElement extends KeyElement {
 
-        private DecimalElement(Text key) {
+        private DoubleNumElement(Text key) {
             super(key);
         }
 

--- a/src/main/java/org/spongepowered/api/util/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/util/command/args/GenericArguments.java
@@ -686,7 +686,7 @@ public final class GenericArguments {
             try {
                 return Integer.parseInt(input);
             } catch (NumberFormatException ex) {
-                throw args.createError(t("Expected an integer, but input '%s' was not", input));
+                throw args.createError(t("Expected a whole number, but input '%s' was not", input));
             }
         }
     }
@@ -714,7 +714,7 @@ public final class GenericArguments {
             try {
                 return Double.parseDouble(input);
             } catch (NumberFormatException ex) {
-                throw args.createError(t("Expected a decimal, but input '%s' was not", input));
+                throw args.createError(t("Expected a whole number or decimal, but input '%s' was not", input));
             }
         }
     }


### PR DESCRIPTION
This adds the much needed useful parsing for non-integer numbers to Sponge.

For further details, see #937