### PR TITLE
Add ability to restrict commands based on the CommandSource type

### DIFF
--- a/src/main/java/org/spongepowered/api/command/CommandCallable.java
+++ b/src/main/java/org/spongepowered/api/command/CommandCallable.java
@@ -79,6 +79,20 @@ public interface CommandCallable {
     boolean testPermission(CommandSource source);
 
     /**
+     * Test whether this command is allowed to be executed by the specified
+     * source depending on it's type.
+     *
+     * <p>Implementations should use this to restrict command execution of
+     * certain command source types. This varies from permissions in that
+     * a source may have permission to execute a command but must be, for
+     * example, a Player because the command uses locational data.</p>
+     *
+     * @param source called of the command
+     * @return whether the source type is permitted to execute the command
+     */
+    boolean testSourceType(CommandSource source);
+
+    /**
      * Get a short one-line description of this command.
      *
      * <p>The help system may display the description in the command list.</p>

--- a/src/main/java/org/spongepowered/api/command/CommandSourceTypeException.java
+++ b/src/main/java/org/spongepowered/api/command/CommandSourceTypeException.java
@@ -22,24 +22,43 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.command.spec;
+package org.spongepowered.api.command;
 
-import org.spongepowered.api.command.CommandException;
-import org.spongepowered.api.command.CommandResult;
-import org.spongepowered.api.command.CommandSource;
-import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.text.Text;
 
 /**
- * Interface containing the method directing how a certain command will be executed.
+ * Exception thrown when a CommandSource tries to execute a command that cannot
+ * be executed by that CommandSource type.
  */
-public interface CommandExecutor<T extends CommandSource> {
+public class CommandSourceTypeException extends CommandException {
+
+    private static final long serialVersionUID = -4945570277201224948L;
+
     /**
-     * Callback for the execution of a command.
+     * Creates a new exception with the specified expected class.
      *
-     * @param source The commander who is executing this command
-     * @param args The parsed command arguments for this command
-     * @return the result of executing this command
-     * @throws CommandException If a user-facing error occurs while executing this command
+     * @param expected class of source type
      */
-    CommandResult execute(T source, CommandContext args) throws CommandException;
+    public CommandSourceTypeException(Class<? extends CommandSource> expected) {
+        super(Text.of("Only users of type " + expected.getName() + " may execute this command."));
+    }
+
+    /**
+     * Creates a new exception with the specified message.
+     *
+     * @param message to display
+     */
+    public CommandSourceTypeException(Text message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new exception with the specified message and original cause.
+     *
+     * @param message to display
+     * @param cause original cause
+     */
+    public CommandSourceTypeException(Text message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/org/spongepowered/api/command/args/ChildCommandElementExecutor.java
+++ b/src/main/java/org/spongepowered/api/command/args/ChildCommandElementExecutor.java
@@ -24,14 +24,11 @@
  */
 package org.spongepowered.api.command.args;
 
-import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
 import static org.spongepowered.api.command.CommandMessageFormatting.error;
+import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimaps;
-import org.spongepowered.api.text.Text;
-import org.spongepowered.api.util.GuavaCollectors;
-import org.spongepowered.api.util.StartsWithPredicate;
 import org.spongepowered.api.command.CommandCallable;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandMapping;
@@ -40,6 +37,9 @@ import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.dispatcher.SimpleDispatcher;
 import org.spongepowered.api.command.spec.CommandExecutor;
 import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.GuavaCollectors;
+import org.spongepowered.api.util.StartsWithPredicate;
 
 import java.util.List;
 import java.util.Optional;
@@ -48,6 +48,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nullable;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class ChildCommandElementExecutor extends CommandElement implements CommandExecutor {
     private static final AtomicInteger COUNTER = new AtomicInteger();
 

--- a/src/main/java/org/spongepowered/api/command/dispatcher/SimpleDispatcher.java
+++ b/src/main/java/org/spongepowered/api/command/dispatcher/SimpleDispatcher.java
@@ -25,8 +25,8 @@
 package org.spongepowered.api.command.dispatcher;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
 import static org.spongepowered.api.command.CommandMessageFormatting.SPACE_TEXT;
+import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
@@ -35,12 +35,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
-import org.spongepowered.api.text.Text;
-import org.spongepowered.api.text.action.TextActions;
-import org.spongepowered.api.text.format.TextColors;
-import org.spongepowered.api.text.format.TextStyles;
-import org.spongepowered.api.util.GuavaCollectors;
-import org.spongepowered.api.util.StartsWithPredicate;
 import org.spongepowered.api.command.CommandCallable;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandMapping;
@@ -49,6 +43,12 @@ import org.spongepowered.api.command.CommandNotFoundException;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.ImmutableCommandMapping;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.action.TextActions;
+import org.spongepowered.api.text.format.TextColors;
+import org.spongepowered.api.text.format.TextStyles;
+import org.spongepowered.api.util.GuavaCollectors;
+import org.spongepowered.api.util.StartsWithPredicate;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -350,6 +350,16 @@ public final class SimpleDispatcher implements Dispatcher {
     public boolean testPermission(CommandSource source) {
         for (CommandMapping mapping : this.commands.values()) {
             if (mapping.getCallable().testPermission(source)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean testSourceType(CommandSource source) {
+        for (CommandMapping mapping : this.commands.values()) {
+            if (mapping.getCallable().testSourceType(source)) {
                 return true;
             }
         }

--- a/src/main/java/org/spongepowered/api/command/spec/CommandSpec.java
+++ b/src/main/java/org/spongepowered/api/command/spec/CommandSpec.java
@@ -25,19 +25,18 @@
 package org.spongepowered.api.command.spec;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
 import static org.spongepowered.api.command.args.GenericArguments.firstParsing;
 import static org.spongepowered.api.command.args.GenericArguments.optional;
+import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
-import org.spongepowered.api.text.Text;
 import org.spongepowered.api.command.CommandCallable;
 import org.spongepowered.api.command.CommandException;
-import org.spongepowered.api.command.CommandMessageFormatting;
 import org.spongepowered.api.command.CommandPermissionException;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.CommandSourceTypeException;
 import org.spongepowered.api.command.args.ArgumentParseException;
 import org.spongepowered.api.command.args.ChildCommandElementExecutor;
 import org.spongepowered.api.command.args.CommandArgs;
@@ -46,6 +45,7 @@ import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.command.args.GenericArguments;
 import org.spongepowered.api.command.args.parsing.InputTokenizer;
 import org.spongepowered.api.command.args.parsing.InputTokenizers;
+import org.spongepowered.api.text.Text;
 
 import java.util.HashMap;
 import java.util.List;
@@ -57,23 +57,30 @@ import javax.annotation.Nullable;
 /**
  * Specification for how command arguments should be parsed.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public final class CommandSpec implements CommandCallable {
 
     private final CommandElement args;
     private final CommandExecutor executor;
     private final Optional<Text> description;
-    @Nullable private final Text extendedDescription;
+    @Nullable
+    private final Text extendedDescription;
     @Nullable private final String permission;
     private final InputTokenizer argumentParser;
+    private final Class<? extends CommandSource> sourceType;
+    private final boolean sourceTypeDeep;
 
-    private CommandSpec(CommandElement args, CommandExecutor executor, @Nullable Text description, @Nullable Text extendedDescription,
-            @Nullable String permission, InputTokenizer parser) {
+    private CommandSpec(CommandElement args, CommandExecutor executor, @Nullable Text description,
+                        @Nullable Text extendedDescription, @Nullable String permission, InputTokenizer parser,
+                        Class<? extends CommandSource> sourceType, boolean sourceTypeDeep) {
         this.args = args;
         this.executor = executor;
         this.permission = permission;
         this.description = Optional.ofNullable(description);
         this.extendedDescription = extendedDescription;
         this.argumentParser = parser;
+        this.sourceType = sourceType;
+        this.sourceTypeDeep = sourceTypeDeep;
     }
 
     /**
@@ -103,6 +110,8 @@ public final class CommandSpec implements CommandCallable {
         @Nullable
         private Map<List<String>, CommandCallable> childCommandMap;
         private InputTokenizer argumentParser = InputTokenizers.quotedStrings(false);
+        private Class<? extends CommandSource> sourceType = CommandSource.class;
+        private boolean sourceTypeDeep = true;
 
         private Builder() {}
 
@@ -123,7 +132,7 @@ public final class CommandSpec implements CommandCallable {
          * @param executor The executor that will be called with this command's parsed arguments
          * @return this
          */
-        public Builder executor(CommandExecutor executor) {
+        public <T extends CommandSource> Builder executor(CommandExecutor<T> executor) {
             checkNotNull(executor, "executor");
             this.executor = executor;
             return this;
@@ -228,6 +237,34 @@ public final class CommandSpec implements CommandCallable {
         }
 
         /**
+         * Restricts the command to the specified CommandSource sub-class. If
+         * deep is true than the specified class and all subsequent sub-classes
+         * will be permitted to execute the command.
+         *
+         * @param senderType type of command source
+         * @param deep whether the type's sub-classes should be included
+         * @return this
+         */
+        public Builder sourceType(Class<? extends CommandSource> senderType, boolean deep) {
+            checkNotNull(senderType, "sender type");
+            this.sourceType = senderType;
+            this.sourceTypeDeep = deep;
+            return this;
+        }
+
+        /**
+         * Restricts the command to the specified CommandSource sub-class and
+         * all of it's subsequent sub-classes.
+         *
+         * @param senderType type of command source
+         * @return this
+         */
+        public Builder sourceType(Class<? extends CommandSource> senderType) {
+            sourceType(senderType, true);
+            return this;
+        }
+
+        /**
          * Create a new {@link CommandSpec} based on the data provided in this builder.
          *
          * @return the new spec
@@ -254,7 +291,7 @@ public final class CommandSpec implements CommandCallable {
             }
 
             return new CommandSpec(this.args, this.executor, this.description, this.extendedDescription, this.permission,
-                    this.argumentParser);
+                    this.argumentParser, this.sourceType, this.sourceTypeDeep);
         }
     }
 
@@ -269,6 +306,20 @@ public final class CommandSpec implements CommandCallable {
         checkNotNull(source, "source");
         if (!testPermission(source)) {
             throw new CommandPermissionException();
+        }
+    }
+
+    /**
+     * Checks if the specified CommandSource is permitted to execute this
+     * command based upon their type.
+     *
+     * @param source source to check
+     * @throws CommandException if the source is not permitted to execute the command
+     */
+    public void checkSourceType(CommandSource source) throws CommandException {
+        checkNotNull(source, "source");
+        if (!testSourceType(source)) {
+            throw new CommandSourceTypeException(this.sourceType);
         }
     }
 
@@ -325,6 +376,7 @@ public final class CommandSpec implements CommandCallable {
 
     @Override
     public CommandResult process(CommandSource source, String arguments) throws CommandException {
+        checkSourceType(source);
         checkPermission(source);
         final CommandArgs args = new CommandArgs(arguments, getInputTokenizer().tokenize(arguments, false));
         final CommandContext context = new CommandContext();
@@ -341,6 +393,12 @@ public final class CommandSpec implements CommandCallable {
     @Override
     public boolean testPermission(CommandSource source) {
         return this.permission == null || source.hasPermission(this.permission);
+    }
+
+    @Override
+    public boolean testSourceType(CommandSource source) {
+        Class<? extends CommandSource> clazz = source.getClass();
+        return this.sourceTypeDeep ? this.sourceType.isAssignableFrom(clazz) : this.sourceType.equals(clazz);
     }
 
     /**


### PR DESCRIPTION
Example usage:

```java
CommandSpec foo = CommandSpec.builder()
    .sourceType(Player.class)
    .executor(new FooExecutor())
    .build();

class FooExecutor extends CommandExecutor<Player> {
    public CommandResult execute(Player player, CommandContext context) {
        // blah blah blah
        return CommandResult.success();
    }
}
```

Note that while `CommandExecutor#execute(T, CommandContext);`'s signature has been changed, this is *not* a breaking change for old implementations.

SpongeCommon PR: https://github.com/SpongePowered/SpongeCommon/pull/477
Signed-off-by: Walker Crouse <walkercrouse@hotmail.com>