### PR TITLE
Add profile property API

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -34,7 +34,6 @@ import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.recipe.RecipeRegistry;
 import org.spongepowered.api.network.status.Favicon;
 import org.spongepowered.api.plugin.PluginContainer;
-import org.spongepowered.api.profile.GameProfile;
 import org.spongepowered.api.registry.CatalogRegistryModule;
 import org.spongepowered.api.registry.RegistryModule;
 import org.spongepowered.api.resourcepack.ResourcePack;
@@ -53,7 +52,6 @@ import org.spongepowered.api.text.translation.Translation;
 import org.spongepowered.api.util.ResettableBuilder;
 import org.spongepowered.api.util.rotation.Rotation;
 import org.spongepowered.api.world.extent.ExtentBufferFactory;
-import org.spongepowered.api.world.gen.WorldGeneratorModifier;
 
 import java.awt.image.BufferedImage;
 import java.io.FileNotFoundException;
@@ -64,7 +62,6 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.function.Supplier;
 
 /**
@@ -242,15 +239,6 @@ public interface GameRegistry {
      * @return The {@link Rotation} with the given degrees or Optional.empty() if not found
      */
     Optional<Rotation> getRotationFromDegree(int degrees);
-
-    /**
-     * Creates a new {@link GameProfile} using the specified unique identifier and name.
-     *
-     * @param uuid The unique identifier for the profile
-     * @param name The name for the profile
-     * @return The created profile
-     */
-    GameProfile createGameProfile(UUID uuid, String name);
 
     /**
      * Loads a {@link Favicon} from the specified encoded string. The format of

--- a/src/main/java/org/spongepowered/api/profile/GameProfile.java
+++ b/src/main/java/org/spongepowered/api/profile/GameProfile.java
@@ -24,12 +24,20 @@
  */
 package org.spongepowered.api.profile;
 
+import com.google.common.collect.Multimap;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.DataSerializable;
+import org.spongepowered.api.profile.property.ProfileProperty;
 import org.spongepowered.api.service.user.UserStorageService;
 import org.spongepowered.api.util.Identifiable;
 
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.annotation.Nullable;
+
 /**
- * Represents a name and an associated unique identifier.
+ * Represents a profile of a user.
  *
  * <p>Use the {@link UserStorageService} service to
  * obtain the stored data associated with a profile.</p>
@@ -37,9 +45,42 @@ import org.spongepowered.api.util.Identifiable;
 public interface GameProfile extends Identifiable, DataSerializable {
 
     /**
-     * Gets the player's last known username.
+     * Creates a {@link GameProfile} from the provided ID and name.
      *
-     * @return The player's last known username
+     * @param uniqueId The unique ID
+     * @param name The name
+     * @return The created profile
      */
-    String getName();
+    static GameProfile of(UUID uniqueId, @Nullable String name) {
+        return Sponge.getServer().getGameProfileManager().createProfile(uniqueId, name);
+    }
+
+    /**
+     * Gets the name associated with this profile.
+     *
+     * @return The associated name if present, otherwise {@link Optional#empty()}
+     */
+    Optional<String> getName();
+
+    /**
+     * Gets the property map for this profile.
+     *
+     * <p>This is a mutable map.</p>
+     *
+     * @return The property map
+     */
+    Multimap<String, ProfileProperty> getPropertyMap();
+
+    /**
+     * Checks if this profile is filled.
+     *
+     * <p>A filled profile contains both a unique id and name.</p>
+     *
+     * @return {@code true} if this profile is filled
+     * @see GameProfileManager#fill(GameProfile)
+     * @see GameProfileManager#fill(GameProfile, boolean)
+     * @see GameProfileManager#fill(GameProfile, boolean, boolean)
+     */
+    boolean isFilled();
+
 }

--- a/src/main/java/org/spongepowered/api/profile/GameProfileManager.java
+++ b/src/main/java/org/spongepowered/api/profile/GameProfileManager.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.profile;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.profile.property.ProfileProperty;
 import org.spongepowered.api.service.user.UserStorageService;
 
 import java.io.IOException;
@@ -33,18 +34,38 @@ import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
+import javax.annotation.Nullable;
+
 /**
- * A service which contacts the authentication servers to get a
- * {@link GameProfile} by a given UUID or name.
+ * Manages {@link GameProfile} creation and data population.
  *
- * <p>The service may cache the data of a request for faster lookups. Note that
+ * <p>The manager may cache the data of a request for faster lookups. Note that
  * the cached data may not always be up to date.</p>
- *
- * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
- * caused by a {@link ProfileNotFoundException} if the profile does not exist or
- * an {@link IOException} if a network error occurred.</p>
  */
 public interface GameProfileManager {
+
+    /**
+     * Creates a {@link GameProfile} from the provided ID and name.
+     *
+     * @param uniqueId The unique ID
+     * @param name The name
+     * @return The created profile
+     * @see GameProfile#of(UUID, String)
+     */
+    GameProfile createProfile(UUID uniqueId, @Nullable String name);
+
+    /**
+     * Creates a {@link ProfileProperty} from the provided name, value,
+     * and optional signature.
+     *
+     * @param name The name for the property
+     * @param value The value of the property
+     * @param signature The signature of the property
+     * @return The created profile property
+     * @see ProfileProperty#of(String, String)
+     * @see ProfileProperty#of(String, String, String)
+     */
+    ProfileProperty createProfileProperty(String name, String value, @Nullable String signature);
 
     /**
      * Looks up a {@link GameProfile} by its unique ID.
@@ -53,13 +74,23 @@ public interface GameProfileManager {
      * profile servers. Use {@link #get(UUID, boolean)} to disable the cache
      * lookup.</p>
      *
+     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
+     * an {@link IOException} if a network error occurred.</p>
+     *
      * @param uniqueId The unique ID
      * @return The result of the request
      */
-    ListenableFuture<GameProfile> get(UUID uniqueId);
+    default ListenableFuture<GameProfile> get(UUID uniqueId) {
+        return this.get(uniqueId, true);
+    }
 
     /**
      * Looks up a {@link GameProfile} by its unique ID.
+     *
+     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
+     * an {@link IOException} if a network error occurred.</p>
      *
      * @param uniqueId The unique ID
      * @param useCache true to perform a cache lookup first
@@ -68,19 +99,42 @@ public interface GameProfileManager {
     ListenableFuture<GameProfile> get(UUID uniqueId, boolean useCache);
 
     /**
+     * Gets a collection of {@link GameProfile}s by their unique IDs.
+     *
+     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
+     * an {@link IOException} if a network error occurred.</p>
+     *
+     * @param uniqueIds The UUIDs
+     * @param useCache true to perform a cache lookup first
+     * @return The result of the request
+     */
+    ListenableFuture<Collection<GameProfile>> getAllById(Iterable<UUID> uniqueIds, boolean useCache);
+
+    /**
      * Looks up a {@link GameProfile} by its user name (case-insensitive).
      *
      * <p>This method checks the local profile cache before contacting the
      * profile servers. Use {@link #get(String, boolean)} to disable the cache
      * lookup.</p>
      *
+     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
+     * an {@link IOException} if a network error occurred.</p>
+     *
      * @param name The username
      * @return The result of the request
      */
-    ListenableFuture<GameProfile> get(String name);
+    default ListenableFuture<GameProfile> get(String name) {
+        return this.get(name, true);
+    }
 
     /**
      * Looks up a {@link GameProfile} by its user name (case-insensitive).
+     *
+     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
+     * an {@link IOException} if a network error occurred.</p>
      *
      * @param name The username
      * @param useCache true to perform a cache lookup first
@@ -92,6 +146,10 @@ public interface GameProfileManager {
      * Gets a collection of {@link GameProfile}s by their user names
      * (case-insensitive).
      *
+     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
+     * an {@link IOException} if a network error occurred.</p>
+     *
      * @param names The user names
      * @param useCache true to perform a cache lookup first
      * @return The result of the request
@@ -99,13 +157,47 @@ public interface GameProfileManager {
     ListenableFuture<Collection<GameProfile>> getAllByName(Iterable<String> names, boolean useCache);
 
     /**
-     * Gets a collection of {@link GameProfile}s by their unique IDs.
+     * Fills a {@link GameProfile}.
      *
-     * @param uniqueIds The UUIDs
+     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
+     * an {@link IOException} if a network error occurred.</p>
+     *
+     * @param profile The profile to fill
+     * @return The result of the request
+     */
+    default ListenableFuture<GameProfile> fill(GameProfile profile) {
+        return this.fill(profile, false);
+    }
+
+    /**
+     * Fills a {@link GameProfile}.
+     *
+     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
+     * an {@link IOException} if a network error occurred.</p>
+     *
+     * @param profile The profile to fill
+     * @param signed true if we should request that the profile data be signed
+     * @return The result of the request
+     */
+    default ListenableFuture<GameProfile> fill(GameProfile profile, boolean signed) {
+        return this.fill(profile, signed, true);
+    }
+
+    /**
+     * Fills a {@link GameProfile}.
+     *
+     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
+     * an {@link IOException} if a network error occurred.</p>
+     *
+     * @param profile The profile to fill
+     * @param signed true if we should request that the profile data be signed
      * @param useCache true to perform a cache lookup first
      * @return The result of the request
      */
-    ListenableFuture<Collection<GameProfile>> getAllById(Iterable<UUID> uniqueIds, boolean useCache);
+    ListenableFuture<GameProfile> fill(GameProfile profile, boolean signed, boolean useCache);
 
     /**
      * Gets a collection of all cached {@link GameProfile}s.

--- a/src/main/java/org/spongepowered/api/profile/property/ProfileProperty.java
+++ b/src/main/java/org/spongepowered/api/profile/property/ProfileProperty.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.profile.property;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.profile.GameProfile;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents a property in a {@link GameProfile}'s profile property map.
+ *
+ * <p>This interface should not be implemented.</p>
+ *
+ * @see #of(String, String)
+ * @see #of(String, String, String)
+ */
+public interface ProfileProperty {
+
+    /**
+     * Creates a new property.
+     *
+     * @param name The name for the property
+     * @param value The value of the property
+     */
+    static ProfileProperty of(String name, String value) {
+        return of(name, value, null);
+    }
+
+    /**
+     * Creates a new signed property.
+     *
+     * <p>Depending on the property name, if the signature is provided it must
+     * originate from Mojang.</p>
+     *
+     * @param name The name for the property
+     * @param value The value of the property
+     * @param signature The signature of the property
+     */
+    static ProfileProperty of(String name, String value, @Nullable String signature) {
+        return Sponge.getServer().getGameProfileManager().createProfileProperty(name, value, signature);
+    }
+
+    /**
+     * Gets the name of this property.
+     *
+     * @return The name
+     */
+    String getName();
+
+    /**
+     * Gets the value of this property.
+     *
+     * @return The value
+     */
+    String getValue();
+
+    /**
+     * Gets the signature of this property.
+     *
+     * <p>Depending on the property name, if the signature is provided it must
+     * originate from Mojang.</p>
+     *
+     * @return The signature, or {@link Optional#empty()} if not present
+     */
+    Optional<String> getSignature();
+
+    /**
+     * Tests if this property has a signature.
+     *
+     * @return Whether this property has a signature
+     */
+    default boolean hasSignature() {
+        return this.getSignature().isPresent();
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/profile/property/package-info.java
+++ b/src/main/java/org/spongepowered/api/profile/property/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.api.profile.property;


### PR DESCRIPTION
[**API**](https://github.com/SpongePowered/SpongeAPI/pull/974) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/344) | [Forge](https://github.com/SpongePowered/SpongeForge/pull/455) | [Vanilla](https://github.com/SpongePowered/SpongeVanilla/pull/194)

This adds access to the property map that is associated with `GameProfile`s.

The property map is represented by a `Multimap` of `String`s to `ProfileProperty`s, although the keys of the multimap are ignored internally. Each `ProfileProperty` contains a name (non-null), value (non-null), and an optional (nullable) signature - if the signature is included, it **must** be a valid signature provided by Mojang which matches the value.
Textures (skins, capes, etc) are one item that is stored in the property map (used for resolving humanoid skins/capes/etc), although there may be other properties in the map, either from Mojang or other modifications/plugins.
Like entity AI, profile properties must be constructed through `GameProfileProperty`, either by extending the class or instantiating with your desired values. Attempting to add an extension of `ProfileProperty` will result in an exception being thrown at you.

Test plugin: https://gist.github.com/kashike/32e61d0ba0ecf76a5d04
