### PR TITLE
TargetedLocation uses Vector3d, not Location<World>

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -848,7 +848,7 @@ public final class Keys {
 
     public static final Key<OptionalValue<UUID>> TAMED_OWNER = null;
 
-    public static final Key<Value<Location<World>>> TARGETED_LOCATION = null;
+    public static final Key<Value<Vector3d>> TARGETED_LOCATION = null;
 
     public static final Key<MutableBoundedValue<Integer>> TOTAL_EXPERIENCE = null;
 

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableTargetedLocationData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableTargetedLocationData.java
@@ -24,30 +24,30 @@
  */
 package org.spongepowered.api.data.manipulator.immutable;
 
+import com.flowpowered.math.vector.Vector3d;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.TargetedLocationData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.entity.projectile.EnderPearl;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
-import org.spongepowered.api.world.Location;
-import org.spongepowered.api.world.World;
 
 /**
  * An {@link ImmutableDataManipulator} handling the supposed targeted
- * {@link Location}. Usually for the case of {@link EnderPearl}s, the targeted
- * {@link Location} is where the {@link EnderPearl} will move towards until it's
- * expiration time. In the case of {@link ItemStack}s of type
- * {@link ItemTypes#COMPASS}, the targeted {@link Location} is where the compass
- * will point towards.
+ * {@link Vector3d}.
+ *
+ * <p>Usually for the case of {@link EnderPearl}s, the targeted {@link Vector3d}
+ * is where the {@link EnderPearl} will move towards until it's expiration time.
+ * In the case of {@link ItemStack}s of type {@link ItemTypes#COMPASS}, the
+ * targeted {@link Vector3d} is where the compass will point towards.</p>
  */
 public interface ImmutableTargetedLocationData extends ImmutableDataManipulator<ImmutableTargetedLocationData, TargetedLocationData> {
 
     /**
-     * Gets the {@link ImmutableValue} for the targeted {@link Location}.
+     * Gets the {@link ImmutableValue} for the targeted {@link Vector3d}.
      *
      * @return The immutable value for the targeted location
      */
-    ImmutableValue<Location<World>> target();
+    ImmutableValue<Vector3d> target();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/TargetedLocationData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/TargetedLocationData.java
@@ -24,29 +24,29 @@
  */
 package org.spongepowered.api.data.manipulator.mutable;
 
+import com.flowpowered.math.vector.Vector3d;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.ImmutableTargetedLocationData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.projectile.EnderPearl;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
-import org.spongepowered.api.world.Location;
-import org.spongepowered.api.world.World;
 
 /**
- * An {@link DataManipulator} handling the supposed targeted {@link Location}.
- * Usually for the case of {@link EnderPearl}s, the targeted {@link Location} is
- * where the {@link EnderPearl} will move towards until it's expiration time. In
- * the case of {@link ItemStack}s of type {@link ItemTypes#COMPASS}, the
- * targeted {@link Location} is where the compass will point towards.
+ * An {@link DataManipulator} handling the supposed targeted {@link Vector3d}.
+ *
+ * <p>Usually for the case of {@link EnderPearl}s, the targeted {@link Vector3d}
+ * is where the {@link EnderPearl} will move towards until it's expiration time.
+ * In the case of {@link ItemStack}s of type {@link ItemTypes#COMPASS}, the
+ * targeted {@link Vector3d} is where the compass will point towards.</p>
  */
 public interface TargetedLocationData extends DataManipulator<TargetedLocationData, ImmutableTargetedLocationData> {
 
     /**
-     * Gets the {@link Value} for the targeted {@link Location}.
+     * Gets the {@link Value} for the targeted {@link Vector3d}.
      *
      * @return The value for the targeted location
      */
-    Value<Location<World>> target();
+    Value<Vector3d> target();
 
 }

--- a/src/main/java/org/spongepowered/api/entity/projectile/EyeOfEnder.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/EyeOfEnder.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.entity.projectile;
 
+import com.flowpowered.math.vector.Vector3d;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.mutable.TargetedLocationData;
 import org.spongepowered.api.data.value.mutable.Value;
@@ -50,7 +51,7 @@ public interface EyeOfEnder extends Projectile {
      *
      * @return The value for the targeted location
      */
-    default Value<Location<World>> target() {
+    default Value<Vector3d> target() {
         return getValue(Keys.TARGETED_LOCATION).get();
     }
 }


### PR DESCRIPTION
[**API**](https://github.com/SpongePowered/SpongeAPI/pull/1065) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/485)
Supersedes #1064

This changes `TargetedLocation` to use `Vector3d` instead of `Location<World>`.