### PR TITLE
Require a Cause when opening or closing an inventory

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/living/player/Player.java
+++ b/src/main/java/org/spongepowered/api/entity/living/player/Player.java
@@ -37,8 +37,10 @@ import org.spongepowered.api.effect.Viewer;
 import org.spongepowered.api.entity.living.Humanoid;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.entity.living.player.tab.TabList;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.network.PlayerConnection;
+import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.resourcepack.ResourcePack;
 import org.spongepowered.api.scoreboard.Scoreboard;
 import org.spongepowered.api.text.channel.ChatTypeMessageReceiver;
@@ -80,14 +82,19 @@ public interface Player extends Humanoid, User, LocatedSource, RemoteSource, Vie
      * Opens the given Inventory for the player to view.
      *
      * @param inventory The inventory to view
+     * @param cause The {@link Cause} to use when opening the inventory
+     * @throws IllegalArgumentException if a {@link PluginContainer} is not the root of the cause
      */
-    void openInventory(Inventory inventory);
+    void openInventory(Inventory inventory, Cause cause) throws IllegalArgumentException;
 
     /**
      * Closes the currently viewed entity of this player, if it is
      * currently viewing one.
+     *
+     * @param cause The {@link Cause} to provide when closing the inventory
+     * @throws IllegalArgumentException if a {@link PluginContainer} is not the root of the cause
      */
-    void closeInventory();
+    void closeInventory(Cause cause) throws IllegalArgumentException;
 
     /**
      * Gets the view distance setting of the player. This value represents the


### PR DESCRIPTION
This PR changes `openInventory` and `closeInventory` to require ` Cause`. When these methods are implemented, the provided `Cause` will be used when firing `InteractInventoryEvent.<Open/Close>`