### PR TITLE
[WIP] Generic channels

### DIFF
--- a/src/main/java/org/spongepowered/api/channel/AbstractMutableChannel.java
+++ b/src/main/java/org/spongepowered/api/channel/AbstractMutableChannel.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.channel;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+public abstract class AbstractMutableChannel<T, M> implements MutableChannel<T, M> {
+
+    protected final Set<M> members;
+
+    /**
+     * The default implementation uses a {@link WeakHashMap} implementation of {@link Set}.
+     */
+    protected AbstractMutableChannel() {
+        this(Collections.newSetFromMap(new WeakHashMap<>()));
+    }
+
+    /**
+     * Creates a new instance of {@link AbstractMutableChannel} with the
+     * provided {@link Set} as the underlying member list.
+     *
+     * <p>The passed {@link Set} directly affects the members of this channel.</p>
+     *
+     * <p>It is recommended to use a weak set to avoid memory leaks. If you do not use
+     * a weak set, please ensure that members are cleaned up properly.</p>
+     *
+     * @param members The set of members
+     */
+    protected AbstractMutableChannel(Set<M> members) {
+        this.members = members;
+    }
+
+    @Override
+    public boolean addMember(M member) {
+        return this.members.add(member);
+    }
+
+    @Override
+    public boolean removeMember(M member) {
+        return this.members.remove(member);
+    }
+
+    @Override
+    public void clearMembers() {
+        this.members.clear();
+    }
+
+    @Override
+    public Collection<M> getMembers() {
+        return this.members;
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/channel/Channel.java
+++ b/src/main/java/org/spongepowered/api/channel/Channel.java
@@ -22,21 +22,40 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.text.channel;
+package org.spongepowered.api.channel;
 
-import org.spongepowered.api.channel.MutableChannel;
-import org.spongepowered.api.text.Text;
+import java.util.Collection;
+
+import javax.annotation.Nullable;
 
 /**
- * Represents a channel that takes a message and transforms it for distribution
- * to a mutable list of members.
+ * @param <T> The type to be sent
+ * @param <M> The member type
  */
-public interface MutableMessageChannel extends MessageChannel, MutableChannel<Text, MessageReceiver> {
+public interface Channel<T, M> {
 
-    @Override
-    default MutableMessageChannel asMutable() {
-        // We're already mutable.
-        return this;
+    /**
+     * Sends a {@link T} to this channel's members.
+     *
+     * @param original The original text to send
+     */
+    default void send(T original) {
+        this.send(null, original);
     }
+
+    /**
+     * Sends a {@link T} to this channel's members.
+     *
+     * @param sender The sender of the message
+     * @param original The original message to send
+     */
+    void send(@Nullable Object sender, T original);
+
+    /**
+     * Gets a collection of all members in this channel.
+     *
+     * @return A collection of all members of this channel
+     */
+    Collection<M> getMembers();
 
 }

--- a/src/main/java/org/spongepowered/api/channel/MutableChannel.java
+++ b/src/main/java/org/spongepowered/api/channel/MutableChannel.java
@@ -22,38 +22,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.text.channel.type;
-
-import com.google.common.collect.ImmutableSet;
-import org.spongepowered.api.text.channel.MessageChannel;
-import org.spongepowered.api.text.channel.MessageReceiver;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Set;
-import java.util.WeakHashMap;
+package org.spongepowered.api.channel;
 
 /**
- * A message channel that targets the given recipients.
+ * @param <T> The type to be sent
+ * @param <M> The member type
  */
-public class FixedMessageChannel implements MessageChannel {
+public interface MutableChannel<T, M> extends Channel<T, M> {
 
-    protected final Set<MessageReceiver> recipients;
+    /**
+     * Adds a member to this channel.
+     *
+     * @param member The member to add
+     * @return {@code true} if this channel did not already contain the member
+     */
+    boolean addMember(M member);
 
-    public FixedMessageChannel(MessageReceiver... recipients) {
-        this(Arrays.asList(recipients));
-    }
+    /**
+     * Removes a member from this channel.
+     *
+     * @param member The member to remove
+     * @return {@code true} if this channel contained the specified member
+     */
+    boolean removeMember(M member);
 
-    public FixedMessageChannel(Collection<? extends MessageReceiver> provided) {
-        Set<MessageReceiver> recipients = Collections.newSetFromMap(new WeakHashMap<>());
-        recipients.addAll(provided);
-        this.recipients = recipients;
-    }
-
-    @Override
-    public Collection<MessageReceiver> getMembers() {
-        return ImmutableSet.copyOf(this.recipients);
-    }
+    /**
+     * Removes all of the members from this channel.
+     */
+    void clearMembers();
 
 }

--- a/src/main/java/org/spongepowered/api/channel/TransformableChannel.java
+++ b/src/main/java/org/spongepowered/api/channel/TransformableChannel.java
@@ -22,21 +22,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.text.channel;
+package org.spongepowered.api.channel;
 
-import org.spongepowered.api.channel.MutableChannel;
-import org.spongepowered.api.text.Text;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
 
 /**
- * Represents a channel that takes a message and transforms it for distribution
- * to a mutable list of members.
+ * @param <T> The type to be sent
+ * @param <M> The member type
  */
-public interface MutableMessageChannel extends MessageChannel, MutableChannel<Text, MessageReceiver> {
+public interface TransformableChannel<T, M> extends Channel<T, M> {
 
-    @Override
-    default MutableMessageChannel asMutable() {
-        // We're already mutable.
-        return this;
+    /**
+     * Handle transforming the input appropriately.
+     *
+     * @param sender The sender of the {@link T}
+     * @param recipient The recipient of the {@link T}
+     * @param original The original {@link T}, to optionally transform
+     * @return The {@link T} to send, if present, otherwise {@link Optional#empty()}
+     */
+    default Optional<T> transform(@Nullable Object sender, M recipient, T original) {
+        return Optional.of(original);
     }
 
 }

--- a/src/main/java/org/spongepowered/api/channel/package-info.java
+++ b/src/main/java/org/spongepowered/api/channel/package-info.java
@@ -22,21 +22,5 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.text.channel;
-
-import org.spongepowered.api.channel.MutableChannel;
-import org.spongepowered.api.text.Text;
-
-/**
- * Represents a channel that takes a message and transforms it for distribution
- * to a mutable list of members.
- */
-public interface MutableMessageChannel extends MessageChannel, MutableChannel<Text, MessageReceiver> {
-
-    @Override
-    default MutableMessageChannel asMutable() {
-        // We're already mutable.
-        return this;
-    }
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.api.channel;

--- a/src/main/java/org/spongepowered/api/text/channel/AbstractMutableMessageChannel.java
+++ b/src/main/java/org/spongepowered/api/text/channel/AbstractMutableMessageChannel.java
@@ -24,59 +24,23 @@
  */
 package org.spongepowered.api.text.channel;
 
-import java.util.Collection;
-import java.util.Collections;
+import org.spongepowered.api.channel.AbstractMutableChannel;
+import org.spongepowered.api.text.Text;
+
 import java.util.Set;
-import java.util.WeakHashMap;
 
 /**
  * An abstract implementation of {@link MutableMessageChannel}, using a
  * {@link Set} as the underlying member list
  */
-public abstract class AbstractMutableMessageChannel implements MutableMessageChannel {
+public abstract class AbstractMutableMessageChannel extends AbstractMutableChannel<Text, MessageReceiver> implements MutableMessageChannel {
 
-    protected final Set<MessageReceiver> members;
-
-    /**
-     * The default implementation uses a {@link WeakHashMap} implementation of {@link Set}.
-     */
     protected AbstractMutableMessageChannel() {
-        this(Collections.newSetFromMap(new WeakHashMap<>()));
+        super();
     }
 
-    /**
-     * Creates a new instance of {@link AbstractMutableMessageChannel} with the
-     * provided {@link Set} as the underlying member list.
-     *
-     * <p>The passed {@link Set} directly affects the members of this channel.</p>
-     *
-     * <p>It is recommended to use a weak set to avoid memory leaks. If you do not use
-     * a weak set, please ensure that members are cleaned up properly.</p>
-     *
-     * @param members The set of members
-     */
     protected AbstractMutableMessageChannel(Set<MessageReceiver> members) {
-        this.members = members;
-    }
-
-    @Override
-    public boolean addMember(MessageReceiver member) {
-        return this.members.add(member);
-    }
-
-    @Override
-    public boolean removeMember(MessageReceiver member) {
-        return this.members.remove(member);
-    }
-
-    @Override
-    public void clearMembers() {
-        this.members.clear();
-    }
-
-    @Override
-    public Collection<MessageReceiver> getMembers() {
-        return this.members;
+        super(members);
     }
 
 }

--- a/src/main/java/org/spongepowered/api/text/channel/TitleChannel.java
+++ b/src/main/java/org/spongepowered/api/text/channel/TitleChannel.java
@@ -1,0 +1,18 @@
+package org.spongepowered.api.text.channel;
+
+import org.spongepowered.api.channel.Channel;
+import org.spongepowered.api.effect.Viewer;
+import org.spongepowered.api.text.title.Title;
+
+import javax.annotation.Nullable;
+
+public interface TitleChannel extends Channel<Title, Viewer> {
+
+    @Override
+    default void send(@Nullable Object sender, Title original) {
+        for (Viewer viewer : this.getMembers()) {
+            viewer.sendTitle(original);
+        }
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/channel/impl/DelegateMutableMessageChannel.java
+++ b/src/main/java/org/spongepowered/api/text/channel/impl/DelegateMutableMessageChannel.java
@@ -50,8 +50,8 @@ public class DelegateMutableMessageChannel extends AbstractMutableMessageChannel
     }
 
     @Override
-    public Optional<Text> transformMessage(@Nullable Object sender, MessageReceiver recipient, Text original) {
-        return this.delegate.transformMessage(sender, recipient, original);
+    public Optional<Text> transform(@Nullable Object sender, MessageReceiver recipient, Text original) {
+        return this.delegate.transform(sender, recipient, original);
     }
 
 }

--- a/src/main/java/org/spongepowered/api/text/channel/type/FixedChannel.java
+++ b/src/main/java/org/spongepowered/api/text/channel/type/FixedChannel.java
@@ -22,21 +22,52 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.text.channel;
+package org.spongepowered.api.text.channel.type;
 
-import org.spongepowered.api.channel.MutableChannel;
+import com.google.common.collect.ImmutableSet;
+import org.spongepowered.api.channel.Channel;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.channel.MessageChannel;
+import org.spongepowered.api.text.channel.MessageReceiver;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
 
 /**
- * Represents a channel that takes a message and transforms it for distribution
- * to a mutable list of members.
+ * A message channel that targets the given recipients.
  */
-public interface MutableMessageChannel extends MessageChannel, MutableChannel<Text, MessageReceiver> {
+public abstract class FixedChannel<T, M> implements Channel<T, M> {
+
+    protected final Set<M> recipients;
+
+    @SafeVarargs
+    protected FixedChannel(M... recipients) {
+        this(Arrays.asList(recipients));
+    }
+
+    public FixedChannel(Collection<? extends M> provided) {
+        Set<M> recipients = Collections.newSetFromMap(new WeakHashMap<>());
+        recipients.addAll(provided);
+        this.recipients = recipients;
+    }
 
     @Override
-    default MutableMessageChannel asMutable() {
-        // We're already mutable.
-        return this;
+    public Collection<M> getMembers() {
+        return ImmutableSet.copyOf(this.recipients);
+    }
+
+    public static class Message extends FixedChannel<Text, MessageReceiver> implements MessageChannel {
+
+        public Message(MessageReceiver... recipients) {
+            super(recipients);
+        }
+
+        public Message(Collection<? extends MessageReceiver> provided) {
+            super(provided);
+        }
     }
 
 }


### PR DESCRIPTION
Implementation PRs coming later today, opening this for comments.

This PR:
- changes `MessageChannel` to be an extension of `Channel`, allowing things such as `TitleChannel` as well as custom channels
- adds `TitleChannel` for sending titles