### PR TITLE
Add missing setters to Achievement + Statistic builders

### DIFF
--- a/src/main/java/org/spongepowered/api/statistic/BlockStatistic.java
+++ b/src/main/java/org/spongepowered/api/statistic/BlockStatistic.java
@@ -25,9 +25,6 @@
 package org.spongepowered.api.statistic;
 
 import org.spongepowered.api.block.BlockType;
-import org.spongepowered.api.text.translation.Translation;
-
-import javax.annotation.Nullable;
 
 /**
  * Represents a {@link Statistic} for a {@link BlockType}.

--- a/src/main/java/org/spongepowered/api/statistic/EntityStatistic.java
+++ b/src/main/java/org/spongepowered/api/statistic/EntityStatistic.java
@@ -25,9 +25,6 @@
 package org.spongepowered.api.statistic;
 
 import org.spongepowered.api.entity.EntityType;
-import org.spongepowered.api.text.translation.Translation;
-
-import javax.annotation.Nullable;
 
 /**
  * Represents a {@link Statistic} for an {@link EntityType}.

--- a/src/main/java/org/spongepowered/api/statistic/ItemStatistic.java
+++ b/src/main/java/org/spongepowered/api/statistic/ItemStatistic.java
@@ -25,9 +25,6 @@
 package org.spongepowered.api.statistic;
 
 import org.spongepowered.api.item.ItemType;
-import org.spongepowered.api.text.translation.Translation;
-
-import javax.annotation.Nullable;
 
 /**
  * Represents a {@link Statistic} for an {@link ItemType}.

--- a/src/main/java/org/spongepowered/api/statistic/Statistic.java
+++ b/src/main/java/org/spongepowered/api/statistic/Statistic.java
@@ -78,9 +78,9 @@ public interface Statistic extends CatalogType, Translatable {
     interface StatisticBuilder<T extends Statistic, B extends StatisticBuilder<T, B>> extends ResettableBuilder<T, B> {
 
         /**
-         * Sets the internal name for the {@link Statistic}.
+         * Sets the human readable name for the {@link Statistic}.
          *
-         * @param name The name of this achievement
+         * @param name The name for the statistic
          * @return This builder, for chaining
          */
         B name(String name);
@@ -113,10 +113,11 @@ public interface Statistic extends CatalogType, Translatable {
         /**
          * Builds and registers an instance of a {@link Statistic}.
          *
+         * @param id The unique for the statistic
          * @return A new instance of a statistic
          * @throws IllegalStateException If the statistic is not completed
          */
-        T buildAndRegister() throws IllegalStateException;
+        T buildAndRegister(String id) throws IllegalStateException;
 
         @Override
         B from(T value);

--- a/src/main/java/org/spongepowered/api/statistic/StatisticGroups.java
+++ b/src/main/java/org/spongepowered/api/statistic/StatisticGroups.java
@@ -40,7 +40,7 @@ public final class StatisticGroups {
     public static final StatisticGroup BREAK_ITEM = DummyObjectProvider.createFor(StatisticGroup.class, "BREAK_ITEM");
 
     /**
-     * Statistic counting the number of crafted items of a specific type.
+     * Statistic counting the number of crafted blocks of a specific type.
      */
     public static final StatisticGroup CRAFT_BLOCK = DummyObjectProvider.createFor(StatisticGroup.class, "CRAFT_BLOCK");
 
@@ -48,6 +48,16 @@ public final class StatisticGroups {
      * Statistic counting the number of crafted items of a specific type.
      */
     public static final StatisticGroup CRAFT_ITEM = DummyObjectProvider.createFor(StatisticGroup.class, "CRAFT_ITEM");
+
+    /**
+     * Statistic counting the number of dropped blocks of a specific type.
+     */
+    public static final StatisticGroup DROP_BLOCK = DummyObjectProvider.createFor(StatisticGroup.class, "DROP_BLOCK");
+
+    /**
+     * Statistic counting the number of dropped items of a specific type.
+     */
+    public static final StatisticGroup DROP_ITEM = DummyObjectProvider.createFor(StatisticGroup.class, "DROP_ITEM");
 
     /**
      * Statistics belonging to the group of 'general' statistics.
@@ -87,6 +97,16 @@ public final class StatisticGroups {
      * type.
      */
     public static final StatisticGroup MINE_BLOCK = DummyObjectProvider.createFor(StatisticGroup.class, "MINE_BLOCK");
+
+    /**
+     * Statistic counting the number of picked up blocks of a specific type.
+     */
+    public static final StatisticGroup PICK_UP_BLOCK = DummyObjectProvider.createFor(StatisticGroup.class, "PICK_UP_BLOCK");
+
+    /**
+     * Statistic counting the number of picked up items of a specific type.
+     */
+    public static final StatisticGroup PICK_UP_ITEM = DummyObjectProvider.createFor(StatisticGroup.class, "PICK_UP_ITEM");
 
     /**
      * Statistic counting the number of used blocks of a specific type.

--- a/src/main/java/org/spongepowered/api/statistic/TeamStatistic.java
+++ b/src/main/java/org/spongepowered/api/statistic/TeamStatistic.java
@@ -25,9 +25,6 @@
 package org.spongepowered.api.statistic;
 
 import org.spongepowered.api.text.format.TextColor;
-import org.spongepowered.api.text.translation.Translation;
-
-import javax.annotation.Nullable;
 
 /**
  * Represents a {@link Statistic} for a team's {@link TextColor}.

--- a/src/main/java/org/spongepowered/api/statistic/achievement/Achievement.java
+++ b/src/main/java/org/spongepowered/api/statistic/achievement/Achievement.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.statistic.achievement;
 
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.statistic.Statistic;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.text.translation.Translation;
@@ -98,9 +99,9 @@ public interface Achievement extends CatalogType, Translatable {
     interface Builder extends ResettableBuilder<Achievement, Builder> {
 
         /**
-         * Sets the internal name for the {@link Achievement}.
+         * Sets the human readable name for the {@link Achievement}.
          *
-         * @param name The name of this achievement
+         * @param name The name for the achievement
          * @return This builder, for chaining
          */
         Builder name(String name);
@@ -120,6 +121,16 @@ public interface Achievement extends CatalogType, Translatable {
          * @return This builder, for chaining
          */
         Builder description(Translation description);
+
+        /**
+         * Sets the item stack used as icon for the {@link Achievement} in the
+         * hover text.
+         *
+         * @param item The item used as icon of this achievement in the hover
+         *        text
+         * @return This builder, for chaining
+         */
+        Builder icon(ItemStack item);
 
         /**
          * Sets the parent of this {@link Achievement}, if there is one.
@@ -154,10 +165,11 @@ public interface Achievement extends CatalogType, Translatable {
         /**
          * Builds and registers an instance of an {@link Achievement}.
          *
+         * @param id The unique for the achievement
          * @return A new instance of a achievement
          * @throws IllegalStateException If the achievement is not completed
          */
-        Achievement buildAndRegister() throws IllegalStateException;
+        Achievement buildAndRegister(String id) throws IllegalStateException;
 
     }
 }


### PR DESCRIPTION
[[API]](https://github.com/SpongePowered/SpongeAPI/pull/958) [[Common]](https://github.com/SpongePowered/SpongeCommon/pull/131)

Required changes to the builders to be properly implemented in [SpongeCommon#131](https://github.com/SpongePowered/SpongeCommon/pull/131)

---

There is also another issue with the `AchievementBuilder`

The [`Achievement`](https://github.com/SpongePowered/SpongeCommon/pull/131/files#diff-d2caa86494b4868deeba86211da08ccbR117) needs a `row` (`displayRow`) and a `column` (`displayColumn`) parameter however I'm not sure whether this is only an implementation detail or whether this is actually relevant to use them. I haven't found a usage of those fields/values, but this might be the case because those values are only needed for the client or the obfuscator trolled me.

Shall I add them here too or not?
