### PR TITLE
Add ability to restrict commands based on the CommandSource type

### DIFF
--- a/src/main/java/org/spongepowered/api/command/CommandCallable.java
+++ b/src/main/java/org/spongepowered/api/command/CommandCallable.java
@@ -79,6 +79,20 @@ public interface CommandCallable {
     boolean testPermission(CommandSource source);
 
     /**
+     * Test whether this command is allowed to be executed by the specified
+     * source depending on it's type.
+     *
+     * <p>Implementations should use this to restrict command execution of
+     * certain command source types. This varies from permissions in that
+     * a source may have permission to execute a command but must be, for
+     * example, a Player because the command uses locational data.</p>
+     *
+     * @param source called of the command
+     * @return whether the source type is permitted to execute the command
+     */
+    boolean testSourceType(CommandSource source);
+
+    /**
      * Get a short one-line description of this command.
      *
      * <p>The help system may display the description in the command list.</p>

--- a/src/main/java/org/spongepowered/api/command/CommandSourceTypeException.java
+++ b/src/main/java/org/spongepowered/api/command/CommandSourceTypeException.java
@@ -22,24 +22,42 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.command.spec;
+package org.spongepowered.api.command;
 
-import org.spongepowered.api.command.CommandException;
-import org.spongepowered.api.command.CommandResult;
-import org.spongepowered.api.command.CommandSource;
-import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.text.Text;
 
 /**
- * Interface containing the method directing how a certain command will be executed.
+ * Exception thrown when a CommandSource tries to execute a command that cannot
+ * be executed by that CommandSource type.
  */
-public interface CommandExecutor<T extends CommandSource> {
+public class CommandSourceTypeException extends CommandException {
+    private static final long serialVersionUID = -4945570277201224948L;
+
     /**
-     * Callback for the execution of a command.
+     * Creates a new exception with the specified expected class.
      *
-     * @param src The commander who is executing this command
-     * @param args The parsed command arguments for this command
-     * @return the result of executing this command
-     * @throws CommandException If a user-facing error occurs while executing this command
+     * @param expected class of source type
      */
-    CommandResult execute(T src, CommandContext args) throws CommandException;
+    public CommandSourceTypeException(Class<? extends CommandSource> expected) {
+        super(Text.of("Only users of type " + expected.getName() + " may execute this command."));
+    }
+
+    /**
+     * Creates a new exception with the specified message.
+     *
+     * @param message to display
+     */
+    public CommandSourceTypeException(Text message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new exception with the specified message and original cause.
+     *
+     * @param message to display
+     * @param cause original cause
+     */
+    public CommandSourceTypeException(Text message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/org/spongepowered/api/command/args/ChildCommandElementExecutor.java
+++ b/src/main/java/org/spongepowered/api/command/args/ChildCommandElementExecutor.java
@@ -24,30 +24,26 @@
  */
 package org.spongepowered.api.command.args;
 
-import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
 import static org.spongepowered.api.command.CommandMessageFormatting.error;
+import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimaps;
-import org.spongepowered.api.text.Text;
-import org.spongepowered.api.util.GuavaCollectors;
-import org.spongepowered.api.util.StartsWithPredicate;
-import org.spongepowered.api.command.CommandCallable;
-import org.spongepowered.api.command.CommandException;
-import org.spongepowered.api.command.CommandMapping;
-import org.spongepowered.api.command.CommandResult;
-import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.*;
 import org.spongepowered.api.command.dispatcher.SimpleDispatcher;
 import org.spongepowered.api.command.spec.CommandExecutor;
 import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.GuavaCollectors;
+import org.spongepowered.api.util.StartsWithPredicate;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.annotation.Nullable;
-
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class ChildCommandElementExecutor extends CommandElement implements CommandExecutor {
     private static final AtomicInteger COUNTER = new AtomicInteger();
 

--- a/src/main/java/org/spongepowered/api/command/dispatcher/SimpleDispatcher.java
+++ b/src/main/java/org/spongepowered/api/command/dispatcher/SimpleDispatcher.java
@@ -25,8 +25,8 @@
 package org.spongepowered.api.command.dispatcher;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
 import static org.spongepowered.api.command.CommandMessageFormatting.SPACE_TEXT;
+import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
@@ -35,21 +35,15 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
+import org.spongepowered.api.command.*;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.action.TextActions;
 import org.spongepowered.api.text.format.TextColors;
 import org.spongepowered.api.text.format.TextStyles;
 import org.spongepowered.api.util.GuavaCollectors;
 import org.spongepowered.api.util.StartsWithPredicate;
-import org.spongepowered.api.command.CommandCallable;
-import org.spongepowered.api.command.CommandException;
-import org.spongepowered.api.command.CommandMapping;
-import org.spongepowered.api.command.CommandMessageFormatting;
-import org.spongepowered.api.command.CommandNotFoundException;
-import org.spongepowered.api.command.CommandResult;
-import org.spongepowered.api.command.CommandSource;
-import org.spongepowered.api.command.ImmutableCommandMapping;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -60,8 +54,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import javax.annotation.Nullable;
 
 /**
  * A simple implementation of a {@link Dispatcher}.
@@ -350,6 +342,16 @@ public final class SimpleDispatcher implements Dispatcher {
     public boolean testPermission(CommandSource source) {
         for (CommandMapping mapping : this.commands.values()) {
             if (mapping.getCallable().testPermission(source)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean testSourceType(CommandSource source) {
+        for (CommandMapping mapping : this.commands.values()) {
+            if (mapping.getCallable().testSourceType(source)) {
                 return true;
             }
         }


### PR DESCRIPTION
Example usage:

```java
CommandSpec foo = CommandSpec.builder()
    .sourceType(Player.class)
    .executor(new FooExecutor())
    .build();

class FooExecutor extends CommandExecutor<Player> {
    public CommandResult execute(Player player, CommandContext context) {
        // blah blah blah
        return CommandResult.success();
    }
}
```

Note that while `CommandExecutor#execute(T, CommandContext);`'s signature has been changed, this is *not* a breaking change for old implementations.

SpongeCommon PR: https://github.com/SpongePowered/SpongeCommon/pull/475

Signed-off-by: Walker Crouse <walkercrouse@hotmail.com>