### PR TITLE
Add Economy API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ genEventImpl {
             'src/main/java/org/spongepowered/api/event/block/',
             'src/main/java/org/spongepowered/api/event/command/',
             'src/main/java/org/spongepowered/api/event/data/',
+            'src/main/java/org/spongepowered/api/event/economy/',
             'src/main/java/org/spongepowered/api/event/entity/',
             'src/main/java/org/spongepowered/api/event/game/',
             'src/main/java/org/spongepowered/api/event/item/inventory/',

--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -93,6 +93,7 @@ import org.spongepowered.api.event.command.MessageSinkEvent;
 import org.spongepowered.api.event.command.SendCommandEvent;
 import org.spongepowered.api.event.command.TabCompleteCommandEvent;
 import org.spongepowered.api.event.data.ChangeDataHolderEvent;
+import org.spongepowered.api.event.economy.EconomyTransactionEvent;
 import org.spongepowered.api.event.entity.AffectEntityEvent;
 import org.spongepowered.api.event.entity.BreedEntityEvent;
 import org.spongepowered.api.event.entity.ChangeEntityEquipmentEvent;
@@ -190,6 +191,7 @@ import org.spongepowered.api.network.status.Favicon;
 import org.spongepowered.api.network.status.StatusClient;
 import org.spongepowered.api.profile.GameProfile;
 import org.spongepowered.api.resourcepack.ResourcePack;
+import org.spongepowered.api.service.economy.transaction.TransactionResult;
 import org.spongepowered.api.statistic.Statistic;
 import org.spongepowered.api.statistic.achievement.Achievement;
 import org.spongepowered.api.text.Text;
@@ -1197,6 +1199,22 @@ public class SpongeEventFactory {
         values.put("originalChanges", originalChanges);
         values.put("targetHolder", targetHolder);
         return SpongeEventFactoryUtils.createEventImpl(ChangeDataHolderEvent.ValueChange.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.economy.EconomyTransactionEvent}.
+     * 
+     * @param cause The cause
+     * @param transactionResult The transaction result
+     * @return A new economy transaction event
+     */
+    public static EconomyTransactionEvent createEconomyTransactionEvent(Cause cause, TransactionResult transactionResult) {
+        Map<String, Object> values = Maps.newHashMap();
+        values.put("cause", cause);
+        values.put("transactionResult", transactionResult);
+        return SpongeEventFactoryUtils.createEventImpl(EconomyTransactionEvent.class, values);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/event/economy/EconomyTransactionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/economy/EconomyTransactionEvent.java
@@ -22,19 +22,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service.permission.context;
+package org.spongepowered.api.event.economy;
+
+import org.spongepowered.api.event.Event;
+import org.spongepowered.api.service.economy.EconomyService;
+import org.spongepowered.api.service.economy.transaction.TransactionResult;
 
 /**
- * A common interface for objects that have a relevant context.
+ * Fired when the {@link EconomyService} has processed a transaction.
  */
-public interface Contextual {
+public interface EconomyTransactionEvent extends Event {
 
     /**
-     * Returns the context most relevant to this object. This context may be the
-     * same across multiple invocations (but may not, so don't count on this
-     * being true).
+     * Gets the {@link TransactionResult} for the transaction that occured.
      *
-     * @return A given context
+     * @return The {@link TransactionResult}
      */
-    Context getContext();
+    TransactionResult getTransactionResult();
+
 }

--- a/src/main/java/org/spongepowered/api/service/context/Context.java
+++ b/src/main/java/org/spongepowered/api/service/context/Context.java
@@ -22,7 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service.permission.context;
+package org.spongepowered.api.service.context;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -31,11 +31,12 @@ import com.google.common.collect.Maps;
 import java.util.Map;
 
 /**
- * The context that a permission check occurs in. Instances of a context are
+ * The context that a service check occurs in. Instances of a context are
  * designed to function as cache keys, meaning they should be fairly lightweight
  * and not hold references to large objects
  */
 public final class Context implements Map.Entry<String, String> {
+    public static final String USER_KEY = "user";
     public static final String WORLD_KEY = "world";
     public static final String DIMENSION_KEY = "dimension";
     public static final String REMOTE_IP_KEY = "remoteip";
@@ -73,6 +74,7 @@ public final class Context implements Map.Entry<String, String> {
      * @return the specific name of the item involved in this context, for
      *         example if the type were {@code world} this would be the name of the
      *         world.
+     * 
      */
     public String getName() {
         return getValue();

--- a/src/main/java/org/spongepowered/api/service/context/ContextCalculator.java
+++ b/src/main/java/org/spongepowered/api/service/context/ContextCalculator.java
@@ -22,36 +22,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service.permission.context;
-
-import org.spongepowered.api.service.permission.Subject;
+package org.spongepowered.api.service.context;
 
 import java.util.Set;
 
 /**
- * Calculate the availability of contexts. These methods may be invoked
- * frequently, and therefore should be fast.
+ * Calculate the availability of {@link Context}s for a {@link Contextual}. 
+ * These methods may be invoked frequently, and therefore should be fast.
+ * 
  */
-public interface ContextCalculator {
+public interface ContextCalculator<T extends Contextual> {
 
     /**
-     * Add any contexts this calculator determines to be applicable to the
-     * provided accumulator.
+     * Add any {@link Context}s this calculator determines to be applicable to the
+     * provided context accumulator.
+     * 
      *
-     * @param subject The subject being checked
-     * @param accumulator The accumulator to add to
+     * @param {@link Contextual} for this operation
+     * @param {@link Set} of {@link Context}s this operation will append to.
      */
-    void accumulateContexts(Subject subject, Set<Context> accumulator);
+    void accumulateContexts(T calculable, Set<Context> accumulator);
 
     /**
-     * Checks if a single context is currently applicable to a single subject.
-     * If this calculator does not handle the given type of context, this method
-     * should return false.
+     * Checks if a {@link Context} is currently applicable to a {@link Contextual}.
+     * 
+     * <p>If this calculator does not handle the given type of context, this method
+     * should return false.</p>
      *
-     * @param context The context being checked
-     * @param subject The subject this context is being checked against
-     * @return Whether the given context is handled by this calculator and is
-     *         applicable to the given subject
+     * @param {@link Context} being checked
+     * @param {@link Contextual} the contextual that is being checked against
+     * @return True if the given {@link Context} is handled by this calculator and is
+     *         applicable to the given {@link Contextual}. Otherwise false.
      */
-    boolean matches(Context context, Subject subject);
+    boolean matches(Context context, T subject);
 }

--- a/src/main/java/org/spongepowered/api/service/context/ContextSource.java
+++ b/src/main/java/org/spongepowered/api/service/context/ContextSource.java
@@ -22,35 +22,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service.permission.option;
+package org.spongepowered.api.service.context;
 
-import org.spongepowered.api.service.context.Context;
-import org.spongepowered.api.service.permission.Subject;
-
-import java.util.Optional;
-import java.util.Set;
-
-public interface OptionSubject extends Subject {
-    @Override
-    OptionSubjectData getSubjectData();
-
-    @Override
-    OptionSubjectData getTransientSubjectData();
+/**
+ * A common interface for objects that have a relevant context.
+ */
+public interface ContextSource {
 
     /**
-     * Get the value of a given option in the given context.
+     * Returns the context most relevant to this object. This context may be the
+     * same across multiple invocations (but may not, so don't count on this
+     * being true).
      *
-     * @param contexts The contexts to get the options from
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
+     * @return A given context
      */
-    Optional<String> getOption(Set<Context> contexts, String key);
-
-    /**
-     * Get the value of a given option in the subject's current context
-     *
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
-     */
-    Optional<String> getOption(String key);
+    Context getContext();
 }

--- a/src/main/java/org/spongepowered/api/service/context/Contextual.java
+++ b/src/main/java/org/spongepowered/api/service/context/Contextual.java
@@ -22,35 +22,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service.permission.option;
+package org.spongepowered.api.service.context;
 
-import org.spongepowered.api.service.context.Context;
-import org.spongepowered.api.service.permission.Subject;
-
-import java.util.Optional;
 import java.util.Set;
 
-public interface OptionSubject extends Subject {
-    @Override
-    OptionSubjectData getSubjectData();
-
-    @Override
-    OptionSubjectData getTransientSubjectData();
-
-    /**
-     * Get the value of a given option in the given context.
-     *
-     * @param contexts The contexts to get the options from
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
-     */
-    Optional<String> getOption(Set<Context> contexts, String key);
+/**
+ * A common interface for objects that have an identifier and are bound by
+ * {@link Context}s.
+ *
+ */
+public interface Contextual {
 
     /**
-     * Get the value of a given option in the subject's current context
+     * Returns the identifier associated with this Contextual. Not guaranteed to
+     * be human-readable.
      *
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
+     * @return The unique identifier for this subject
      */
-    Optional<String> getOption(String key);
+    String getIdentifier();
+
+    /**
+     * Calculate active contexts, using the {@link ContextCalculator}s for the
+     * service.
+     *
+     * <p>The result of these calculations may be cached.</p>
+     *
+     * @return An immutable set of active contexts
+     */
+    Set<Context> getActiveContexts();
 }

--- a/src/main/java/org/spongepowered/api/service/context/ContextualService.java
+++ b/src/main/java/org/spongepowered/api/service/context/ContextualService.java
@@ -22,35 +22,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service.permission.option;
+package org.spongepowered.api.service.context;
 
-import org.spongepowered.api.service.context.Context;
-import org.spongepowered.api.service.permission.Subject;
 
-import java.util.Optional;
-import java.util.Set;
-
-public interface OptionSubject extends Subject {
-    @Override
-    OptionSubjectData getSubjectData();
-
-    @Override
-    OptionSubjectData getTransientSubjectData();
+public interface ContextualService<T extends Contextual> {
 
     /**
-     * Get the value of a given option in the given context.
+     * Register a function that calculates {@link Context}s relevant to a 
+     * {@link Contextual} given at the time the function is called.
      *
-     * @param contexts The contexts to get the options from
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
+     * @param calculator The context calculator to register
      */
-    Optional<String> getOption(Set<Context> contexts, String key);
-
-    /**
-     * Get the value of a given option in the subject's current context
-     *
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
-     */
-    Optional<String> getOption(String key);
+    void registerContextCalculator(ContextCalculator<T> calculator);
 }

--- a/src/main/java/org/spongepowered/api/service/economy/Currency.java
+++ b/src/main/java/org/spongepowered/api/service/economy/Currency.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.economy;
+
+import org.spongepowered.api.text.Text;
+
+import java.math.BigDecimal;
+
+/**
+ * Represents a form of currency. At least one type of currency is always supported.
+ * Depending on the provider of the {@link EconomyService}, more currencies may be available.
+ */
+public interface Currency {
+
+    /**
+     * The currency's display name, in singular form. Ex: Dollar.
+     *
+     * @return displayName of the currency singular
+     */
+    Text getDisplayName();
+
+    /**
+     * The currency's display name in plural form. Ex: Dollars.
+     *
+     * <p>Not all currencies will have a plural name that differs from the
+     * display name.</p>
+     *
+     * @return displayName of the currency plural
+     */
+    Text getPluralDisplayName();
+
+    /**
+     * The currency's symbol. Ex. $
+     *
+     * @return symbol of the currency
+     */
+    Text getSymbol();
+
+    /**
+     * Formats the given amount using the default number of fractional digits.
+     *
+     * <p>Should include the symbol if it is present</p>
+     *
+     * @param amount to format
+     * @return String formatted amount
+     */
+    Text format(BigDecimal amount);
+
+    /**
+     * Formats the given amount using the specified number of fractional digits.
+     *
+     *  <p>Should include the symbol if it is present</p>
+     *
+     * @param amount
+     * @param numFractionDigits
+     * @return String formatted amount.
+     */
+    Text format(BigDecimal amount, int numFractionDigits);
+
+    /**
+     * This is the default number of fractional digits that is utilized for
+     * formatting purposes.
+     *
+     * @return defaultFractionDigits utilized.
+     */
+    int getDefaultFractionDigits();
+
+    /**
+     * Returns true if this currency is the default currency for the economy,
+     * otherwise false.
+     *
+     * @return true if this is the default currency
+     */
+    boolean isDefault();
+
+}

--- a/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
+++ b/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.economy;
+
+import org.spongepowered.api.service.context.ContextualService;
+import org.spongepowered.api.service.economy.account.Account;
+import org.spongepowered.api.service.economy.account.UserAccount;
+import org.spongepowered.api.service.economy.account.VirtualAccount;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Represents a service for managing a server economy.
+ *
+ * <p>Unlike other services provided by the API, the economy service
+ * does **not** have an implementation registered by default. Since Vanilla has
+ * no concept of economy, the economy service implementation must always be
+ * provided by a plugin. This service exists to provide a common API which
+ * can be used by implementors and consumers.</p>
+ */
+public interface EconomyService extends ContextualService<Account> {
+
+    /**
+     * Retrieves the default {@link Currency} used by the {@link EconomyService}.
+     *
+     * @return {@link Currency} default for the EconomyService
+     *
+     * @see Currency
+     */
+    Currency getDefaultCurrency();
+
+    /**
+     * Returns the {@link Collection} of supported {@link Currency} objects that are
+     * implemented by this EconomyService.
+     *
+     * <p>The collection returned is only a view of all currencies available in the
+     * EconomyService. Attempting to inject new currencies may or may not work and
+     * may cause an exception to be raised depending on implementation.</p>
+     *
+     * @return Collection of all Currencies
+     */
+    Collection<Currency> getCurrencies();
+
+    /**
+     * Gets the {@link UserAccount} with the specified {@link UUID}, if available.
+     *
+     * @param uuid The {@link UUID} of the account to get
+     * @return The {@link UserAccount}, if available.
+     */
+    Optional<UserAccount> getAccount(UUID uuid);
+
+    /**
+     * Attempts to create a {@link UserAccount} for the user with the specified {@link UUID}.
+     *
+     * <p>If an account already exists for the user with the specified {@link UUID}, it will be
+     * returned. No further action will be taken.</p>
+     *
+     * <p>Creation may fail if the provided {@link UUID} does not correspond to an actual
+     * player, or for an implementation-defined reason.</p>
+     *
+     * @param uuid The {@link UUID} of the account to create.
+     * @return The created {@link UserAccount}, if available.
+     */
+    Optional<UserAccount> createAccount(UUID uuid);
+
+    /**
+     * Gets the {@link VirtualAccount} with the specified identifier, if available.
+     *
+     * @param identifier The identifier of the account to get
+     * @return The {@link VirtualAccount}, if available.
+     */
+    Optional<VirtualAccount> getVirtualAccount(String identifier);
+
+    /**
+     * Attempts to create a {@link VirtualAccount} with the specified identifier
+     *
+     * <p>If an account already exists with the specified identifier, it will be
+     * returned. No further action will be taken.</p>
+     *
+     * <p>Creation may fail for an implementation-defined reason.</p>
+     *
+     * @param identifier The identifier of the account to create.
+     * @return The created {@link VirtualAccount}, if available.
+     */
+    Optional<VirtualAccount> createVirtualAccount(String identifier);
+}

--- a/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
+++ b/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
@@ -91,12 +91,15 @@ public interface EconomyService extends ContextualService<Account> {
     Optional<UniqueAccount> createAccount(UUID uuid);
 
     /**
-     * Gets the {@link VirtualAccount} with the specified identifier, if available.
+     * Gets the {@link Account} with the specified identifier, if available.
+     *
+     * <p>The returned {@link Account} may be a {@link UniqueAccount} or
+     * a {@link VirtualAccount}, depending on the implementation.</p>
      *
      * @param identifier The identifier of the account to get
      * @return The {@link VirtualAccount}, if available.
      */
-    Optional<VirtualAccount> getVirtualAccount(String identifier);
+    Optional<Account> getAccount(String identifier);
 
     /**
      * Attempts to create a {@link VirtualAccount} with the specified identifier

--- a/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
+++ b/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
@@ -26,7 +26,7 @@ package org.spongepowered.api.service.economy;
 
 import org.spongepowered.api.service.context.ContextualService;
 import org.spongepowered.api.service.economy.account.Account;
-import org.spongepowered.api.service.economy.account.UserAccount;
+import org.spongepowered.api.service.economy.account.UniqueAccount;
 import org.spongepowered.api.service.economy.account.VirtualAccount;
 
 import java.util.Collection;
@@ -66,26 +66,26 @@ public interface EconomyService extends ContextualService<Account> {
     Collection<Currency> getCurrencies();
 
     /**
-     * Gets the {@link UserAccount} with the specified {@link UUID}, if available.
+     * Gets the {@link UniqueAccount} with the specified {@link UUID}, if available.
      *
      * @param uuid The {@link UUID} of the account to get
-     * @return The {@link UserAccount}, if available.
+     * @return The {@link UniqueAccount}, if available.
      */
-    Optional<UserAccount> getAccount(UUID uuid);
+    Optional<UniqueAccount> getAccount(UUID uuid);
 
     /**
-     * Attempts to create a {@link UserAccount} for the user with the specified {@link UUID}.
+     * Attempts to create a {@link UniqueAccount} for the user with the specified {@link UUID}.
      *
-     * <p>If an account already exists for the user with the specified {@link UUID}, it will be
+     * <p>If an account already exists with the specified {@link UUID}, it will be
      * returned. No further action will be taken.</p>
      *
-     * <p>Creation may fail if the provided {@link UUID} does not correspond to an actual
+     * <p>Creation might fail if the provided {@link UUID} does not correspond to an actual
      * player, or for an implementation-defined reason.</p>
      *
      * @param uuid The {@link UUID} of the account to create.
-     * @return The created {@link UserAccount}, if available.
+     * @return The created {@link UniqueAccount}, if available.
      */
-    Optional<UserAccount> createAccount(UUID uuid);
+    Optional<UniqueAccount> createAccount(UUID uuid);
 
     /**
      * Gets the {@link VirtualAccount} with the specified identifier, if available.

--- a/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
+++ b/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
@@ -31,6 +31,7 @@ import org.spongepowered.api.service.economy.account.VirtualAccount;
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -54,16 +55,18 @@ public interface EconomyService extends ContextualService<Account> {
     Currency getDefaultCurrency();
 
     /**
-     * Returns the {@link Collection} of supported {@link Currency} objects that are
+     * Returns the {@link Set} of supported {@link Currency} objects that are
      * implemented by this EconomyService.
      *
-     * <p>The collection returned is only a view of all currencies available in the
-     * EconomyService. Attempting to inject new currencies may or may not work and
-     * may cause an exception to be raised depending on implementation.</p>
+     * <p>The economy service provider may only support one currency, in which case
+     * {@link #getDefaultCurrency()} will be the only member of the set.</p>
      *
-     * @return Collection of all Currencies
+     * <p>The set returned is a read-only a view of all currencies available in the
+     * EconomyService.</p>
+     *
+     * @return The {@link Set} of all {@link Currency}s
      */
-    Collection<Currency> getCurrencies();
+    Set<Currency> getCurrencies();
 
     /**
      * Gets the {@link UniqueAccount} with the specified {@link UUID}, if available.

--- a/src/main/java/org/spongepowered/api/service/economy/account/Account.java
+++ b/src/main/java/org/spongepowered/api/service/economy/account/Account.java
@@ -44,10 +44,9 @@ import org.spongepowered.api.text.Text;
 /**
  * Represents an account, which stores amounts of various {@link Currency currencies}.
  *
- * <p>Accounts come in two varieties: {@link UserAccount user accounts} and {@link VirtualAccount} virtual accounts.
+ * <p>Accounts come in two varieties: {@link UniqueAccount user accounts} and {@link VirtualAccount} virtual accounts.
  *
- * User account's are bound to the {@link UUID} of a particular {@link User}'s {@link GameProfile}.
- * They persist across name changes for the user.
+ * Unique accounts are bound to a {@link UUID}, usually of a particular {@link User}'s {@link GameProfile}.
  *
  * Virtual accounts are identified by a String identifier, which may have any value. They are
  * not tied to any {@link Entity}, player or otherwise. Virtual accounts may be used for purposes
@@ -59,7 +58,7 @@ public interface Account extends Contextual {
      * Gets the display name for this account.
      *
      * <p>This should be used by plugins to get a human-readable name for an
-     * account, regardless of the specific type ({@link UserAccount} or
+     * account, regardless of the specific type ({@link UniqueAccount} or
      * {@link VirtualAccount}).</p>
      *
      * <p>Its contents are dependent on the provider of {@link EconomyService}.

--- a/src/main/java/org/spongepowered/api/service/economy/account/Account.java
+++ b/src/main/java/org/spongepowered/api/service/economy/account/Account.java
@@ -1,0 +1,359 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.economy.account;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.profile.GameProfile;
+import org.spongepowered.api.service.context.Context;
+import org.spongepowered.api.service.context.Contextual;
+import org.spongepowered.api.service.economy.Currency;
+import org.spongepowered.api.service.economy.EconomyService;
+import org.spongepowered.api.service.economy.transaction.TransactionResult;
+import org.spongepowered.api.service.economy.transaction.TransferResult;
+import org.spongepowered.api.text.Text;
+
+/**
+ * Represents an account, which stores amounts of various {@link Currency currencies}.
+ *
+ * <p>Accounts come in two varieties: {@link UserAccount user accounts} and {@link VirtualAccount} virtual accounts.
+ *
+ * User account's are bound to the {@link UUID} of a particular {@link User}'s {@link GameProfile}.
+ * They persist across name changes for the user.
+ *
+ * Virtual accounts are identified by a String identifier, which may have any value. They are
+ * not tied to any {@link Entity}, player or otherwise. Virtual accounts may be used for purposes
+ * such as bank accounts, non-player {@link Entity} accounts, or other things.</p>
+ */
+public interface Account extends Contextual {
+
+    /**
+     * Gets the display name for this account.
+     *
+     * <p>This should be used by plugins to get a human-readable name for an
+     * account, regardless of the specific type ({@link UserAccount} or
+     * {@link VirtualAccount}).</p>
+     *
+     * <p>Its contents are dependent on the provider of {@link EconomyService}.
+     * For example, an economy plugin could allow players to configure the
+     * display name of their account</p>.
+     *
+     * @return the display name for this account.
+     */
+    Text getDisplayName();
+
+    /**
+     * Gets the default balance of this account for the specified
+     * {@link Currency}.
+     *
+     * <p>The default balance is used when the balance is retrieved for the
+     * first time for a given {@link Currency} on this account, or if no
+     * balance is available for the {@link Context}s used when retrieving
+     * a balance.</p>
+     *
+     * @param currency the currency to get the default balance for.
+     * @return The default balance for the specified {@link Currency}.
+     */
+    BigDecimal getDefaultBalance(Currency currency);
+
+    /**
+     * Returns whether this account has a set balance for the specified
+     * {@link Currency}, with the specified {@link Context}s.
+     *
+     * <p>If this method returns <code>false</code>, then {@link #getDefaultBalance(Currency)}
+     * will be used when retrieving a balance for the specifid {@link Currency} with
+     * the specified {@link Context}s.</p>
+     *
+     * @param currency The {@link Currency} to determine if a balance is set for.
+     * @param contexts The {@link Context}s to use with the {@link Currency}.
+     * @return Whether this account has a set balance for the speicified {@link Currency} and {@link Context}s
+     */
+    boolean hasBalance(Currency currency, Set<Context> contexts);
+
+    /**
+     * Returns whether this account has a set balance for the specified
+     * {@link Currency}, with the current active contexts.
+     *
+     * <p>If this method returns <code>false</code>, then {@link #getDefaultBalance(Currency)}
+     * will be used when retrieving a balance for the specifid {@link Currency} with the
+     * current active contexts</p>.
+     *
+     * @param currency The {@link Currency} to determine if a balance is set for.
+     * @return Whether this account has a set balance for the speicified {@link Currency} and current active contexts.
+     */
+    default boolean hasBalance(Currency currency) {
+        return this.hasBalance(currency, this.getActiveContexts());
+    }
+
+    /**
+     * Returns a {@link BigDecimal} representative of the balance stored within this
+     * {@link Account} for the {@link Currency} given and the set of {@link Context}s.
+     *
+     * <p>The default result when the account does not have a balance of the given
+     * {@link Currency} should be {@link BigDecimal#ZERO}.</p>
+     *
+     * <p>The balance may be unavailable depending on the set of {@link Context}s used.</p>
+     *
+     * @param currency a {@link Currency} to check the balance of
+     * @param contexts a set of contexts to check the balance against
+     *
+     * @return he value for the specified {@link Currency} with the specified {@link Context}s.
+     */
+    BigDecimal getBalance(Currency currency, Set<Context> contexts);
+
+    /**
+     * Returns a {@link BigDecimal} representative of the balance stored within this
+     * {@link Account} for the {@link Currency} given, with the current active contexts.
+     *
+     * <p>The default result when the account does not have a balance of the given
+     * {@link Currency} will be {@link #getDefaultBalance(Currency)}.</p>
+     *
+     * @param currency a {@link Currency} to check the balance of
+     *
+     * @return the value for the specified {@link Currency}.
+     */
+    default BigDecimal getBalance(Currency currency) {
+        return this.getBalance(currency, this.getActiveContexts());
+    }
+
+    /**
+     * Returns a {@link Map} of all currently set balances the account holds within
+     * the set of {@link Context}s.
+     *
+     * <p>Amounts may differ depending on the {@link Context}s specified and
+     * the implementation. The set of {@link Context}s may be empty.</p>
+     *
+     * <p>{@link Currency} amounts which are 0 may or may not be included in the
+     * returned mapping.</p>
+     *
+     * <p>Changes to the returned {@link Map} will not be reflected in the underlying
+     * {@link Account}.
+     * See {@link #setBalance(Currency, BigDecimal, Cause, Set)}  to set values.</p>
+     *
+     * @param contexts the set of {@link Context}s to use with the speciied amounts.
+     *
+     * @return {@link Map} of {@link Currency} to {@link BigDecimal} amounts that this
+     *         account holds.
+     */
+    Map<Currency, BigDecimal> getBalances(Set<Context> contexts);
+
+    /**
+     * Returns a {@link Map} of all currently set balances the account holds within
+     * the current active {@link Context}s.2
+     *
+     * <p>Amounts may differ depending on the {@link Context}s specified and
+     * the implementation. The set of {@link Context}s may be empty.</p>
+     *
+     * <p>{@link Currency} amounts which are 0 may or may not be included in the
+     * returned mapping.</p>
+     *
+     * <p>Changes to the returned {@link Map} will not be reflected in the underlying
+     * {@link Account} and may result in runtime exceptions depending on implementation.
+     * See {@link #setBalance(Currency, BigDecimal, Cause, Set)}  to set values.</p>
+     *
+     * @return {@link Map} of {@link Currency} to {@link BigDecimal} amounts that this
+     *         account holds.
+     */
+    default Map<Currency, BigDecimal> getBalances() {
+        return this.getBalances(this.getActiveContexts());
+    }
+
+    /**
+     * Sets the balance for this account to the specified amount for the specified
+     * {@link Currency}, with the specified set of {@link Context}s.
+     *
+     * <p>Negative balances may or may not be supported depending on
+     * the {@link Currency} specified and the implementation.</p>
+     *
+     * @param currency The {@link Currency} to set the balance for
+     * @param amount The amount to set for the specified {@link Currency}
+     * @param cause The {@link Cause} for the transaction
+     * @param contexts The set of {@link Context}s to use with the specified {@link Currency}
+     *
+     * @return The result of the transaction
+     */
+    TransactionResult setBalance(Currency currency, BigDecimal amount, Cause cause, Set<Context> contexts);
+
+    /**
+     * Sets the balance for this account to the specified amount for the specified
+     * {@link Currency}, with the current active {@link Context}s.
+     *
+     * <p>Negative balances may or may not be supported depending on
+     * the {@link Currency} specified and the implementation.</p>
+     *
+     * @param currency The {@link Currency} to set the balance for
+     * @param amount The amount to set for the specified {@link Currency}
+     * @param cause The {@link Cause} for the transaction
+     * @return The result of the transaction
+     */
+    default TransactionResult setBalance(Currency currency, BigDecimal amount, Cause cause) {
+        return this.setBalance(currency, amount, cause, this.getActiveContexts());
+    }
+
+    /**
+     * Resets the balances for all {@link Currency}s used on this account to their
+     * default values ({@link #getDefaultBalance(Currency)}), using the specified {@link Context}s.
+     *
+     * @param cause The {@link Cause} for the transaction
+     * @param contexts the {@link Context}s to use when resetting the balances.
+     *
+     * @return The result of the transaction
+     */
+    TransactionResult resetBalances(Cause cause, Set<Context> contexts);
+
+    /**
+     * Resets the balances for all {@link Currency}s used on this account to their
+     * default values ({@link #getDefaultBalance(Currency)}), using the current active {@link Context}
+     *
+     * @param cause The {@link Cause} for the transaction
+     *
+     * @return The result of the transaction
+     */
+    default TransactionResult resetBalances(Cause cause) {
+        return this.resetBalances(cause, this.getActiveContexts());
+    }
+
+    /**
+     * Resets the balance for the specified {@link Currency} to its default value
+     * ({@link #getDefaultBalance(Currency)}), using the specified {@link Context}s.
+     *
+     * @param currency The {@link Currency} to reset the balance for
+     * @param cause The {@link Cause} for the transaction
+     * @param contexts The {@link Context}s to use when resetting the balance
+     *
+     * @return The result of the transaction
+     */
+    TransactionResult resetBalance(Currency currency, Cause cause, Set<Context> contexts);
+
+    /**
+     * Resets the balance for the specified {@link Currency} to its default value
+     * ({@link #getDefaultBalance(Currency)}), using the current active {@link Context}s.
+     *
+     * @param currency The {@link Currency} to reset the balance for
+     * @param cause The {@link Cause} for the transaction
+     *
+     * @return The result of the transaction
+     */
+    default TransactionResult resetBalance(Currency currency, Cause cause) {
+        return this.resetBalance(currency, cause, this.getActiveContexts());
+    }
+
+    /**
+     * Deposits the specified amount of the specified {@link Currency} to this account,
+     * using the specified {@link Context}s.
+     *
+     * @param currency The {@link Currency} to deposit the specified amount for
+     * @param amount The amount to deposit for the specified {@link Currency}.
+     * @param cause The {@link Cause} for the transaction
+     * @param contexts the {@link Context}s to use with the specified {@link Currency}
+     *
+     * @return The result of the transaction
+     */
+    TransactionResult deposit(Currency currency, BigDecimal amount, Cause cause, Set<Context> contexts);
+
+    /**
+     * Deposits the given amount of the specified {@link Currency} to this account,
+     * using the current active {@link Context}s.
+     *
+     * @param currency The {@link Currency} to deposit the specified amount for
+     * @param amount The amount to deposit for the specified {@link Currency}.
+     * @param cause The {@link Cause} for the transaction
+     *
+     * @return The result of the transaction
+     */
+    default TransactionResult deposit(Currency currency, BigDecimal amount, Cause cause) {
+        return this.deposit(currency, amount, cause, this.getActiveContexts());
+    }
+
+    /**
+     * Withdraws the specified amount of the specified {@link Currency} from this account,
+     * using the specified {@link Context}s.
+     *
+     * @param currency The {@link Currency} to deposit the specifie amount for
+     * @param amount The amount to deposit for the specified {@link Currency}
+     * @param cause The {@link Cause} for the transaction
+     * @param contexts The {@link Context}s to use with the specified {@link Currency}
+     *
+     * @return The result of the transaction
+     */
+    TransactionResult withdraw(Currency currency, BigDecimal amount, Cause cause, Set<Context> contexts);
+
+    /**
+     * Withdraws the specified amount of the specified {@link Currency} from this account,
+     * using the current active {@link Context}s.
+     *
+     * @param currency The {@link Currency} to deposit the specified amount for
+     * @param amount The amount to deposit for the specified {@link Currency}
+     * @param cause The {@link Cause} for the transaction
+     *
+     * @return The result of the transaction
+     */
+    default TransactionResult withdraw(Currency currency, BigDecimal amount, Cause cause) {
+        return this.withdraw(currency, amount, cause, this.getActiveContexts());
+    }
+
+    /**
+     * Transfers the specified amount of the specified {@link Currency} from this account
+     * the destination account, using the specified {@link Context}s.
+     *
+     * <p>This operation is a merged {@link #withdraw(Currency, BigDecimal, Cause, Set)}  from this account
+     * with a {@link #deposit(Currency, BigDecimal, Cause, Set)}  into the specified account.</p>
+     *
+     * @param to the Account to transfer the amounts to.
+     * @param currency The {@link Currency} to transfer the specified amount for
+     * @param amount The amount to transfer for the specified {@link Currency}
+     * @param cause The {@link Cause} for the transaction
+     * @param contexts The {@link Context}s to use with the specified {@link Currency} and account
+     *
+     * @return a {@link TransferResult} representative of the effects of the
+     *         operation
+     */
+    TransferResult transfer(Account to, Currency currency, BigDecimal amount, Cause cause, Set<Context> contexts);
+
+    /**
+     * Transfers the specified amount of the specified {@link Currency} from this account
+     * the destination account, using the current active {@link Context}s.
+     *
+     * <p>This operation is a merged {@link #withdraw(Currency, BigDecimal, Cause, Set)} from this account
+     * with a {@link #deposit(Currency, BigDecimal, Cause, Set)} into the specified account.</p>
+     *
+     * @param to the Account to transfer the amounts to.
+     * @param currency The {@link Currency} to transfer the specified amount for
+     * @param amount The amount to transfer for the specified {@link Currency}
+     * @param cause The {@link Cause} for the transaction
+     *
+     * @return a {@link TransferResult} representative of the effects of the
+     *         operation
+     */
+    default TransferResult transfer(Account to, Currency currency, BigDecimal amount, Cause cause) {
+        return this.transfer(to, currency, amount, cause, this.getActiveContexts());
+    }
+}

--- a/src/main/java/org/spongepowered/api/service/economy/account/UniqueAccount.java
+++ b/src/main/java/org/spongepowered/api/service/economy/account/UniqueAccount.java
@@ -30,10 +30,12 @@ import org.spongepowered.api.profile.GameProfile;
 import java.util.UUID;
 
 /**
- * Represents an {@link Account} which is linked to a particular {@link User}'s {@link GameProfile},
- * through a UUID.
+ * Represents an {@link Account} identified by a {@link UUID}.
+ *
+ * <p>This is usually linked to a particular {@link User}'s {@link GameProfile},
+ * through the {@link UUID}</p>.
  */
-public interface UserAccount extends Account {
+public interface UniqueAccount extends Account {
 
     /**
      * Gets the UUID of the associated {@link User}.

--- a/src/main/java/org/spongepowered/api/service/economy/account/UserAccount.java
+++ b/src/main/java/org/spongepowered/api/service/economy/account/UserAccount.java
@@ -22,35 +22,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service.permission.option;
+package org.spongepowered.api.service.economy.account;
 
-import org.spongepowered.api.service.context.Context;
-import org.spongepowered.api.service.permission.Subject;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.profile.GameProfile;
 
-import java.util.Optional;
-import java.util.Set;
+import java.util.UUID;
 
-public interface OptionSubject extends Subject {
-    @Override
-    OptionSubjectData getSubjectData();
-
-    @Override
-    OptionSubjectData getTransientSubjectData();
+/**
+ * Represents an {@link Account} which is linked to a particular {@link User}'s {@link GameProfile},
+ * through a UUID.
+ */
+public interface UserAccount extends Account {
 
     /**
-     * Get the value of a given option in the given context.
+     * Gets the UUID of the associated {@link User}.
      *
-     * @param contexts The contexts to get the options from
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
+     * @return The uuid
      */
-    Optional<String> getOption(Set<Context> contexts, String key);
+    UUID getUUID();
 
-    /**
-     * Get the value of a given option in the subject's current context
-     *
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
-     */
-    Optional<String> getOption(String key);
 }

--- a/src/main/java/org/spongepowered/api/service/economy/account/VirtualAccount.java
+++ b/src/main/java/org/spongepowered/api/service/economy/account/VirtualAccount.java
@@ -22,35 +22,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service.permission.option;
+package org.spongepowered.api.service.economy.account;
 
-import org.spongepowered.api.service.context.Context;
-import org.spongepowered.api.service.permission.Subject;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.player.User;
 
-import java.util.Optional;
-import java.util.Set;
+/**
+ * Represents an {@link Account} which is not tied to a particular {@link User}.
+ *
+ * <p>Examples of virtual accounts include:
+ *   * A global server account
+ *   * A 'bank account', shared among multiple users
+ *   * A account for a non-player {@link Entity}.
+ *  </p>
+ */
+public interface VirtualAccount extends Account {
 
-public interface OptionSubject extends Subject {
-    @Override
-    OptionSubjectData getSubjectData();
-
-    @Override
-    OptionSubjectData getTransientSubjectData();
-
-    /**
-     * Get the value of a given option in the given context.
-     *
-     * @param contexts The contexts to get the options from
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
-     */
-    Optional<String> getOption(Set<Context> contexts, String key);
-
-    /**
-     * Get the value of a given option in the subject's current context
-     *
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
-     */
-    Optional<String> getOption(String key);
 }

--- a/src/main/java/org/spongepowered/api/service/economy/package-info.java
+++ b/src/main/java/org/spongepowered/api/service/economy/package-info.java
@@ -22,35 +22,4 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service.permission.option;
-
-import org.spongepowered.api.service.context.Context;
-import org.spongepowered.api.service.permission.Subject;
-
-import java.util.Optional;
-import java.util.Set;
-
-public interface OptionSubject extends Subject {
-    @Override
-    OptionSubjectData getSubjectData();
-
-    @Override
-    OptionSubjectData getTransientSubjectData();
-
-    /**
-     * Get the value of a given option in the given context.
-     *
-     * @param contexts The contexts to get the options from
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
-     */
-    Optional<String> getOption(Set<Context> contexts, String key);
-
-    /**
-     * Get the value of a given option in the subject's current context
-     *
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
-     */
-    Optional<String> getOption(String key);
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.service.economy;

--- a/src/main/java/org/spongepowered/api/service/economy/transaction/ResultType.java
+++ b/src/main/java/org/spongepowered/api/service/economy/transaction/ResultType.java
@@ -22,35 +22,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service.permission.option;
+package org.spongepowered.api.service.economy.transaction;
 
 import org.spongepowered.api.service.context.Context;
-import org.spongepowered.api.service.permission.Subject;
 
-import java.util.Optional;
-import java.util.Set;
-
-public interface OptionSubject extends Subject {
-    @Override
-    OptionSubjectData getSubjectData();
-
-    @Override
-    OptionSubjectData getTransientSubjectData();
+/**
+ * Represents the success or failure state of a {@link TransactionResult}.
+ */
+public enum ResultType {
 
     /**
-     * Get the value of a given option in the given context.
-     *
-     * @param contexts The contexts to get the options from
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
+     * Transaction finished with no errors
      */
-    Optional<String> getOption(Set<Context> contexts, String key);
+    SUCCESS,
 
     /**
-     * Get the value of a given option in the subject's current context
-     *
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
+     * The transaction attempt resulted in a difference in {@link Context}s.
      */
-    Optional<String> getOption(String key);
+    CONTEXT_MISMATCH,
+
+    /**
+     * The transaction failed for an unspecific reason.
+     */
+    FAILED,
+
+    /**
+     * The account did not have enough funds requested.
+     */
+    ACCOUNT_NO_FUNDS,
+
+    /**
+     * The account would be put past it's maximum capacity, so the transaction failed.
+     *
+     */
+    ACCOUNT_NO_SPACE
 }

--- a/src/main/java/org/spongepowered/api/service/economy/transaction/ResultType.java
+++ b/src/main/java/org/spongepowered/api/service/economy/transaction/ResultType.java
@@ -53,7 +53,6 @@ public enum ResultType {
 
     /**
      * The account would be put past it's maximum capacity, so the transaction failed.
-     *
      */
     ACCOUNT_NO_SPACE
 }

--- a/src/main/java/org/spongepowered/api/service/economy/transaction/TransactionResult.java
+++ b/src/main/java/org/spongepowered/api/service/economy/transaction/TransactionResult.java
@@ -22,35 +22,60 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service.permission.option;
+package org.spongepowered.api.service.economy.transaction;
 
 import org.spongepowered.api.service.context.Context;
-import org.spongepowered.api.service.permission.Subject;
+import org.spongepowered.api.service.economy.Currency;
+import org.spongepowered.api.service.economy.account.Account;
 
-import java.util.Optional;
+import java.math.BigDecimal;
 import java.util.Set;
 
-public interface OptionSubject extends Subject {
-    @Override
-    OptionSubjectData getSubjectData();
-
-    @Override
-    OptionSubjectData getTransientSubjectData();
-
-    /**
-     * Get the value of a given option in the given context.
-     *
-     * @param contexts The contexts to get the options from
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
-     */
-    Optional<String> getOption(Set<Context> contexts, String key);
+/**
+ * Represents the result of a particular transaction, such as a deposit
+ * or withdrawal.
+ */
+public interface TransactionResult {
 
     /**
-     * Get the value of a given option in the subject's current context
+     * Gets the {@link Account} involved in the transaction.
      *
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
+     * @return The {@link Account}
      */
-    Optional<String> getOption(String key);
+    Account getAccount();
+
+    /**
+     * Gets the {@link Currency} involved in the transaction.
+     *
+     * @return The {@link Currency}
+     */
+    Currency getCurrency();
+
+    /**
+     * Gets the amount of the {@link Currency} involved in the transaction.
+     *
+     * @return The amount
+     */
+    BigDecimal getAmount();
+
+    /**
+     * Returns the set of {@link Context}s used to perform the
+     * transaction.
+     *
+     * @return optional set of contexts
+     */
+    Set<Context> getContexts();
+
+    /**
+     * Get the {@link ResultType} of this transaction
+     * @return resultType
+     */
+    ResultType getResult();
+
+    /**
+     * Returns the {@link TransactionType} of this result
+     *
+     * @return type of Transaction
+     */
+    TransactionType getType();
 }

--- a/src/main/java/org/spongepowered/api/service/economy/transaction/TransactionType.java
+++ b/src/main/java/org/spongepowered/api/service/economy/transaction/TransactionType.java
@@ -22,35 +22,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service.permission.option;
+package org.spongepowered.api.service.economy.transaction;
 
-import org.spongepowered.api.service.context.Context;
-import org.spongepowered.api.service.permission.Subject;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
-import java.util.Optional;
-import java.util.Set;
+/**
+ * Represents the type of a transaction.
+ */
+@CatalogedBy(TransactionTypes.class)
+public interface TransactionType extends CatalogType {
 
-public interface OptionSubject extends Subject {
-    @Override
-    OptionSubjectData getSubjectData();
-
-    @Override
-    OptionSubjectData getTransientSubjectData();
-
-    /**
-     * Get the value of a given option in the given context.
-     *
-     * @param contexts The contexts to get the options from
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
-     */
-    Optional<String> getOption(Set<Context> contexts, String key);
-
-    /**
-     * Get the value of a given option in the subject's current context
-     *
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
-     */
-    Optional<String> getOption(String key);
 }

--- a/src/main/java/org/spongepowered/api/service/economy/transaction/TransactionTypes.java
+++ b/src/main/java/org/spongepowered/api/service/economy/transaction/TransactionTypes.java
@@ -22,35 +22,29 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service.permission.option;
+package org.spongepowered.api.service.economy.transaction;
 
-import org.spongepowered.api.service.context.Context;
-import org.spongepowered.api.service.permission.Subject;
+import org.spongepowered.api.service.economy.Currency;
+import org.spongepowered.api.service.economy.account.Account;
 
-import java.util.Optional;
-import java.util.Set;
-
-public interface OptionSubject extends Subject {
-    @Override
-    OptionSubjectData getSubjectData();
-
-    @Override
-    OptionSubjectData getTransientSubjectData();
+public final class TransactionTypes {
 
     /**
-     * Get the value of a given option in the given context.
-     *
-     * @param contexts The contexts to get the options from
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
+     * Represents a transaction where an {@link Account} received some amount of a {@link Currency}.
      */
-    Optional<String> getOption(Set<Context> contexts, String key);
+    public static final TransactionType DEPOSIT = null;
 
     /**
-     * Get the value of a given option in the subject's current context
-     *
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
+     * Represents a transaction where an {@link Account} lost some amount of a {@link Currency}.
      */
-    Optional<String> getOption(String key);
+    public static final TransactionType WITHDRAW = null;
+
+    /**
+     * Represents a transaction where an {@link Account} transferred some amount of a currency to another {@link Account}.
+     */
+    public static final TransactionType TRANSFER = null;
+
+    private TransactionTypes() {
+    }
+
 }

--- a/src/main/java/org/spongepowered/api/service/economy/transaction/TransferResult.java
+++ b/src/main/java/org/spongepowered/api/service/economy/transaction/TransferResult.java
@@ -22,35 +22,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service.permission.option;
+package org.spongepowered.api.service.economy.transaction;
 
-import org.spongepowered.api.service.context.Context;
-import org.spongepowered.api.service.permission.Subject;
+import org.spongepowered.api.service.economy.Currency;
+import org.spongepowered.api.service.economy.account.Account;
 
-import java.util.Optional;
-import java.util.Set;
-
-public interface OptionSubject extends Subject {
-    @Override
-    OptionSubjectData getSubjectData();
-
-    @Override
-    OptionSubjectData getTransientSubjectData();
+/**
+ * Represents a {@link TransactionResult} specific to a transaction
+ * of type {@link TransactionTypes#TRANSFER}.
+ */
+public interface TransferResult extends TransactionResult {
 
     /**
-     * Get the value of a given option in the given context.
+     * Gets the {@link Account} that an amount of a {@link Currency} is being transferred to.
      *
-     * @param contexts The contexts to get the options from
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
+     * <p>{@link #getAccount()} can be used to get the {@link Account} that the currency
+     * is being transferred from.</p>
+     *
+     * @return The {@link Account}
      */
-    Optional<String> getOption(Set<Context> contexts, String key);
+    Account getAccountTo();
 
-    /**
-     * Get the value of a given option in the subject's current context
-     *
-     * @param key The key to get an option by. Case-insensitive.
-     * @return The value of the option, if any is present
-     */
-    Optional<String> getOption(String key);
 }

--- a/src/main/java/org/spongepowered/api/service/permission/MemorySubjectData.java
+++ b/src/main/java/org/spongepowered/api/service/permission/MemorySubjectData.java
@@ -30,7 +30,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import org.spongepowered.api.service.permission.context.Context;
+
+import org.spongepowered.api.service.context.Context;
 import org.spongepowered.api.service.permission.option.OptionSubjectData;
 import org.spongepowered.api.util.Tristate;
 

--- a/src/main/java/org/spongepowered/api/service/permission/PermissionService.java
+++ b/src/main/java/org/spongepowered/api/service/permission/PermissionService.java
@@ -24,7 +24,8 @@
  */
 package org.spongepowered.api.service.permission;
 
-import org.spongepowered.api.service.permission.context.ContextCalculator;
+import org.spongepowered.api.service.context.ContextCalculator;
+import org.spongepowered.api.service.context.ContextualService;
 
 import java.util.Collection;
 import java.util.Map;
@@ -35,7 +36,7 @@ import java.util.Optional;
  * Represents a provider for permissions. This is the interface that a
  * permissions plugin must implement to provide permissions for a user.
  */
-public interface PermissionService {
+public interface PermissionService extends ContextualService<Subject> {
 
     String SUBJECTS_USER = "user";
     String SUBJECTS_GROUP = "group";
@@ -82,14 +83,6 @@ public interface PermissionService {
      * @return The known subjects for this map
      */
     Map<String, SubjectCollection> getKnownSubjects();
-
-    /**
-     * Register a function that calculates contexts relevant to a given user at
-     * the time the function is called.
-     *
-     * @param calculator The context calculator to register
-     */
-    void registerContextCalculator(ContextCalculator calculator);
 
     /**
      * Creates a new description builder for the given plugin's permission. May

--- a/src/main/java/org/spongepowered/api/service/permission/Subject.java
+++ b/src/main/java/org/spongepowered/api/service/permission/Subject.java
@@ -24,8 +24,9 @@
  */
 package org.spongepowered.api.service.permission;
 
-import org.spongepowered.api.service.permission.context.Context;
-import org.spongepowered.api.service.permission.context.ContextCalculator;
+import org.spongepowered.api.service.context.Context;
+import org.spongepowered.api.service.context.ContextCalculator;
+import org.spongepowered.api.service.context.Contextual;
 import org.spongepowered.api.util.Tristate;
 import org.spongepowered.api.command.CommandSource;
 
@@ -63,15 +64,7 @@ import java.util.Set;
  *
  * @see PermissionService
  */
-public interface Subject {
-
-    /**
-     * Returns the identifier associated with this subject. May not be
-     * human-readable, but always refers to a single subject
-     *
-     * @return The unique identifier for this subject
-     */
-    String getIdentifier();
+public interface Subject extends Contextual {
 
     /**
      * If this subject represents an actual user currently connected, this
@@ -111,7 +104,7 @@ public interface Subject {
     /**
      * Test whether the subject is permitted to perform an action given as the
      * given permission string.
-
+     *
      * @param contexts The set of contexts that represents the subject's current environment
      * @param permission The permission string
      * @return True if permission is granted
@@ -172,13 +165,4 @@ public interface Subject {
      * @return An immutable list of parents
      */
     List<Subject> getParents(Set<Context> contexts);
-
-    /**
-     * Calculate active contexts, using the {@link ContextCalculator}s
-     * from {@link PermissionService#registerContextCalculator(ContextCalculator)}.
-     * The result of these calculations may be cached.
-     *
-     * @return An immutable set of active contexts
-     */
-    Set<Context> getActiveContexts();
 }

--- a/src/main/java/org/spongepowered/api/service/permission/SubjectCollection.java
+++ b/src/main/java/org/spongepowered/api/service/permission/SubjectCollection.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.service.permission;
 
-import org.spongepowered.api.service.permission.context.Context;
+import org.spongepowered.api.service.context.Context;
 
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/org/spongepowered/api/service/permission/SubjectData.java
+++ b/src/main/java/org/spongepowered/api/service/permission/SubjectData.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.service.permission;
 
-import org.spongepowered.api.service.permission.context.Context;
+import org.spongepowered.api.service.context.Context;
 import org.spongepowered.api.util.Tristate;
 
 import java.util.Collections;

--- a/src/main/java/org/spongepowered/api/service/permission/option/OptionSubjectData.java
+++ b/src/main/java/org/spongepowered/api/service/permission/option/OptionSubjectData.java
@@ -24,8 +24,8 @@
  */
 package org.spongepowered.api.service.permission.option;
 
+import org.spongepowered.api.service.context.Context;
 import org.spongepowered.api.service.permission.SubjectData;
-import org.spongepowered.api.service.permission.context.Context;
 
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/org/spongepowered/api/world/Dimension.java
+++ b/src/main/java/org/spongepowered/api/world/Dimension.java
@@ -24,12 +24,12 @@
  */
 package org.spongepowered.api.world;
 
-import org.spongepowered.api.service.permission.context.Contextual;
+import org.spongepowered.api.service.context.ContextSource;
 
 /**
  * Represents the dimension of a {@link World}.
  */
-public interface Dimension extends Contextual {
+public interface Dimension extends ContextSource {
 
     /**
      * Returns the name of this {@link Dimension}.

--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -28,7 +28,7 @@ import com.flowpowered.math.vector.Vector3d;
 import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.effect.Viewer;
 import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.service.permission.context.Contextual;
+import org.spongepowered.api.service.context.Contextual;
 import org.spongepowered.api.world.difficulty.Difficulty;
 import org.spongepowered.api.world.explosion.Explosion;
 import org.spongepowered.api.world.extent.Extent;


### PR DESCRIPTION
This PR adds an Economy API, to be implemented by economy plugins

Features:
* Supports multiple Currencies. Each Currency determines its display name formattig
* Supports two types of Accounts: User and Virtual
 * User accounts are bound to a User's GameProfile's UUID
 * Virtual accounts are bound to a String identifier
* Accounts support various transactions (set, deposit, withdraw, transfer)
* The balance of an Account may vary depending on the Context's that are provided
* EconomyTransactionEvent allows plugins to be notified of processed transactions. The event is fired after they occur, and is not cancellable.

Note that `Context` and related classes have been refactored out of permissions, as they are used by the Economy API as well.

This supersedes PR https://github.com/SpongePowered/SpongeAPI/pull/675