### PR TITLE
Add dual setter for header and footer, in addition to single setters

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/living/player/tab/TabList.java
+++ b/src/main/java/org/spongepowered/api/entity/living/player/tab/TabList.java
@@ -65,6 +65,17 @@ public interface TabList {
     void setFooter(Text footer);
 
     /**
+     * Sets this list's header and footer.
+     *
+     * @param header The new header
+     * @param footer The new footer
+     */
+    default void setHeaderAndFooter(Text header, Text footer) {
+        this.setHeader(header);
+        this.setFooter(footer);
+    }
+
+    /**
      * Gets the players on the list. The list should be immutable.
      *
      * @return The players on the list


### PR DESCRIPTION
This adds a new dual (header and footer) setter for the tablist header and footer. Since the header and footer are sent together, it makes sense to allow setting both at once, as well as individually.