### PR TITLE
Add stuck arrows API

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -75,6 +75,7 @@ import org.spongepowered.api.data.manipulator.mutable.block.TreeData;
 import org.spongepowered.api.data.manipulator.mutable.entity.AffectsSpawningData;
 import org.spongepowered.api.data.manipulator.mutable.entity.FallDistanceData;
 import org.spongepowered.api.data.manipulator.mutable.entity.MinecartBlockData;
+import org.spongepowered.api.data.manipulator.mutable.entity.StuckArrowsData;
 import org.spongepowered.api.data.manipulator.mutable.item.HideData;
 import org.spongepowered.api.data.manipulator.mutable.item.SplashPotionData;
 import org.spongepowered.api.data.meta.ItemEnchantment;
@@ -881,6 +882,14 @@ public final class Keys {
      * @see StoneData#type()
      */
     public static final Key<Value<StoneType>> STONE_TYPE = null;
+
+    /**
+     * Represents the {@link Key} for representing the amount of "stuck arrows"
+     * in {@link Living} entities.
+     *
+     * @see StuckArrowsData#stuckArrows()
+     */
+    public static final Key<MutableBoundedValue<Integer>> STUCK_ARROWS = null;
 
     /**
      * Represents the {@link Key} for representing the "suspended" state

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableStuckArrowsData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableStuckArrowsData.java
@@ -25,21 +25,21 @@
 package org.spongepowered.api.data.manipulator.immutable.entity;
 
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
-import org.spongepowered.api.data.manipulator.mutable.entity.AffectsSpawningData;
-import org.spongepowered.api.data.value.immutable.ImmutableValue;
-import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.data.manipulator.mutable.entity.StuckArrowsData;
+import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
+import org.spongepowered.api.entity.living.Living;
 
 /**
- * An {@link ImmutableDataManipulator} for the "affects spawning" state of
- * a {@link Player}.
+ * An {@link ImmutableDataManipulator} for the number of "stuck arrows" in
+ * {@link Living} entities.
  */
-public interface ImmutableAffectsSpawningData extends ImmutableDataManipulator<ImmutableAffectsSpawningData, AffectsSpawningData> {
+public interface ImmutableStuckArrowsData extends ImmutableDataManipulator<ImmutableStuckArrowsData, StuckArrowsData> {
 
     /**
-     * Gets the {@link ImmutableValue} for the "affects spawning" state.
+     * Gets the {@link ImmutableBoundedValue} for the stuck arrows.
      *
-     * @return The immutable value for the affects spawning state
+     * @return The immutable value of stuck arrows
      */
-    ImmutableValue<Boolean> affectsSpawning();
+    ImmutableBoundedValue<Integer> stuckArrows();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/StuckArrowsData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/StuckArrowsData.java
@@ -22,24 +22,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.manipulator.immutable.entity;
+package org.spongepowered.api.data.manipulator.mutable.entity;
 
-import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
-import org.spongepowered.api.data.manipulator.mutable.entity.AffectsSpawningData;
-import org.spongepowered.api.data.value.immutable.ImmutableValue;
-import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableStuckArrowsData;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.entity.living.Living;
 
 /**
- * An {@link ImmutableDataManipulator} for the "affects spawning" state of
- * a {@link Player}.
+ * A {@link DataManipulator} for the number of "stuck arrows" in
+ * {@link Living} entities.
  */
-public interface ImmutableAffectsSpawningData extends ImmutableDataManipulator<ImmutableAffectsSpawningData, AffectsSpawningData> {
+public interface StuckArrowsData extends DataManipulator<StuckArrowsData, ImmutableStuckArrowsData> {
 
     /**
-     * Gets the {@link ImmutableValue} for the "affects spawning" state.
+     * Gets the {@link MutableBoundedValue} for the stuck arrows.
      *
-     * @return The immutable value for the affects spawning state
+     * @return The mutable value of stuck arrows
      */
-    ImmutableValue<Boolean> affectsSpawning();
+    MutableBoundedValue<Integer> stuckArrows();
 
 }


### PR DESCRIPTION
[**API**](https://github.com/SpongePowered/SpongeAPI/pull/994) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/375)

This adds data to manipulate the amount of stuck arrows in living entities.

Also fixes the reference in ImmutableAffectsSpawningData to point to Player instead of Human