### PR TITLE
[WIP] ItemStack and TradeOffer Generators

### DIFF
--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -25,12 +25,15 @@
 package org.spongepowered.api;
 
 import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.data.type.Career;
 import org.spongepowered.api.data.value.ValueFactory;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.ai.task.AITaskType;
 import org.spongepowered.api.entity.ai.task.AbstractAITask;
 import org.spongepowered.api.entity.living.Agent;
 import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.merchant.VillagerRegistry;
+import org.spongepowered.api.item.merchant.TradeOfferGenerator;
 import org.spongepowered.api.item.recipe.RecipeRegistry;
 import org.spongepowered.api.network.status.Favicon;
 import org.spongepowered.api.plugin.PluginContainer;
@@ -337,6 +340,15 @@ public interface GameRegistry {
      * @return The value factory
      */
     ValueFactory getValueFactory();
+
+    /**
+     * Gets the {@link VillagerRegistry} for the register mappings
+     * of {@link Career}s to {@link TradeOfferGenerator}s based on
+     * a level.
+     *
+     * @return The villager registry instance
+     */
+    VillagerRegistry getVillagerRegistry();
 
     /**
      * Gets the internal {@link TextSerializerFactory}.

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
@@ -35,8 +35,10 @@ import org.spongepowered.api.block.tileentity.TileEntity;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.DataView;
+import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.ResettableBuilder;
@@ -137,6 +139,21 @@ public interface ItemStack extends DataHolder, DataSerializable, Translatable {
          * @throws IllegalArgumentException If the quantity is outside the allowed bounds
          */
         Builder quantity(int quantity) throws IllegalArgumentException;
+
+        /**
+         * Adds a {@link Key} and related {@link Object} value to apply to the
+         * resulting {@link ItemStack}. Note that the resulting
+         * {@link ItemStack} may not actually accept the provided {@code Key}
+         * for various reasons due to support or simply that the value itself
+         * is not supported. Offering custom data is not supported through this,
+         * use {@link #itemData(DataManipulator)} instead.
+         *
+         * @param key The key to identiy the value to
+         * @param value The value to apply
+         * @param <E> The type of value
+         * @return This builder, for chaining
+         */
+        <E> Builder keyValue(Key<? extends BaseValue<E>> key, E value);
 
         /**
          * Sets the {@link DataManipulator} to add to the {@link ItemStack}.

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackBuilderPopulators.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackBuilderPopulators.java
@@ -1,0 +1,645 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.item.inventory;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.spongepowered.api.util.weighted.VariableAmount.baseWithRandomAddition;
+import static org.spongepowered.api.util.weighted.VariableAmount.fixed;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.meta.ItemEnchantment;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.mutable.ListValue;
+import org.spongepowered.api.data.value.mutable.SetValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.item.Enchantment;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.util.Tuple;
+import org.spongepowered.api.util.weighted.VariableAmount;
+import org.spongepowered.api.util.weighted.WeightedTable;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * A factory for generating {@link BiConsumer}s to apply to an
+ * {@link ItemStack.Builder}, usually through an {@link ItemStackGenerator}.
+ *
+ * <p>Note that the {@link BiConsumer}s are expected to utilize the passed in
+ * {@link Random} and use the builder as necessary.</p>
+ */
+public final class ItemStackBuilderPopulators {
+
+    /**
+     * Creates a new {@link BiConsumer} to set the {@link ItemStack.Builder}
+     * to use the provided {@link ItemStackSnapshot} as a "default". Note
+     * that the normal behavior of the builder is to reset according to
+     * the snapshot.
+     *
+     * @param snapshot The snapshot to set the builder to use
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> itemStack(ItemStackSnapshot snapshot) {
+        checkNotNull(snapshot, "ItemStackSnapshot cannot be null!");
+        return (builder, random) -> builder.fromSnapshot(snapshot);
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that uses a randomized selection
+     * of the provided {@link ItemStackSnapshot}s. The builder, when called will
+     * only use one at random selection to default to.
+     *
+     * @param snapshot The first snapshot
+     * @param snapshots The additional snapshots
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> itemStacks(ItemStackSnapshot snapshot, ItemStackSnapshot... snapshots) {
+        checkNotNull(snapshot, "ItemStackSnapshot cannot be null!");
+        final WeightedTable<ItemStackSnapshot> table = new WeightedTable<>(1);
+        table.add(snapshot, 1);
+        for (ItemStackSnapshot stackSnapshot : snapshots) {
+            table.add(checkNotNull(stackSnapshot, "ItemStackSnapshot cannot be null!"), 1);
+        }
+        return (builder, random) -> builder.fromSnapshot(table.get(random).get(0));
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that defines the provided
+     * {@link ItemType}.
+     *
+     * @param itemType The given item type
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> item(ItemType itemType) {
+        checkNotNull(itemType, "ItemType cannot be null!");
+        return (builder, random) -> builder.itemType(itemType);
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that defines the provided
+     * {@link ItemType}, provided that the {@link Supplier} does not
+     * return null.
+     *
+     * <p>Note that the {@link Supplier} is not queried for an
+     * {@link ItemType} until the generated {@link BiConsumer} is
+     * called.</p>
+     *
+     * @param supplier The supplier of the item type
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> item(Supplier<ItemType> supplier) {
+        checkNotNull(supplier, "Supplier cannot be null!");
+        return (builder, random) -> builder.itemType(checkNotNull(supplier.get(), "Supplier returned a null ItemType"));
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that provides a random
+     * {@link ItemType} of the provided item types.
+     *
+     * <p>Note that the desired {@link ItemType} given to the builder is only
+     * defined at the time of calling {@link BiConsumer#accept(Object, Object)}.
+     * </p>
+     *
+     * @param itemType The first item type
+     * @param itemTypes The additional item types
+     * @return The new biconsumer to apply to an item stack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> items(ItemType itemType, ItemType... itemTypes) {
+        return items(ImmutableList.<ItemType>builder().add(itemType).addAll(Arrays.asList(itemTypes)).build());
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that provides a random
+     * {@link ItemType} from the provided collection of item types.
+     *
+     * @param itemTypes The item types to use
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> items(final Collection<ItemType> itemTypes) {
+        final ImmutableList<ItemType> copiedItemTypes = ImmutableList.copyOf(itemTypes);
+        return (builder, random) -> builder.itemType(copiedItemTypes.get(random.nextInt(copiedItemTypes.size())));
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that sets the desired quantity
+     * for creating an {@link ItemStack}.
+     *
+     * <p>Note that the default behavior of the item stack builder is still
+     * expected to take place. Negative values are not allowed.</p>
+     *
+     * @param amount The variable amount
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> quantity(VariableAmount amount) {
+        checkNotNull(amount, "VariableAmount cannot be null!");
+        return (builder, random) -> builder.quantity(amount.getFlooredAmount(random));
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that sets the desired quantity
+     * for creating an {@link ItemStack}. The supplier is not queried for
+     * a {@link VariableAmount} until the generated bi consumer is
+     * called on.
+     *
+     * <p>Note that the default behavior of an item stack builder is still
+     * expected to take place. Negative values are not allowed.</p>
+     *
+     * @param supplier The supplier of the variable amount
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> quantity(Supplier<VariableAmount> supplier) {
+        checkNotNull(supplier, "Supplier cannot be null!");
+        return (builder, random) -> builder.quantity(supplier.get().getFlooredAmount(random));
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that sets the provided {@link Key}'ed
+     * object where the value is possibly ignored or not supported. No checks
+     * on whether the key or object is supported until called upon.
+     *
+     * <p>Note that custom data is not supported through this method, use
+     * {@link #data(Collection)} or any variant thereof for applying custom data.</p>
+     *
+     * @param key The key to use
+     * @param value The value to use
+     * @param <E> The type of value
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static <E> BiConsumer<ItemStack.Builder, Random> keyValue(Key<? extends BaseValue<E>> key, E value) {
+        return (builder, random) -> {
+            final ItemStack itemStack = builder.build();
+            final DataTransactionResult dataTransactionResult = itemStack.offer(key, value);
+            if (dataTransactionResult.isSuccessful()) {
+                builder.from(itemStack);
+            }
+        };
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that sets a single provided
+     * value with the provided {@link Key}. Only a single value is chosen
+     * to provide to the itemstack builder.
+     *
+     * <p>Note that custom data is not supported through this method, use
+     * {@link #data(Collection)} or any variant thereof for applying custom data.</p>
+     *
+     * @param key The key to use
+     * @param values The pool of possible values
+     * @param <E> The type of value
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static <E> BiConsumer<ItemStack.Builder, Random> keyValues(Key<? extends BaseValue<E>> key, Iterable<E> values) {
+        checkNotNull(values, "Iterable cannot be null!");
+        checkNotNull(key, "Key cannot be null!");
+        WeightedTable<E> tableEntries = new WeightedTable<>(1);
+        for (E e : values) {
+            tableEntries.add(checkNotNull(e, "Value cannot be null!"), 1);
+        }
+        return (builder, random) -> {
+            final ItemStack itemStack = builder.build();
+            final DataTransactionResult dataTransactionResult = itemStack.offer(key, tableEntries.get(random).get(0));
+            if (dataTransactionResult.isSuccessful()) {
+                builder.from(itemStack);
+            }
+        };
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} where the {@link Key} is responsible
+     * for a {@link List} based {@link Value}. Given that the provided elements
+     * are chosent with a {@link Random}, it's not clear that the elements will
+     * be added in bundles or in the same iteration order.
+     *
+     * <p>Note that custom data is not supported through this method, use
+     * {@link #data(Collection)} or any variant thereof for applying custom data.</p>
+     *
+     * @param key The key to use
+     * @param elementPool The pool of possible values
+     * @param amount The variable amount of elements to add
+     * @param <E> The type of elements
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static <E> BiConsumer<ItemStack.Builder, Random> listValues(Key<? extends ListValue<E>> key, List<E> elementPool, VariableAmount amount) {
+        checkNotNull(key, "Key cannot be null!");
+        checkNotNull(elementPool, "Element pool cannot be null!");
+        checkNotNull(amount, "VariableAmount cannot be null!");
+        checkArgument(!elementPool.isEmpty(), "Element pool cannot be empty!");
+        WeightedTable<E> elementTable = new WeightedTable<>(amount);
+        for (E element : elementPool) {
+            elementTable.add(checkNotNull(element, "Element cannot be null!"), 1);
+        }
+        return listValues(key, elementTable);
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} where the {@link Key} is responsible
+     * for a {@link List} based {@link Value}. Given that the provided elements
+     * are chosent with a {@link Random}, it's not clear that the elements will
+     * be added in bundles or in the same iteration order. The default variance
+     * is provided as {@link VariableAmount#baseWithRandomAddition(double, double)}
+     * where at the least, a single element is chosen, and at most the entire
+     * collection is chosen.
+     *
+     * <p>Note that custom data is not supported through this method, use
+     * {@link #data(Collection)} or any variant thereof for applying custom data.</p>
+     *
+     * @param key The key to use
+     * @param elementPool The pool of possible values
+     * @param <E> The type of elements
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static <E> BiConsumer<ItemStack.Builder, Random> listValues(Key<? extends ListValue<E>> key, List<E> elementPool) {
+        return listValues(key, elementPool, baseWithRandomAddition(1, elementPool.size() - 1));
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} where the {@link Key} is responsible
+     * for a {@link List} based {@link Value}. Given the {@link WeightedTable}
+     * is already generated, the values requested are only retrieved when
+     * the generated biconsumer is called upon.
+     *
+     * <p>Note that custom data is not supported through this method, use
+     * {@link #data(Collection)} or any variant thereof for applying custom data.</p>
+     *
+     * @param key The key to use
+     * @param weightedTable The weighted table
+     * @param <E> The type of elements
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static <E> BiConsumer<ItemStack.Builder, Random> listValues(Key<? extends ListValue<E>> key, WeightedTable<E> weightedTable) {
+        checkNotNull(weightedTable, "Weighted table cannot be null!");
+        checkNotNull(key, "Key cannot be null!");
+        return setValue(key, random -> ImmutableList.copyOf(weightedTable.get(random)));
+
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} where the {@link Key} is responsible
+     * for a {@link List} based {@link Value}. Given the
+     * {@link WeightedTable} is exclusively used with {@link Function}s,
+     * the {@link Function}s themselves are queried with a {@link Random}
+     * and expected to present a singular element of the defined type. It's
+     * expected that there are multiple functions to provide additional
+     * elements for a particular key'ed {@link ListValue}.
+     *
+     * <p>An example usage of this can be for generating a randomized list
+     * of {@link ItemEnchantment}s with varying enchantment levels.</p>
+     *
+     * <p>Note that custom data is not supported through this method, use
+     * {@link #data(Collection)} or any variant thereof for applying custom data.</p>
+     *
+     * @param key The key to use
+     * @param weightedTable The weighted table containing all the desired
+     *     functions producing the randomized elements
+     * @param <E> The type of element
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static <E> BiConsumer<ItemStack.Builder, Random> listValueSuppliers(Key<? extends ListValue<E>> key, WeightedTable<Function<Random, E>> weightedTable) {
+        checkNotNull(key, "Key cannot be null!");
+        checkNotNull(weightedTable, "WeightedTable cannot be null!");
+        return (builder, random) -> {
+            final ItemStack itemStack = builder.build();
+            final List<Function<Random, E>> suppliers = weightedTable.get(random);
+            final List<E> suppliedElements = suppliers.stream()
+                    .map(randomEFunction -> randomEFunction.apply(random))
+                    .collect(Collectors.toList());
+            final DataTransactionResult result = itemStack.offer(key, suppliedElements);
+            if (result.isSuccessful()) {
+                builder.from(itemStack);
+            }
+        };
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} where the {@link Key} is responsible
+     * for a {@link Set} based {@link Value}. Given the {@link Set} of element
+     * to act as a pool, the consumer will pull a random amount of the
+     * given pool and apply it as a new {@link Set}.
+     *
+     * <p>Note that custom data is not supported through this method, use
+     * {@link #data(Collection)} or any variant thereof for applying custom data.</p>
+     *
+     * @param key The key to use
+     * @param elementPool The set of elements to use as a pool
+     * @param <E> The type of element
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static <E> BiConsumer<ItemStack.Builder, Random> setValues(Key<? extends SetValue<E>> key, Set<E> elementPool) {
+        checkNotNull(key, "Key cannot be null!");
+        checkNotNull(elementPool, "ElementPool cannot be null!");
+        return setValues(key, elementPool, baseWithRandomAddition(1, elementPool.size() - 1));
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} where the {@link Key} is responsible
+     * for a {@link Set} based {@link Value}. Given the {@link Set} of
+     * elements to act as a pool, the consumer will pull a variable amount
+     * based on the provided {@link VariableAmount}, and apply it as a new
+     * {@link Set}.
+     *
+     * <p>Note that custom data is not supported through this method, use
+     * {@link #data(Collection)} or any variant thereof for applying custom data.</p>
+     *
+     * @param key The key to use
+     * @param elementPool The set of elements to use as a pool
+     * @param amount The variable amount of elements to get
+     * @param <E> The type of element
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static <E> BiConsumer<ItemStack.Builder, Random> setValues(Key<? extends SetValue<E>> key, Set<E> elementPool, VariableAmount amount) {
+        checkNotNull(key, "Key cannot be null!");
+        checkNotNull(elementPool, "Element pool cannot be null!");
+        checkNotNull(amount, "VariableAmount cannot be null!");
+        checkArgument(!elementPool.isEmpty());
+        WeightedTable<E> elementTable = new WeightedTable<>(amount);
+        for (E element : elementPool) {
+            elementTable.add(element, 1);
+        }
+        return setValues(key, elementTable);
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} where the {@link Key} is
+     * responsible for a {@link Set} based {@link Value}. Given
+     * the provided {@link WeightedTable}, the consumer will retrieve
+     * a {@link List} of values and add them as a new {@link Set}.
+     *
+     * <p>Note that custom data is not supported through this method, use
+     * {@link #data(Collection)} or any variant thereof for applying custom data.</p>
+     *
+     * @param key The key to use
+     * @param weightedTable The weighted table acting as an element pool
+     * @param <E> The type of element
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static <E> BiConsumer<ItemStack.Builder, Random> setValues(Key<? extends SetValue<E>> key, WeightedTable<E> weightedTable) {
+        checkNotNull(weightedTable, "WeightedTable cannot be null!");
+        checkNotNull(key, "Key cannot be null!");
+        checkArgument(!weightedTable.isEmpty(), "WeightedTable cannot be empty!");
+        return setValue(key, random -> ImmutableSet.copyOf(weightedTable.get(random)));
+    }
+
+    /*Note : This is used interanlly only, no validation is performed.*/
+    private static <E> BiConsumer<ItemStack.Builder, Random> setValue(Key<? extends BaseValue<E>> key, Function<Random, E> element) {
+        return (builder, random) -> {
+            final ItemStack itemStack = builder.build();
+            final DataTransactionResult result = itemStack.offer(key, element.apply(random));
+            if (result.isSuccessful()) {
+                builder.from(itemStack);
+            }
+        };
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that applies the provided {@link Value}
+     * to the generated {@link ItemStack}.
+     *
+     * <p>Note that custom data is not supported through this method, use
+     * {@link #data(Collection)} or any variant thereof for applying custom data.</p>
+     *
+     * @param value The value to use
+     * @param <E> The type of element
+     * @param <V> The type of value
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static <E, V extends BaseValue<E>> BiConsumer<ItemStack.Builder, Random> value(V value) {
+        return (builder, random) -> {
+            final ItemStack itemStack = builder.build();
+            final DataTransactionResult dataTransactionResult = itemStack.offer(value);
+            if (dataTransactionResult.isSuccessful()) {
+                builder.from(itemStack);
+            }
+        };
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that applies a random selection of the
+     * provided {@link BaseValue}s.
+     *
+     * <p>Note that custom data is not supported through this method, use
+     * {@link #data(Collection)} or any variant thereof for applying custom data.</p>
+     *
+     * @param values The iterable collection of values to choose from
+     * @param <E> The type of element
+     * @param <V> The type of value
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static <E, V extends BaseValue<E>> BiConsumer<ItemStack.Builder, Random> values(Iterable<V> values) {
+        WeightedTable<V> tableEntries = new WeightedTable<>(1);
+        for (V value : values) {
+            tableEntries.add(checkNotNull(value, "Value cannot be null!"), 1);
+        }
+        return ((builder, random) -> {
+            final V value = tableEntries.get(random).get(0);
+            final ItemStack itemStack = builder.build();
+            final DataTransactionResult result = itemStack.offer(value);
+            if (result.isSuccessful()) {
+                builder.from(itemStack);
+            }
+        });
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that sets a particular
+     * {@link DataManipulator} onto an {@link ItemStack}. Note
+     * that no validation can be performed, however the builder
+     * will ignore unsupported data. This can be used to provide
+     * custom data manipulators.
+     *
+     * @param manipulator The manipulator to apply to an itemstack
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> data(DataManipulator<?, ?> manipulator) {
+        checkNotNull(manipulator, "DataManipulator cannot be null!");
+        return (builder, random) -> builder.itemData(manipulator);
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that sets a single
+     * {@link DataManipulator} form the provided collection of manipulators.
+     * Note that no validation can be performed, however the builder will
+     * ignore unsupported data. This can be used to provide custom data
+     * manipulators. To apply multiple manipulators, use
+     * {@link #data(Collection, VariableAmount)}.
+     *
+     * @param manipulators The pool of manipulators to use
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> data(Collection<DataManipulator<?, ?>> manipulators) {
+        checkNotNull(manipulators, "DataManipulators cannot be null!");
+        final WeightedTable<DataManipulator<?, ?>> table = new WeightedTable<>();
+        manipulators.forEach(manipulator -> table.add(checkNotNull(manipulator, "DataManipulator cannot be null!"), 1));
+        return (builder, random) -> builder.itemData(table.get(random).get(0));
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that provides a {@link VariableAmount}
+     * of {@link DataManipulator}s from the provided pool. Note that no
+     * validation can be performed, however the builder will ignore unsupported
+     * data. This can be used to provide custom data manipulators.
+     *
+     * @param manipulators The manipulator pool to use
+     * @param rolls The variable amount of manipulators to apply
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> data(Collection<DataManipulator<?, ?>> manipulators, VariableAmount rolls) {
+        checkNotNull(manipulators, "Manipulators cannot be null!");
+        checkNotNull(rolls, "VariableAmount cannot be null!");
+        final ImmutableList<DataManipulator<?, ?>> copied = ImmutableList.copyOf(manipulators);
+        final WeightedTable<DataManipulator<?, ?>> table = new WeightedTable<>();
+        table.setRolls(rolls);
+        copied.forEach(manipulator1 -> table.add(manipulator1, 1));
+        return data(table);
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that provides a variable
+     * amount of {@link DataManipulator}s from the provided
+     * {@link WeightedTable}. Note that no validation can be performed, however
+     * the builder will ignore unsupported data. This can be used to provide
+     * custom data manipulators.
+     *
+     * @param weightedTable The weighted table containing manipulators
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> data(WeightedTable<DataManipulator<?, ?>> weightedTable) {
+        checkNotNull(weightedTable, "WeightedTable cannot be null!");
+        return (builder, random) -> weightedTable.get(random).forEach(builder::itemData);
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that takes the provided
+     * {@link Enchantment} and applies it to the generated {@link ItemStack}.
+     * The enchantment level is varied based on vanilla mechanics.
+     *
+     * @param enchantment The singular enchantment to add
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> enchantment(Enchantment enchantment) {
+        return enchantment(fixed(1), enchantment);
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that takes the provided
+     * {@link Enchantment} and applies it to the generated {@link ItemStack}.
+     * The enchantment level is defined by the variable amount provided.
+     *
+     * @param level The variance in enchantment level
+     * @param enchantment The enchantment to add
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> enchantment(VariableAmount level, Enchantment enchantment) {
+        checkNotNull(level, "VariableAmount cannot be null!");
+        checkNotNull(enchantment, "Enchantment cannot be null!");
+        return enchantments(fixed(1), ImmutableList.of(new Tuple<>(enchantment, level)));
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that takes the provided
+     * {@link Collection} of {@link Enchantment}s and applies a
+     * singular {@link Enchantment} with varying levels to the generated
+     * {@link ItemStack}.
+     *
+     * @param enchantments The enchantment pool to choose from
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> enchantmentsWithVanillaLevelVariance(Collection<Enchantment> enchantments) {
+        return enchantmentsWithVanillaLevelVariance(fixed(1), ImmutableList.copyOf(enchantments));
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that takes the provided
+     * {@link Enchantment}s and applies a variable amount of enchantments
+     * with varying levels to the generated {@link ItemStack}.
+     *
+     * @param amount The variable amount of enchantments to use
+     * @param enchantment The first enchantment to add
+     * @param enchantments The additional enchantments to use
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> enchantmentsWithVanillaLevelVariance(VariableAmount amount, Enchantment enchantment, Enchantment... enchantments) {
+        return enchantmentsWithVanillaLevelVariance(amount, ImmutableList.<Enchantment>builder().add(enchantment).addAll(Arrays.asList(enchantments)).build());
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that takes the provided
+     * {@link Collection} of {@link Enchantment}s and applies a varying amount
+     * of generated enchantments to the generated {@link ItemStack}.
+     *
+     * @param amount The varying amount of enchantments to use
+     * @param itemEnchantments The enchantment pool to use
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> enchantmentsWithVanillaLevelVariance(VariableAmount amount, Collection<Enchantment> itemEnchantments) {
+        checkNotNull(amount, "Variable amount cannot be null!");
+        checkNotNull(itemEnchantments, "Enchantment collection cannot be null!");
+        List<Tuple<Enchantment, VariableAmount>> list = itemEnchantments.stream()
+                .map(enchantment -> {
+                    checkNotNull(enchantment, "Enchantment cannot be null!");
+                    final int minimum = enchantment.getMinimumLevel();
+                    final int maximum = enchantment.getMaximumLevel();
+                    return new Tuple<>(enchantment, baseWithRandomAddition(minimum, maximum - minimum));
+                })
+                .collect(Collectors.toList());
+        return enchantments(amount, list);
+    }
+
+    /**
+     * Creates a new {@link BiConsumer} that takes the provided
+     * {@link Collection} of coupled {@link Enchantment} and
+     * {@link VariableAmount} to apply varying enchantments of varying amounts
+     * to the generated {@link ItemStack}.
+     *
+     * @param amount The varying amount of enchantments
+     * @param enchantments The collection of enchantment tuples combining the
+     *     enchantment and the variable amount of level to apply
+     * @return The new biconsumer to apply to an itemstack builder
+     */
+    public static BiConsumer<ItemStack.Builder, Random> enchantments(VariableAmount amount, Collection<Tuple<Enchantment, VariableAmount>> enchantments) {
+        checkNotNull(amount, "VariableAmount cannot be null!");
+        final WeightedTable<Function<Random, ItemEnchantment>> suppliers = new WeightedTable<>(amount);
+        for (Tuple<Enchantment, VariableAmount> enchantment : enchantments) {
+            suppliers.add(random -> new ItemEnchantment(enchantment.getFirst(), enchantment.getSecond().getFlooredAmount(random)), 1);
+        }
+        return listValueSuppliers(Keys.ITEM_ENCHANTMENTS, suppliers);
+    }
+
+    private ItemStackBuilderPopulators() {
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackGenerator.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackGenerator.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.item.inventory;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.util.ResettableBuilder;
+
+import java.util.Collection;
+import java.util.Random;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/**
+ * A simple generator that takes a {@link Random} and generates
+ * an {@link ItemStack}.
+ */
+public interface ItemStackGenerator extends Function<Random, ItemStack> {
+
+    /**
+     * Creates a new builder to build an {@link ItemStackGenerator}.
+     *
+     * @return The builder to create an itemstack generator
+     */
+    static Builder builder() {
+        return Sponge.getRegistry().createBuilder(Builder.class);
+    }
+
+    /**
+     * A builder to add various {@link BiConsumer}s that will be applied in order
+     * to an {@link ItemStackGenerator}. Normally, most all biconsumers can be
+     * created from {@link ItemStackBuilderPopulators}.
+     */
+    interface Builder extends ResettableBuilder<ItemStackGenerator, Builder> {
+
+        /**
+         * Adds a new biconsumer in the current order.
+         *
+         * @param consumer The consumer that mutates an itemstack builder
+         * @return This builder, for chaining
+         */
+        Builder add(BiConsumer<ItemStack.Builder, Random> consumer);
+
+        /**
+         * Adds all the provided biconsumers from the provided collection.
+         *
+         * @param collection The collection of consumer to add
+         * @return This builder, for chaining
+         */
+        Builder addAll(Collection<BiConsumer<ItemStack.Builder, Random>> collection);
+
+        /**
+         * Sets the base {@link ItemType} for the {@link ItemStackGenerator}. A
+         * base type must be set to avoid issues.
+         *
+         * @param itemType The base item type
+         * @return This builder, for chaining
+         */
+        Builder baseItem(ItemType itemType);
+
+        /**
+         * Creates a new {@link ItemStackGenerator} with all of the added
+         * {@link BiConsumer}s.
+         *
+         * @return The newly created itemstack generator
+         */
+        ItemStackGenerator build();
+
+    }
+}

--- a/src/main/java/org/spongepowered/api/item/inventory/generation/TestItemGenrator.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/generation/TestItemGenrator.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.item.inventory.generation;
+
+import static org.spongepowered.api.item.inventory.ItemStackBuilderPopulators.enchantmentsWithVanillaLevelVariance;
+import static org.spongepowered.api.item.inventory.ItemStackBuilderPopulators.keyValue;
+import static org.spongepowered.api.item.inventory.ItemStackBuilderPopulators.keyValues;
+import static org.spongepowered.api.item.inventory.ItemStackBuilderPopulators.listValues;
+import static org.spongepowered.api.item.inventory.ItemStackBuilderPopulators.quantity;
+import static org.spongepowered.api.item.inventory.ItemStackBuilderPopulators.items;
+import static org.spongepowered.api.util.weighted.VariableAmount.baseWithRandomAddition;
+import static org.spongepowered.api.util.weighted.VariableAmount.fixed;
+
+import com.google.common.collect.ImmutableList;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.meta.PatternLayer;
+import org.spongepowered.api.data.type.BannerPatternShape;
+import org.spongepowered.api.data.type.BannerPatternShapes;
+import org.spongepowered.api.data.type.DyeColors;
+import org.spongepowered.api.item.Enchantments;
+import org.spongepowered.api.item.ItemTypes;
+import org.spongepowered.api.item.inventory.ItemStackGenerator;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+import org.spongepowered.api.text.format.TextStyles;
+
+public class TestItemGenrator {
+
+
+    public static ItemStackGenerator provide() {
+        return ItemStackGenerator.builder()
+                .add(items(ItemTypes.IRON_SWORD, ItemTypes.IRON_AXE, ItemTypes.IRON_HOE))
+                .add(quantity(fixed(1)))
+                .add(listValues(Keys.BANNER_PATTERNS, ImmutableList.of(PatternLayer.of(BannerPatternShapes.BASE, DyeColors.BLACK))))
+                .add(enchantmentsWithVanillaLevelVariance(baseWithRandomAddition(1, 2), Enchantments.SHARPNESS, Enchantments.FIRE_ASPECT, Enchantments.KNOCKBACK, Enchantments.LOOTING))
+                .add(keyValue(Keys.DISPLAY_NAME, Text.of(TextColors.DARK_AQUA, TextStyles.BOLD, "LEGENDARY")))
+                .add(keyValue(Keys.UNBREAKABLE, true))
+                .build();
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/item/inventory/generation/package-info.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/generation/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.api.item.inventory.generation;

--- a/src/main/java/org/spongepowered/api/item/merchant/TradeOffer.java
+++ b/src/main/java/org/spongepowered/api/item/merchant/TradeOffer.java
@@ -29,6 +29,7 @@ import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.entity.living.Humanoid;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 
 import java.util.Optional;
 
@@ -58,7 +59,7 @@ public interface TradeOffer extends DataSerializable {
      *
      * @return The first buying item
      */
-    ItemStack getFirstBuyingItem();
+    ItemStackSnapshot getFirstBuyingItem();
 
     /**
      * Returns whether this trade offer has a second item the merchant is buying
@@ -77,7 +78,7 @@ public interface TradeOffer extends DataSerializable {
      *
      * @return The second buying item, if available
      */
-    Optional<ItemStack> getSecondBuyingItem();
+    Optional<ItemStackSnapshot> getSecondBuyingItem();
 
     /**
      * Gets the selling item the {@link Merchant} will give to the customer
@@ -87,7 +88,7 @@ public interface TradeOffer extends DataSerializable {
      *
      * @return The selling item
      */
-    ItemStack getSellingItem();
+    ItemStackSnapshot getSellingItem();
 
     /**
      * <p>Gets the current uses of this offer.</p>

--- a/src/main/java/org/spongepowered/api/item/merchant/TradeOfferGenerator.java
+++ b/src/main/java/org/spongepowered/api/item/merchant/TradeOfferGenerator.java
@@ -1,0 +1,143 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.item.merchant;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackGenerator;
+import org.spongepowered.api.util.ResettableBuilder;
+import org.spongepowered.api.util.weighted.VariableAmount;
+
+import java.util.List;
+import java.util.Random;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents a generator to create {@link TradeOffer}s with a bit of randomization
+ * based on {@link ItemStackGenerator}s for populating {@link ItemStack}s and
+ * finally generating a {@link TradeOffer}.
+ *
+ * <p>The primary use of this, and why the {@link Random} must be provided as
+ * part of the {@link Function} signature is that during multiple world instances,
+ * there's different {@link Random} instances instantiated, and more can be provided
+ * without the necessity to change the generator. One advantage to using a generator
+ * is the ability to provide some "randomization" or "chance" on the various aspects
+ * of the generated {@link TradeOffer} versus creating a static non-changing offer.
+ * Normally, the vanilla {@link TradeOffer}s are using a similar generator with
+ * limited scopes of what the {@link ItemStack} can be customized as.</p>
+ */
+@FunctionalInterface
+public interface TradeOfferGenerator extends Function<Random, TradeOffer>, TradeOfferListMutator {
+
+    /**
+     * Gets a new {@link Builder} to create a new {@link TradeOfferGenerator}.
+     *
+     * @return The new builder
+     */
+    static Builder builder() {
+        return Sponge.getRegistry().createBuilder(Builder.class);
+    }
+
+    @Override
+    default void accept(List<TradeOffer> tradeOffers, Random random) {
+        tradeOffers.add(apply(random));
+    }
+
+    /**
+     * A simple builder to create a {@link TradeOfferGenerator}.
+     */
+    interface Builder extends ResettableBuilder<TradeOfferGenerator, Builder> {
+
+        /**
+         * Sets the {@link ItemStackGenerator} for creating the primary item
+         * to be bought by the merchant.
+         *
+         * @param generator The generator that will create the first purchased
+         *     itemstack
+         * @return This builder, for chaining
+         */
+        Builder setPrimaryItemGenerator(ItemStackGenerator generator);
+
+        /**
+         * Sets the second {@link ItemStackGenerator} for creating the secondary
+         * item to be bought by the merchant.
+         *
+         * @param generator The generator that will create (if not null) the
+         *      second purchased itemstack
+         * @return This builder, for chaining
+         */
+        Builder setSecondItemGenerator(@Nullable ItemStackGenerator generator);
+
+        /**
+         * Sets the buying {@link ItemStackGenerator} for creating the selling
+         * item that players are buying.
+         *
+         * @param sellingGenerator The generator that will create the selling
+         *      item
+         * @return This builder, for chaining
+         */
+        Builder setSellingGenerator(ItemStackGenerator sellingGenerator);
+
+        /**
+         * Sets the chance when {@link Random#nextDouble()} is called where
+         * if the double is greater than the desired experience chance, the
+         * generated {@link TradeOffer} will grant experience upon a
+         * successful trade.
+         *
+         * @param experienceChance The experience chance
+         * @return This builder, for chaining
+         */
+        Builder experienceChance(double experienceChance);
+
+        /**
+         * Sets the {@link VariableAmount} of starting uses for the generated
+         * {@link TradeOffer}.
+         *
+         * @param amount The variable amount of starting uses
+         * @return This builder, for chaining
+         */
+        Builder startingUses(VariableAmount amount);
+
+        /**
+         * Sets the {@link VariableAmount} of maximum uses of the generated
+         * {@link TradeOffer}.
+         *
+         * @param amount The variable amount of maximum uses
+         * @return This buidler, for chaining
+         */
+        Builder maxUses(VariableAmount amount);
+
+        /**
+         * Builds a new {@link TradeOfferGenerator}.
+         *
+         * @return The newly created generator
+         */
+        TradeOfferGenerator build();
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/item/merchant/TradeOfferListMutator.java
+++ b/src/main/java/org/spongepowered/api/item/merchant/TradeOfferListMutator.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.item.merchant;
+
+import java.util.List;
+import java.util.Random;
+import java.util.function.BiConsumer;
+
+public interface TradeOfferListMutator extends BiConsumer<List<TradeOffer>, Random> {
+
+    @Override
+    void accept(List<TradeOffer> tradeOffers, Random random);
+
+}

--- a/src/main/java/org/spongepowered/api/item/merchant/VillagerRegistry.java
+++ b/src/main/java/org/spongepowered/api/item/merchant/VillagerRegistry.java
@@ -1,0 +1,157 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.item.merchant;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+import org.spongepowered.api.data.type.Career;
+import org.spongepowered.api.util.GuavaCollectors;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+public interface VillagerRegistry {
+
+    /**
+     * Gets an immutable {@link Multimap} of the {@link Career}'s registered
+     * {code level} to {@link TradeOfferListMutator}s. Note that the map is
+     * immutable and cannot be modified directly.
+     *
+     * @param career The career
+     * @return The immutable multimap
+     */
+    Multimap<Integer, TradeOfferListMutator> getTradeOfferLevelMap(Career career);
+
+    /**
+     * Gets the available {@link TradeOfferListMutator}s for the desired
+     * {@link Career} and {@code level}.
+     *
+     * @param career The career
+     * @param level The level
+     * @return The collection of trade offer mutators, if available
+     */
+    default Collection<TradeOfferListMutator> getMutatorsForCareer(Career career, int level) {
+        final Multimap<Integer, TradeOfferListMutator> map = getTradeOfferLevelMap(checkNotNull(career, "Career cannot be null!"));
+        final Collection<TradeOfferListMutator> mutators = map.get(level);
+        return ImmutableList.copyOf(mutators);
+    }
+
+    /**
+     * Adds the provided {@link TradeOfferListMutator} for the given
+     * {@link Career} and {@code level}. Note that the level
+     * must be at least 1. There can be multiple {@link TradeOfferListMutator}s
+     * per level.
+     *
+     * @param career The career
+     * @param level The level
+     * @param mutator The mutator to register
+     * @return This registry, for chaining
+     */
+    VillagerRegistry addMutator(Career career, int level, TradeOfferListMutator mutator);
+
+    /**
+     * Adds the provided {@link TradeOfferListMutator}s for the given
+     * {@link Career} and {@code level}. Note that the level
+     * must be at least 1. There can be multiple {@link TradeOfferListMutator}s
+     * per level.
+     *
+     * @param career The career
+     * @param level The level
+     * @param mutator The mutator to register
+     * @param mutators The additional mutators
+     * @return This registry, for chaining
+     */
+    VillagerRegistry addMutators(Career career, int level, TradeOfferListMutator mutator, TradeOfferListMutator... mutators);
+
+    /**
+     * Sets the provided {@link TradeOfferListMutator} for the given
+     * {@link Career} and {@code level}. Note that the level
+     * must be at least 1. There can be multiple {@link TradeOfferListMutator}s
+     * per level. Any previously provided {@link TradeOfferListMutator}s will
+     * be erased.
+     *
+     * @param career The career
+     * @param level The level
+     * @param mutators The mutators to register
+     * @return This registry, for chaining
+     */
+    VillagerRegistry setMutators(Career career, int level, List<TradeOfferListMutator> mutators);
+
+    /**
+     * Sets the provided {@link TradeOfferListMutator} for the given
+     * {@link Career} and {@code level}. Note that the level
+     * must be at least 1. There can be multiple {@link TradeOfferListMutator}s
+     * per level. Any previously provided {@link TradeOfferListMutator}s will
+     * be erased.
+     *
+     * @param career The career
+     * @param mutatorMap The mutator map
+     * @return This registry, for chaining
+     */
+    VillagerRegistry setMutators(Career career, Multimap<Integer, TradeOfferListMutator> mutatorMap);
+
+    /**
+     * Generates a new {@link List} of {@link TradeOffer}s based on the
+     * provided {@link Career}, {@code level}, and {@link Random}.
+     *
+     * @param career The career
+     * @param level The level
+     * @param random The random
+     * @return The generated list of trade offers
+     */
+    default Collection<TradeOffer> generateTradeOffers(Career career, int level, Random random) {
+        checkNotNull(random, "Random cannot be null!");
+        List<TradeOffer> generatedList = new ArrayList<>();
+        this.getMutatorsForCareer(career, level)
+                .stream()
+                .forEach(mutator -> mutator.accept(generatedList,random));
+        return generatedList;
+    }
+
+    /**
+     * Populates the provided {@link List} of {@link TradeOffer}s with
+     * potentially new {@link TradeOffer}s based on the
+     * {@link TradeOfferListMutator}s and {@code level}. If there are no
+     * {@link TradeOfferListMutator}s registered for the desired level
+     * and {@link Career}, the list remains unmodified.
+     *
+     * @param currentOffers The current offers
+     * @param career The career
+     * @param level The level
+     * @param random The random to use
+     * @return The list of offers modified
+     */
+    default List<TradeOffer> populateOffers(List<TradeOffer> currentOffers, Career career, int level, Random random) {
+        this.getMutatorsForCareer(career, level)
+                .forEach(mutator -> mutator.accept(currentOffers, random));
+        return currentOffers;
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/util/weighted/WeightedTable.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/WeightedTable.java
@@ -50,6 +50,10 @@ public class WeightedTable<T> extends RandomObjectTable<T> {
         super(rolls);
     }
 
+    public WeightedTable(VariableAmount rolls) {
+        super(rolls);
+    }
+
     @Override
     public boolean add(TableEntry<T> entry) {
         boolean added = super.add(entry);


### PR DESCRIPTION
This adds some dynamic "recipe" generators that can be used to not only generate `ItemStack`s and `TradeOffer`s. Namely, this adds `TradeOfferGenerator`s to be used and queried for with `Villager` `Career`s.

Granted, there was #662, but I feel that with the various "chance" utils introduced from #734 can be of better use and instead of adding new interfaces to populate an `ItemStack.Builder`, when a `BiConsumer` is perfectly acceptable, and not only does it achieve full customizability, but it's base intentions are to make semi-random generation simple. @Deamon5550 mentioned he'd be adding some utility methods to `WeightedTable` so that some cases where the `WeightedTable` does not have to be re-created every single invocation of `BiConsumer.apply` for the various `ItemStackBuilderPopulators` used.