### PR TITLE
Add Fluid API representation

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -53,7 +53,6 @@ import org.spongepowered.api.text.translation.Translation;
 import org.spongepowered.api.util.ResettableBuilder;
 import org.spongepowered.api.util.rotation.Rotation;
 import org.spongepowered.api.world.extent.ExtentBufferFactory;
-import org.spongepowered.api.world.gen.WorldGeneratorModifier;
 
 import java.awt.image.BufferedImage;
 import java.io.FileNotFoundException;

--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -47,6 +47,7 @@ import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.entity.vehicle.minecart.Minecart;
 import org.spongepowered.api.entity.vehicle.minecart.MinecartCommandBlock;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
@@ -64,6 +65,7 @@ import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -346,12 +348,26 @@ public final class Keys {
     public static final Key<Value<Fish>> FISH_TYPE = null;
 
     /**
+    /**
+     * Represents the {@link Key} for representing the
+     * {@link FluidStackSnapshot} contained within an item container. Item
+     * containers may include buckets and other mod added items.
+     */
+    public static final Key<Value<FluidStackSnapshot>> FLUID_ITEM_STACK = null;
+
+    /**
      * Represents the {@link Key} for representing the "fluid level" state
      * of a {@link BlockState}.
      *
      * @see FluidLevelData#level()
      */
     public static final Key<MutableBoundedValue<Integer>> FLUID_LEVEL = null;
+
+    /**
+     * Represents the {@link Key} for representing the directional tank
+     * information
+     */
+    public static final Key<MapValue<Direction, List<FluidStackSnapshot>>> FLUID_TANK_CONTENTS = null;
 
     public static final Key<Value<Double>> FLYING_SPEED = null;
 

--- a/src/main/java/org/spongepowered/api/extra/fluid/FluidStack.java
+++ b/src/main/java/org/spongepowered/api/extra/fluid/FluidStack.java
@@ -1,0 +1,134 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.extra.fluid;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.item.ItemTypes;
+import org.spongepowered.api.util.persistence.DataBuilder;
+
+/**
+ * Represents a stack of a particular {@link FluidType} and
+ * volume measured in "milliBuckets" where <code>1000</code>mB is equal to
+ * 1 {@link ItemTypes#BUCKET}.
+ */
+public interface FluidStack extends DataHolder {
+
+    /**
+     * Creates a new {@link Builder} to make fluid stacks.
+     *
+     * @return The newly created builder
+     */
+    static Builder builder() {
+        return Sponge.getRegistry().createBuilder(Builder.class);
+    }
+
+    /**
+     * Gets the {@link FluidType} for this fluid stack.
+     *
+     * @return The fluid type of this stack
+     */
+    FluidType getFluid();
+
+    /**
+     * Gets the "volume" of this {@link FluidStack}.
+     *
+     * <p>Note that the volume is measured in "milli buckets", otherwise read
+     * as {@code mB}. The scaling is as follows: 1 bucket = 1000mB, whereas 1
+     * block usually equals 1000mB.</p>
+     *
+     * @return The volume in milli buckets
+     */
+    int getVolume();
+
+    /**
+     * Sets the desired volume for this stack.
+     *
+     * <p>Note that the volume is measured in "milli buckets", otherwise read
+     * as {@code mB}. The scaling is as follows: 1 bucket = 1000mB, whereas 1
+     * block usually equals 1000mB.</p>
+     *
+     * @param volume The volume to set
+     * @return This fluid stack
+     */
+    FluidStack setVolume(int volume);
+
+    /**
+     * Creates a snapshot of this {@link FluidStack}.
+     *
+     * @return The fluid stack snapshot
+     */
+    FluidStackSnapshot createSnapshot();
+
+    interface Builder extends DataBuilder<FluidStack> {
+
+        /**
+         * Sets the {@link FluidType} to use to build the {@link FluidStack}.
+         *
+         * @param fluidType The fluid type
+         * @return This builder, for chaining
+         */
+        Builder fluid(FluidType fluidType);
+
+        /**
+         * Sets the desired volume of the {@link FluidStack}.
+         *
+         * <p>Note that the volume is measured in "milli buckets", otherwise
+         * read as {@code mB}. The scaling is as follows: 1 bucket = 1000mB,
+         * whereas 1 block usually equals 1000mB.</p>
+         *
+         * @param volume The volume
+         * @return This builder, for chaining
+         */
+        Builder volume(int volume);
+
+        /**
+         * Resets and fills this builder with all the information from the
+         * provided {@link FluidStackSnapshot}.
+         *
+         * @param fluidStackSnapshot The fluid stack snapshot to copy data from
+         * @return This builder, for chaining
+         */
+        Builder from(FluidStackSnapshot fluidStackSnapshot);
+
+        /**
+         * Builds a new {@link FluidStack} based on the desired volume and
+         * {@link FluidType}. If either are not set (invalid), an
+         * {@link IllegalStateException} may be thrown.
+         *
+         * @return The newly created fluid stack
+         */
+        FluidStack build();
+
+        @Override
+        Builder from(FluidStack value);
+
+        @Override
+        Builder reset();
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/extra/fluid/FluidStackSnapshot.java
+++ b/src/main/java/org/spongepowered/api/extra/fluid/FluidStackSnapshot.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.extra.fluid;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.ImmutableDataBuilder;
+import org.spongepowered.api.data.ImmutableDataHolder;
+
+public interface FluidStackSnapshot extends ImmutableDataHolder<FluidStackSnapshot> {
+
+    /**
+     * Creates a new {@link Builder} to build a new {@link FluidStackSnapshot}.
+     *
+     * @return The new builder
+     */
+    static Builder builder() {
+        return Sponge.getRegistry().createBuilder(Builder.class);
+    }
+
+    /**
+     * Gets the {@link FluidType} of this snapshot.
+     *
+     * @return The fluid type
+     */
+    FluidType getFluid();
+
+    /**
+     * Gets the volume of this snapshot.
+     *
+     * <p>Note that the volume is measured in "milli buckets", otherwise read
+     * as {@code mB}. The scaling is as follows: 1 bucket = 1000mB, whereas 1
+     * block usually equals 1000mB.</p>
+     *
+     * @return The volume
+     */
+    int getVolume();
+
+    /**
+     * Creates a new {@link FluidStack} based on this snapshot.
+     *
+     * @return The newly created stack
+     */
+    FluidStack createStack();
+
+    interface Builder extends ImmutableDataBuilder<FluidStackSnapshot, Builder> {
+
+        Builder fluid(FluidType fluidType);
+
+        Builder volume(int volume);
+
+        /**
+         * Resets this builder and accepts all data from the incoming {@link FluidStack}.
+         *
+         * @param fluidStack The fluid stack to accept
+         * @return This builder, for chaining
+         */
+        Builder from(FluidStack fluidStack);
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/extra/fluid/FluidType.java
+++ b/src/main/java/org/spongepowered/api/extra/fluid/FluidType.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.extra.fluid;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.block.tileentity.TileEntity;
+import org.spongepowered.api.data.property.PropertyHolder;
+import org.spongepowered.api.extra.fluid.data.manipulator.mutable.FluidTankData;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
+import java.util.Optional;
+
+/**
+ * The functional equivalent of an {@link ItemType} or {@link BlockType},
+ * except for fluids. Normally, the gameplay mechanics of fluids are entirely
+ * dependent on the implementation of a fluid; however, they are representable
+ * as {@link FluidStack}s, where a certain amount of a {@link FluidType} for
+ * a specified volume "exists" within a {@link FluidTankData}.
+ *
+ * <p>Normally, {@link FluidTankData} can be either retrieved from either a
+ * {@link BlockState} or {@link TileEntity} that specifically handles fluids.
+ * Depending on the implementation, a fluid stack may be used differently than
+ * how vanilla implementations handle them.</p>
+ */
+@CatalogedBy(FluidTypes.class)
+public interface FluidType extends CatalogType, PropertyHolder {
+
+    /**
+     * Gets the {@link BlockType} that normally would represent this fluid
+     * type if it exists as a block in the world.
+     *
+     * @return The optional block representation of a fluid in a world
+     */
+    Optional<BlockType> getBlockTypeBase();
+
+}

--- a/src/main/java/org/spongepowered/api/extra/fluid/FluidTypes.java
+++ b/src/main/java/org/spongepowered/api/extra/fluid/FluidTypes.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.extra.fluid;
+
+public final class FluidTypes {
+
+    public static final FluidType WATER = null;
+    public static final FluidType LAVA = null;
+
+    private FluidTypes() { }
+
+}

--- a/src/main/java/org/spongepowered/api/extra/fluid/data/manipulator/immutable/ImmutableFluidItemData.java
+++ b/src/main/java/org/spongepowered/api/extra/fluid/data/manipulator/immutable/ImmutableFluidItemData.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.extra.fluid.data.manipulator.immutable;
+
+import org.spongepowered.api.block.tileentity.TileEntity;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
+import org.spongepowered.api.extra.fluid.data.manipulator.mutable.FluidItemData;
+import org.spongepowered.api.extra.fluid.data.manipulator.mutable.FluidTankData;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.ItemTypes;
+import org.spongepowered.api.item.inventory.ItemStack;
+
+/**
+ * Represented data for a {@link FluidStackSnapshot}, which may be owned by
+ * various instances of {@link ItemStack}s, {@link TileEntity} instances,
+ * and possibly {@link Entity} instances. Traditionally,
+ * {@link ItemTypes#BUCKET}s will not have changeable instances of data without
+ * changing the {@link ItemType}. Provided that a {@link TileEntity} contains
+ * multiple fluids, it may have optionaly {@link FluidTankData} instead of
+ * {@link FluidItemData}.
+ */
+public interface ImmutableFluidItemData extends ImmutableDataManipulator<ImmutableFluidItemData, FluidItemData> {
+
+    /**
+     * Gets the {@link ImmutableValue} of the {@link FluidStackSnapshot}.
+     *
+     * @return The immutable value of the fluid stack snapshot
+     */
+    ImmutableValue<FluidStackSnapshot> fluid();
+
+}

--- a/src/main/java/org/spongepowered/api/extra/fluid/data/manipulator/immutable/ImmutableFluidTankData.java
+++ b/src/main/java/org/spongepowered/api/extra/fluid/data/manipulator/immutable/ImmutableFluidTankData.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.extra.fluid.data.manipulator.immutable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.immutable.ImmutableListValue;
+import org.spongepowered.api.data.value.immutable.ImmutableMapValue;
+import org.spongepowered.api.data.value.mutable.MapValue;
+import org.spongepowered.api.extra.fluid.FluidStack;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
+import org.spongepowered.api.extra.fluid.data.manipulator.mutable.FluidTankData;
+import org.spongepowered.api.util.Direction;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public interface ImmutableFluidTankData extends ImmutableDataManipulator<ImmutableFluidTankData, FluidTankData> {
+
+    /**
+     * Gets the {@link MapValue} of the various {@link FluidStackSnapshot}s
+     * available from the owner. Note that a fluid tank may have multiple
+     * {@link FluidStack}s differing based on {@link Direction}.
+     *
+     * @return The map value of direction to list of fluid snapshots
+     */
+    ImmutableMapValue<Direction, List<FluidStackSnapshot>> fluids();
+
+    /**
+     * Gets the {@link List} of {@link FluidStackSnapshot}s at a defined
+     * {@link Direction}.
+     *
+     * @param direction The direction
+     * @return The list of fluid stack snapshots, if available
+     */
+    default Optional<List<FluidStackSnapshot>> fluidAtDirection(Direction direction) {
+        ImmutableMapValue<Direction, List<FluidStackSnapshot>> fluids = fluids();
+        if (fluids.containsKey(checkNotNull(direction, "Direction was null!"))) {
+            return Optional.of(new ArrayList<>(fluids.get().get(direction)));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/spongepowered/api/extra/fluid/data/manipulator/immutable/package-info.java
+++ b/src/main/java/org/spongepowered/api/extra/fluid/data/manipulator/immutable/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.extra.fluid.data.manipulator.immutable;

--- a/src/main/java/org/spongepowered/api/extra/fluid/data/manipulator/mutable/FluidItemData.java
+++ b/src/main/java/org/spongepowered/api/extra/fluid/data/manipulator/mutable/FluidItemData.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.extra.fluid.data.manipulator.mutable;
+
+import org.spongepowered.api.block.tileentity.TileEntity;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
+import org.spongepowered.api.extra.fluid.data.manipulator.immutable.ImmutableFluidItemData;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.ItemTypes;
+import org.spongepowered.api.item.inventory.ItemStack;
+
+/**
+ * Represented data for a {@link FluidStackSnapshot}, which may be owned by
+ * various instances of {@link ItemStack}s, {@link TileEntity} instances,
+ * and possibly {@link Entity} instances. Traditionally,
+ * {@link ItemTypes#BUCKET}s will not have changeable instances of data without
+ * changing the {@link ItemType}. Provided that a {@link TileEntity} contains
+ * multiple fluids, it may have optionaly {@link FluidTankData} instead of
+ * {@link FluidItemData}.
+ */
+public interface FluidItemData extends DataManipulator<FluidItemData, ImmutableFluidItemData> {
+
+    /**
+     * Gets the {@link FluidStackSnapshot} from the owner as a value.
+     *
+     * @return The value of the fluid stack snapshot
+     */
+    Value<FluidStackSnapshot> fluid();
+
+}

--- a/src/main/java/org/spongepowered/api/extra/fluid/data/manipulator/mutable/FluidTankData.java
+++ b/src/main/java/org/spongepowered/api/extra/fluid/data/manipulator/mutable/FluidTankData.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.api.extra.fluid.data.manipulator.mutable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.value.mutable.ListValue;
+import org.spongepowered.api.data.value.mutable.MapValue;
+import org.spongepowered.api.extra.fluid.FluidStack;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
+import org.spongepowered.api.extra.fluid.data.manipulator.immutable.ImmutableFluidTankData;
+import org.spongepowered.api.util.Direction;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The primary definition of a "tank" is that at any given {@link Direction},
+ * the {@link DataHolder} may have multiple {@link FluidStack}s existing within
+ * itself. Granted, in most cases, the {@link Direction} doesn't quite matter as
+ * the tank itself is just a single container containing multiple
+ * {@link FluidStack}s, however, in some cases, mod added tanks may have
+ * different tanks for different directions. Note that setting an empty
+ * {@link List} of {@link FluidStackSnapshot}s to a {@link Direction} is the
+ * functional equivalent to saying "remove all fluids from that direction".
+ */
+public interface FluidTankData extends DataManipulator<FluidTankData, ImmutableFluidTankData> {
+
+    /**
+     * Gets the {@link MapValue} of the various {@link FluidStackSnapshot}s
+     * available from the owner. Note that a fluid tank may have multiple
+     * {@link FluidStack}s differing based on {@link Direction}.
+     *
+     * @return The map value of direction to list of fluid snapshots
+     */
+    MapValue<Direction, List<FluidStackSnapshot>> fluids();
+
+    /**
+     * Gets the {@link List} of {@link FluidStackSnapshot}s at a defined
+     * {@link Direction}.
+     *
+     * @param direction The direction
+     * @return The list of fluid stack snapshots, if available
+     */
+    default Optional<List<FluidStackSnapshot>> fluidAtDirection(Direction direction) {
+        MapValue<Direction, List<FluidStackSnapshot>> fluids = fluids();
+        if (fluids.containsKey(checkNotNull(direction, "Direction was null!"))) {
+            return Optional.of(new ArrayList<>(fluids.get().get(direction)));
+        }
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/extra/fluid/data/manipulator/mutable/package-info.java
+++ b/src/main/java/org/spongepowered/api/extra/fluid/data/manipulator/mutable/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.extra.fluid.data.manipulator.mutable;

--- a/src/main/java/org/spongepowered/api/extra/fluid/data/package-info.java
+++ b/src/main/java/org/spongepowered/api/extra/fluid/data/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.extra.fluid.data;

--- a/src/main/java/org/spongepowered/api/extra/fluid/data/property/FluidTemperatureProperty.java
+++ b/src/main/java/org/spongepowered/api/extra/fluid/data/property/FluidTemperatureProperty.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.extra.fluid.data.property;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.spongepowered.api.data.property.IntProperty;
+
+/**
+ * Temperature of the fluid - completely arbitrary; higher temperature indicates
+ * that the fluid is hotter than air. Usually, depending on the implementation, the
+ * "hotter" the fluid, the more likely it is to make flamable blocks and entities
+ * catch on fire.
+ *
+ * Default value is approximately the real-life room temperature of water in degrees
+ * Kelvin, otherwise known as 300K.
+ */
+public class FluidTemperatureProperty extends IntProperty {
+
+    /**
+     * Creates a new {@link FluidTemperatureProperty} with the desired temperature.
+     *
+     * @param value The temperature
+     */
+    public FluidTemperatureProperty(int value) {
+        super(value);
+        checkArgument(value >= 0, "Temperature of a fluid cannot be less than zero!");
+    }
+
+    /**
+     * Creates a new {@link FluidTemperatureProperty} with the desired temperature
+     * and {@link Operator} for comparisons.
+     *
+     * @param value The temperature
+     * @param operator The operator
+     */
+    public FluidTemperatureProperty(int value, Operator operator) {
+        super(value, operator);
+        checkArgument(value >= 0, "Temperature of a fluid cannot be less than zero!");
+    }
+}

--- a/src/main/java/org/spongepowered/api/extra/fluid/data/property/FluidViscosityProperty.java
+++ b/src/main/java/org/spongepowered/api/extra/fluid/data/property/FluidViscosityProperty.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.extra.fluid.data.property;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.spongepowered.api.data.property.IntProperty;
+
+/**
+ * Viscosity ("thickness") of the fluid - completely arbitrary; negative values
+ * are not valid. The default viscosity is closely approximated to that
+ * of what exists in real life water: <code>meter/second^2 * (x10^-3)</code>.
+ *
+ * Higher viscosity means that a fluid flows more slowly, like molasses.
+ * Lower viscosity means that a fluid flows more quickly, like alcohol.
+ *
+ */
+public class FluidViscosityProperty extends IntProperty {
+
+    /**
+     * Creates a new {@link FluidViscosityProperty} with the desired viscosity.
+     *
+     * @param value The viscosity
+     */
+    public FluidViscosityProperty(int value) {
+        super(value);
+        checkArgument(value >= 0, "Temperature of a fluid cannot be less than zero!");
+    }
+
+    /**
+     * Creates a new {@link FluidViscosityProperty} with the desired viscosity
+     * and {@link Operator} for comparisons.
+     *
+     * @param value The viscosity
+     * @param operator The operator
+     */
+    public FluidViscosityProperty(int value, Operator operator) {
+        super(value, operator);
+        checkArgument(value >= 0, "Viscosity of a fluid cannot be less than zero!");
+    }
+}

--- a/src/main/java/org/spongepowered/api/extra/fluid/data/property/package-info.java
+++ b/src/main/java/org/spongepowered/api/extra/fluid/data/property/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.extra.fluid.data.property;

--- a/src/main/java/org/spongepowered/api/extra/fluid/package-info.java
+++ b/src/main/java/org/spongepowered/api/extra/fluid/package-info.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+/**
+ * The base Fluid API that attempts to bridge the Data API and Forges Fluid API.
+ * While {@link org.spongepowered.api.item.inventory.ItemStack}s are literal
+ * stacks of an {@link org.spongepowered.api.item.ItemType} with extra data on
+ * it, {@link org.spongepowered.api.extra.fluid.FluidStack} are literal stacks
+ * of a {@link org.spongepowered.api.extra.fluid.FluidType} with some extra data
+ * on it. There is no real detail of what constitutes a {@code FluidStack} as a
+ * tangible item, but more so that there are items in the world that are
+ * "containers" of either one or several {@code FluidStack}s.
+ *
+ * <p>In vanilla, there are very few items that contain a {@code FluidStack}.
+ * The first item that comes to mind is a
+ * {@link org.spongepowered.api.item.ItemTypes#WATER_BUCKET} will always contain
+ * a {@code FluidStack} of
+ * {@link org.spongepowered.api.extra.fluid.FluidTypes#WATER} with the quantity
+ * of exactly {@code 1000mB}. The {@code FluidStack} itself on the bucket cannot
+ * be changed, but the {@code ItemStack} would be changed from being a water
+ * bucket to just a normal empty bucket. This is also the case for lava buckets.
+ * </p>
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.extra.fluid;


### PR DESCRIPTION
SpongeAPI | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/410) | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/489)
Forge has a Fluid API system that mods use to interact with each other for various purposes, and this exposes that system with the Data API. Plugins will be able to interact and interface with `TileEntity` based `IFluidHandler`s and `IFluidContainerItem`s.

The API itself was aided with @diesieben07's comments, and likewise the implementation of this will rely on Forge, with SpongeCommon providing some interfacing with vanilla based containers (namely buckets and such).