### PR TITLE
GameDictionary revamp

### DIFF
--- a/src/main/java/org/spongepowered/api/GameDictionary.java
+++ b/src/main/java/org/spongepowered/api/GameDictionary.java
@@ -24,44 +24,90 @@
  */
 package org.spongepowered.api;
 
+import com.google.common.collect.SetMultimap;
 import org.spongepowered.api.item.ItemType;
-import org.spongepowered.api.item.ItemTypes;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 
-import java.util.Map;
 import java.util.Set;
 
 /**
- * A GameDictionary is a store of {@link ItemTypes}.
+ * A GameDictionary is a store of {@link GameDictionary.Entry}s.
  *
- * <p>Note that the GameDictionary's keys are different from Minecraft item
- * ids. Minecraft item IDs are namespaces, e.g. minecraft:carrot while
- * ItemDictionary keys are not, by design(e.g. carrot). This is mainly to keep
- * supporting the existing Forge 'ore dictionary'.</p>
+ * <p>Note that the GameDictionary's keys are different from Minecraft item ids.
+ * Minecraft item IDs are namespaces, e.g. minecraft:carrot while ItemDictionary
+ * keys are not, by design(e.g. carrot). This is mainly to keep supporting the
+ * existing Forge 'ore dictionary'.</p>
  */
 public interface GameDictionary {
 
     /**
-     * Registers an ItemType in the dictionary with a String key.
+     * Registers an {@link GameDictionary.Entry} in the dictionary with a String
+     * key. The stack size is ignored.
      *
      * @param key The key of the item as a String
-     * @param type The item type to register
+     * @param entry The item to register
      */
-    void register(String key, ItemType type);
+    void register(String key, Entry entry);
 
     /**
-     * Retrieves the item types registered for the given key.
+     * Retrieves the entries registered for the given key. The stack sizes are set
+     * to 1.
      *
-     * @param key The key of the items as a String
-     * @return The item types registered for the given key
+     * @param key The key of the entries as a String
+     * @return The entries registered for the given key
      */
-    Set<ItemType> get(String key);
+    Set<Entry> get(String key);
 
     /**
-     * Retrieves all items registered in this item dictionary, mapped by
-     * their key.
+     * Retrieves all entries registered in this game dictionary, mapped by their
+     * key.
      *
-     * @return A map of all items registered
+     * @return A map of all entries registered
      */
-    Map<String, Set<ItemType>> getAllItems();
+    SetMultimap<String, Entry> getAll();
+
+    interface Entry {
+
+        /**
+         * Returns the type of item contained by this entry.
+         *
+         * @return The item type
+         */
+        ItemType getType();
+
+        /**
+         * Tests whether the provided item stack matches this entry's
+         * specifications.
+         *
+         * @param stack The item stack to test
+         * @return {@code true} if the stack matches this entry
+         */
+        boolean matches(ItemStack stack);
+
+        /**
+         * Returns whether this entry checks against the item type and extra
+         * data associated with the stack. If this returns {@link true}, any
+         * {@link ItemStack} whose {@link ItemType} and manipulators match
+         * those of the {@linkplain #getTemplate() template} will {@linkplain
+         * #matches(ItemStack) match} this entry; however, not all manipulators
+         * present in the template are required to match those in the item
+         * stack to cause them to match. If this returns {@code false}, any
+         * item stack whose {@link ItemType} matches that of the entry will
+         * match this entry.
+         *
+         * @return {@code true} if the entry checks extra data on the stack
+         */
+        boolean isSpecific();
+
+        /**
+         * Returns an item stack snapshot for plugins to inspect this entry.
+         * The returned snapshot will {@linkplain #matches(ItemStack) match}
+         * this entry. The size of the snapshot will always be 1.
+         *
+         * @return A snapshot that matches this entry
+         */
+        ItemStackSnapshot getTemplate();
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/item/ItemType.java
+++ b/src/main/java/org/spongepowered/api/item/ItemType.java
@@ -24,10 +24,14 @@
  */
 package org.spongepowered.api.item;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.GameDictionary;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.data.Property;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -37,7 +41,7 @@ import java.util.Optional;
  * A type of item.
  */
 @CatalogedBy(ItemTypes.class)
-public interface ItemType extends CatalogType, Translatable {
+public interface ItemType extends CatalogType, Translatable, GameDictionary.Entry {
 
     /**
      * Gets the corresponding {@link BlockType} of this item if one exists.
@@ -80,5 +84,25 @@ public interface ItemType extends CatalogType, Translatable {
      * @return The item property, if available
      */
     <T extends Property<?, ?>> Optional<T> getDefaultProperty(Class<T> propertyClass);
+    
+    @Override
+    default ItemType getType() {
+        return this;
+    }
+    
+    @Override
+    default boolean matches(ItemStack stack) {
+        return checkNotNull(stack, "stack").getItem().equals(this);
+    }
+
+    @Override
+    default boolean isSpecific() {
+        return false;
+    }
+
+    @Override
+    default ItemStackSnapshot getTemplate() {
+        return ItemStack.of(this, 1).createSnapshot();
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackSnapshot.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackSnapshot.java
@@ -25,6 +25,7 @@
 
 package org.spongepowered.api.item.inventory;
 
+import org.spongepowered.api.GameDictionary;
 import org.spongepowered.api.data.ImmutableDataHolder;
 import org.spongepowered.api.item.ItemType;
 
@@ -62,5 +63,15 @@ public interface ItemStackSnapshot extends ImmutableDataHolder<ItemStackSnapshot
      * @return The newly generated item stack
      */
     ItemStack createStack();
+
+    /**
+     * Creates a {@link GameDictionary.Entry} that compares stacks to this
+     * {@link ItemStackSnapshot}. Note that not all data stored in this
+     * {@link ItemStackSnapshot} may be stored in the returned entry.
+     * 
+     * @return A {@link GameDictionary.Entry} based on this
+     * {@link ItemStackSnapshot}
+     */
+    GameDictionary.Entry createGameDictionaryEntry();
 
 }


### PR DESCRIPTION
**SpongeAPI PR** | [SpongeCommon PR](https://github.com/SpongePowered/SpongeCommon/pull/314) | [SpongeForge PR](https://github.com/SpongePowered/SpongeForge/pull/439)

Originally, `GameDictionary` only provides access to `ItemType`s. This has the problem of false positives when performing comparisons using it, which can lead to **duplication bugs** (see #806). This PR changes it to store `GameDictionaryEntry`s instead. `GameDictionaryEntry`s can come from `ItemType` (which now extends it) or from a method in `ItemStackSnapshot`, and they provide methods to inspect their data and check whether an item stack matches them.

This change may break plugins.

Fixes #806.