### PR TITLE
Switch from using ListenableFuture to CompletableFuture

### DIFF
--- a/src/main/java/org/spongepowered/api/Server.java
+++ b/src/main/java/org/spongepowered/api/Server.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api;
 
 import com.flowpowered.math.vector.Vector3d;
-import com.google.common.util.concurrent.ListenableFuture;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.channel.MessageChannel;
@@ -44,6 +43,7 @@ import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Represents a typical Minecraft Server.
@@ -240,7 +240,7 @@ public interface Server {
      * @return An {@link Optional} containing the properties of the new world
      *         instance, if the copy was successful
      */
-    ListenableFuture<Optional<WorldProperties>> copyWorld(WorldProperties worldProperties, String copyName);
+    CompletableFuture<Optional<WorldProperties>> copyWorld(WorldProperties worldProperties, String copyName);
 
     /**
      * Renames an unloaded world.
@@ -259,7 +259,7 @@ public interface Server {
      * @param worldProperties The world properties to delete
      * @return True if the deletion was successful.
      */
-    ListenableFuture<Boolean> deleteWorld(WorldProperties worldProperties);
+    CompletableFuture<Boolean> deleteWorld(WorldProperties worldProperties);
 
     /**
      * Persists the given {@link WorldProperties} to the world storage for it,

--- a/src/main/java/org/spongepowered/api/profile/GameProfileManager.java
+++ b/src/main/java/org/spongepowered/api/profile/GameProfileManager.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.profile;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.profile.property.ProfileProperty;
 import org.spongepowered.api.service.user.UserStorageService;
@@ -32,6 +31,7 @@ import org.spongepowered.api.service.user.UserStorageService;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import javax.annotation.Nullable;
@@ -74,21 +74,21 @@ public interface GameProfileManager {
      * profile servers. Use {@link #get(UUID, boolean)} to disable the cache
      * lookup.</p>
      *
-     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
      * caused by a {@link ProfileNotFoundException} if the profile does not exist or
      * an {@link IOException} if a network error occurred.</p>
      *
      * @param uniqueId The unique ID
      * @return The result of the request
      */
-    default ListenableFuture<GameProfile> get(UUID uniqueId) {
+    default CompletableFuture<GameProfile> get(UUID uniqueId) {
         return this.get(uniqueId, true);
     }
 
     /**
      * Looks up a {@link GameProfile} by its unique ID.
      *
-     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
      * caused by a {@link ProfileNotFoundException} if the profile does not exist or
      * an {@link IOException} if a network error occurred.</p>
      *
@@ -96,12 +96,12 @@ public interface GameProfileManager {
      * @param useCache true to perform a cache lookup first
      * @return The result of the request
      */
-    ListenableFuture<GameProfile> get(UUID uniqueId, boolean useCache);
+    CompletableFuture<GameProfile> get(UUID uniqueId, boolean useCache);
 
     /**
      * Gets a collection of {@link GameProfile}s by their unique IDs.
      *
-     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
      * caused by a {@link ProfileNotFoundException} if the profile does not exist or
      * an {@link IOException} if a network error occurred.</p>
      *
@@ -109,7 +109,7 @@ public interface GameProfileManager {
      * @param useCache true to perform a cache lookup first
      * @return The result of the request
      */
-    ListenableFuture<Collection<GameProfile>> getAllById(Iterable<UUID> uniqueIds, boolean useCache);
+    CompletableFuture<Collection<GameProfile>> getAllById(Iterable<UUID> uniqueIds, boolean useCache);
 
     /**
      * Looks up a {@link GameProfile} by its user name (case-insensitive).
@@ -118,21 +118,21 @@ public interface GameProfileManager {
      * profile servers. Use {@link #get(String, boolean)} to disable the cache
      * lookup.</p>
      *
-     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
      * caused by a {@link ProfileNotFoundException} if the profile does not exist or
      * an {@link IOException} if a network error occurred.</p>
      *
      * @param name The username
      * @return The result of the request
      */
-    default ListenableFuture<GameProfile> get(String name) {
+    default CompletableFuture<GameProfile> get(String name) {
         return this.get(name, true);
     }
 
     /**
      * Looks up a {@link GameProfile} by its user name (case-insensitive).
      *
-     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
      * caused by a {@link ProfileNotFoundException} if the profile does not exist or
      * an {@link IOException} if a network error occurred.</p>
      *
@@ -140,13 +140,13 @@ public interface GameProfileManager {
      * @param useCache true to perform a cache lookup first
      * @return The result of the request
      */
-    ListenableFuture<GameProfile> get(String name, boolean useCache);
+    CompletableFuture<GameProfile> get(String name, boolean useCache);
 
     /**
      * Gets a collection of {@link GameProfile}s by their user names
      * (case-insensitive).
      *
-     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
      * caused by a {@link ProfileNotFoundException} if the profile does not exist or
      * an {@link IOException} if a network error occurred.</p>
      *
@@ -154,26 +154,26 @@ public interface GameProfileManager {
      * @param useCache true to perform a cache lookup first
      * @return The result of the request
      */
-    ListenableFuture<Collection<GameProfile>> getAllByName(Iterable<String> names, boolean useCache);
+    CompletableFuture<Collection<GameProfile>> getAllByName(Iterable<String> names, boolean useCache);
 
     /**
      * Fills a {@link GameProfile}.
      *
-     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
      * caused by a {@link ProfileNotFoundException} if the profile does not exist or
      * an {@link IOException} if a network error occurred.</p>
      *
      * @param profile The profile to fill
      * @return The result of the request
      */
-    default ListenableFuture<GameProfile> fill(GameProfile profile) {
+    default CompletableFuture<GameProfile> fill(GameProfile profile) {
         return this.fill(profile, false);
     }
 
     /**
      * Fills a {@link GameProfile}.
      *
-     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
      * caused by a {@link ProfileNotFoundException} if the profile does not exist or
      * an {@link IOException} if a network error occurred.</p>
      *
@@ -181,14 +181,14 @@ public interface GameProfileManager {
      * @param signed true if we should request that the profile data be signed
      * @return The result of the request
      */
-    default ListenableFuture<GameProfile> fill(GameProfile profile, boolean signed) {
+    default CompletableFuture<GameProfile> fill(GameProfile profile, boolean signed) {
         return this.fill(profile, signed, true);
     }
 
     /**
      * Fills a {@link GameProfile}.
      *
-     * <p>The returned {@link ListenableFuture} throws an {@link ExecutionException}
+     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
      * caused by a {@link ProfileNotFoundException} if the profile does not exist or
      * an {@link IOException} if a network error occurred.</p>
      *
@@ -197,7 +197,7 @@ public interface GameProfileManager {
      * @param useCache true to perform a cache lookup first
      * @return The result of the request
      */
-    ListenableFuture<GameProfile> fill(GameProfile profile, boolean signed, boolean useCache);
+    CompletableFuture<GameProfile> fill(GameProfile profile, boolean signed, boolean useCache);
 
     /**
      * Gets a collection of all cached {@link GameProfile}s.

--- a/src/main/java/org/spongepowered/api/world/storage/WorldStorage.java
+++ b/src/main/java/org/spongepowered/api/world/storage/WorldStorage.java
@@ -25,12 +25,12 @@
 package org.spongepowered.api.world.storage;
 
 import com.flowpowered.math.vector.Vector3i;
-import com.google.common.util.concurrent.ListenableFuture;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.world.Chunk;
 import org.spongepowered.api.world.World;
 
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Represents the storage manager of a particular {@link World}.
@@ -59,13 +59,13 @@ public interface WorldStorage {
      * not be guaranteed to remain in synch with the server, let alone on the
      * server thread.</p>
      *
-     * <p>It is imperative to avoid waiting for the {@link ListenableFuture} to
+     * <p>It is imperative to avoid waiting for the {@link CompletableFuture} to
      * complete its task.</p>
      *
      * @param chunkCoords The chunk coordinates
      * @return Whether the chunk exists or not
      */
-    ListenableFuture<Boolean> doesChunkExist(Vector3i chunkCoords);
+    CompletableFuture<Boolean> doesChunkExist(Vector3i chunkCoords);
 
     /**
      * Gets a {@link DataContainer} including all data related to a
@@ -78,14 +78,14 @@ public interface WorldStorage {
      * <p>This may not return a {@link DataContainer} in the event there is no
      * chunk data generated at the desired coordinates.</p>
      *
-     * <p>It is imperative to understand that the {@link ListenableFuture} task
-     * is blocking, and should avoid using {@link ListenableFuture#get()} while
+     * <p>It is imperative to understand that the {@link CompletableFuture} task
+     * is blocking, and should avoid using {@link CompletableFuture#get()} while
      * on the main thread.</p>
      *
      * @param chunkCoords The chunk coordinates
      * @return The data container representing the chunk data, if available
      */
-    ListenableFuture<Optional<DataContainer>> getChunkData(Vector3i chunkCoords);
+    CompletableFuture<Optional<DataContainer>> getChunkData(Vector3i chunkCoords);
 
     /**
      * Gets the {@link WorldProperties} of this storage. In the vanilla storage


### PR DESCRIPTION
**SpongeAPI PR | [SpongeCommon PR](https://github.com/SpongePowered/SpongeCommon/pull/473)**

CompletableFuture is the jdk8 equivalent of guava's ListenableFuture
class, with similar capabilities but better lambda integration.

There shouldn't be any reason to prefer guava classes over java classes, but this PR is here in case anyone wants to discuss that.