### PR TITLE
Detach LocatedSource from CommandSource heirarchy

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -36,7 +36,7 @@ import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandMessageFormatting;
 import org.spongepowered.api.command.CommandSource;
-import org.spongepowered.api.command.source.LocatedSource;
+import org.spongepowered.api.world.Locatable;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.GuavaCollectors;
@@ -1021,9 +1021,9 @@ public final class GenericArguments {
                 yStr = args.next();
                 zStr = args.next();
             }
-            final double x = parseRelativeDouble(args, xStr, source instanceof LocatedSource ? ((LocatedSource) source).getLocation().getX() : null);
-            final double y = parseRelativeDouble(args, yStr, source instanceof LocatedSource ? ((LocatedSource) source).getLocation().getY() : null);
-            final double z = parseRelativeDouble(args, zStr, source instanceof LocatedSource ? ((LocatedSource) source).getLocation().getZ() : null);
+            final double x = parseRelativeDouble(args, xStr, source instanceof Locatable ? ((Locatable) source).getLocation().getX() : null);
+            final double y = parseRelativeDouble(args, yStr, source instanceof Locatable ? ((Locatable) source).getLocation().getY() : null);
+            final double z = parseRelativeDouble(args, zStr, source instanceof Locatable ? ((Locatable) source).getLocation().getZ() : null);
 
             return new Vector3d(x, y, z);
         }
@@ -1084,10 +1084,10 @@ public final class GenericArguments {
                 world = checkNotNull(this.worldParser.parseValue(source, args), "worldVal");
             } catch (ArgumentParseException ex) {
                 args.setState(state);
-                if (!(source instanceof LocatedSource)) {
+                if (!(source instanceof Locatable)) {
                     throw args.createError(t("Source must have a location in order to have a fallback world"));
                 }
-                world = ((LocatedSource) source).getWorld().getProperties();
+                world = ((Locatable) source).getWorld().getProperties();
                 try {
                     vec = checkNotNull(this.vectorParser.parseValue(source, args), "vectorVal");
                 } catch (ArgumentParseException ex2) {

--- a/src/main/java/org/spongepowered/api/command/source/CommandBlockSource.java
+++ b/src/main/java/org/spongepowered/api/command/source/CommandBlockSource.java
@@ -24,19 +24,21 @@
  */
 package org.spongepowered.api.command.source;
 
+import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.mutable.CommandData;
 import org.spongepowered.api.data.value.mutable.OptionalValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.world.Locatable;
 
 import java.util.Optional;
 
 /**
  * Represents a CommandBlock source, either a placed block or a MinecartCommandBlock.
  */
-public interface CommandBlockSource extends LocatedSource, DataHolder {
+public interface CommandBlockSource extends Locatable, CommandSource, DataHolder {
 
     /**
      * Gets the {@link CommandData} for this source.

--- a/src/main/java/org/spongepowered/api/command/source/ProxySource.java
+++ b/src/main/java/org/spongepowered/api/command/source/ProxySource.java
@@ -30,7 +30,7 @@ import org.spongepowered.api.command.CommandSource;
  * Proxy sources are {@link CommandSource}s that are run by one source as a
  * different source.
  */
-public interface ProxySource extends LocatedSource {
+public interface ProxySource extends CommandSource {
 
     /**
      * Gets the {@link CommandSource} this source is proxying.

--- a/src/main/java/org/spongepowered/api/command/source/SignSource.java
+++ b/src/main/java/org/spongepowered/api/command/source/SignSource.java
@@ -27,12 +27,13 @@ package org.spongepowered.api.command.source;
 import org.spongepowered.api.block.tileentity.Sign;
 import org.spongepowered.api.block.tileentity.TileEntity;
 import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.world.Locatable;
 
 /**
  * Sign sources are {@link CommandSource}s that execute commands when a player
  * clicks a sign. Their location is set to the sign's location.
  */
-public interface SignSource extends ProxySource {
+public interface SignSource extends ProxySource, Locatable {
 
     /**
      * Gets the sign {@link TileEntity} that this source has been created for.

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -28,8 +28,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.flowpowered.math.vector.Vector3d;
-import com.flowpowered.math.vector.Vector3i;
-import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.DataTransactionResult;
@@ -41,6 +39,7 @@ import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.Identifiable;
 import org.spongepowered.api.util.RelativePositions;
+import org.spongepowered.api.world.Locatable;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.TeleportHelper;
 import org.spongepowered.api.world.World;
@@ -71,7 +70,7 @@ import javax.annotation.Nullable;
  *
  * <p>Blocks and items (when they are in inventories) are not entities.</p>
  */
-public interface Entity extends Identifiable, DataHolder, DataSerializable, Translatable {
+public interface Entity extends Identifiable, Locatable, DataHolder, DataSerializable, Translatable {
 
     /**
      * Get the type of entity.
@@ -79,13 +78,6 @@ public interface Entity extends Identifiable, DataHolder, DataSerializable, Tran
      * @return The type of entity
      */
     EntityType getType();
-
-    /**
-     * Gets the current world this entity resides in.
-     *
-     * @return The current world this entity resides in
-     */
-    World getWorld();
 
     /**
      * Creates a {@link EntitySnapshot} containing the {@link EntityType} and data of this entity.
@@ -98,13 +90,6 @@ public interface Entity extends Identifiable, DataHolder, DataSerializable, Tran
      * @return The RNG
      */
     Random getRandom();
-
-    /**
-     * Get the location of this entity.
-     *
-     * @return The location
-     */
-    Location<World> getLocation();
 
     /**
      * Sets the location of this entity. This is equivalent to a teleport,

--- a/src/main/java/org/spongepowered/api/entity/living/player/Player.java
+++ b/src/main/java/org/spongepowered/api/entity/living/player/Player.java
@@ -25,7 +25,7 @@
 package org.spongepowered.api.entity.living.player;
 
 import org.spongepowered.api.Server;
-import org.spongepowered.api.command.source.LocatedSource;
+import org.spongepowered.api.world.Locatable;
 import org.spongepowered.api.command.source.RemoteSource;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.mutable.DisplayNameData;
@@ -57,7 +57,7 @@ import java.util.Set;
  * <p>Any methods called on Player that are not on User do not store any data
  * that persists across server restarts.</p>
  */
-public interface Player extends Humanoid, User, LocatedSource, RemoteSource, Viewer, ChatTypeMessageReceiver {
+public interface Player extends Humanoid, User, Locatable, RemoteSource, Viewer, ChatTypeMessageReceiver {
 
     /**
      * Returns whether this player has an open inventory at the moment

--- a/src/main/java/org/spongepowered/api/world/Locatable.java
+++ b/src/main/java/org/spongepowered/api/world/Locatable.java
@@ -22,16 +22,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.command.source;
-
-import org.spongepowered.api.command.CommandSource;
-import org.spongepowered.api.world.Location;
-import org.spongepowered.api.world.World;
+package org.spongepowered.api.world;
 
 /**
- * Location sources are {@link CommandSource}s that have a current location.
+ * Location sources are anything that have a current location.
  */
-public interface LocatedSource extends CommandSource {
+@FunctionalInterface
+public interface Locatable {
 
     /**
      * Gets the location of the source.
@@ -45,6 +42,8 @@ public interface LocatedSource extends CommandSource {
      *
      * @return The World
      */
-    World getWorld();
+    default World getWorld() {
+        return getLocation().getExtent();
+    }
 
 }


### PR DESCRIPTION
[**API**](https://github.com/SpongePowered/SpongeAPI/pull/1102) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/535)

Pretty self-explanatory. This opens up the opportunity for a variety of use cases. For instance, say I want to track a player's eye location over time.

```java
Locatable locatable = () -> new Location(player.getWorld(), player.getProperty(EyeLocationProperty.class).get().getValue())
```