### PR TITLE
Add Dragon Heads to API

### DIFF
--- a/src/main/java/org/spongepowered/api/data/type/SkullTypes.java
+++ b/src/main/java/org/spongepowered/api/data/type/SkullTypes.java
@@ -34,6 +34,7 @@ public final class SkullTypes {
     public static final SkullType ZOMBIE = null;
     public static final SkullType PLAYER = null;
     public static final SkullType CREEPER = null;
+    public static final SkullType ENDER_DRAGON = null;
 
     private SkullTypes() {
     }


### PR DESCRIPTION
SpongeAPI | SpongePowered/SpongeCommon#529
This pull request adds Dragon Head from 1.9 release to skull types.