### PR TITLE
[WIP] Refactor explosion events

### DIFF
--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -4385,14 +4385,12 @@ public class SpongeEventFactory {
      * {@link org.spongepowered.api.event.world.ExplosionEvent}.
      * 
      * @param cause The cause
-     * @param explosion The explosion
      * @param targetWorld The target world
      * @return A new explosion event
      */
-    public static ExplosionEvent createExplosionEvent(Cause cause, Explosion explosion, World targetWorld) {
+    public static ExplosionEvent createExplosionEvent(Cause cause, World targetWorld) {
         HashMap<String, Object> values = new HashMap<>();
         values.put("cause", cause);
-        values.put("explosion", explosion);
         values.put("targetWorld", targetWorld);
         return SpongeEventFactoryUtils.createEventImpl(ExplosionEvent.class, values);
     }
@@ -4443,18 +4441,36 @@ public class SpongeEventFactory {
      * AUTOMATICALLY GENERATED, DO NOT EDIT.
      * Creates a new instance of
      * {@link org.spongepowered.api.event.world.ExplosionEvent.Pre}.
-     * 
+     *
      * @param cause The cause
-     * @param explosion The explosion
      * @param targetWorld The target world
      * @return A new pre explosion event
      */
-    public static ExplosionEvent.Pre createExplosionEventPre(Cause cause, Explosion explosion, World targetWorld) {
+    public static ExplosionEvent.Pre createExplosionEventPre(Cause cause, World targetWorld) {
         HashMap<String, Object> values = new HashMap<>();
         values.put("cause", cause);
-        values.put("explosion", explosion);
         values.put("targetWorld", targetWorld);
         return SpongeEventFactoryUtils.createEventImpl(ExplosionEvent.Pre.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.world.ExplosionEvent.Start}.
+     * 
+     * @param cause The cause
+     * @param originalExplosion The original explosion
+     * @param explosion The explosion
+     * @param targetWorld The target world
+     * @return A new start explosion event
+     */
+    public static ExplosionEvent.Start createExplosionEventStart(Cause cause, Explosion originalExplosion, Explosion explosion, World targetWorld) {
+        HashMap<String, Object> values = new HashMap<>();
+        values.put("cause", cause);
+        values.put("originalExplosion", originalExplosion);
+        values.put("explosion", explosion);
+        values.put("targetWorld", targetWorld);
+        return SpongeEventFactoryUtils.createEventImpl(ExplosionEvent.Start.class, values);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/event/cause/NamedCause.java
+++ b/src/main/java/org/spongepowered/api/event/cause/NamedCause.java
@@ -53,6 +53,10 @@ public final class NamedCause {
     public static final String THROWER = "Thrower";
     public static final String PLAYER_SIMULATED = "PlayerSimulated";
 
+    public static NamedCause igniter(Object object) {
+        return of(IGNITER, object);
+    }
+
     public static NamedCause source(Object object) {
         return of(SOURCE, object);
     }

--- a/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
@@ -36,16 +36,33 @@ import org.spongepowered.api.world.explosion.Explosion;
 public interface ExplosionEvent extends TargetWorldEvent {
 
     /**
-     * Gets the {@link Explosion} involved in this event.
+     * An event that is fired before an explosion starts to occur.
      *
-     * @return The explosion that this event is involved in
-     */
-    Explosion getExplosion();
-
-    /**
-     * An event that is fired before the explosion occurs.
+     * <p>The {@link Explosion} has not been created at this point.</p>
      */
     interface Pre extends ExplosionEvent, Cancellable {
+    }
+
+    /**
+     * An event that is fired when the explosion starts to occur.
+     *
+     * <p>The {@link Explosion} is available from here onwards.</p>
+     */
+    interface Start extends ExplosionEvent, Cancellable {
+
+        /**
+         * Gets the original {@link Explosion} involved in this event.
+         *
+         * @return The original explosion that this event is involved in
+         */
+        Explosion getOriginalExplosion();
+
+        /**
+         * Gets the {@link Explosion} involved in this event.
+         *
+         * @return The explosion that this event is involved in
+         */
+        Explosion getExplosion();
 
         /**
          * Sets the {@link Explosion} involved for this event. This
@@ -55,14 +72,29 @@ public interface ExplosionEvent extends TargetWorldEvent {
          * @param explosion The new explosion
          */
         void setExplosion(Explosion explosion);
-
     }
 
     /**
      * An event that is fired as the explosion is going to start affecting
      * multiple blocks and entities.
      */
-    interface Detonate extends ExplosionEvent, AffectEntityEvent, ChangeBlockEvent {}
+    interface Detonate extends ExplosionEvent, AffectEntityEvent, ChangeBlockEvent {
 
-    interface Post extends ExplosionEvent {}
+        /**
+         * Gets the {@link Explosion} involved in this event.
+         *
+         * @return The explosion that this event is involved in
+         */
+        Explosion getExplosion();
+    }
+
+    interface Post extends ExplosionEvent {
+
+        /**
+         * Gets the {@link Explosion} involved in this event.
+         *
+         * @return The explosion that this event is involved in
+         */
+        Explosion getExplosion();
+    }
 }


### PR DESCRIPTION
Supersedes #1009 
[**API**](https://github.com/SpongePowered/SpongeAPI/pull/1011) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/453) | [Forge](https://github.com/SpongePowered/SpongeForge/pull/513)

- Renames the original `ExplosionEvent.Pre` event to `ExplosionEvent.Start`
- Adds a new `ExplosionEvent.Pre` event
 - This event is fired **before** an `Explosion` is created, so the `getExplosion` method has been moved to `Start`, `Detonate`, and `Post`
- Adds `getOriginalExplosion` to `ExplosionEvent.Start`
- Adds `NamedCause.igniter(Object)` method.

Without this event, these side effects can happen:
- block removals
- playing sounds
- playing visual effects
- killing entities
- damaging items

as well as other ones I'm sure I've forgotten.
This event also includes a more complete `Cause`, containing information other explosion events don't.