### PR TITLE
Text Representables

### DIFF
--- a/src/main/java/org/spongepowered/api/CatalogType.java
+++ b/src/main/java/org/spongepowered/api/CatalogType.java
@@ -24,6 +24,10 @@
  */
 package org.spongepowered.api;
 
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.TextRepresentable;
+import org.spongepowered.api.text.action.TextActions;
+
 /**
  * Represents a type of a catalog that can be used to identify types without
  * using an {@link Enum}.
@@ -35,7 +39,7 @@ package org.spongepowered.api;
  * <code>`a.getId().equalsIgnoreCase(b.getId())`</code> are true then all must
  * be true.</p>
  */
-public interface CatalogType {
+public interface CatalogType extends TextRepresentable {
 
     /**
      * Gets the unique identifier of this {@link CatalogType}. The identifier is
@@ -60,5 +64,13 @@ public interface CatalogType {
      * @return The human-readable name of this catalog type
      */
     String getName();
+    
+    @Override
+    default Text toText() {
+        final Text.Builder builder = Text.builder(getName());
+        builder.onHover(TextActions.showText(Text.of("Id: " + getId() + "\nName: " + getName())));
+        builder.onShiftClick(TextActions.insertText(getId()));
+        return builder.toText();
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -38,6 +38,7 @@ import org.spongepowered.api.data.manipulator.mutable.TargetedLocationData;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
+import org.spongepowered.api.text.TextRepresentable;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.Identifiable;
 import org.spongepowered.api.util.RelativePositions;
@@ -71,7 +72,7 @@ import javax.annotation.Nullable;
  *
  * <p>Blocks and items (when they are in inventories) are not entities.</p>
  */
-public interface Entity extends Identifiable, DataHolder, DataSerializable, Translatable {
+public interface Entity extends Identifiable, DataHolder, DataSerializable, Translatable, TextRepresentable {
 
     /**
      * Get the type of entity.

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
@@ -38,6 +38,7 @@ import org.spongepowered.api.data.DataView;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.text.TextRepresentable;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.ResettableBuilder;
 
@@ -49,7 +50,7 @@ import org.spongepowered.api.util.ResettableBuilder;
  * use {@link DataHolder#get(Class)} to retrieve different information
  * regarding this item stack.</p>
  */
-public interface ItemStack extends DataHolder, DataSerializable, Translatable {
+public interface ItemStack extends DataHolder, DataSerializable, Translatable, TextRepresentable {
 
     /**
      * Creates a new {@link Builder} to build an {@link ItemStack}.

--- a/src/main/java/org/spongepowered/api/statistic/achievement/Achievement.java
+++ b/src/main/java/org/spongepowered/api/statistic/achievement/Achievement.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.statistic.achievement;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.statistic.Statistic;
+import org.spongepowered.api.text.TextRepresentable;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.text.translation.Translation;
 import org.spongepowered.api.util.ResettableBuilder;
@@ -41,7 +42,7 @@ import javax.annotation.Nullable;
  * Represents an in-game achievement which may be earned by or given to players.
  */
 @CatalogedBy(Achievements.class)
-public interface Achievement extends CatalogType, Translatable {
+public interface Achievement extends CatalogType, Translatable, TextRepresentable {
 
     /**
      * Creates a new {@link Builder} to build a {@link Achievement}.

--- a/src/main/java/org/spongepowered/api/text/TextRepresentable.java
+++ b/src/main/java/org/spongepowered/api/text/TextRepresentable.java
@@ -27,19 +27,38 @@ package org.spongepowered.api.text;
 
 import org.spongepowered.api.text.action.HoverAction;
 import org.spongepowered.api.text.action.TextAction;
+import org.spongepowered.api.text.format.TextStyles;
 
 /**
  * Represents an instance that have a {@link Text} representation that should be
- * used when this instance should be used inside a {@link Text}.
+ * used when this instance should be displayed in chat or wrapped in
+ * {@link Text} objects. Developers should use the default text representation
+ * of this instance whenever they want to use this instance in chat. Only in
+ * cases where the default representation does not fit the requirements of the
+ * situation a different text representation may be used. However developers
+ * should stick to the original text representation as closely as possible to
+ * avoid inconsistent user experience.
  */
-interface TextRepresentable {
+public interface TextRepresentable {
 
     /**
-     * Gets the textual representation of this instance for its usage in other
-     * {@link Text} objects. This may but does not need to include
-     * {@link HoverAction hover texts} or other {@link TextAction actions}. This
-     * method is basically the {@link Object#toString() toString()} equivalent
-     * for {@link Text}s.
+     * Gets the representation of this instance as a {@link Text}.
+     *
+     * <p>The resulting {@link Text} should contain of the following:</p>
+     *
+     * <ul>
+     * <li>A formated name of this instance. The usage of
+     * {@link TextStyles#OBFUSCATED} and TextStyles#STRIKETHROUGH} is
+     * discouraged.</li>
+     * <li>A {@link HoverAction} with more details concerning this instance or
+     * its current state. This may but does not need to include the id, uuid,
+     * the plain name, an image, a short description or other appropriate
+     * details.</li>
+     * <li>Optionally one or more other {@link TextAction} or similar things to
+     * interact with this instance. Examples for this could be starting a
+     * conversation with this instance, opening some kind of gui related to this
+     * instance or proposing a command or keyword related to this instance.</li>
+     * </ul>
      *
      * @return The text instance representing this instance
      */

--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -30,6 +30,8 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.effect.Viewer;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.service.context.ContextSource;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.TextRepresentable;
 import org.spongepowered.api.world.difficulty.Difficulty;
 import org.spongepowered.api.world.explosion.Explosion;
 import org.spongepowered.api.world.extent.Extent;
@@ -47,7 +49,7 @@ import java.util.UUID;
 /**
  * A loaded Minecraft world.
  */
-public interface World extends Extent, WeatherUniverse, Viewer, ContextSource {
+public interface World extends Extent, WeatherUniverse, Viewer, ContextSource, TextRepresentable {
 
     @Override
     default Location<World> getLocation(Vector3i position) {
@@ -301,5 +303,10 @@ public interface World extends Extent, WeatherUniverse, Viewer, ContextSource {
 
     @Override
     MutableBlockVolumeWorker<? extends World> getBlockWorker();
+
+    @Override
+    default Text toText() {
+        return Text.of(getName());
+    }
 
 }


### PR DESCRIPTION
Implemenation: https://github.com/SpongePowered/SpongeCommon/pull/483

## The issue

Currently it is not possible to have a default representation for a particular instance.

This has the following disadvantages:
* Code duplication (both in different plugins and in the same plugin) to format the instances
* Dismatching presentation style of the same instance across plugins
* Ugly fallback to `toString()` if no custom representation is set

````java
Text myMessage = Text.of("I got an ", toText(itemStack));

// [...]

public static Text toText(ItemStack stack) {
    final TextBuilder builder;
    final Optional<DisplayNameData> optName = stack.get(DisplayNameData.class);
    if (optName.isPresent()) {
        Value<Text> displayName = optName.get().displayName();
        if (displayName.exists()) {
            builder = displayName.get().builder();
        } else {
            builder = Texts.builder(stack.getTranslation());
        }
    } else {
        builder = Texts.builder(stack.getTranslation());
    }
    builder.onHover(TextActions.showItem(stack));
    return builder.build();
}
````

## Solutions

* Level 1: Allow classes to specify their default representation
* Level 2: Level 1 + Use special format if available
* Level 3: Level 2 + Use the human readable name if available

### The minimal solution (level 1)

Expose the `TextRepresentable` interface and allow the server and plugins to implement it where they want so a lot of instances (can) have a default representation and can easily be passed to `Text.of(Object...)`. This solution does not force any implementation to implement anything at all, because it. With this solution you can pass the single instance to `Text.of(Object....)` and can style the resulting instance without knowledge of the original class and its methods (e.g. `getName()` or `getDisplayName()`). IMO everything that has a human readable name (e.g. `getName()` method) should implement this class.

**None breaking.**

````java
Text myMessage = Text.of("I got an ", itemStack);
````

### The medium solution (level 2)

Expose the `TextRepresentable` interface and mark some classes (mainly those classes which have a representation in vanilla by default) with this interface, so there is a basic set of classes that are forced to have a special representation. Server and plugins can still implement it how they want and can also implement it in a lot of other classes. With this solution you can easily pass the instances to `Text.of(Object...)` or adjust the `Text` representation to your needs (replace click action or alike) without having to style/write it from scratch.

* `Achievement`
* `Entity` and `Player` (maybe `User` as well for consistency reasons)
* `ItemStack`
* `Statistic` (has a representation, but not yet tested)

**Minimal implementation changes required**
* 1x `shadow$getDisplayName()` + 1 line implemenation per class

````java
// Optional customization
Object blueStack = itemStack.toText().toBuilder().color(TextColors.BLUE);

Text myMessage = Text.of("I got an ", blueStack);
````

### The advanced solution (level 3)

Expose the `TextRepresentable` interface and mark all classes with this interface that are used in chat or commands frequently. (All classes that have a `getName()` or a similar method)
* The classes mentioned in level 2
* `CatalogType`s are often used in commands and they have a discrepancy
between their human readable name and their internal id which requires
them to use special representations to be usable in commands.
* `World`s are often used in chat messages and they have a name so, the name
should be displayed.

There are probably more that will match the criteria for this level.

**Minimal implementation changes required**
* Same as level 2
* Most of the other necessary changes can be `default` implemented.

## Noteworthy

Server and plugins are still able to overwrite the default `Text` representation of the object. They just have to do it before `Text.of(Object...)`. They could also rely on the default representation and just optimize it for their current needs.

I added the required code for all three levels, but we can drop one or two of them if you disagree with them. Although I would like to see them all.