### PR TITLE
ClientConnectionEvent.Prepare event

### DIFF
--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -3966,6 +3966,22 @@ public class SpongeEventFactory {
     /**
      * AUTOMATICALLY GENERATED, DO NOT EDIT.
      * Creates a new instance of
+     * {@link org.spongepowered.api.event.network.ClientConnectionEvent.Prepare}.
+     *
+     * @param cause The cause
+     * @param targetEntity The target entity
+     * @return A new prepare client connection event
+     */
+    public static ClientConnectionEvent.Prepare createClientConnectionEventPrepare(Cause cause, Player targetEntity) {
+        Map<String, Object> values = Maps.newHashMap();
+        values.put("cause", cause);
+        values.put("targetEntity", targetEntity);
+        return SpongeEventFactoryUtils.createEventImpl(ClientConnectionEvent.Prepare.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
      * {@link org.spongepowered.api.event.network.PardonIpEvent}.
      * 
      * @param cause The cause

--- a/src/main/java/org/spongepowered/api/event/network/ClientConnectionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/network/ClientConnectionEvent.java
@@ -143,6 +143,16 @@ public interface ClientConnectionEvent extends Event {
     }
 
     /**
+     * Fired after {@link Login}, but before {@link Join}.
+     *
+     * <p>This event should be used to set any data on the {@link Player}
+     * before it is spawned into the {@link World}.</p>
+     */
+    interface Prepare extends ClientConnectionEvent, TargetPlayerEvent {
+
+    }
+
+    /**
      * Called when a {@link Player} joins the game {@link World} for the first
      * time after initial connection.
      *


### PR DESCRIPTION
[**API**](https://github.com/SpongePowered/SpongeAPI/pull/1020) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/408)

This is a new event fired between `ClientConnectionEvent.Login` and `ClientConnectionEvent.Join` that allows setting data on the `Player` before the player is spawned.