### PR TITLE
Humanoids do not have clients therefore they cannot "view" inventories or "interact" with things

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/living/Humanoid.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Humanoid.java
@@ -32,44 +32,11 @@ import org.spongepowered.api.entity.Tamer;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 import org.spongepowered.api.item.inventory.Carrier;
-import org.spongepowered.api.item.inventory.Inventory;
-
-import java.util.Optional;
 
 /**
  * Represents a human-like entity in game, such as {@link Player} or {@link Human}s.
  */
 public interface Humanoid extends Living, ProjectileSource, ArmorEquipable, Tamer, Carrier {
-
-    /**
-     * Returns whether this human entity has an open inventory at the moment
-     * or not.
-     *
-     * @return Whether this human is viewing an inventory or not
-     */
-    boolean isViewingInventory();
-
-    /**
-     * Gets the currently viewed inventory of this human entity, if it is
-     * currently viewing one.
-     *
-     * @return An inventory if this human entity is viewing one, otherwise
-     * {@link Optional#empty()}
-     */
-    Optional<Inventory> getOpenInventory();
-
-    /**
-     * Opens the given Inventory for the player to view.
-     *
-     * @param inventory The inventory to view
-     */
-    void openInventory(Inventory inventory);
-
-    /**
-     * Closes the currently viewed entity of this human entity, if it is
-     * currently viewing one.
-     */
-    void closeInventory();
 
     /**
      * Gets a copy of the current {@link FoodData} for this {@link Humanoid}.

--- a/src/main/java/org/spongepowered/api/entity/living/player/Player.java
+++ b/src/main/java/org/spongepowered/api/entity/living/player/Player.java
@@ -37,6 +37,7 @@ import org.spongepowered.api.effect.Viewer;
 import org.spongepowered.api.entity.living.Humanoid;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.entity.living.player.tab.TabList;
+import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.network.PlayerConnection;
 import org.spongepowered.api.resourcepack.ResourcePack;
 import org.spongepowered.api.scoreboard.Scoreboard;
@@ -44,6 +45,7 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.chat.ChatVisibility;
 
 import java.time.Instant;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -55,6 +57,36 @@ import java.util.Set;
  * that persists across server restarts.</p>
  */
 public interface Player extends Humanoid, User, LocatedSource, RemoteSource, Viewer {
+
+    /**
+     * Returns whether this player has an open inventory at the moment
+     * or not.
+     *
+     * @return Whether this player is viewing an inventory or not
+     */
+    boolean isViewingInventory();
+
+    /**
+     * Gets the currently viewed inventory of this player, if it is
+     * currently viewing one.
+     *
+     * @return An inventory if this player is viewing one, otherwise
+     * {@link Optional#empty()}
+     */
+    Optional<Inventory> getOpenInventory();
+
+    /**
+     * Opens the given Inventory for the player to view.
+     *
+     * @param inventory The inventory to view
+     */
+    void openInventory(Inventory inventory);
+
+    /**
+     * Closes the currently viewed entity of this player, if it is
+     * currently viewing one.
+     */
+    void closeInventory();
 
     /**
      * Gets the view distance setting of the player. This value represents the

--- a/src/main/java/org/spongepowered/api/item/inventory/Container.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Container.java
@@ -24,24 +24,24 @@
  */
 package org.spongepowered.api.item.inventory;
 
-import org.spongepowered.api.entity.living.Humanoid;
+import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.item.inventory.type.Interactable;
 
 import java.util.Set;
 
 /**
  * A Container is effectively a <em>ViewModel</em> for a particular set of
- * {@link Inventory} objects used to allow players ({@link Humanoid}s) to interact
+ * {@link Inventory} objects used to allow players to interact
  * with the Inventories, usually via a GUI (the View).
  */
-public interface Container extends Interactable<Humanoid> {
+public interface Container extends Interactable {
 
     /**
      * Gets the current viewers looking at this Inventory.
      *
      * @return The current viewers of this inventory
      */
-    Set<Humanoid> getViewers();
+    Set<Player> getViewers();
 
     /**
      * Checks for whether this Inventory currently has viewers.
@@ -55,13 +55,13 @@ public interface Container extends Interactable<Humanoid> {
      *
      * @param viewer The viewer to show this inventory to
      */
-    void open(Humanoid viewer);
+    void open(Player viewer);
 
     /**
      * Stops showing this Inventory to the given viewer.
      *
      * @param viewer The viewer to stop showing this inventory to
      */
-    void close(Humanoid viewer);
+    void close(Player viewer);
 
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/type/Interactable.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/type/Interactable.java
@@ -24,23 +24,20 @@
  */
 package org.spongepowered.api.item.inventory.type;
 
-import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.item.inventory.Inventory;
 
 /**
- * Interface for inventories which may be interacted with by specific types of
- * Entity.
- *
- * @param <T> Base type of entity which may interact with this object  
+ * Interface for inventories which may be interacted with by Players.
  */
-public interface Interactable<T extends Entity> extends Inventory {
+public interface Interactable extends Inventory {
 
     /**
-     * Get whether the specified entity can interact with this object.
+     * Get whether the specified player can interact with this object.
      * 
-     * @param entity the Entity wishing to interact with this Inventory
+     * @param player the Player wishing to interact with this Inventory
      * @return true if the Entity is able to interact with this Inventory
      */
-    boolean canInteractWith(T entity);
+    boolean canInteractWith(Player player);
     
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/type/TileEntityInventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/type/TileEntityInventory.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.item.inventory.type;
 
 import org.spongepowered.api.block.tileentity.TileEntity;
-import org.spongepowered.api.entity.living.Humanoid;
 import org.spongepowered.api.item.inventory.Carrier;
 import org.spongepowered.api.item.inventory.Inventory;
 
@@ -52,7 +51,7 @@ import java.util.Optional;
  * @param <T> Tile entity type, the specified TE must be a {@link Carrier}
  */
 public interface TileEntityInventory<T extends TileEntity & Carrier>
-        extends PersistentInventory, Interactable<Humanoid>, CarriedInventory<T> {
+        extends PersistentInventory, Interactable, CarriedInventory<T> {
 
     /**
      * Returns the owner of this Inventory.


### PR DESCRIPTION
Common PR: https://github.com/SpongePowered/SpongeCommon/pull/501

The reason for this change is for clarity in the API. To say that a humanoid "views" an inventory or an entity can "interact" with a container is misleading: these are properties of a client connection. I am not saying that Humanoids or other entities should not have inventories, I have no qualms about that.

Pinging @Mumfrey 

Signed-off-by: Walker Crouse <walkercrouse@hotmail.com>