### PR TITLE
[WIP] Localization API

### DIFF
--- a/src/main/java/org/spongepowered/api/Game.java
+++ b/src/main/java/org/spongepowered/api/Game.java
@@ -92,11 +92,11 @@ public interface Game {
     GameRegistry getRegistry();
 
     /**
-     * Retrieves the GameDictionary (item dictionary) for this GameRegistry.
+     * Retrieves the ItemDictionary (item dictionary) for this GameRegistry.
      *
      * @return The item dictionary
      */
-    GameDictionary getGameDictionary();
+    ItemDictionary getItemDictionary();
 
     /**
      * Gets the game's instance of the service manager, which is the gateway

--- a/src/main/java/org/spongepowered/api/ItemDictionary.java
+++ b/src/main/java/org/spongepowered/api/ItemDictionary.java
@@ -32,17 +32,17 @@ import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import java.util.Set;
 
 /**
- * A GameDictionary is a store of {@link GameDictionary.Entry}s.
+ * A ItemDictionary is a store of {@link ItemDictionary.Entry}s.
  *
- * <p>Note that the GameDictionary's keys are different from Minecraft item ids.
+ * <p>Note that the ItemDictionary's keys are different from Minecraft item ids.
  * Minecraft item IDs are namespaces, e.g. minecraft:carrot while ItemDictionary
  * keys are not, by design(e.g. carrot). This is mainly to keep supporting the
  * existing Forge 'ore dictionary'.</p>
  */
-public interface GameDictionary {
+public interface ItemDictionary {
 
     /**
-     * Registers an {@link GameDictionary.Entry} in the dictionary with a String
+     * Registers an {@link ItemDictionary.Entry} in the dictionary with a String
      * key. The stack size is ignored.
      *
      * @param key The key of the item as a String

--- a/src/main/java/org/spongepowered/api/Server.java
+++ b/src/main/java/org/spongepowered/api/Server.java
@@ -25,15 +25,16 @@
 package org.spongepowered.api;
 
 import com.flowpowered.math.vector.Vector3d;
+import org.spongepowered.api.command.source.ConsoleSource;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.text.channel.MessageChannel;
 import org.spongepowered.api.profile.GameProfileManager;
 import org.spongepowered.api.resourcepack.ResourcePack;
 import org.spongepowered.api.scoreboard.Scoreboard;
-import org.spongepowered.api.world.ChunkTicketManager;
 import org.spongepowered.api.text.Text;
-import org.spongepowered.api.command.source.ConsoleSource;
+import org.spongepowered.api.text.channel.MessageChannel;
+import org.spongepowered.api.text.translation.locale.Locales;
+import org.spongepowered.api.world.ChunkTicketManager;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.WorldCreationSettings;
 import org.spongepowered.api.world.storage.ChunkLayout;
@@ -41,6 +42,7 @@ import org.spongepowered.api.world.storage.WorldProperties;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -410,4 +412,14 @@ public interface Server {
      * @return The default resource pack
      */
     Optional<ResourcePack> getDefaultResourcePack();
+
+    /**
+     * Returns the {@link Locale} this server is using.
+     *
+     * @return Server locale
+     */
+    default Locale getLocale() {
+        return Locales.DEFAULT;
+    }
+
 }

--- a/src/main/java/org/spongepowered/api/Sponge.java
+++ b/src/main/java/org/spongepowered/api/Sponge.java
@@ -80,8 +80,8 @@ public final class Sponge {
         return getGame().getServer();
     }
 
-    public static GameDictionary getDictionary() {
-        return getGame().getGameDictionary();
+    public static ItemDictionary getItemDictionary() {
+        return getGame().getItemDictionary();
     }
 
     public static CommandManager getCommandManager() {

--- a/src/main/java/org/spongepowered/api/item/ItemType.java
+++ b/src/main/java/org/spongepowered/api/item/ItemType.java
@@ -27,7 +27,7 @@ package org.spongepowered.api.item;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.spongepowered.api.CatalogType;
-import org.spongepowered.api.GameDictionary;
+import org.spongepowered.api.ItemDictionary;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.data.Property;
 import org.spongepowered.api.item.inventory.ItemStack;
@@ -41,7 +41,7 @@ import java.util.Optional;
  * A type of item.
  */
 @CatalogedBy(ItemTypes.class)
-public interface ItemType extends CatalogType, Translatable, GameDictionary.Entry {
+public interface ItemType extends CatalogType, Translatable, ItemDictionary.Entry {
 
     /**
      * Gets the corresponding {@link BlockType} of this item if one exists.

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackSnapshot.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackSnapshot.java
@@ -25,7 +25,7 @@
 
 package org.spongepowered.api.item.inventory;
 
-import org.spongepowered.api.GameDictionary;
+import org.spongepowered.api.ItemDictionary;
 import org.spongepowered.api.data.ImmutableDataHolder;
 import org.spongepowered.api.item.ItemType;
 
@@ -65,13 +65,13 @@ public interface ItemStackSnapshot extends ImmutableDataHolder<ItemStackSnapshot
     ItemStack createStack();
 
     /**
-     * Creates a {@link GameDictionary.Entry} that compares stacks to this
+     * Creates a {@link ItemDictionary.Entry} that compares stacks to this
      * {@link ItemStackSnapshot}. Note that not all data stored in this
      * {@link ItemStackSnapshot} may be stored in the returned entry.
      * 
-     * @return A {@link GameDictionary.Entry} based on this
+     * @return A {@link ItemDictionary.Entry} based on this
      * {@link ItemStackSnapshot}
      */
-    GameDictionary.Entry createGameDictionaryEntry();
+    ItemDictionary.Entry createGameDictionaryEntry();
 
 }

--- a/src/main/java/org/spongepowered/api/locale/AbstractConfigDictionary.java
+++ b/src/main/java/org/spongepowered/api/locale/AbstractConfigDictionary.java
@@ -22,34 +22,39 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service;
+package org.spongepowered.api.locale;
 
-import org.spongepowered.api.event.cause.Cause;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 /**
- * Represents the registration information for the provider of a service.
+ * Abstract implementation of {@link ConfigDictionary}.
  */
-public interface ProviderRegistration<T> {
+public abstract class AbstractConfigDictionary extends AbstractRemoteDictionary implements ConfigDictionary {
 
-    /**
-     * Gets the service of this provider registration.
-     *
-     * @return The service
-     */
-    Class<T> getService();
+    protected final Map<Locale, ConfigResourceBundle> bundles = new HashMap<>();
 
-    /**
-     * Gets the service provider of this provider regitration.
-     *
-     * @return The provider
-     */
-    T getProvider();
+    public AbstractConfigDictionary(Object subject, Locale defaultLocale) {
+        super(subject, defaultLocale);
+    }
 
-    /**
-     * Returns the {@link Cause} of the registration.
-     *
-     * @return Cause of registration
-     */
-    Cause getCause();
+    @Override
+    public ConfigResourceBundle getBundle(Locale locale) {
+        checkNotNull(locale, "locale");
+        ConfigResourceBundle bundle = this.bundles.get(locale);
+        if (bundle == null) {
+            setBundle(locale, bundle = new ConfigResourceBundle(getNode(locale)));
+        }
+        return bundle;
+    }
+
+    @Override
+    public void setBundle(Locale locale, ConfigResourceBundle bundle) {
+        checkNotNull(locale, "locale");
+        this.bundles.put(locale, bundle);
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/locale/AbstractDictionary.java
+++ b/src/main/java/org/spongepowered/api/locale/AbstractDictionary.java
@@ -22,34 +22,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service;
+package org.spongepowered.api.locale;
 
-import org.spongepowered.api.event.cause.Cause;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Locale;
 
 /**
- * Represents the registration information for the provider of a service.
+ * Abstract implementation of {@link Dictionary}.
  */
-public interface ProviderRegistration<T> {
+public abstract class AbstractDictionary implements Dictionary {
 
-    /**
-     * Gets the service of this provider registration.
-     *
-     * @return The service
-     */
-    Class<T> getService();
+    protected final Object subject;
+    protected final Locale defaultLocale;
 
-    /**
-     * Gets the service provider of this provider regitration.
-     *
-     * @return The provider
-     */
-    T getProvider();
+    public AbstractDictionary(Object subject, Locale defaultLocale) {
+        this.subject = checkNotNull(subject, "subject");
+        this.defaultLocale = checkNotNull(defaultLocale, "default locale");
+    }
 
-    /**
-     * Returns the {@link Cause} of the registration.
-     *
-     * @return Cause of registration
-     */
-    Cause getCause();
+    @Override
+    public Object getSubject() {
+        return this.subject;
+    }
+
+    @Override
+    public Locale getDefaultLocale() {
+        return this.defaultLocale;
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/locale/AbstractRemoteDictionary.java
+++ b/src/main/java/org/spongepowered/api/locale/AbstractRemoteDictionary.java
@@ -22,34 +22,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service;
+package org.spongepowered.api.locale;
 
-import org.spongepowered.api.event.cause.Cause;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.InputStream;
+import java.util.Locale;
 
 /**
- * Represents the registration information for the provider of a service.
+ * Abstract implementation of {@link RemoteDictionary}.
  */
-public interface ProviderRegistration<T> {
+public abstract class AbstractRemoteDictionary extends AbstractDictionary implements RemoteDictionary {
+
+    protected final SourceResolver resolver = new SourceResolver();
+
+    public AbstractRemoteDictionary(Object subject, Locale defaultLocale) {
+        super(subject, defaultLocale);
+    }
 
     /**
-     * Gets the service of this provider registration.
+     * Returns the {@link SourceResolver} for this Dictionary.
      *
-     * @return The service
+     * @return Source resolver
      */
-    Class<T> getService();
+    public SourceResolver getResolver() {
+        return this.resolver;
+    }
 
-    /**
-     * Gets the service provider of this provider regitration.
-     *
-     * @return The provider
-     */
-    T getProvider();
-
-    /**
-     * Returns the {@link Cause} of the registration.
-     *
-     * @return Cause of registration
-     */
-    Cause getCause();
+    @Override
+    public InputStream getSource(Locale locale) throws Exception {
+        checkNotNull(locale, "locale");
+        return this.resolver.resolve(locale).orElseThrow(() -> new IllegalStateException("Could not resolve source for locale " + locale + "."));
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/locale/ConfigDictionary.java
+++ b/src/main/java/org/spongepowered/api/locale/ConfigDictionary.java
@@ -1,0 +1,157 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.locale;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Objects;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
+import ninja.leaping.configurate.loader.ConfigurationLoader;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.ResourceBundle;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a {@link RemoteDictionary} that is loaded by Configurate.
+ */
+public interface ConfigDictionary extends RemoteDictionary, ResourceBundleDictionary<ConfigDictionary.ConfigResourceBundle> {
+
+    /**
+     * Returns the {@link ConfigurationLoader} for this Dictionary for the
+     * specified {@link Locale}.
+     *
+     * @return Config loader
+     */
+    default ConfigurationLoader getLoader(Locale locale) {
+        checkNotNull(locale, "locale");
+        return HoconConfigurationLoader.builder().setSource(() -> new BufferedReader(new InputStreamReader(getSource(locale)))).build();
+    }
+
+    /**
+     * Returns the {@link ConfigurationLoader} for the default {@link Locale}.
+     *
+     * @return Config loader
+     */
+    default ConfigurationLoader getLoader() {
+        return getLoader(getDefaultLocale());
+    }
+
+    /**
+     * Loads the specified {@link Locale}.
+     *
+     * @param locale Locale to load
+     * @return Loaded ConfigurationNode
+     * @throws IOException
+     */
+    default ConfigurationNode load(Locale locale) throws IOException {
+        return getLoader(locale).load();
+    }
+
+    /**
+     * Loads the default {@link Locale}.
+     *
+     * @return Loaded ConfigurationNode
+     * @throws IOException
+     */
+    default ConfigurationNode load() throws IOException {
+        return load(getDefaultLocale());
+    }
+
+    /**
+     * Returns the ConfigurationNode for the specified {@link Locale}.
+     *
+     * @param locale Locale to get node for
+     * @return Result node
+     */
+    ConfigurationNode getNode(Locale locale);
+
+    /**
+     * Returns the ConfigurationNode for the default {@link Locale}.
+     *
+     * @return Result node
+     */
+    default ConfigurationNode getNode() {
+        return getNode(getDefaultLocale());
+    }
+
+    /**
+     * Represents a {@link ResourceBundle} wrapper for a {@link ConfigurationNode}.
+     */
+    final class ConfigResourceBundle extends ResourceBundle {
+
+        final ConfigurationNode node;
+
+        ConfigResourceBundle(ConfigurationNode node) {
+            this.node = checkNotNull(node, "node");
+        }
+
+        /**
+         * Returns the wrapped node.
+         *
+         * @return Wrapped node
+         */
+        public ConfigurationNode getNode() {
+            return this.node;
+        }
+
+        @Override
+        protected Object handleGetObject(String key) {
+            checkNotNull(key, "key");
+            return this.node.getNode(key).getString();
+        }
+
+        @Override
+        public Enumeration<String> getKeys() {
+            return Collections.enumeration(this.node.getChildrenList().stream()
+                    .map(node -> node.getKey().toString()).collect(Collectors.toList()));
+        }
+
+        @Override
+        public String toString() {
+            return Objects.toStringHelper(this)
+                    .add("node", this.node)
+                    .toString();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(this.node);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof ConfigResourceBundle && ((ConfigResourceBundle) obj).node.equals(this.node);
+        }
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/locale/DefaultDictionary.java
+++ b/src/main/java/org/spongepowered/api/locale/DefaultDictionary.java
@@ -22,34 +22,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service;
+package org.spongepowered.api.locale;
 
-import org.spongepowered.api.event.cause.Cause;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
 
 /**
- * Represents the registration information for the provider of a service.
+ * Default {@link Dictionary} implementation used by Sponge. This
+ * implementation first tries to resolve the dictionary within a directory
+ * and falls-back to the class loader if that file is not found.
  */
-public interface ProviderRegistration<T> {
+public class DefaultDictionary extends SimpleConfigDictionary {
 
-    /**
-     * Gets the service of this provider registration.
-     *
-     * @return The service
-     */
-    Class<T> getService();
+    protected final Path path;
 
-    /**
-     * Gets the service provider of this provider regitration.
-     *
-     * @return The provider
-     */
-    T getProvider();
+    public DefaultDictionary(Object subject, Locale defaultLocale, Path path) {
+        super(subject, defaultLocale);
+        this.path = path;
+        this.resolver.primary(this::resolveSource);
+    }
 
-    /**
-     * Returns the {@link Cause} of the registration.
-     *
-     * @return Cause of registration
-     */
-    Cause getCause();
+    protected InputStream resolveSource() throws IOException {
+        if (Files.exists(this.path)) {
+            return Files.newInputStream(this.path);
+        }
+        return this.subject.getClass().getClassLoader().getResourceAsStream(this.path.getFileName().toString());
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/locale/DefaultPluginDictionary.java
+++ b/src/main/java/org/spongepowered/api/locale/DefaultPluginDictionary.java
@@ -22,34 +22,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service;
+package org.spongepowered.api.locale;
 
-import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.Sponge;
+
+import java.nio.file.Path;
+import java.util.Locale;
 
 /**
- * Represents the registration information for the provider of a service.
+ * Represents the default {@link Dictionary} implementation for plugins. This
+ * dictionary will automatically be named to <code><pluginId>.dict</code>.
  */
-public interface ProviderRegistration<T> {
+public class DefaultPluginDictionary extends DefaultDictionary {
 
     /**
-     * Gets the service of this provider registration.
-     *
-     * @return The service
+     * File extension used in this implementation.
      */
-    Class<T> getService();
+    public static final String FILE_EXTENSION = ".dict";
 
-    /**
-     * Gets the service provider of this provider regitration.
-     *
-     * @return The provider
-     */
-    T getProvider();
+    public DefaultPluginDictionary(Object plugin, Locale defaultLocale, Path dir) {
+        super(plugin, defaultLocale, dir.resolve(Sponge.getPluginManager().fromInstance(plugin).get().getId() + FILE_EXTENSION));
+    }
 
-    /**
-     * Returns the {@link Cause} of the registration.
-     *
-     * @return Cause of registration
-     */
-    Cause getCause();
+    public DefaultPluginDictionary(Object plugin, Path dir) {
+        this(plugin, Sponge.getServer().getLocale(), dir);
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/locale/Dictionary.java
+++ b/src/main/java/org/spongepowered/api/locale/Dictionary.java
@@ -22,34 +22,54 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service;
+package org.spongepowered.api.locale;
 
-import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.text.translation.locale.Locales;
+
+import java.util.Locale;
+import java.util.Optional;
 
 /**
- * Represents the registration information for the provider of a service.
+ * Represents a Dictionary for a particular subject. Dictionaries take a
+ * given string key and return a localized result.
  */
-public interface ProviderRegistration<T> {
+public interface Dictionary {
 
     /**
-     * Gets the service of this provider registration.
+     * Returns the "subject" for this dictionary.
      *
-     * @return The service
+     * @return Subject of dictionary
      */
-    Class<T> getService();
+    Object getSubject();
 
     /**
-     * Gets the service provider of this provider regitration.
+     * Returns the default {@link Locale} to be used if no Locale is specified.
      *
-     * @return The provider
+     * @return Default Locale
      */
-    T getProvider();
+    default Locale getDefaultLocale() {
+        return Locales.DEFAULT;
+    }
 
     /**
-     * Returns the {@link Cause} of the registration.
+     * Returns the entry for the specified key for the specified
+     * {@link Locale}.
      *
-     * @return Cause of registration
+     * @param key Key to search for
+     * @param locale Locale to get
+     * @return Localized string for "key"
      */
-    Cause getCause();
+    Optional<String> get(String key, Locale locale);
+
+    /**
+     * Returns the entry for the specified key for the default {@link Locale}
+     * defined by {@link #getDefaultLocale()}.
+     *
+     * @param key Key to search for
+     * @return Localized string for "key"
+     */
+    default Optional<String> get(String key) {
+        return get(key, getDefaultLocale());
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/locale/MultiSourceConfigDictionary.java
+++ b/src/main/java/org/spongepowered/api/locale/MultiSourceConfigDictionary.java
@@ -22,34 +22,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service;
+package org.spongepowered.api.locale;
 
-import org.spongepowered.api.event.cause.Cause;
+import ninja.leaping.configurate.ConfigurationNode;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 /**
- * Represents the registration information for the provider of a service.
+ * Represents a {@link ConfigDictionary} with a different source per-locale.
  */
-public interface ProviderRegistration<T> {
+public class MultiSourceConfigDictionary extends AbstractConfigDictionary {
 
-    /**
-     * Gets the service of this provider registration.
-     *
-     * @return The service
-     */
-    Class<T> getService();
+    protected final Map<Locale, ConfigurationNode> nodes = new HashMap<>();
 
-    /**
-     * Gets the service provider of this provider regitration.
-     *
-     * @return The provider
-     */
-    T getProvider();
+    public MultiSourceConfigDictionary(Object subject, Locale defaultLocale) {
+        super(subject, defaultLocale);
+    }
 
-    /**
-     * Returns the {@link Cause} of the registration.
-     *
-     * @return Cause of registration
-     */
-    Cause getCause();
+    @Override
+    public ConfigurationNode load(Locale locale) throws IOException {
+        ConfigurationNode localeNode = super.load(locale);
+        this.nodes.put(locale, localeNode);
+        this.bundles.put(locale, new ConfigResourceBundle(localeNode));
+        return localeNode;
+    }
+
+    @Override
+    public ConfigurationNode getNode(Locale locale) {
+        ConfigurationNode node = this.nodes.get(locale);
+        if (node == null) {
+            throw new IllegalStateException("Tried to read MultiSourceConfigDictionary before locale " + locale + " was loaded.");
+        }
+        return node;
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/locale/NullDictionary.java
+++ b/src/main/java/org/spongepowered/api/locale/NullDictionary.java
@@ -22,34 +22,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service;
+package org.spongepowered.api.locale;
 
-import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.text.translation.locale.Locales;
+
+import java.util.Locale;
+import java.util.Optional;
 
 /**
- * Represents the registration information for the provider of a service.
+ * Represents a {@link Dictionary} that returns all null values for each key.
  */
-public interface ProviderRegistration<T> {
+public final class NullDictionary extends AbstractDictionary {
 
-    /**
-     * Gets the service of this provider registration.
-     *
-     * @return The service
-     */
-    Class<T> getService();
+    public NullDictionary(Object subject) {
+        super(subject, Locales.DEFAULT);
+    }
 
-    /**
-     * Gets the service provider of this provider regitration.
-     *
-     * @return The provider
-     */
-    T getProvider();
+    @Override
+    public Optional<String> get(String key, Locale locale) {
+        return Optional.empty();
+    }
 
-    /**
-     * Returns the {@link Cause} of the registration.
-     *
-     * @return Cause of registration
-     */
-    Cause getCause();
+    @Override
+    public Optional<String> get(String key) {
+        return Optional.empty();
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/locale/RemoteDictionary.java
+++ b/src/main/java/org/spongepowered/api/locale/RemoteDictionary.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.locale;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+/**
+ * Represents a {@link Dictionary} with a remote source.
+ */
+public interface RemoteDictionary extends Dictionary {
+
+    /**
+     * Returns an {@link InputStream} for the remote source of this Dictionary.
+     *
+     * @return Source of dictionary
+     * @throws IOException
+     */
+    InputStream getSource(Locale locale) throws Exception;
+
+    /**
+     * Returns an {@link InputStream} for the remote source of this Dictionary.
+     *
+     * @return Source of dictionary
+     * @throws IOException
+     */
+    default InputStream getSource() throws Exception {
+        return getSource(getDefaultLocale());
+    }
+
+    /**
+     * Class that resolves an {@link InputStream} source for a given {@link Locale}.
+     */
+    class SourceResolver {
+
+        Callable<InputStream> primary;
+        final Map<Locale, List<Callable<InputStream>>> sources = new HashMap<>();
+
+        SourceResolver() {
+        }
+
+        /**
+         * Sets the primary or "default" resolver.
+         *
+         * @param primary Resolver
+         * @return This resolver
+         */
+        public SourceResolver primary(Callable<InputStream> primary) {
+            this.primary = checkNotNull(primary, "primary");
+            return this;
+        }
+
+        /**
+         * Adds a {@link Callable} to supply an {@link InputStream} for the
+         * given {@link Locale}.
+         *
+         * @param locale Locale to supply for
+         * @param callable Callable to supply InputStream
+         * @return This resolver
+         */
+        public SourceResolver add(Locale locale, Callable<InputStream> callable) {
+            checkNotNull(locale, "locale");
+            checkNotNull(callable, "callable");
+            List<Callable<InputStream>> list = this.sources.get(locale);
+            if (list == null) {
+                list = new ArrayList<>();
+            }
+            list.add(callable);
+            this.sources.put(locale, list);
+            return this;
+        }
+
+        /**
+         * Resolves the {@link InputStream} source for the given
+         * {@link Locale}.
+         *
+         * @param locale Locale to resolve source for
+         * @return Optional InputStream. Empty if unresolved.
+         * @throws Exception
+         */
+        public Optional<InputStream> resolve(Locale locale) throws Exception {
+            checkNotNull(locale, "locale");
+            List<Callable<InputStream>> list = this.sources.get(locale);
+            if (list == null) {
+                list = Collections.emptyList();
+            }
+            for (Callable<InputStream> callable : list) {
+                InputStream in = callable.call();
+                if (in != null) {
+                    return Optional.of(in);
+                }
+            }
+            if (this.primary != null) {
+                return Optional.ofNullable(this.primary.call());
+            }
+            return Optional.empty();
+        }
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/locale/ResourceBundleDictionary.java
+++ b/src/main/java/org/spongepowered/api/locale/ResourceBundleDictionary.java
@@ -22,34 +22,47 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service;
+package org.spongepowered.api.locale;
 
-import org.spongepowered.api.event.cause.Cause;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.Optional;
+import java.util.ResourceBundle;
 
 /**
- * Represents the registration information for the provider of a service.
+ * Represents a {@link Dictionary} that handles retrieval through {@link ResourceBundle}s.
+ *
+ * @param <B> Bundle type
  */
-public interface ProviderRegistration<T> {
+public interface ResourceBundleDictionary<B extends ResourceBundle> extends Dictionary {
 
     /**
-     * Gets the service of this provider registration.
+     * Returns the {@link ResourceBundle} for the specified {@link Locale}.
      *
-     * @return The service
+     * @param locale Locale to get bundle for
+     * @return Optional bundle
      */
-    Class<T> getService();
+    B getBundle(Locale locale);
 
     /**
-     * Gets the service provider of this provider regitration.
+     * Sets the {@link ResourceBundle} for the specified {@link Locale}.
      *
-     * @return The provider
+     * @param locale Locale to set
+     * @param bundle Bundle to use for Locale
      */
-    T getProvider();
+    void setBundle(Locale locale, B bundle);
 
-    /**
-     * Returns the {@link Cause} of the registration.
-     *
-     * @return Cause of registration
-     */
-    Cause getCause();
+    @Override
+    default Optional<String> get(String key, Locale locale) {
+        checkNotNull(key, "key");
+        checkNotNull(locale, "locale");
+        try {
+            return Optional.of(getBundle(locale).getString(key));
+        } catch (MissingResourceException e) {
+            return Optional.empty();
+        }
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/locale/SimpleConfigDictionary.java
+++ b/src/main/java/org/spongepowered/api/locale/SimpleConfigDictionary.java
@@ -22,34 +22,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.service;
+package org.spongepowered.api.locale;
 
-import org.spongepowered.api.event.cause.Cause;
+import ninja.leaping.configurate.ConfigurationNode;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 /**
- * Represents the registration information for the provider of a service.
+ * Represents a simple implementation of {@link ConfigDictionary} with a single source.
  */
-public interface ProviderRegistration<T> {
+public class SimpleConfigDictionary extends AbstractConfigDictionary {
 
-    /**
-     * Gets the service of this provider registration.
-     *
-     * @return The service
-     */
-    Class<T> getService();
+    protected ConfigurationNode root;
+    protected final Map<Locale, ConfigResourceBundle> bundles = new HashMap<>();
 
-    /**
-     * Gets the service provider of this provider regitration.
-     *
-     * @return The provider
-     */
-    T getProvider();
+    public SimpleConfigDictionary(Object subject, Locale defaultLocale) {
+        super(subject, defaultLocale);
+    }
 
-    /**
-     * Returns the {@link Cause} of the registration.
-     *
-     * @return Cause of registration
-     */
-    Cause getCause();
+    @Override
+    public ConfigurationNode load(Locale locale) throws IOException {
+        return this.root = super.load(locale);
+    }
+
+    @Override
+    public ConfigurationNode getNode(Locale locale) {
+        if (this.root == null) {
+            throw new IllegalStateException("Tried to read SimpleConfigDictionary before it was loaded.");
+        }
+        return this.root.getNode(locale.toString());
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/locale/SimpleResourceBundleDictionary.java
+++ b/src/main/java/org/spongepowered/api/locale/SimpleResourceBundleDictionary.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.locale;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+/**
+ * Represents a simple implementation of {@link ResourceBundleDictionary} using
+ * a "base name" and {@link ResourceBundle#getBundle(String)} to retrieve
+ * bundles.
+ */
+public class SimpleResourceBundleDictionary extends AbstractDictionary implements ResourceBundleDictionary<ResourceBundle> {
+
+    protected final String baseName;
+    protected final Map<Locale, ResourceBundle> bundles = new HashMap<>();
+
+    public SimpleResourceBundleDictionary(Object subject, Locale defaultLocale, String baseName) {
+        super(subject, defaultLocale);
+        this.baseName = baseName;
+    }
+
+    @Override
+    public ResourceBundle getBundle(Locale locale) {
+        checkNotNull(locale, "locale");
+        ResourceBundle bundle = this.bundles.get(locale);
+        if (bundle == null) {
+            setBundle(locale, bundle = ResourceBundle.getBundle(this.baseName, locale));
+        }
+        return bundle;
+    }
+
+    @Override
+    public void setBundle(Locale locale, ResourceBundle bundle) {
+        checkNotNull(locale, "locale");
+        this.bundles.put(locale, bundle);
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/plugin/PluginContainer.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginContainer.java
@@ -30,6 +30,9 @@ import org.slf4j.LoggerFactory;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.asset.Asset;
 import org.spongepowered.api.asset.AssetManager;
+import org.spongepowered.api.locale.Dictionary;
+import org.spongepowered.api.locale.NullDictionary;
+import org.spongepowered.api.service.ServiceManager;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -143,6 +146,16 @@ public interface PluginContainer {
     }
 
     /**
+     * Returns the {@link Dictionary} for this plugin.
+     *
+     * @return Dictionary provided by plugin or {@link NullDictionary} if none
+     *         was provided
+     */
+    default Dictionary getDictionary() {
+        return getServiceManager().provideFirst(Dictionary.class).orElse(new NullDictionary(this));
+    }
+
+    /**
      * Returns the source the plugin was loaded from.
      *
      * @return The source the plugin was loaded from or {@link Optional#empty()}
@@ -158,6 +171,13 @@ public interface PluginContainer {
      * @return The instance if available
      */
     Optional<?> getInstance();
+
+    /**
+     * Returns the plugin's internal service manager.
+     *
+     * @return Internal service manager
+     */
+    ServiceManager getServiceManager();
 
     /**
      * Returns the assigned logger to this {@link Plugin}.

--- a/src/main/java/org/spongepowered/api/service/ServiceManager.java
+++ b/src/main/java/org/spongepowered/api/service/ServiceManager.java
@@ -48,10 +48,10 @@ public interface ServiceManager {
      * <p>Services should only be registered during initialization. If services
      * are registered later, then they may not be utilized.</p>
      *
-     * @param plugin The instance of a plugin
+     * @param <T> The type of service
+     * @param plugin The cause of the provider change.
      * @param service The service
      * @param provider The implementation
-     * @param <T> The type of service
      * @throws IllegalArgumentException Thrown if {@code plugin} is not a
      *     plugin instance
      */
@@ -68,6 +68,15 @@ public interface ServiceManager {
      * @return A provider, if available
      */
     <T> Optional<T> provide(Class<T> service);
+
+    /**
+     * Returns the first provider that is derived from the specified service.
+     *
+     * @param service The service
+     * @param <T> The type of service
+     * @return A provider, if available
+     */
+    <T> Optional<T> provideFirst(Class<T> service);
 
     /**
      * Gets the {@link ProviderRegistration} for the given service, if available.

--- a/src/main/java/org/spongepowered/api/text/Text.java
+++ b/src/main/java/org/spongepowered/api/text/Text.java
@@ -35,6 +35,8 @@ import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.Queries;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.locale.Dictionary;
 import org.spongepowered.api.scoreboard.Score;
 import org.spongepowered.api.text.action.ClickAction;
 import org.spongepowered.api.text.action.HoverAction;
@@ -58,6 +60,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Locale;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -1007,6 +1010,37 @@ public abstract class Text implements TextRepresentable, DataSerializable, Compa
         }
 
         return builder.build();
+    }
+
+    public static Optional<Text> get(Dictionary dictionary, String key, Locale locale) {
+        return get(dictionary.get(key, locale));
+    }
+
+    public static Optional<Text> get(Dictionary dictionary, String key) {
+        return get(dictionary.get(key));
+    }
+
+    private static Optional<Text> get(Optional<String> result) {
+        if (result.isPresent()) {
+            return Optional.of(Text.of(result.get()));
+        }
+        return Optional.empty();
+    }
+
+    public static Optional<Text> get(Object plugin, String key, Locale locale) {
+        return get(Sponge.getPluginManager().fromInstance(plugin).get().getDictionary(), key, locale);
+    }
+
+    public static Optional<Text> get(Object plugin, String key) {
+        return get(Sponge.getPluginManager().fromInstance(plugin).get().getDictionary(), key);
+    }
+
+    public static Optional<Text> get(String key, Locale locale) {
+        return get(Sponge.getServiceManager().provide(Dictionary.class).get(), key, locale);
+    }
+
+    public static Optional<Text> get(String key) {
+        return get(Sponge.getServiceManager().provide(Dictionary.class).get(), key);
     }
 
     /**

--- a/src/test/java/org/spongepowered/api/service/SimpleServiceManagerTest.java
+++ b/src/test/java/org/spongepowered/api/service/SimpleServiceManagerTest.java
@@ -25,8 +25,6 @@
 package org.spongepowered.api.service;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -41,7 +39,6 @@ import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.plugin.PluginManager;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Sponge.class)
@@ -53,18 +50,18 @@ public class SimpleServiceManagerTest {
     private final EventManager testEventManager = Mockito.mock(EventManager.class);
 
     {
-        Mockito.when(testPluginContainer.getId()).thenReturn("TestPlugin");
-        Mockito.when(manager.fromInstance(testPlugin)).thenReturn(Optional.of(testPluginContainer));
+        Mockito.when(this.testPluginContainer.getId()).thenReturn("TestPlugin");
+        Mockito.when(this.manager.fromInstance(this.testPlugin)).thenReturn(Optional.of(this.testPluginContainer));
     }
 
     @Test
     public void testRegisterService() {
         PowerMockito.mockStatic(Sponge.class);
-        PowerMockito.when(Sponge.getEventManager()).thenReturn(testEventManager);
+        PowerMockito.when(Sponge.getEventManager()).thenReturn(this.testEventManager);
 
-        SimpleServiceManager serviceManager = new SimpleServiceManager(manager);
+        SimpleServiceManager serviceManager = new SimpleServiceManager(this.manager);
 
-        serviceManager.setProvider(testPlugin, TestInterface.class, new TestImplCow());
+        serviceManager.setProvider(this.testPlugin, TestInterface.class, new TestImplCow());
 
         Optional<TestInterface> returned = serviceManager.provide(TestInterface.class);
         assertTrue(returned.isPresent());
@@ -76,11 +73,11 @@ public class SimpleServiceManagerTest {
     @Test
     public void testDuplicateRegistrationAllowed() {
         PowerMockito.mockStatic(Sponge.class);
-        PowerMockito.when(Sponge.getEventManager()).thenReturn(testEventManager);
+        PowerMockito.when(Sponge.getEventManager()).thenReturn(this.testEventManager);
 
-        SimpleServiceManager serviceManager = new SimpleServiceManager(manager);
-        serviceManager.setProvider(testPlugin, TestInterface.class, new TestImplCow());
-        serviceManager.setProvider(testPlugin, TestInterface.class, new TestImplDog());
+        SimpleServiceManager serviceManager = new SimpleServiceManager(this.manager);
+        serviceManager.setProvider(this.testPlugin, TestInterface.class, new TestImplCow());
+        serviceManager.setProvider(this.testPlugin, TestInterface.class, new TestImplDog());
 
         assertEquals("woof", serviceManager.provideUnchecked(TestInterface.class).bark());
     }
@@ -88,18 +85,17 @@ public class SimpleServiceManagerTest {
     @Test
     public void testGetProviderRegistration() {
         PowerMockito.mockStatic(Sponge.class);
-        PowerMockito.when(Sponge.getEventManager()).thenReturn(testEventManager);
+        PowerMockito.when(Sponge.getEventManager()).thenReturn(this.testEventManager);
 
         TestImplCow testImplCow = new TestImplCow();
 
-        SimpleServiceManager serviceManager = new SimpleServiceManager(manager);
-        serviceManager.setProvider(testPlugin, TestInterface.class, testImplCow);
+        SimpleServiceManager serviceManager = new SimpleServiceManager(this.manager);
+        serviceManager.setProvider(this.testPlugin, TestInterface.class, testImplCow);
 
         ProviderRegistration<TestInterface> registration = serviceManager.getRegistration(TestInterface.class).get();
 
         assertEquals(TestInterface.class, registration.getService());
         assertEquals(testImplCow, registration.getProvider());
-        assertEquals(testPluginContainer, registration.getPlugin());
     }
 
     public interface TestInterface {


### PR DESCRIPTION
[**API**](https://github.com/SpongePowered/SpongeAPI/pull/1088) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/525) | [Forge](https://github.com/SpongePowered/SpongeForge/pull/549)

This PR adds a localization API to SpongeAPI among some other breaking changes. The `provideFirst(Class)` method has been added to ServiceManager to allow for extensible services and `getServiceManager` has been added to `PluginContainer` for internal services. In the context of localization, this allows plugins to register their own `Dictionary` and have it be received with `plugin.getServiceManager().provideFirst(Dictionary.class);` without the need to know the exact implementing class.

----

**Example usage:**

```java
@Listener
public void onGameStarted(GameStartedServerEvent event) {
    DefaultPluginDictionary dict = new DefaultPluginDictionary(this, Locales.DEFAULT, configDir);
    try {
        dict.load();
    } catch (IOException e) {
        e.printStackTrace();
    }
    Sponge.getPluginManager().getServiceManager(this).setProvider(Cause.of(this), Dictionary.class, dict);
}
```

This will create a new dictionary that will first look for the dictionary file in `<configDir>/<pluginId>.dict` and then as a resource at `<pluginId>.dict`. Plugins are of course free to implement their localization through dictionaries however they want.

**Example .dict file:**

```
en_US {
    hello="Hello"
}
en_GB {
    hello="'Ello govna'"
}
```

```java
dictionary.get("hello").get(); // "Hello"
dictionary.get("hello", Locale.UK).get(); // "'Ello govna'"

// alternatively

Text.get(this, "hello").get(); // Text{"Hello"}
Text.get(this, "hello", Locale.UK).get(); // Text{"'Ello govna'"}

// localize for player's client locale

Text.get(this, "hello", player.getLocale()).get();
```

