### PR TITLE
Extend plugin metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,12 @@ version = '4.0.0-SNAPSHOT'
 ext.api = project
 apply from: 'gradle/sponge.gradle'
 
+sourceSets {
+    ap {
+        compileClasspath += main.compileClasspath + main.output
+    }
+}
+
 // Project dependencies
 dependencies {
     // Logging
@@ -40,6 +46,9 @@ dependencies {
 
     // Dependency injection
     compile 'com.google.inject:guice:4.0'
+
+    // Plugin meta
+    compile 'org.spongepowered:plugin-meta:0.1-SNAPSHOT'
 
     // Configuration
     compile 'ninja.leaping.configurate:configurate-hocon:3.1.1'
@@ -56,6 +65,8 @@ dependencies {
 
 // JAR manifest configuration
 jar {
+    from sourceSets.ap.output
+
     manifest {
         attributes('Main-Class': 'org.spongepowered.api.util.InformativeMain')
     }
@@ -64,6 +75,7 @@ jar {
 task sourceJar(type: Jar) {
     classifier = 'sources'
     from sourceSets.main.allSource
+    from sourceSets.ap.allSource
 }
 
 artifacts {
@@ -111,6 +123,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 shadowJar {
     classifier = 'shaded'
+    from sourceSets.ap.output
 }
 
 artifacts {

--- a/gradle/sponge.gradle
+++ b/gradle/sponge.gradle
@@ -35,7 +35,7 @@ dependencies {
 }
 
 // Source compiler configuration
-configure([compileJava, compileTestJava]) {
+tasks.withType(JavaCompile) {
     options.compilerArgs += ['-Xlint:all', '-Xlint:-path']
     options.deprecation = true
     options.encoding = 'UTF-8'

--- a/src/ap/java/org/spongepowered/plugin/processor/AnnotationWrapper.java
+++ b/src/ap/java/org/spongepowered/plugin/processor/AnnotationWrapper.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.plugin.processor;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.lang.annotation.Annotation;
+
+import javax.lang.model.AnnotatedConstruct;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.QualifiedNameable;
+
+final class AnnotationWrapper<T extends Annotation> {
+
+    private final T annotation;
+    private final AnnotationMirror mirror;
+    private final ImmutableMap<String, AnnotationValue> values;
+
+    AnnotationWrapper(T annotation, AnnotationMirror mirror) {
+        this.annotation = annotation;
+        this.mirror = mirror;
+
+        ImmutableMap.Builder<String, AnnotationValue> builder = ImmutableMap.builder();
+        mirror.getElementValues().forEach((field, value) -> builder.put(field.getSimpleName().toString(), value));
+        this.values = builder.build();
+    }
+
+    T get() {
+        return this.annotation;
+    }
+
+    AnnotationMirror getMirror() {
+        return this.mirror;
+    }
+
+    ImmutableMap<String, AnnotationValue> getValues() {
+        return this.values;
+    }
+
+    AnnotationValue getValue(String name) {
+        AnnotationValue value = this.values.get(name);
+        checkArgument(value != null, "Annotation value '%s' is not present in %s", name, this.mirror);
+        return value;
+    }
+
+    static <T extends Annotation> AnnotationWrapper<T> get(AnnotatedConstruct element, Class<T> annotationClass) {
+        checkNotNull(element, "element");
+        checkNotNull(annotationClass, "annotationClass");
+
+        final T annotation = element.getAnnotation(annotationClass);
+        final String name = annotationClass.getName();
+        for (AnnotationMirror mirror : element.getAnnotationMirrors()) {
+            if (((QualifiedNameable) mirror.getAnnotationType().asElement()).getQualifiedName().contentEquals(name)) {
+                return new AnnotationWrapper<>(annotation, mirror);
+            }
+        }
+
+        throw new IllegalArgumentException("Annotation " + annotation + " not found in " + element);
+    }
+
+}

--- a/src/ap/java/org/spongepowered/plugin/processor/PluginElement.java
+++ b/src/ap/java/org/spongepowered/plugin/processor/PluginElement.java
@@ -1,0 +1,220 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.plugin.processor;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static javax.tools.Diagnostic.Kind.ERROR;
+import static javax.tools.Diagnostic.Kind.WARNING;
+import static org.spongepowered.api.plugin.Plugin.ID_PATTERN;
+
+import org.spongepowered.api.plugin.Dependency;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.plugin.meta.PluginMetadata;
+import org.spongepowered.plugin.meta.version.InvalidVersionSpecificationException;
+import org.spongepowered.plugin.meta.version.VersionRange;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import javax.annotation.processing.Messager;
+import javax.lang.model.element.TypeElement;
+
+final class PluginElement {
+
+    private final TypeElement element;
+    private final AnnotationWrapper<Plugin> annotation;
+    private final PluginMetadata metadata;
+
+    PluginElement(TypeElement element, AnnotationWrapper<Plugin> annotation, PluginMetadata metadata) {
+        this.element = checkNotNull(element, "element");
+        this.annotation = checkNotNull(annotation, "annotation");
+        this.metadata = metadata;
+    }
+
+    TypeElement getElement() {
+        return this.element;
+    }
+
+    AnnotationWrapper<Plugin> getAnnotation() {
+        return this.annotation;
+    }
+
+    PluginMetadata getMetadata() {
+        return this.metadata;
+    }
+
+    void apply(Messager messager) {
+        String value = this.annotation.get().id();
+        if (!ID_PATTERN.matcher(value).matches()) {
+            messager.printMessage(ERROR, "Plugin ID '" + value + "' should match pattern " + ID_PATTERN.pattern(),
+                    this.element, this.annotation.getMirror(), this.annotation.getValue("id"));
+        }
+
+        if (value.indexOf('.') == -1) {
+            messager.printMessage(WARNING, "Unqualified plugin ID '" + value + "'. It is recommend to prefix your plugin ID with a qualified group. "
+                    + "See the @Plugin Javadocs for details.", this.element, this.annotation.getMirror(), this.annotation.getValue("id"));
+        }
+
+        value = this.annotation.get().description();
+        if (value.isEmpty()) {
+            if (this.metadata.getName() == null) {
+                messager.printMessage(WARNING, "Missing plugin name", this.element, this.annotation.getMirror());
+            }
+        } else {
+            this.metadata.setName(value);
+        }
+
+        value = this.annotation.get().version();
+        if (value.isEmpty()) {
+            if (this.metadata.getVersion() == null) {
+                messager.printMessage(WARNING, "Missing plugin version", this.element, this.annotation.getMirror());
+            }
+        } else {
+            this.metadata.setVersion(value);
+        }
+
+        value = this.annotation.get().description();
+        if (value.isEmpty()) {
+            if (this.metadata.getDescription() == null) {
+                messager.printMessage(WARNING, "Missing plugin description", this.element, this.annotation.getMirror());
+            }
+        } else {
+            this.metadata.setDescription(value);
+        }
+
+        value = this.annotation.get().url();
+        if (!value.isEmpty()) {
+            if (!isLikelyValidUrl(value)) {
+                messager.printMessage(ERROR, "Invalid URL: " + value, this.element, this.annotation.getMirror(), this.annotation.getValue("url"));
+            }
+
+            this.metadata.setUrl(value);
+        } else if ((value = this.metadata.getUrl()) != null) {
+            if (!isLikelyValidUrl(value)) {
+                messager.printMessage(ERROR, "Invalid URL: " + value + " in extra metadata files", this.element, this.annotation.getMirror());
+            }
+        }
+
+        String[] authors = this.annotation.get().authors();
+        if (authors.length > 0) {
+            this.metadata.getAuthors().clear();
+            for (String author : authors) {
+                if (author.isEmpty()) {
+                    messager.printMessage(ERROR, "Empty author is not allowed", this.element, this.annotation.getMirror(),
+                            this.annotation.getValue("authors"));
+                    continue;
+                }
+
+                this.metadata.addAuthor(author);
+            }
+        }
+
+        checkDependencies(this.metadata.getRequiredDependencies(), messager);
+        checkDependencies(this.metadata.getLoadAfter(), messager);
+        checkDependencies(this.metadata.getLoadBefore(), messager);
+
+        Dependency[] dependencies = this.annotation.get().dependencies();
+        if (dependencies.length > 0) {
+            for (Dependency dependency : dependencies) {
+                final String id = dependency.id();
+                if (id.isEmpty()) {
+                    messager.printMessage(ERROR, "Dependency ID should not be empty", this.element, this.annotation.getMirror(),
+                            this.annotation.getValue("dependencies"));
+                }
+
+                final String version = dependency.version();
+                if (!version.isEmpty()) {
+                    try {
+                        VersionRange.createFromVersionSpec(version);
+                    } catch (InvalidVersionSpecificationException e) {
+                        messager.printMessage(ERROR, "Invalid dependency version range: " + version + " (" + e.getMessage() +
+                                ") Please check the Javadocs of @Dependency.version() for details.",
+                                this.element, this.annotation.getMirror(), this.annotation.getValue("dependencies"));
+                    }
+                }
+
+                // TODO: Load order
+                this.metadata.loadAfter(new PluginMetadata.Dependency(id, dependency.version()), !dependency.optional());
+            }
+        }
+    }
+
+    private void checkDependencies(Iterable<PluginMetadata.Dependency> dependencies, Messager messager) {
+        for (PluginMetadata.Dependency dependency : dependencies) {
+            final String version = dependency.getVersion();
+            if (version != null) {
+                try {
+                    VersionRange.createFromVersionSpec(version);
+                } catch (InvalidVersionSpecificationException e) {
+                    messager.printMessage(ERROR, "Invalid dependency version range from extra metadata file: " + version + " (" + e.getMessage() +
+                            ") Please check the Javadocs of @Dependency.version() for details.", this.element, this.annotation.getMirror());
+                }
+            }
+        }
+    }
+
+    private static boolean isLikelyValidUrl(String url) {
+        try {
+            new URL(url).toURI();
+            return true;
+        } catch (MalformedURLException | URISyntaxException ignored) {
+            return false;
+        }
+    }
+
+    static void applyMeta(PluginMetadata meta, PluginMetadata other, Messager messager) {
+        checkArgument(meta.getId().equals(other.getId()), "Plugin meta IDs don't match");
+
+        if (other.getName() != null) {
+            meta.setName(other.getName());
+        }
+        if (other.getVersion() != null) {
+            meta.setVersion(other.getVersion());
+        }
+        if (other.getDescription() != null) {
+            meta.setDescription(other.getDescription());
+        }
+        if (other.getUrl() != null) {
+            meta.setUrl(other.getUrl());
+        }
+
+        // TODO: Dependencies
+        if (!other.getRequiredDependencies().isEmpty() || !other.getLoadAfter().isEmpty() || !other.getLoadBefore().isEmpty()) {
+            messager.printMessage(WARNING, "Trying to merge dependencies from extra metadata file. This is currently not supported.");
+        }
+
+        other.getExtensions().forEach((key, extension) -> {
+            // TODO
+            if (meta.getExtensions().containsKey(key)) {
+                messager.printMessage(WARNING, "Cannot merge extension " + key + " of type " + extension.getClass() + " from extra metadata file");
+            } else {
+                meta.setExtension(key, extension);
+            }
+        });
+    }
+
+}

--- a/src/ap/java/org/spongepowered/plugin/processor/PluginProcessExeption.java
+++ b/src/ap/java/org/spongepowered/plugin/processor/PluginProcessExeption.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.plugin.processor;
+
+/**
+ * Thrown if an exception occurs in the plugin annotation processor.
+ */
+final class PluginProcessExeption extends RuntimeException {
+
+    private static final long serialVersionUID = -8573308144869929605L;
+
+    public PluginProcessExeption() {
+    }
+
+    public PluginProcessExeption(String message) {
+        super(message);
+    }
+
+    public PluginProcessExeption(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PluginProcessExeption(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/ap/java/org/spongepowered/plugin/processor/PluginProcessor.java
+++ b/src/ap/java/org/spongepowered/plugin/processor/PluginProcessor.java
@@ -1,0 +1,220 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.plugin.processor;
+
+import static javax.tools.Diagnostic.Kind.ERROR;
+import static javax.tools.Diagnostic.Kind.NOTE;
+import static javax.tools.Diagnostic.Kind.WARNING;
+import static javax.tools.StandardLocation.CLASS_OUTPUT;
+
+import com.google.common.base.Splitter;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.plugin.meta.McModInfo;
+import org.spongepowered.plugin.meta.PluginMetadata;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedOptions;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import javax.tools.FileObject;
+
+@SupportedAnnotationTypes({
+        "org.spongepowered.api.plugin.Plugin",
+        "org.spongepowered.api.plugin.Dependency"
+})
+@SupportedOptions({
+        PluginProcessor.EXTRA_FILES_OPTION,
+        PluginProcessor.OUTPUT_FILE_OPTION
+})
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+public class PluginProcessor extends AbstractProcessor {
+
+    public static final String EXTRA_FILES_OPTION = "extraMetadataFiles";
+    public static final String OUTPUT_FILE_OPTION = "metadataOutputFile";
+
+    private static final Splitter FILE_SPLITTER = Splitter.on(';');
+
+    private final Map<String, PluginMetadata> meta = new HashMap<>();
+    private final Map<String, PluginElement> plugins = new HashMap<>();
+    private final Set<String> duplicates = new HashSet<>();
+
+    private Path outputPath;
+
+    @Override
+    public void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+
+        String extraFiles = processingEnv.getOptions().get(EXTRA_FILES_OPTION);
+        if (extraFiles != null && !extraFiles.isEmpty()) {
+            for (String file : FILE_SPLITTER.split(extraFiles)) {
+                Path path = Paths.get(file);
+                getMessager().printMessage(NOTE, "Reading extra plugin metadata from " + path);
+                try {
+                    for (PluginMetadata meta : McModInfo.DEFAULT.read(path)) {
+                        PluginMetadata base = this.meta.putIfAbsent(meta.getId(), meta);
+                        if (base != null) {
+                            PluginElement.applyMeta(base, meta, getMessager());
+                        }
+                    }
+                } catch (IOException e) {
+                    throw new PluginProcessExeption("Failed to read extra plugin metadata from " + path, e);
+                }
+            }
+        }
+
+        String outputFile = processingEnv.getOptions().get(OUTPUT_FILE_OPTION);
+        if (outputFile != null && !outputFile.isEmpty()) {
+            this.outputPath = Paths.get(outputFile);
+        }
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (roundEnv.processingOver()) {
+            if (!roundEnv.errorRaised()) {
+                finish();
+            }
+
+            return true;
+        }
+
+        if (!contains(annotations, Plugin.class)) {
+            return false;
+        }
+
+        for (Element e : roundEnv.getElementsAnnotatedWith(Plugin.class)) {
+            if (e.getKind() != ElementKind.CLASS) {
+                getMessager().printMessage(ERROR, "Invalid element of type " + e.getKind() + " annotated with @Plugin", e);
+                continue;
+            }
+
+            final TypeElement pluginElement = (TypeElement) e;
+            AnnotationWrapper<Plugin> annotation = AnnotationWrapper.get(pluginElement, Plugin.class);
+
+            final String id = annotation.get().id();
+            if (id.isEmpty()) {
+                getMessager().printMessage(ERROR, "Plugin ID cannot be empty", pluginElement, annotation.getMirror(), annotation.getValue("id"));
+                continue;
+            }
+
+            PluginMetadata meta = this.meta.remove(id);
+            if (meta == null) {
+                meta = new PluginMetadata(id);
+            }
+
+            PluginElement plugin = new PluginElement(pluginElement, annotation, meta);
+
+            // Check for conflicting plugin IDs
+            if (this.duplicates.contains(id) || this.plugins.containsKey(id)) {
+                PluginElement otherPlugin = this.plugins.remove(id);
+                if (otherPlugin != null) {
+                    reportDuplicatePlugin(id, otherPlugin);
+                    this.duplicates.add(id);
+                }
+
+                reportDuplicatePlugin(id, plugin);
+                continue;
+            }
+
+            this.plugins.put(id, plugin);
+            plugin.apply(getMessager());
+        }
+
+        return true;
+    }
+
+    private void finish() {
+        if (!this.meta.isEmpty()) {
+            getMessager().printMessage(WARNING, "The following extra plugin IDs were not found: " + this.meta.keySet());
+        }
+
+        List<PluginMetadata> meta = this.plugins.values().stream()
+                .map(PluginElement::getMetadata)
+                .collect(Collectors.toList());
+
+        try (BufferedWriter writer = createWriter()) {
+            McModInfo.DEFAULT.write(writer, meta);
+        } catch (IOException e) {
+            throw new PluginProcessExeption("Failed to write plugin metadata", e);
+        }
+    }
+
+    private BufferedWriter createWriter() throws IOException {
+        if (this.outputPath != null) {
+            getMessager().printMessage(NOTE, "Writing plugin metadata to " + this.outputPath);
+            return Files.newBufferedWriter(this.outputPath, StandardOpenOption.CREATE);
+        } else {
+            FileObject obj = this.processingEnv.getFiler().createResource(CLASS_OUTPUT, "", McModInfo.STANDARD_FILENAME);
+            getMessager().printMessage(NOTE, "Writing plugin metadata to " + obj.toUri());
+            return new BufferedWriter(obj.openWriter());
+        }
+    }
+
+    private void reportDuplicatePlugin(String id, PluginElement plugin) {
+        getMessager().printMessage(ERROR, "Duplicate plugin ID: " + id, plugin.getElement(), plugin.getAnnotation().getMirror(),
+                plugin.getAnnotation().getValue("id"));
+    }
+
+    private Messager getMessager() {
+        return this.processingEnv.getMessager();
+    }
+
+    private static boolean contains(Collection<? extends TypeElement> elements, Class<?> clazz) {
+        if (elements.isEmpty()) {
+            return false;
+        }
+
+        final String name = clazz.getName();
+        for (TypeElement element : elements) {
+            if (element.getQualifiedName().contentEquals(name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/src/ap/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/src/ap/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.spongepowered.plugin.processor.PluginProcessor

--- a/src/main/java/org/spongepowered/api/plugin/Dependency.java
+++ b/src/main/java/org/spongepowered/api/plugin/Dependency.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.plugin;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Represents a dependency for a {@link Plugin}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({})
+public @interface Dependency {
+
+    /**
+     * The plugin ID of the dependency.
+     *
+     * @return The dependency plugin ID
+     * @see Plugin#id()
+     */
+    String id();
+
+    /**
+     * The required version range of the dependency in <b>Maven version range
+     * syntax</b>:
+     *
+     * <table>
+     * <tr><th>Range</th><th>Meaning</th></tr>
+     * <tr><td>1.0</td><td>Any dependency version, 1.0 is recommended</td></tr>
+     * <tr><td>[1.0]</td><td>x == 1.0</td></tr>
+     * <tr><td>[1.0,)</td><td>x &gt;= 1.0</td></tr>
+     * <tr><td>(1.0,)</td><td>x &gt; 1.0</td></tr>
+     * <tr><td>(,1.0]</td><td>x &lt;= 1.0</td></tr>
+     * <tr><td>(,1.0)</td><td>x &lt; 1.0</td></tr>
+     * <tr><td>(1.0,2.0)</td><td>1.0 &lt; x &lt; 2.0</td></tr>
+     * <tr><td>[1.0,2.0]</td><td>1.0 &lt;= x &lt;= 2.0</td></tr>
+     * </table>
+     *
+     * @return The required version range, or an empty string if unspecified
+     * @see <a href="https://goo.gl/edrup4">Maven version range specification</a>
+     * @see <a href="https://goo.gl/WBsFIu">Maven version design document</a>
+     */
+    String version() default "";
+
+    /**
+     * If this dependency is optional for the plugin to work. By default
+     * this is {@code false}.
+     *
+     * @return True if the dependency is optional for the plugin to work
+     */
+    boolean optional() default false;
+
+}

--- a/src/main/java/org/spongepowered/api/plugin/Plugin.java
+++ b/src/main/java/org/spongepowered/api/plugin/Plugin.java
@@ -24,24 +24,32 @@
  */
 package org.spongepowered.api.plugin;
 
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.regex.Pattern;
 
 /**
  * An annotation used to describe and mark a Sponge plugin.
  */
-@Target(TYPE)
-@Retention(RUNTIME)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
 public @interface Plugin {
+
+    Pattern ID_PATTERN = Pattern.compile("[a-z](?:[a-z0-9-_.]*[a-z0-9])?");
 
     /**
      * An ID for the plugin to be used internally. The ID should be unique as to
      * not conflict with other plugins.
      *
+     * <p>The plugin ID must be lowercase and start with a alphabetic character.
+     * It is recommended to qualify the plugin ID with a unique group identifier
+     * as prefix, e.g. {@code me.spongeplugindev.testplugin}. Usually it is a
+     * good idea to use a group similar to your plugin main class package.</p>
+     *
      * @return The plugin identifier
+     * @see <a href="https://goo.gl/MRRYSJ">Java package naming conventions</a>
      */
     String id();
 
@@ -49,39 +57,43 @@ public @interface Plugin {
      * The human readable name of the plugin as to be used in descriptions and
      * similar things.
      *
-     * @return The plugin name
+     * @return The plugin name, or an empty string if unknown
      */
-    String name();
+    String name() default "";
 
     /**
      * The version of the plugin.
      *
-     * @return The plugin version
+     * @return The plugin version, or an empty string if unknown
      */
-    String version() default "unknown";
+    String version() default "";
 
     /**
-     * A simple dependency string for this mod separated by a ";"
-     * example:
-     * <pre>"required-after:Sponge@[1.2.3.2222,);
-     * required-after:myLibraryPlugin;after:towny;before:worldguard"</pre>
-     *
-     * <p>supported options:
-     * <dl>
-     *   <dt>after</dt>
-     *   <dd>when present this plugin will run after plugin x</dd>
-     *   <dt>required-after</dt>
-     *   <dd>plugin x must be present, load after plugin x</dd>
-     *   <dt>before</dt>
-     *   <dd>when present run before plugin x</dd>
-     *   <dt>required-before</dt>
-     *   <dd>plugin x must be present, load before plugin x</dd>
-     * </dl>
-     * supports maven version ranges after @ in any field</p>
+     * The dependencies required to load <strong>before</strong> this plugin.
      *
      * @return The plugin dependencies
      */
-    String dependencies() default "";
+    Dependency[] dependencies() default {};
 
+    /**
+     * The description of the plugin, explaining what it can be used for.
+     *
+     * @return The plugin description, or an empty string if unknown
+     */
+    String description() default "";
+
+    /**
+     * The URL or website of the plugin.
+     *
+     * @return The plugin url, or an empty string if unknown
+     */
+    String url() default "";
+
+    /**
+     * The authors of the plugin.
+     *
+     * @return The plugin authors, or empty if unknown
+     */
+    String[] authors() default {};
 
 }

--- a/src/main/java/org/spongepowered/api/plugin/PluginContainer.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginContainer.java
@@ -24,9 +24,12 @@
  */
 package org.spongepowered.api.plugin;
 
+import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -36,25 +39,102 @@ import java.util.Optional;
 public interface PluginContainer {
 
     /**
-     * Gets the id of the {@link Plugin} within this container.
+     * Gets the qualified ID of the {@link Plugin} within this container.
      *
-     * @return The id
+     * @return The plugin ID
+     * @see Plugin#id()
      */
     String getId();
 
     /**
+     * Gets the <b>unqualified</b> ID of the {@link Plugin} within this
+     * container. If the {@link Plugin} is using a qualified ID the result
+     * is equal to the last section of the qualified ID.
+     *
+     * <p><b>Examples:</b>
+     * <table>
+     *     <tr><th>Plugin ID</th><th>Unqualified plugin ID</th></tr>
+     *     <tr>
+     *         <td>{@code me.spongeplugin.dev.testplugin}</td>
+     *         <td>{@code testplugin}</td>
+     *     </tr>
+     *     <tr>
+     *         <td>{@code testplugin}</td>
+     *         <td>{@code testplugin}</td>
+     *     </tr>
+     * </ul></p>
+     *
+     * @return The unqualified plugin ID
+     * @see Plugin#id()
+     */
+    String getUnqualifiedId();
+
+    /**
      * Gets the name of the {@link Plugin} within this container.
      *
-     * @return The name
+     * @return The plugin name, or {@link #getUnqualifiedId()} if unknown
+     * @see Plugin#name()
      */
-    String getName();
+    default String getName() {
+        return getUnqualifiedId();
+    }
 
     /**
      * Gets the version of the {@link Plugin} within this container.
      *
-     * @return The name
+     * @return The plugin version, or {@link Optional#empty()} if unknown
+     * @see Plugin#version()
      */
-    String getVersion();
+    default Optional<String> getVersion() {
+        return Optional.empty();
+    }
+
+    /**
+     * Gets the description of the {@link Plugin} within this container.
+     *
+     * @return The plugin description, or {@link Optional#empty()} if unknown
+     * @see Plugin#description()
+     */
+    default Optional<String> getDescription() {
+        return Optional.empty();
+    }
+
+    /**
+     * Gets the url or website of the {@link Plugin} within this container.
+     *
+     * @return The plugin url, or {@link Optional#empty()} if unknown
+     * @see Plugin#url()
+     */
+    default Optional<String> getUrl() {
+        return Optional.empty();
+    }
+
+    /**
+     * Gets the authors of the {@link Plugin} within this container.
+     *
+     * @return The plugin authors, or empty if unknown
+     * @see Plugin#authors()
+     */
+    default List<String> getAuthors() {
+        return ImmutableList.of();
+    }
+
+    /**
+     * Returns the source the plugin was loaded from.
+     *
+     * @return The source the plugin was loaded from or {@link Optional#empty()}
+     *     if unknown
+     */
+    default Optional<Path> getSource() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the created instance of {@link Plugin} if it is available.
+     *
+     * @return The instance if available
+     */
+    Optional<?> getInstance();
 
     /**
      * Returns the assigned logger to this {@link Plugin}.
@@ -64,12 +144,5 @@ public interface PluginContainer {
     default Logger getLogger() {
         return LoggerFactory.getLogger(getId());
     }
-
-    /**
-     * Returns the created instance of {@link Plugin} if it is available.
-     *
-     * @return The instance if available
-     */
-    Optional<Object> getInstance();
 
 }

--- a/src/main/java/org/spongepowered/api/plugin/PluginManager.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginManager.java
@@ -53,14 +53,6 @@ public interface PluginManager {
     Optional<PluginContainer> getPlugin(String id);
 
     /**
-     * Gets the {@link Logger} for the {@link PluginContainer}.
-     *
-     * @param plugin The plugin
-     * @return The logger
-     */
-    Logger getLogger(PluginContainer plugin);
-
-    /**
      * Gets a {@link Collection} of all {@link PluginContainer}s.
      *
      * @return The plugins


### PR DESCRIPTION
This pull request extends the `@Plugin` annotation with several new fields for additional plugin metadata and adds an annotation processor for the `@Plugin` annotation which generates a `mcmod.info` file based on the values of the `@Plugin` annotation.

**Additions for plugin metadata:** (for #822)
- Description
- URL
- Plugin authors
- Simplified dependency syntax

Example for new dependency syntax:
```java
@Plugin(id = "net.minecrell.testplugin", dependencies = {
    // Require WorldEdit to be loaded before plugin is constructed
    @Dependency(id = "com.sk89q.worldedit"),
    // Load updatifier first if it is present
    @Dependency(id = "me.flibio.updatifier", optional = true)
})
```

### File metadata (for #624)
As discussed in #624, this implements `mcmod.info` as the format for plugin metadata in the JAR file. This is how it works (or is supposed to work) currently: (I would appreciate suggestions or feedback here)

- File metadata (`mcmod.info`) in the JAR is **optional** for _running_ the plugin (makes testing difficult otherwise), however I would like to make it **required** for submitting plugins on Ore. A warning will be shown in the logs if the server attempts to load a plugin without a `mcmod.info` file. If file metadata is present in the JAR, the annotation will be ignored completely and only used for finding the plugin class.

- The `@Plugin` annotation processor included in SpongeAPI generates a `mcmod.info` file based on the values specified in the annotation. **With Gradle (and likely also Maven) no additional configuration is required.** When creating the JARs manually (e.g. through Eclipse or something) it can _theoretically_ also run, however annotation processing will need to be enabled manually (I haven't tested this).

- I've made an additional **optional** Gradle plugin (WIP) which provides additional integration for plugin meta (and maybe also a proper way for simple testing in the IDE in the future). With the plugin, a simple Gradle plugin setup with plugin metadata integration looks like this:

    ```gradle
    plugins {
        id 'org.spongepowered.plugin' version '0.1'
    }

    group = 'net.minecrell'
    version = '1.0-SNAPSHOT'
    description = 'This is my test plugin'

    dependencies {
        compile 'org.spongepowered:spongeapi:3.1.0-SNAPSHOT'
    }
    ```
    ```java
    @Plugin(id = "net.minecrell.testplugin", authors = "Minecrell")
    public class TestPlugin {

    }
    ```

  With this setup, the plugin automatically handles the following:

  - Basic Gradle Java setup
  - Set `sourceCompatibility` to Java 8 by default
  - Add Sponge maven repositories
  - Set up a plugin with the project name in lower case as ID and configures the Gradle project name, description and version to be included in file metadata. (the plugin ID is optionally also manually configurable)
  - Ensure the annotation processor actually runs (otherwise it will print an error)
  - Add any metadata specified manually from a `mcmod.info` file in the resources to the resulting file. This allows adding Forge-specific properties (e.g. logo, screenshot) manually which are currently not supported by Sponge's metadata directly.

  ... and finally, the resulting `mcmod.info` file for the plugin above looks like this:

    ```json
    {
        "modid": "net.minecrell.testplugin",
        "name": "TestPlugin",
        "version": "1.0-SNAPSHOT",
        "description": "This is my test plugin",
        "authorList": [
            "Minecrell"
        ]
    }
    ```

#### Additional repositories
- `mcmod.info` serializer: https://github.com/Minecrell/plugin-meta (used in the annotation processor (SpongeAPI) and the Gradle plugin)
- Gradle plugin for Sponge plugins: https://github.com/SpongePowered/SpongeGradle/pull/2

### Implementation (SpongeForge/SpongeVanilla)
- **SpongeCommon:** https://github.com/SpongePowered/SpongeCommon/pull/523
- **SpongeVanilla:** https://github.com/SpongePowered/SpongeVanilla/pull/225
- **SpongeForge:** https://github.com/SpongePowered/SpongeForge/pull/544

### TODO
- ~~Publish plugin-meta and Gradle plugin to Sponge's maven repository.~~ Done!