### PR TITLE
TextTemplate API

### DIFF
--- a/src/main/java/org/spongepowered/api/data/Queries.java
+++ b/src/main/java/org/spongepowered/api/data/Queries.java
@@ -75,6 +75,9 @@ public final class Queries {
     public static final DataQuery CREATOR_ID = of("Creator");
     public static final DataQuery NOTIFIER_ID = of("Notifier");
 
+    // Text
+    public static final DataQuery JSON = of("JSON");
+
     private Queries() {
     }
 

--- a/src/main/java/org/spongepowered/api/text/Text.java
+++ b/src/main/java/org/spongepowered/api/text/Text.java
@@ -29,6 +29,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
+import com.google.common.reflect.TypeToken;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializers;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataSerializable;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.Queries;
 import org.spongepowered.api.scoreboard.Score;
 import org.spongepowered.api.text.action.ClickAction;
 import org.spongepowered.api.text.action.HoverAction;
@@ -39,6 +45,7 @@ import org.spongepowered.api.text.format.TextFormat;
 import org.spongepowered.api.text.format.TextStyle;
 import org.spongepowered.api.text.format.TextStyles;
 import org.spongepowered.api.text.selector.Selector;
+import org.spongepowered.api.text.serializer.TextConfigSerializer;
 import org.spongepowered.api.text.serializer.TextSerializers;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.text.translation.Translation;
@@ -75,7 +82,11 @@ import javax.annotation.Nullable;
  * @see SelectorText
  * @see ScoreText
  */
-public abstract class Text implements TextRepresentable {
+public abstract class Text implements TextRepresentable, DataSerializable, Comparable<Text> {
+
+    static {
+        TypeSerializers.getDefaultSerializers().registerType(TypeToken.of(Text.class), new TextConfigSerializer());
+    }
 
     /**
      * The empty, unformatted {@link Text} instance.
@@ -246,6 +257,44 @@ public abstract class Text implements TextRepresentable {
      */
     public final String toPlain() {
         return TextSerializers.PLAIN.serialize(this);
+    }
+
+    /**
+     * Concatenates the specified {@link Text} to this Text and returns the
+     * result.
+     *
+     * @param other To concatenate
+     * @return Concatenated text
+     */
+    public final Text concat(Text other) {
+        return toBuilder().append(other).build();
+    }
+
+    /**
+     * Removes all empty texts from the beginning and end of this
+     * text.
+     *
+     * @return Text result
+     */
+    public final Text trim() {
+        return toBuilder().trim().build();
+    }
+
+    @Override
+    public int getContentVersion() {
+        return 1;
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return new MemoryDataContainer()
+                .set(Queries.CONTENT_VERSION, getContentVersion())
+                .set(Queries.JSON, TextSerializers.JSON.serialize(this));
+    }
+
+    @Override
+    public int compareTo(Text o) {
+        return PLAIN_COMPARATOR.compare(this, o);
     }
 
     @Override
@@ -652,6 +701,32 @@ public abstract class Text implements TextRepresentable {
          */
         public Builder removeAll() {
             this.children.clear();
+            return this;
+        }
+
+        /**
+         * Removes all empty texts from the beginning and end of this
+         * builder.
+         *
+         * @return This builder
+         */
+        public Builder trim() {
+            Iterator<Text> front = this.children.iterator();
+            while (front.hasNext()) {
+                if (front.next().isEmpty()) {
+                    front.remove();
+                } else {
+                    break;
+                }
+            }
+            ListIterator<Text> back = this.children.listIterator(this.children.size());
+            while (back.hasPrevious()) {
+                if (back.next().isEmpty()) {
+                    back.remove();
+                } else {
+                    break;
+                }
+            }
             return this;
         }
 

--- a/src/main/java/org/spongepowered/api/text/TextElement.java
+++ b/src/main/java/org/spongepowered/api/text/TextElement.java
@@ -22,45 +22,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.text.action;
-
-import org.spongepowered.api.text.Text;
+package org.spongepowered.api.text;
 
 /**
- * Represents a {@link TextAction} that responds to shift-clicks.
- *
- * @param <R> the type of the result of the action
+ * Represents anything that can be applied to a {@link Text.Builder}.
  */
-public abstract class ShiftClickAction<R> extends TextAction<R> {
+public interface TextElement {
 
     /**
-     * Constructs a new {@link ShiftClickAction} with the given result.
+     * Applies this element to the end of the specified builder.
      *
-     * @param result The result of the shift click action
+     * @param builder Text builder to apply to
      */
-    ShiftClickAction(R result) {
-        super(result);
-    }
+    void applyTo(Text.Builder builder);
 
-    @Override
-    public void applyTo(Text.Builder builder) {
-        builder.onShiftClick(this);
-    }
-
-    /**
-     * Inserts some text into the chat prompt.
-     */
-    public static final class InsertText extends ShiftClickAction<String> {
-
-        /**
-         * Constructs a new {@link InsertText} instance that will insert text at
-         * the current cursor position in the chat when it is shift-clicked.
-         *
-         * @param text The text to insert
-         */
-        InsertText(String text) {
-            super(text);
-        }
-
-    }
 }

--- a/src/main/java/org/spongepowered/api/text/TextRepresentable.java
+++ b/src/main/java/org/spongepowered/api/text/TextRepresentable.java
@@ -32,7 +32,7 @@ import org.spongepowered.api.text.action.TextAction;
  * Represents an instance that have a {@link Text} representation that should be
  * used when this instance should be used inside a {@link Text}.
  */
-interface TextRepresentable {
+public interface TextRepresentable extends TextElement {
 
     /**
      * Gets the textual representation of this instance for its usage in other
@@ -44,5 +44,10 @@ interface TextRepresentable {
      * @return The text instance representing this instance
      */
     Text toText();
+
+    @Override
+    default void applyTo(Text.Builder builder) {
+        builder.append(toText());
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/text/TextTemplate.java
+++ b/src/main/java/org/spongepowered/api/text/TextTemplate.java
@@ -1,0 +1,614 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.text;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializers;
+import org.spongepowered.api.text.format.TextColor;
+import org.spongepowered.api.text.format.TextFormat;
+import org.spongepowered.api.text.format.TextStyle;
+import org.spongepowered.api.text.serializer.TextTemplateConfigSerializer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents a re-usable template that produces a formatted
+ * {@link Text.Builder}. Elements will be appended to the result builder in the
+ * order that they are specified in {@link #of(Object...)}.
+ */
+public final class TextTemplate implements TextRepresentable, Iterable<Object> {
+
+    static {
+        TypeSerializers.getDefaultSerializers().registerType(TypeToken.of(TextTemplate.class), new TextTemplateConfigSerializer());
+    }
+
+    /**
+     * Default "open" String for how arguments are contained within the template.
+     */
+    public static final String DEFAULT_OPEN_ARG = "{";
+
+    /**
+     * Default "close" String for how arguments are contained within the template.
+     */
+    public static final String DEFAULT_CLOSE_ARG = "}";
+
+    /**
+     * Empty representation of a {@link TextTemplate}. This is returned if the
+     * array supplied to {@link #of(Object...)} is empty.
+     */
+    public static final TextTemplate EMPTY = new TextTemplate(DEFAULT_OPEN_ARG, DEFAULT_CLOSE_ARG, new Object[]{});
+
+    final ImmutableList<Object> elements;
+    final ImmutableMap<String, Arg> arguments;
+    final Text text;
+    final String openArg;
+    final String closeArg;
+
+    TextTemplate(String openArg, String closeArg, Object[] elements) {
+        this.openArg = openArg;
+        this.closeArg = closeArg;
+
+        // collect elements
+        ImmutableList.Builder<Object> elementList = ImmutableList.builder();
+        Map<String, Arg> argumentMap = new HashMap<>();
+        for (Object element : elements) {
+            if (element instanceof Arg.Builder) {
+                element = ((Arg.Builder) element).build();
+            }
+            if (element instanceof Arg) {
+                // check for non-equal duplicate argument
+                Arg newArg = new Arg((Arg) element, this.openArg, this.closeArg);
+                Arg oldArg = argumentMap.get(newArg.name);
+                if (oldArg != null && !oldArg.equals(newArg)) {
+                    throw new TextTemplateArgumentException("Tried to supply an unequal argument with a duplicate name \""
+                            + newArg.name + "\" to TextTemplate.");
+                }
+                argumentMap.put(newArg.name, newArg);
+                element = newArg;
+            }
+            elementList.add(element);
+        }
+        this.elements = elementList.build();
+        this.arguments = ImmutableMap.copyOf(argumentMap);
+
+        // build text representation
+        Text.Builder builder = null;
+        for (Object element : this.elements) {
+            builder = apply(element, builder);
+        }
+        this.text = Optional.ofNullable(builder).orElse(Text.builder()).build();
+    }
+
+    /**
+     * Returns the elements contained in this TextTemplate.
+     *
+     * @return The elements within the template
+     */
+    public List<Object> getElements() {
+        return this.elements;
+    }
+
+    /**
+     * Returns the arguments contained within the TextTemplate.
+     *
+     * @return The arguments within this TextTemplate
+     */
+    public Map<String, Arg> getArguments() {
+        return this.arguments;
+    }
+
+    /**
+     * Returns the string used for containing Args within the template.
+     *
+     * @return String containing args
+     */
+    public String getOpenArgString() {
+        return this.openArg;
+    }
+
+    /**
+     * Returns the string used for containing Args within the template.
+     *
+     * @return String containing args
+     */
+    public String getCloseArgString() {
+        return this.closeArg;
+    }
+
+    /**
+     * Concatenates the specified {@link TextTemplate} to this template and
+     * returns the result. In the event that the two templates' open/close
+     * argument containers vary, this template's argument containers will be
+     * used.
+     *
+     * @param other To concatenate
+     * @return Concatenated template
+     */
+    public TextTemplate concat(TextTemplate other) {
+        List<Object> elements = new ArrayList<>(this.elements);
+        elements.addAll(other.elements);
+        return of(this.openArg, this.closeArg, elements.toArray(new Object[elements.size()]));
+    }
+
+    /**
+     * Applies an empty map of parameters to this TextTemplate and returns the
+     * result in a {@link Text.Builder}.
+     *
+     * @return Text builder containing result
+     * @throws TextTemplateArgumentException if required parameters are missing
+     */
+    public Text.Builder apply() {
+        return apply(Collections.emptyMap());
+    }
+
+    /**
+     * Applies the specified parameters to this TextTemplate and returns the
+     * result in a {@link Text.Builder}.
+     *
+     * @param params Parameters to apply
+     * @return Text builder containing result
+     * @throws TextTemplateArgumentException if required parameters are missing
+     */
+    public Text.Builder apply(Map<String, TextElement> params) {
+        return apply(null, params);
+    }
+
+    private Text.Builder apply(@Nullable Text.Builder result, Map<String, TextElement> params) {
+        checkNotNull(params, "params");
+        for (Object element : this.elements) {
+            result = apply(element, result, params);
+        }
+        return Optional.ofNullable(result).orElse(Text.builder());
+    }
+
+    @Nullable
+    private Text.Builder apply(Object element, @Nullable Text.Builder builder, Map<String, TextElement> params) {
+        // Note: The builder is initialized as null to avoid unnecessary Text nesting
+        if (element instanceof Arg) {
+            Arg arg = (Arg) element;
+            TextElement param = params.get(arg.name);
+            if (param == null) {
+                arg.checkOptional();
+                if (arg.defaultValue != null) {
+                    builder = applyArg(arg.defaultValue, arg, builder);
+                }
+            } else {
+                builder = applyArg(param, arg, builder);
+            }
+        } else {
+            builder = apply(element, builder);
+        }
+        return builder;
+    }
+
+    private Text.Builder applyArg(TextElement param, Arg arg, @Nullable Text.Builder builder) {
+        // wrap the parameter in the argument format
+        Text.Builder wrapper = Text.builder().format(arg.format);
+        param.applyTo(wrapper);
+        if (builder == null) {
+            builder = wrapper;
+        } else {
+            builder.append(wrapper.build());
+        }
+        return builder;
+    }
+
+    private Text.Builder apply(Object element, @Nullable Text.Builder builder) {
+        if (element instanceof Text) {
+            Text text = (Text) element;
+            if (builder == null) {
+                builder = text.toBuilder();
+            } else {
+                builder.append(text);
+            }
+        } else if (element instanceof TextElement) {
+            if (builder == null) {
+                builder = Text.builder();
+            }
+            ((TextElement) element).applyTo(builder);
+        } else {
+            String str = element.toString();
+            if (builder == null) {
+                builder = Text.builder(str);
+            } else {
+                builder.append(Text.of(str));
+            }
+        }
+        return builder;
+    }
+
+    /**
+     * Constructs a new TextTemplate for the given elements. The order of the
+     * elements is the order in which they will be appended to the result
+     * builder via {@link #apply(Map)}.
+     *
+     * <p>The provided elements may be of any type.</p>
+     *
+     * <p>In the case that an element is a {@link TextElement},
+     * {@link TextElement#applyTo(Text.Builder)} will be used to append the
+     * element to the builder.</p>
+     *
+     * <p>In the case that an element is an {@link Arg} the argument will be
+     * replaced with the {@link TextElement} provided by the corresponding
+     * parameter supplied by {@link #apply(Map)}</p>
+     *
+     * <p>In the case that an element is any other type, the parameter value's
+     * {@link Object#toString()} method will be used to create a {@link Text}
+     * object.</p>
+     *
+     * @param elements Elements to append to builder
+     * @param openArg String to use for beginning of Arg containers
+     * @param closeArg String to use for end of Arg containers
+     * @return Newly constructed TextTemplate
+     */
+    public static TextTemplate of(String openArg, String closeArg, Object[] elements) {
+        checkNotNull(openArg, "open arg");
+        checkArgument(!openArg.isEmpty(), "open arg cannot be empty");
+        checkNotNull(closeArg, "close arg");
+        checkArgument(!closeArg.isEmpty(), "close arg cannot be empty");
+        checkNotNull(elements, "elements");
+        if (elements.length == 0) {
+            return of();
+        }
+        return new TextTemplate(openArg, closeArg, elements);
+    }
+
+    /**
+     * Constructs a new TextTemplate for the given elements. The order of the
+     * elements is the order in which they will be appended to the result
+     * builder via {@link #apply(Map)}.
+     *
+     * <p>The provided elements may be of any type.</p>
+     *
+     * <p>In the case that an element is a {@link TextElement},
+     * {@link TextElement#applyTo(Text.Builder)} will be used to append the
+     * element to the builder.</p>
+     *
+     * <p>In the case that an element is an {@link Arg} the argument will be
+     * replaced with the {@link TextElement} provided by the corresponding
+     * parameter supplied by {@link #apply(Map)}</p>
+     *
+     * <p>In the case that an element is any other type, the parameter value's
+     * {@link Object#toString()} method will be used to create a {@link Text}
+     * object.</p>
+     *
+     * @param elements Elements to append to builder
+     * @return Newly constructed TextTemplate
+     */
+    public static TextTemplate of(Object... elements) {
+        return of(DEFAULT_OPEN_ARG, DEFAULT_CLOSE_ARG, elements);
+    }
+
+    /**
+     * Returns the empty representation of a TextTemplate.
+     *
+     * @return Empty TextTemplate
+     */
+    public static TextTemplate of() {
+        return EMPTY;
+    }
+
+    /**
+     * Constructs a new {@link Arg} to be supplied to {@link #of(Object...)}.
+     * This argument expects a {@link TextElement} parameter.
+     *
+     * @param name name of argument
+     * @return argument builder
+     */
+    public static Arg.Builder arg(String name) {
+        return new Arg.Builder(name);
+    }
+
+    @Override
+    public Text toText() {
+        return this.text;
+    }
+
+    @Override
+    public Iterator<Object> iterator() {
+        return this.elements.iterator();
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("elements", this.elements)
+                .add("arguments", this.arguments)
+                .add("text", this.text)
+                .add("openArg", this.openArg)
+                .add("closeArg", this.closeArg)
+                .toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.elements, this.openArg, this.closeArg);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof TextTemplate)) {
+            return false;
+        }
+        TextTemplate that = (TextTemplate) obj;
+        return that.elements.equals(this.elements)
+                && that.openArg.equals(this.openArg)
+                && that.closeArg.equals(this.closeArg);
+    }
+
+    /**
+     * Represents a variable element within a TextTemplate. Arguments are
+     * replaced by parameters in {@link #apply(Map)}.
+     */
+    @ConfigSerializable
+    public final static class Arg implements TextRepresentable {
+
+        @Setting final boolean optional;
+        @Setting @Nullable final Text defaultValue;
+        final String name; // defined by node name
+        final TextFormat format; // defined in "content" node
+        final String openArg;
+        final String closeArg;
+
+        Arg(String name, boolean optional, @Nullable Text defaultValue, TextFormat format, String openArg, String closeArg) {
+            this.name = name;
+            this.optional = optional;
+            this.defaultValue = defaultValue;
+            this.format = format;
+            this.openArg = openArg;
+            this.closeArg = closeArg;
+        }
+
+        Arg(String name, boolean optional, @Nullable Text defaultValue, TextFormat format) {
+            this(name, optional, defaultValue, format, DEFAULT_OPEN_ARG, DEFAULT_CLOSE_ARG);
+        }
+
+        Arg(Arg arg, String openArg, String closeArg) {
+            this(arg.name, arg.optional, arg.defaultValue, arg.format, openArg, closeArg);
+        }
+
+        void checkOptional() {
+            if (!this.optional) {
+                throw new TextTemplateArgumentException("Missing required argument in TextTemplate \"" + this.name + "\".");
+            }
+        }
+
+        /**
+         * Returns the name of this argument to be matched with incoming
+         * parameters.
+         *
+         * @return Argument name
+         */
+        public String getName() {
+            return this.name;
+        }
+
+        /**
+         * Returns true if this Arg is optional. If a parameter is missing for
+         * a non-optional Arg, a {@link TextTemplateArgumentException} will be
+         * thrown.
+         *
+         * @return True if optional
+         */
+        public boolean isOptional() {
+            return this.optional;
+        }
+
+        /**
+         * Returns the default value to use if the Arg {@link #isOptional()}
+         * and no parameter is supplied.
+         *
+         * @return Default value
+         */
+        public Optional<Text> getDefaultValue() {
+            return Optional.ofNullable(this.defaultValue);
+        }
+
+        /**
+         * Returns the base format to be applied to this Arg.
+         *
+         * @return Base format
+         */
+        public TextFormat getFormat() {
+            return this.format;
+        }
+
+        /**
+         * Returns the beginning string of the Arg's container.
+         *
+         * @return Open string
+         */
+        public String getOpenArgString() {
+            return this.openArg;
+        }
+
+        /**
+         * Returns the end string of the Arg's container.
+         *
+         * @return Close string
+         */
+        public String getCloseArgString() {
+            return this.closeArg;
+        }
+
+        @Override
+        public Text toText() {
+            return Text.builder(this.openArg + this.name + this.closeArg).format(this.format).build();
+        }
+
+        @Override
+        public String toString() {
+            return Objects.toStringHelper(this)
+                    .omitNullValues()
+                    .add("optional", this.optional)
+                    .add("defaultValue", this.defaultValue)
+                    .add("name", this.name)
+                    .add("format", this.format.isEmpty() ? null : this.format)
+                    .add("openArg", this.openArg)
+                    .add("closeArg", this.closeArg)
+                    .toString();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(this.name, this.optional, this.defaultValue, this.openArg, this.closeArg);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof Arg)) {
+                return false;
+            }
+            Arg that = (Arg) obj;
+            return that.name.equals(this.name)
+                    && that.optional == this.optional
+                    && (that.defaultValue != null ? that.defaultValue.equals(this.defaultValue) : this.defaultValue == null)
+                    && that.openArg.equals(this.openArg)
+                    && that.closeArg.equals(this.closeArg);
+        }
+
+        /**
+         * Represents a builder for {@link Arg}s.
+         */
+        public static final class Builder {
+
+            final String name;
+            boolean optional = false;
+            @Nullable Text defaultValue;
+            TextFormat format = TextFormat.NONE;
+
+            Builder(String name) {
+                this.name = name;
+            }
+
+            /**
+             * Builds a new {@link Arg}. Note that it is not necessary to call
+             * this method when supplying an argument to a template. You may
+             * pass the builder to {@link TextTemplate#of(Object...)} directly.
+             *
+             * @return Newly created Arg
+             */
+            public Arg build() {
+                return new Arg(this.name, this.optional, this.defaultValue, this.format);
+            }
+
+            /**
+             * Sets whether the Arg should be optional (false by default).
+             *
+             * @param optional True if should be optional
+             * @return This builder
+             */
+            public Builder optional(boolean optional) {
+                this.optional = optional;
+                return this;
+            }
+
+            /**
+             * Makes the Arg optional.
+             *
+             * @return This builder
+             */
+            public Builder optional() {
+                return optional(true);
+            }
+
+            /**
+             * Sets the default value for the Argument. The argument must by
+             * optional in order for this value to be used.
+             *
+             * @param defaultValue Default value
+             * @return This builder
+             */
+            public Builder defaultValue(Text defaultValue) {
+                this.defaultValue = defaultValue;
+                return this;
+            }
+
+            /**
+             * Sets the "base" format of the Arg. This acts as a default format
+             * when no formatting data is provided by the parameter.
+             *
+             * @param format Base format of Arg
+             * @return This builder
+             */
+            public Builder format(TextFormat format) {
+                this.format = format;
+                return this;
+            }
+
+            /**
+             * Sets the "base" color of the Arg. This acts as a default color
+             * when no color data is provided by the parameter.
+             *
+             * @param color Base color of Arg
+             * @return This builder
+             */
+            public Builder color(TextColor color) {
+                this.format = this.format.color(color);
+                return this;
+            }
+
+            /**
+             * Sets the "base" style of the Arg. This acts as a default style
+             * when no style data is provided by the parameter.
+             *
+             * @param style Base style of Arg
+             * @return This builder
+             */
+            public Builder style(TextStyle style) {
+                this.format = this.format.style(style);
+                return this;
+            }
+
+            @Override
+            public String toString() {
+                return Objects.toStringHelper(this)
+                        .omitNullValues()
+                        .add("name", this.name)
+                        .add("optional", this.optional)
+                        .add("defaultValue", this.defaultValue)
+                        .add("format", this.format.isEmpty() ? null : this.format)
+                        .toString();
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/TextTemplateArgumentException.java
+++ b/src/main/java/org/spongepowered/api/text/TextTemplateArgumentException.java
@@ -22,45 +22,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.text.action;
-
-import org.spongepowered.api.text.Text;
+package org.spongepowered.api.text;
 
 /**
- * Represents a {@link TextAction} that responds to shift-clicks.
- *
- * @param <R> the type of the result of the action
+ * Exception thrown when invalid arguments are provided to a
+ * {@link TextTemplate}.
  */
-public abstract class ShiftClickAction<R> extends TextAction<R> {
+public class TextTemplateArgumentException extends IllegalArgumentException {
+
+    private static final long serialVersionUID = 4163260231862633490L;
 
     /**
-     * Constructs a new {@link ShiftClickAction} with the given result.
+     * Creates exception with the specified message.
      *
-     * @param result The result of the shift click action
+     * @param msg Exception message
      */
-    ShiftClickAction(R result) {
-        super(result);
+    public TextTemplateArgumentException(String msg) {
+        super(msg);
     }
 
-    @Override
-    public void applyTo(Text.Builder builder) {
-        builder.onShiftClick(this);
-    }
-
-    /**
-     * Inserts some text into the chat prompt.
-     */
-    public static final class InsertText extends ShiftClickAction<String> {
-
-        /**
-         * Constructs a new {@link InsertText} instance that will insert text at
-         * the current cursor position in the chat when it is shift-clicked.
-         *
-         * @param text The text to insert
-         */
-        InsertText(String text) {
-            super(text);
-        }
-
-    }
 }

--- a/src/main/java/org/spongepowered/api/text/action/ClickAction.java
+++ b/src/main/java/org/spongepowered/api/text/action/ClickAction.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.text.action;
 
 import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.text.Text;
 
 import java.net.URL;
 import java.util.function.Consumer;
@@ -43,6 +44,11 @@ public abstract class ClickAction<R> extends TextAction<R> {
      */
     ClickAction(R result) {
         super(result);
+    }
+
+    @Override
+    public void applyTo(Text.Builder builder) {
+        builder.onClick(this);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/text/action/HoverAction.java
+++ b/src/main/java/org/spongepowered/api/text/action/HoverAction.java
@@ -53,6 +53,11 @@ public abstract class HoverAction<R> extends TextAction<R> {
         super(result);
     }
 
+    @Override
+    public void applyTo(Text.Builder builder) {
+        builder.onHover(this);
+    }
+
     /**
      * Shows some text.
      */

--- a/src/main/java/org/spongepowered/api/text/channel/MessageReceiver.java
+++ b/src/main/java/org/spongepowered/api/text/channel/MessageReceiver.java
@@ -28,6 +28,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.TextElement;
+import org.spongepowered.api.text.TextTemplate;
+
+import java.util.Map;
 
 /**
  * Represents something that can receive (and send) messages.
@@ -67,6 +71,27 @@ public interface MessageReceiver {
         for (Text message : checkNotNull(messages, "messages")) {
             this.sendMessage(message);
         }
+    }
+
+    /**
+     * Sends the result of the specified {@link TextTemplate} with the
+     * specified parameters to the receiver.
+     *
+     * @param template TextTemplate to apply
+     * @param params Parameters to apply to template
+     */
+    default void sendMessage(TextTemplate template, Map<String, TextElement> params) {
+        this.sendMessage(template.apply(params).build());
+    }
+
+    /**
+     * Sends the result of the specified {@link TextTemplate} with an empty
+     * parameter map.
+     *
+     * @param template TextTemplate to apply
+     */
+    default void sendMessage(TextTemplate template) {
+        this.sendMessage(template.apply().build());
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/text/format/TextColor.java
+++ b/src/main/java/org/spongepowered/api/text/format/TextColor.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.text.format;
 
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.TextElement;
 import org.spongepowered.api.util.Color;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -35,7 +36,7 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * @see TextColors
  */
 @CatalogedBy(TextColors.class)
-public interface TextColor extends CatalogType {
+public interface TextColor extends CatalogType, TextElement {
 
     /**
      * Returns the corresponding {@link Color} for this {@link TextColor}.
@@ -43,5 +44,10 @@ public interface TextColor extends CatalogType {
      * @return The RGB color of this text color
      */
     Color getColor();
+
+    @Override
+    default void applyTo(Text.Builder builder) {
+        builder.color(this);
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/text/format/TextFormat.java
+++ b/src/main/java/org/spongepowered/api/text/format/TextFormat.java
@@ -27,11 +27,13 @@ package org.spongepowered.api.text.format;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Objects;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.TextElement;
 
 /**
  * Represents a pair of {@link TextStyle} and {@link TextColor}.
  */
-public final class TextFormat {
+public final class TextFormat implements TextElement {
 
     /**
      * An empty {@link TextFormat} with no {@link TextColor} and no {@link TextStyle}.
@@ -154,6 +156,11 @@ public final class TextFormat {
      */
     public boolean isEmpty() {
         return this.color == TextColors.NONE && this.style.isEmpty();
+    }
+
+    @Override
+    public void applyTo(Text.Builder builder) {
+        builder.format(this);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/text/format/TextStyle.java
+++ b/src/main/java/org/spongepowered/api/text/format/TextStyle.java
@@ -29,6 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.Objects;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.TextElement;
 import org.spongepowered.api.util.OptBool;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -58,7 +59,7 @@ import javax.annotation.Nullable;
  * @see TextStyles
  */
 @CatalogedBy(TextStyles.class)
-public class TextStyle {
+public class TextStyle implements TextElement {
 
     /**
      * Whether text where this style is applied is bolded.
@@ -406,6 +407,11 @@ public class TextStyle {
                 strikethroughAcc,
                 obfuscatedAcc
         );
+    }
+
+    @Override
+    public void applyTo(Text.Builder builder) {
+        builder.style(this);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/text/serializer/TextConfigSerializer.java
+++ b/src/main/java/org/spongepowered/api/text/serializer/TextConfigSerializer.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.text.serializer;
+
+import com.google.common.reflect.TypeToken;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.gson.GsonConfigurationLoader;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataView;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.Queries;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.persistence.DataBuilder;
+import org.spongepowered.api.util.persistence.InvalidDataException;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Optional;
+
+/**
+ * Represents a {@link TypeSerializer} for {@link Text} objects. Serialization
+ * is handled by serializing the text to String with the
+ * {@link TextSerializers#JSON} serializer, loading the String into a
+ * {@link GsonConfigurationLoader}, and setting the value of the
+ * {@link ConfigurationNode} to the root node of the GsonConfigurationLoader.
+ * Although JSON is used for serialization internally, this has no effect on
+ * the actual configuration format the developer chooses to use.
+ */
+public class TextConfigSerializer implements TypeSerializer<Text>, DataBuilder<Text> {
+
+    @Override
+    public Text deserialize(TypeToken<?> type, ConfigurationNode value) throws ObjectMappingException {
+        StringWriter writer = new StringWriter();
+        GsonConfigurationLoader gsonLoader = GsonConfigurationLoader.builder().setSink(() -> new BufferedWriter(writer)).build();
+        try {
+            gsonLoader.save(value);
+        } catch (IOException e) {
+            throw new ObjectMappingException(e);
+        }
+        return Sponge.getDataManager().deserialize(Text.class, new MemoryDataContainer().set(Queries.JSON, writer.getBuffer().toString())).get();
+    }
+
+    @Override
+    public void serialize(TypeToken<?> type, Text obj, ConfigurationNode value) throws ObjectMappingException {
+        String json = (String) obj.toContainer().get(Queries.JSON).get();
+        GsonConfigurationLoader gsonLoader = GsonConfigurationLoader.builder().setSource(() -> new BufferedReader(new StringReader(json))).build();
+        try {
+            value.setValue(gsonLoader.load());
+        } catch (IOException e) {
+            throw new ObjectMappingException(e);
+        }
+    }
+
+    @Override
+    public Optional<Text> build(DataView container) throws InvalidDataException {
+        Optional<Object> json = container.get(Queries.JSON);
+        if (json.isPresent()) {
+            try {
+                //noinspection ConstantConditions
+                return Optional.of(TextSerializers.JSON.deserialize(json.get().toString()));
+            } catch (TextParseException e) {
+                throw new InvalidDataException(e);
+            }
+        }
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/serializer/TextTemplateConfigSerializer.java
+++ b/src/main/java/org/spongepowered/api/text/serializer/TextTemplateConfigSerializer.java
@@ -1,0 +1,134 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.text.serializer;
+
+import com.google.common.reflect.TypeToken;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+import org.spongepowered.api.text.LiteralText;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.TextTemplate;
+import org.spongepowered.api.text.format.TextFormat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a {@link TypeSerializer} for {@link TextTemplate}s. TextTemplates
+ * are serialized in two parts.
+ *
+ * <p>First, the template's arguments as defined by
+ * {@link TextTemplate#getArguments()} are serialized to the "arguments" node.
+ * This is where the argument definitions are kept.</p>
+ *
+ * <p>Second, the template's text representation as defined by
+ * {@link TextTemplate#toText()} is serialized to the "content" node.</p>
+ *
+ * <p>Deserialization is a bit more complicated. We start by loading the
+ * "content" Text and check the root Text element as well as it's children. If
+ * a {@link LiteralText} value is found that is wrapped in curly braces we
+ * check to see if the value inside the braces is defined as an argument in the
+ * "arguments" nodes. If so, we use the name and format from the original
+ * LiteralText and obtain whether the argument is optional from the definition.
+ * This is repeated until there are no more Text children to check and we
+ * return a TextTemplate of the elements we have collected.</p>
+ */
+public class TextTemplateConfigSerializer implements TypeSerializer<TextTemplate> {
+
+    private static final String NODE_CONTENT = "content";
+
+    private static final String NODE_ARGS = "arguments";
+    private static final String NODE_OPT = "optional";
+    private static final String NODE_DEF_VAL = "defaultValue";
+
+    private static final String NODE_OPTIONS = "options";
+    private static final String NODE_OPEN_ARG = "openArg";
+    private static final String NODE_CLOSE_ARG = "closeArg";
+
+    private static final TypeToken<Text> TOKEN_TEXT = TypeToken.of(Text.class);
+    private static final TypeToken<Map<String, TextTemplate.Arg>> TOKEN_ARGS = new TypeToken<Map<String, TextTemplate.Arg>>() {};
+
+    @SuppressWarnings("NullableProblems") private ConfigurationNode root;
+    @SuppressWarnings("NullableProblems") private String openArg;
+    @SuppressWarnings("NullableProblems") private String closeArg;
+
+    @Override
+    public TextTemplate deserialize(TypeToken<?> type, ConfigurationNode value) throws ObjectMappingException {
+        this.root = value;
+        this.openArg = value.getNode(NODE_OPEN_ARG).getString(TextTemplate.DEFAULT_OPEN_ARG);
+        this.closeArg = value.getNode(NODE_CLOSE_ARG).getString(TextTemplate.DEFAULT_CLOSE_ARG);
+        Text content = value.getNode(NODE_CONTENT).getValue(TypeToken.of(Text.class));
+        List<Object> elements = new ArrayList<>();
+        parse(content, elements);
+        return TextTemplate.of(elements.toArray(new Object[elements.size()]));
+    }
+
+    @Override
+    public void serialize(TypeToken<?> type, TextTemplate obj, ConfigurationNode value) throws ObjectMappingException {
+        value.getNode(NODE_OPTIONS, NODE_OPEN_ARG).setValue(obj.getOpenArgString());
+        value.getNode(NODE_OPTIONS, NODE_CLOSE_ARG).setValue(obj.getCloseArgString());
+        value.getNode(NODE_ARGS).setValue(TOKEN_ARGS, obj.getArguments());
+        value.getNode(NODE_CONTENT).setValue(TOKEN_TEXT, obj.toText());
+    }
+
+    private void parse(Text content, List<Object> into) throws ObjectMappingException {
+        if (isArg(content)) {
+            parseArg((LiteralText) content, into);
+        } else {
+            into.add(content.toBuilder().removeAll().build());
+        }
+        for (Text child : content.getChildren()) {
+            parse(child, into);
+        }
+    }
+
+    private void parseArg(LiteralText source, List<Object> into) throws ObjectMappingException {
+        String name = unwrap(source.getContent());
+        boolean optional = this.root.getNode(NODE_ARGS, name, NODE_OPT).getBoolean();
+        Text defaultValue = this.root.getNode(NODE_ARGS, name, NODE_DEF_VAL).getValue(TypeToken.of(Text.class));
+        TextFormat format = source.getFormat();
+        into.add(TextTemplate.arg(name).format(format).optional(optional).defaultValue(defaultValue).build());
+    }
+
+    private boolean isArg(Text element) {
+        if (!(element instanceof LiteralText)) {
+            return false;
+        }
+        String literal = ((LiteralText) element).getContent();
+        return literal.startsWith(this.openArg) && literal.endsWith(this.closeArg)
+                && isArgDefined(unwrap(literal));
+    }
+
+    private String unwrap(String str) {
+        return str.substring(this.openArg.length(), str.length() - this.closeArg.length());
+    }
+
+
+    private boolean isArgDefined(String argName) {
+        return !this.root.getNode(NODE_ARGS, argName).isVirtual();
+    }
+}

--- a/src/main/java/org/spongepowered/api/text/transform/DynamicPartitionedTextFormatter.java
+++ b/src/main/java/org/spongepowered/api/text/transform/DynamicPartitionedTextFormatter.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.text.transform;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Implementation of {@link PartitionedTextFormatter} that allows for
+ * modifications on the partitions.
+ */
+public class DynamicPartitionedTextFormatter implements PartitionedTextFormatter<SimpleTextFormatter> {
+
+    protected final List<SimpleTextFormatter> partitions;
+
+    public DynamicPartitionedTextFormatter(int initialSize) {
+        checkArgument(initialSize >= 0, "initial size must be greater than or equal to zero");
+        this.partitions = new ArrayList<>(initialSize);
+        for (int i = 0; i < initialSize; i++) {
+            this.partitions.add(new SimpleTextFormatter());
+        }
+    }
+
+    public DynamicPartitionedTextFormatter() {
+        this(0);
+    }
+
+    @Override
+    public ImmutableList<SimpleTextFormatter> getAll() {
+        return ImmutableList.copyOf(this.partitions);
+    }
+
+    @Override
+    public SimpleTextFormatter get(int i) {
+        return this.partitions.get(i);
+    }
+
+    @Override
+    public SimpleTextFormatter set(int i, SimpleTextFormatter element) {
+        return this.partitions.set(i, element);
+    }
+
+    @Override
+    public int size() {
+        return this.partitions.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.partitions.isEmpty();
+    }
+
+    @Override
+    public boolean contains(SimpleTextFormatter element) {
+        return this.partitions.contains(element);
+    }
+
+    @Override
+    public void clear() {
+        this.partitions.clear();
+    }
+
+    @Override
+    public boolean add(SimpleTextFormatter element) {
+        return this.partitions.add(element);
+    }
+
+    @Override
+    public boolean add(Collection<SimpleTextFormatter> elements) {
+        return this.partitions.addAll(elements);
+    }
+
+    @Override
+    public void insert(int i, SimpleTextFormatter element) {
+        this.partitions.add(i, element);
+    }
+
+    @Override
+    public void insert(int i, Collection<SimpleTextFormatter> elements) {
+        this.partitions.addAll(i, elements);
+    }
+
+    @Override
+    public boolean remove(SimpleTextFormatter element) {
+        return this.partitions.remove(element);
+    }
+
+    @Override
+    public boolean remove(Collection<SimpleTextFormatter> elements) {
+        return this.partitions.removeAll(elements);
+    }
+
+    @Override
+    public boolean retain(Collection<SimpleTextFormatter> elements) {
+        return this.partitions.retainAll(elements);
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/transform/FixedPartitionedTextFormatter.java
+++ b/src/main/java/org/spongepowered/api/text/transform/FixedPartitionedTextFormatter.java
@@ -1,0 +1,140 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.text.transform;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.Collection;
+
+/**
+ * Implementation of {@link PartitionedTextFormatter} that has a fixed amount
+ * of partitions.
+ */
+public class FixedPartitionedTextFormatter implements PartitionedTextFormatter<SimpleTextFormatter> {
+
+    final SimpleTextFormatter[] partitions;
+
+    public FixedPartitionedTextFormatter(int size) {
+        checkArgument(size >= 0, "size must be greater than or equal to zero");
+        this.partitions = new SimpleTextFormatter[size];
+        for (int i = 0; i < size; i++) {
+            this.partitions[i] = new SimpleTextFormatter();
+        }
+    }
+
+    public FixedPartitionedTextFormatter() {
+        this(2);
+    }
+
+    @Override
+    public ImmutableList<SimpleTextFormatter> getAll() {
+        return ImmutableList.copyOf(this.partitions);
+    }
+
+    @Override
+    public SimpleTextFormatter get(int i) {
+        return this.partitions[i];
+    }
+
+    @Override
+    public SimpleTextFormatter set(int i, SimpleTextFormatter element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int size() {
+        return this.partitions.length;
+    }
+
+    /**
+     * Returns true if each partition is empty.
+     *
+     * @return True if each partition is empty
+     */
+    @Override
+    public boolean isEmpty() {
+        boolean empty = true;
+        for (SimpleTextFormatter partition : this) {
+            empty &= partition.isEmpty();
+        }
+        return empty;
+    }
+
+    @Override
+    public boolean contains(SimpleTextFormatter element) {
+        for (SimpleTextFormatter partition : this) {
+            if (partition.equals(element)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Clears each partition. Retains the actual partitions themselves.
+     */
+    @Override
+    public void clear() {
+        forEach(SimpleTextFormatter::clear);
+    }
+
+    @Override
+    public boolean add(SimpleTextFormatter element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean add(Collection<SimpleTextFormatter> elements) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void insert(int i, SimpleTextFormatter element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void insert(int i, Collection<SimpleTextFormatter> elements) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(SimpleTextFormatter element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Collection<SimpleTextFormatter> elements) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retain(Collection<SimpleTextFormatter> elements) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/transform/PartitionedTextFormatter.java
+++ b/src/main/java/org/spongepowered/api/text/transform/PartitionedTextFormatter.java
@@ -22,45 +22,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.text.action;
-
-import org.spongepowered.api.text.Text;
+package org.spongepowered.api.text.transform;
 
 /**
- * Represents a {@link TextAction} that responds to shift-clicks.
+ * Represents a {@link TextFormatter} that is sectioned into different
+ * sub-formatters.
  *
- * @param <R> the type of the result of the action
+ * @param <E> Type of formatter
  */
-public abstract class ShiftClickAction<R> extends TextAction<R> {
+public interface PartitionedTextFormatter<E extends TextFormatter> extends TextFormatter<E> {
 
-    /**
-     * Constructs a new {@link ShiftClickAction} with the given result.
-     *
-     * @param result The result of the shift click action
-     */
-    ShiftClickAction(R result) {
-        super(result);
-    }
-
-    @Override
-    public void applyTo(Text.Builder builder) {
-        builder.onShiftClick(this);
-    }
-
-    /**
-     * Inserts some text into the chat prompt.
-     */
-    public static final class InsertText extends ShiftClickAction<String> {
-
-        /**
-         * Constructs a new {@link InsertText} instance that will insert text at
-         * the current cursor position in the chat when it is shift-clicked.
-         *
-         * @param text The text to insert
-         */
-        InsertText(String text) {
-            super(text);
-        }
-
-    }
 }

--- a/src/main/java/org/spongepowered/api/text/transform/SimpleTextFormatter.java
+++ b/src/main/java/org/spongepowered/api/text/transform/SimpleTextFormatter.java
@@ -1,0 +1,134 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.text.transform;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A basic implementation of {@link TextFormatter} backed by an
+ * {@link ArrayList}.
+ */
+public class SimpleTextFormatter implements TextFormatter<SimpleTextTemplateApplier> {
+
+    protected final List<SimpleTextTemplateApplier> parts;
+
+    /**
+     * Constructs a new {@link SimpleTextFormatter} with the specified amount
+     * of initial {@link TextTemplateApplier}s.
+     *
+     * @param initialSize Initial amount of Parts
+     */
+    public SimpleTextFormatter(int initialSize) {
+        checkArgument(initialSize >= 0, "initial size must be greater than or equal to zero");
+        this.parts = new ArrayList<>(initialSize);
+        for (int i = 0; i < initialSize; i++) {
+            this.parts.add(new SimpleTextTemplateApplier());
+        }
+    }
+
+    /**
+     * Constructs an empty text formatter.
+     */
+    public SimpleTextFormatter() {
+        this(0);
+    }
+
+    @Override
+    public ImmutableList<SimpleTextTemplateApplier> getAll() {
+        return ImmutableList.copyOf(this.parts);
+    }
+
+    @Override
+    public SimpleTextTemplateApplier get(int i) {
+        return this.parts.get(i);
+    }
+
+    @Override
+    public SimpleTextTemplateApplier set(int i, SimpleTextTemplateApplier element) {
+        return this.parts.set(i, element);
+    }
+
+    @Override
+    public int size() {
+        return this.parts.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.parts.isEmpty();
+    }
+
+    @Override
+    public boolean contains(SimpleTextTemplateApplier element) {
+        return this.parts.contains(element);
+    }
+
+    @Override
+    public void clear() {
+        this.parts.clear();
+    }
+
+    @Override
+    public boolean add(SimpleTextTemplateApplier element) {
+        return this.parts.add(element);
+    }
+
+    @Override
+    public boolean add(Collection<SimpleTextTemplateApplier> elements) {
+        return this.parts.addAll(elements);
+    }
+
+    @Override
+    public void insert(int i, SimpleTextTemplateApplier element) {
+        this.parts.add(i, element);
+    }
+
+    @Override
+    public void insert(int i, Collection<SimpleTextTemplateApplier> elements) {
+        this.parts.addAll(i, elements);
+    }
+
+    @Override
+    public boolean remove(SimpleTextTemplateApplier element) {
+        return this.parts.remove(element);
+    }
+
+    @Override
+    public boolean remove(Collection<SimpleTextTemplateApplier> elements) {
+        return this.parts.removeAll(elements);
+    }
+
+    @Override
+    public boolean retain(Collection<SimpleTextTemplateApplier> elements) {
+        return this.parts.retainAll(elements);
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/transform/SimpleTextTemplateApplier.java
+++ b/src/main/java/org/spongepowered/api/text/transform/SimpleTextTemplateApplier.java
@@ -22,70 +22,53 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.text.action;
+package org.spongepowered.api.text.transform;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Objects;
-import org.spongepowered.api.text.Text;
+import com.google.common.collect.ImmutableMap;
 import org.spongepowered.api.text.TextElement;
+import org.spongepowered.api.text.TextTemplate;
 
-import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
- * Represents an action happening as a response to an event on a {@link Text}.
- *
- * @param <R> The type of the result
- *
- * @see ClickAction
- * @see HoverAction
- * @see ShiftClickAction
+ * A basic implementation of {@link TextTemplateApplier} backed by a {@link HashMap} and
+ * an empty {@link TextTemplate} by default.
  */
-public abstract class TextAction<R> implements TextElement {
+public class SimpleTextTemplateApplier implements TextTemplateApplier {
 
-    protected final R result;
+    protected final Map<String, TextElement> params = new HashMap<>();
+    protected TextTemplate template;
 
-    /**
-     * Constructs a new {@link TextAction} with the given result.
-     *
-     * @param result The result of the text action
-     */
-    protected TextAction(R result) {
-        this.result = checkNotNull(result, "result");
+    public SimpleTextTemplateApplier(TextTemplate template) {
+        this.template = checkNotNull(template, "template");
     }
 
-    /**
-     * Returns the result of this {@link TextAction}.
-     *
-     * @return The result
-     */
-    public final R getResult() {
-        return this.result;
+    public SimpleTextTemplateApplier() {
+        this(TextTemplate.EMPTY);
     }
 
     @Override
-    public boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        TextAction<?> that = (TextAction<?>) o;
-        return this.result.equals(that.result);
+    public ImmutableMap<String, TextElement> getParameters() {
+        return ImmutableMap.copyOf(this.params);
     }
 
     @Override
-    public int hashCode() {
-        return this.result.hashCode();
+    public void setParameter(String key, TextElement value) {
+        checkNotNull(key, "key");
+        this.params.put(key, value);
     }
 
     @Override
-    public String toString() {
-        return Objects.toStringHelper(this)
-                .addValue(this.result)
-                .toString();
+    public TextTemplate getTemplate() {
+        return this.template;
+    }
+
+    @Override
+    public void setTemplate(TextTemplate template) {
+        this.template = checkNotNull(template, "template");
     }
 
 }

--- a/src/main/java/org/spongepowered/api/text/transform/TextFormatter.java
+++ b/src/main/java/org/spongepowered/api/text/transform/TextFormatter.java
@@ -1,0 +1,329 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.text.transform;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.TextRepresentable;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * A TextFormatter is a mutable collection of {@link TextRepresentable}s which
+ * are all concatenated to an empty {@link Text} object on {@link #format()}.
+ */
+public interface TextFormatter<E extends TextRepresentable> extends TextRepresentable, Iterable<E> {
+
+    /**
+     * Returns an {@link ImmutableList} of this formatter's elements.
+     *
+     * @return All elements
+     */
+    ImmutableList<E> getAll();
+
+    /**
+     * Returns the element at the specified index.
+     *
+     * @param i Index to retrieve from
+     * @return Element at index
+     */
+    E get(int i);
+
+    /**
+     * Returns the first element of the specified type after the specified
+     * index.
+     *
+     * @param index To start at
+     * @param clazz Class of type
+     * @param <T> Type of TextRepresentable
+     * @return Element if found
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends TextRepresentable> Optional<T> firstAfter(int index, Class<T> clazz) {
+        checkNotNull(clazz, "class");
+        for (int i = index; i < size(); i++) {
+            E e = get(i);
+            if (clazz.isAssignableFrom(e.getClass())) {
+                return Optional.of((T) e);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the first element of the specified type.
+     *
+     * @param clazz Type to get
+     * @param <T> Type of {@link TextRepresentable}
+     * @return TextRepresentable of type if found, empty otherwise
+     */
+    default <T extends TextRepresentable> Optional<T> first(Class<T> clazz) {
+        return firstAfter(0, clazz);
+    }
+
+    /**
+     * Applies the specified consumer to each element of the specified type
+     * after the specified index.
+     *
+     * @param index Index to start at
+     * @param clazz Class of type
+     * @param consumer Consumer
+     * @param <T> Type
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends TextRepresentable> void forEachAfter(int index, Class<T> clazz, Consumer<T> consumer) {
+        checkNotNull(clazz, "class");
+        for (int i = index; i < size(); i++) {
+            E e = get(i);
+            if (clazz.isAssignableFrom(e.getClass())) {
+                consumer.accept((T) e);
+            }
+        }
+    }
+
+    /**
+     * Applies the specified consumer to each element of the specified type
+     * after the specified index.
+     *
+     * @param clazz Class of type
+     * @param consumer Consumer
+     * @param <T> Type
+     */
+    default <T extends TextRepresentable> void forEach(Class<T> clazz, Consumer<T> consumer) {
+        forEachAfter(0, clazz, consumer);
+    }
+
+    /**
+     * Replaces the element previously at the specified index with the
+     * specified element.
+     *
+     * @param i Index to replace
+     * @param e Element to replace with
+     * @return Element previously at index
+     */
+    E set(int i, E e);
+
+    /**
+     * Returns the amount of elements in this formatter.
+     *
+     * @return Amount of elements
+     */
+    int size();
+
+    /**
+     * Returns true if the formatter contains no elements.
+     *
+     * @return True if contains no elements
+     */
+    boolean isEmpty();
+
+    /**
+     * Returns true if the specified element is in the formatter.
+     *
+     * @param e Element to check
+     * @return True if in formatter
+     */
+    boolean contains(E e);
+
+    /**
+     * Clears all elements from this formatter.
+     */
+    void clear();
+
+    /**
+     * Adds the specified element to the end of this formatter.
+     *
+     * @param element Element to add
+     * @return True if the formatter changed as a result of the call
+     */
+    boolean add(E element);
+
+    /**
+     * Adds the specified elements to the end of this formatter.
+     *
+     * @param elements Elements to add
+     * @return True if the formatter changed as a result of the call
+     */
+    boolean add(Collection<E> elements);
+
+    /**
+     * Adds the specified elements to the end of this formatter.
+     *
+     * @param elements Elements to add
+     * @return True if the formatter changed as a result of the call
+     */
+    default boolean add(Iterable<E> elements) {
+        return add(Lists.newArrayList(elements));
+    }
+
+    /**
+     * Adds the specified elements to the end of this formatter.
+     *
+     * @param elements Elements to add
+     * @return True if the formatter changed as a result of the call
+     */
+    default boolean add(Iterator<E> elements) {
+        return add(Lists.newArrayList(elements));
+    }
+
+    /**
+     * Inserts the specified element at the specified index within the
+     * formatter.
+     *
+     * @param i Index to insert at
+     * @param element Element to insert
+     */
+    void insert(int i, E element);
+
+    /**
+     * Inserts the specified elements at the specified index within the
+     * formatter.
+     *
+     * @param i Index to insert at
+     * @param elements Elements to insert
+     */
+    void insert(int i, Collection<E> elements);
+
+    /**
+     * Inserts the specified elements at the specified index within the
+     * formatter.
+     *
+     * @param i Index to insert at
+     * @param elements Elements to insert
+     */
+    default void insert(int i, Iterable<E> elements) {
+        insert(i, Lists.newArrayList(elements));
+    }
+
+    /**
+     * Inserts the specified elements at the specified index within the
+     * formatter.
+     *
+     * @param i Index to insert at
+     * @param elements Elements to insert
+     */
+    default void insert(int i, Iterator<E> elements) {
+        insert(i, Lists.newArrayList(elements));
+    }
+
+    /**
+     * Removes the specified element from the formatter.
+     *
+     * @param element Element to remove
+     * @return True if this formatter contained the Element
+     */
+    boolean remove(E element);
+
+    /**
+     * Removes the specified elements from the formatter.
+     *
+     * @param elements Elements to remove
+     * @return True if the formatter changed as a result of this call
+     */
+    boolean remove(Collection<E> elements);
+
+    /**
+     * Removes the specified elements from the formatter.
+     *
+     * @param elements Elements to remove
+     * @return True if the formatter changed as a result of this call
+     */
+    default boolean remove(Iterable<E> elements) {
+        return remove(Lists.newArrayList(elements));
+    }
+
+    /**
+     * Removes the specified elements from the formatter.
+     *
+     * @param elements Elements to remove
+     * @return True if the formatter changed as a result of this call
+     */
+    default boolean remove(Iterator<E> elements) {
+        return remove(Lists.newArrayList(elements));
+    }
+
+    /**
+     * Removes all elements from the formatter except for these specified
+     * elements.
+     *
+     * @param elements Elements to retain
+     * @return True if the formatter changed as a result of this call
+     */
+    boolean retain(Collection<E> elements);
+
+    /**
+     * Removes all elements from the formatter except for these specified
+     * elements.
+     *
+     * @param elements Elements to retain
+     * @return True if the formatter changed as a result of this call
+     */
+    default boolean retain(Iterable<E> elements) {
+        return retain(Lists.newArrayList(elements));
+    }
+
+    /**
+     * Removes all elements from the formatter except for these specified
+     * elements.
+     *
+     * @param elements Elements to retain
+     * @return True if the formatter changed as a result of this call
+     */
+    default boolean retain(Iterator<E> elements) {
+        return retain(Lists.newArrayList(elements));
+    }
+
+    /**
+     * Builds the result {@link Text} for this formatter using the current
+     * configuration of each element. The result of each element is
+     * concatenated to an empty {@link Text} to yield the result.
+     *
+     * @return Text result of formatter
+     */
+    default Text format() {
+        Text text = Text.EMPTY;
+        for (E e : this) {
+            text = text.concat(e.toText());
+        }
+        return text.trim();
+    }
+
+    @Override
+    default Iterator<E> iterator() {
+        return getAll().iterator();
+    }
+
+    @Override
+    default Text toText() {
+        return format();
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/transform/TextTemplateApplier.java
+++ b/src/main/java/org/spongepowered/api/text/transform/TextTemplateApplier.java
@@ -22,70 +22,64 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.text.action;
+package org.spongepowered.api.text.transform;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.TextElement;
+import org.spongepowered.api.text.TextRepresentable;
+import org.spongepowered.api.text.TextTemplate;
 
 import javax.annotation.Nullable;
 
 /**
- * Represents an action happening as a response to an event on a {@link Text}.
- *
- * @param <R> The type of the result
- *
- * @see ClickAction
- * @see HoverAction
- * @see ShiftClickAction
+ * Wrapper class to hold {@link TextTemplate} parameters and a TextTemplate.
  */
-public abstract class TextAction<R> implements TextElement {
-
-    protected final R result;
+public interface TextTemplateApplier extends TextRepresentable {
 
     /**
-     * Constructs a new {@link TextAction} with the given result.
+     * Returns an {@link ImmutableList} of this applier's parameters.
      *
-     * @param result The result of the text action
+     * @return Applier parameters
      */
-    protected TextAction(R result) {
-        this.result = checkNotNull(result, "result");
+    ImmutableMap<String, TextElement> getParameters();
+
+    /**
+     * Returns the current value of the parameter with the specified key.
+     *
+     * @param key Parameter key
+     * @return Parameter value
+     */
+    default TextElement getParameter(String key) {
+        return getParameters().get(key);
     }
 
     /**
-     * Returns the result of this {@link TextAction}.
+     * Sets the value of the specified parameter key within this applier.
      *
-     * @return The result
+     * @param key Parameter key
+     * @param value Parameter value
      */
-    public final R getResult() {
-        return this.result;
-    }
+    void setParameter(String key, @Nullable TextElement value);
+
+    /**
+     * Returns the current {@link TextTemplate} for this applier.
+     *
+     * @return TextTemplate
+     */
+    TextTemplate getTemplate();
+
+    /**
+     * Sets the {@link TextTemplate} to use for this applier.
+     *
+     * @param template TextTemplate to use
+     */
+    void setTemplate(TextTemplate template);
 
     @Override
-    public boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        TextAction<?> that = (TextAction<?>) o;
-        return this.result.equals(that.result);
-    }
-
-    @Override
-    public int hashCode() {
-        return this.result.hashCode();
-    }
-
-    @Override
-    public String toString() {
-        return Objects.toStringHelper(this)
-                .addValue(this.result)
-                .toString();
+    default Text toText() {
+        return getTemplate().apply(getParameters()).build();
     }
 
 }


### PR DESCRIPTION
This PR adds re-usable, serializable, text templates to SpongeAPI. This is useful in plugin development when a developer wishes to store a message in a config file with variable elements.

## Example

```java
import static org.spongepowered.api.text.template.TextTemplate.*;

TextTemplate template = of(
    TextColors.BLUE, "Hello, ", arg("playerName").color(TextColors.AQUA).style(TextStyles.BOLD), "!"
);

void onPlayerJoin() {
    player.sendMessage(template, ImmutableMap.of("playerName", Text.of(player.getName()));
}
```

A few things to note:
* Repeated arguments are permitted but must be "equivalent", meaning that if argument 1 named 'x' is optional argument 2 named 'x' must also be optional.
* Elements are appended to the text builder in the order in which they appear.
* Arguments are required by default. You can change this with `arg("name").optional()`.
* TextTemplates are immutable.
* Arguments can have a TextFormat which can be overwritten (or not) by the TextElement supplied to the parameter map.
* A "placeholder" representation of the template can be obtained with `TextTemplate.toText()`
* TextTemplates are Iterable and `iterator()` returns an unmodifiable Iterator of it's elements.
* Green is my favorite color.

## Serialization

TextTemplates are config serializable with @zml2008's Configurate. The above template will produce the following serialized output:

```hocon
template {
    arguments {
        playerName {
            optional=false
        }
    }
    content {
        color=blue
        extra=[
            "Hello, ",
            {
                bold=true
                color=aqua
                text="{playerName}"
            },
            "!"
        ]
        text=""
    }
    options {
        openArg={
        closeArg=}
    }
}
```

Templates are serialized and deserialized like so:

```java
node.getNode("template").setValue(TypeToken.of(TextTemplate.class), template); // serialize
node.getNode("template").getValue(TypeToken.of(TextTemplate.class)); // deserialize
```

This PR also makes Text objects config serializable:

```java
node.getNode("text").setValue(TypeToken.of(Text.class), text); // serialize
node.getNode("text").getValue(TypeToken.of(Text.class)); // deserialize
```

Signed-off-by: Walker Crouse <walkercrouse@hotmail.com>