### PR TITLE
Add a getServer method to Sponge

### DIFF
--- a/src/main/java/org/spongepowered/api/Sponge.java
+++ b/src/main/java/org/spongepowered/api/Sponge.java
@@ -71,6 +71,10 @@ public final class Sponge {
         return getGame().getPlatform();
     }
 
+    public static Server getServer() {
+        return getGame().getServer();
+    }
+
     public static GameDictionary getDictionary() {
         return getGame().getGameDictionary();
     }


### PR DESCRIPTION
`Server` is something constantly accessed, I see no point in not having this method if we have ones for far less used things.