### PR TITLE
Add More Event Filters

### DIFF
--- a/src/main/java/org/spongepowered/api/event/filter/Getter.java
+++ b/src/main/java/org/spongepowered/api/event/filter/Getter.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.filter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Optional;
+
+/**
+ * Annotates a parameter in an event listener whose value should be fetched from
+ * a getter on the event type with the specified name.
+ * 
+ * <p>For example if the event type has a method 'T getObject();' then you would
+ * annotate a parameter of type T with '@Getter("getObject")'.</p>
+ * 
+ * <p>For optional types the value of the parameter can be either
+ * {@link Optional} or the type of the enclosed object. If the type is the
+ * enclosed type then the optional will be automatically unwrapped and if the
+ * optional is not present then your event listener will not be called.</p>
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Getter {
+
+    /**
+     * The name of the method to fetch the value from within the event type.
+     * 
+     * @return The method name
+     */
+    String value();
+
+}

--- a/src/main/java/org/spongepowered/api/util/generator/event/factory/plugin/AccessorModifierEventFactoryPlugin.java
+++ b/src/main/java/org/spongepowered/api/util/generator/event/factory/plugin/AccessorModifierEventFactoryPlugin.java
@@ -29,6 +29,7 @@ import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.GETFIELD;
 import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
 import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.IRETURN;
 
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
@@ -100,7 +101,7 @@ public class AccessorModifierEventFactoryPlugin implements EventFactoryPlugin {
         mv.visitMethodInsn(opcode, Type.getInternalName(transformerMethod.getDeclaringClass()), transformerMethod.getName(),
                 Type.getMethodDescriptor(transformerMethod), opcode == INVOKEVIRTUAL ? false : true);
 
-        mv.visitInsn(ClassGenerator.getReturnOpcode(property.getType()));
+        mv.visitInsn(Type.getType(property.getType()).getOpcode(IRETURN));
         mv.visitMaxs(0, 0);
         mv.visitEnd();
     }


### PR DESCRIPTION
Implemented by https://github.com/SpongePowered/SpongeCommon/pull/519

This PR adds an event filter for retrieving values from getters on the event type. This annotation annotates a parameter and acts as a source for the parameter value. The annotation specifies a method name which must be a method on the specified event type. The parameter's value is set to the result of calling the specified method on the event. 

Example:
```java
    @Listener
    public void onPlayerDamage(EntityDamageEvent event, @Getter("getTargetEntity") Player player) {
        // do something with player
    }
```
Here we have a Player parameter annotated with the `Getter` annotation. The value for the parameter will be the result of calling `event.getTargetEntity()`. You'll notice that the return type of getTargetEntity is `Entity` but our parameter is of type `Player`, in the case that the returned value is not a player (whenever a non-player is damaged) then the filter will silently fail and your event listener will not be called.

If the return type of the method is an `Optional` then your parameter type can either be Optional, or the type contained within the optional. If you specify your parameter as the type contained within the Optional then your event listener will not be called if the Optional was not present.