### PR TITLE
Add CustomNameData

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -231,6 +231,14 @@ public final class Keys {
 
     public static final Key<Value<Boolean>> CRITICAL_HIT = null;
 
+    /**
+     * Represents the {@link Key} for the "custom name visible" state
+     * of an {@link Entity}.
+     *
+     * @see CustomNameVisibleData#customNameVisible()
+     */
+    public static final Key<Value<Boolean>> CUSTOM_NAME_VISIBLE = null;
+
     public static final Key<MapValue<EntityType, Double>> DAMAGE_ENTITY_MAP = null;
 
     /**
@@ -723,8 +731,6 @@ public final class Keys {
      * @see DropData#willDrop()
      */
     public static final Key<Value<Boolean>> SHOULD_DROP = null;
-
-    public static final Key<Value<Boolean>> SHOWS_DISPLAY_NAME = null;
 
     /**
      * Represents the {@link Key} for representing the {@link ShrubType}

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableDisplayNameData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableDisplayNameData.java
@@ -31,7 +31,6 @@ import org.spongepowered.api.text.Text;
 
 public interface ImmutableDisplayNameData extends ImmutableDataManipulator<ImmutableDisplayNameData, DisplayNameData> {
 
-
     /**
      * Gets the display name as a {@link Text}. The display name may be
      * player set, or it may be undefined.
@@ -39,12 +38,5 @@ public interface ImmutableDisplayNameData extends ImmutableDataManipulator<Immut
      * @return The display name, if available
      */
     ImmutableValue<Text> displayName();
-
-    /**
-     * Returns whether the custom name is visible to players.
-     *
-     * @return Whether the custom name is visible or not
-     */
-    ImmutableValue<Boolean> customNameVisible();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableCustomNameVisibleData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableCustomNameVisibleData.java
@@ -22,31 +22,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.manipulator.mutable;
+package org.spongepowered.api.data.manipulator.immutable.entity;
 
-import org.spongepowered.api.block.tileentity.TileEntity;
-import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.ImmutableDisplayNameData;
-import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.data.manipulator.mutable.entity.CustomNameVisibleData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.item.inventory.ItemStack;
-import org.spongepowered.api.text.Text;
 
 /**
- * Represents the display name of an {@link ItemStack}, {@link Entity}, or
- * {@link TileEntity}.
+ * An {@link ImmutableDataManipulator} for the "custom name vislble" state
+ * of an {@link Entity}.
  *
- * <p>Exceptions are made with written books as the title and display name
- * are one and the same.</p>
+ * @see ImmutableDisplayNameData
  */
-public interface DisplayNameData extends DataManipulator<DisplayNameData, ImmutableDisplayNameData> {
+public interface ImmutableCustomNameVisibleData extends ImmutableDataManipulator<ImmutableCustomNameVisibleData, CustomNameVisibleData> {
 
     /**
-     * Gets the display name as a {@link Text}. The display name may be
-     * player set, or it may be undefined.
+     * Returns whether the display name is visible to players.
      *
-     * @return The display name, if available
+     * @return Whether the display name is visible or not
      */
-    Value<Text> displayName();
+    ImmutableValue<Boolean> customNameVisible();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/CustomNameVisibleData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/CustomNameVisibleData.java
@@ -22,31 +22,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.manipulator.mutable;
+package org.spongepowered.api.data.manipulator.mutable.entity;
 
-import org.spongepowered.api.block.tileentity.TileEntity;
 import org.spongepowered.api.data.manipulator.DataManipulator;
-import org.spongepowered.api.data.manipulator.immutable.ImmutableDisplayNameData;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableCustomNameVisibleData;
+import org.spongepowered.api.data.manipulator.mutable.DisplayNameData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.item.inventory.ItemStack;
-import org.spongepowered.api.text.Text;
 
 /**
- * Represents the display name of an {@link ItemStack}, {@link Entity}, or
- * {@link TileEntity}.
+ * A {@link DataManipulator} for the "custom name visible" state
+ * of an {@link Entity}.
  *
- * <p>Exceptions are made with written books as the title and display name
- * are one and the same.</p>
+ * @see DisplayNameData
  */
-public interface DisplayNameData extends DataManipulator<DisplayNameData, ImmutableDisplayNameData> {
+public interface CustomNameVisibleData extends DataManipulator<CustomNameVisibleData, ImmutableCustomNameVisibleData> {
 
     /**
-     * Gets the display name as a {@link Text}. The display name may be
-     * player set, or it may be undefined.
+     * Returns whether the display name is visible to players.
      *
-     * @return The display name, if available
+     * @return Whether the display name is visible or not
      */
-    Value<Text> displayName();
+    Value<Boolean> customNameVisible();
 
 }


### PR DESCRIPTION
[**API**](https://github.com/SpongePowered/SpongeAPI/pull/1013) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/403)

This moves the `customNameVisible` method from `DisplayNameData` to the new `CustomNameData`, and renames the associated `Key`.