### PR TITLE
Append 'Minecart' to names instead of prepending

### DIFF
--- a/src/main/java/org/spongepowered/api/command/source/CommandBlockSource.java
+++ b/src/main/java/org/spongepowered/api/command/source/CommandBlockSource.java
@@ -34,7 +34,7 @@ import org.spongepowered.api.text.Text;
 import java.util.Optional;
 
 /**
- * Represents a CommandBlock source, either a placed block or a MinecartCommandBlock.
+ * Represents a CommandBlock source, either a placed block or a CommandBlockMinecart.
  */
 public interface CommandBlockSource extends LocatedSource, DataHolder {
 

--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -45,8 +45,8 @@ import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
+import org.spongepowered.api.entity.vehicle.minecart.CommandBlockMinecart;
 import org.spongepowered.api.entity.vehicle.minecart.Minecart;
-import org.spongepowered.api.entity.vehicle.minecart.MinecartCommandBlock;
 import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.ItemTypes;
@@ -169,7 +169,7 @@ public final class Keys {
 
     /**
      * Represents a key for the stored command, mostly related to
-     * {@link CommandBlock}s and {@link MinecartCommandBlock}s.
+     * {@link CommandBlock}s and {@link CommandBlockMinecart}s.
      *
      * @see CommandData#storedCommand()
      */
@@ -832,7 +832,7 @@ public final class Keys {
 
     /**
      * Reprsents a key for the amount of successful executions of a command
-     * stored in a {@link CommandBlock} or {@link MinecartCommandBlock}.
+     * stored in a {@link CommandBlock} or {@link CommandBlockMinecart}.
      *
      * @see CommandData#successCount()
      */

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableCommandData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableCommandData.java
@@ -30,7 +30,7 @@ import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.CommandData;
 import org.spongepowered.api.data.value.immutable.ImmutableOptionalValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
-import org.spongepowered.api.entity.vehicle.minecart.MinecartCommandBlock;
+import org.spongepowered.api.entity.vehicle.minecart.CommandBlockMinecart;
 import org.spongepowered.api.text.Text;
 
 import java.util.Optional;
@@ -38,7 +38,7 @@ import java.util.Optional;
 /**
  * An {@link ImmutableDataManipulator} handling all related
  * {@link ImmutableValue}s for command related {@link DataHolder}s, such as
- * {@link CommandBlock}s and {@link MinecartCommandBlock}s.
+ * {@link CommandBlock}s and {@link CommandBlockMinecart}s.
  */
 public interface ImmutableCommandData extends ImmutableDataManipulator<ImmutableCommandData, CommandData> {
 

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableMobSpawnerData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableMobSpawnerData.java
@@ -36,7 +36,7 @@ import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntitySnapshot;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.entity.vehicle.minecart.MinecartMobSpawner;
+import org.spongepowered.api.entity.vehicle.minecart.MobSpawnerMinecart;
 import org.spongepowered.api.util.weighted.WeightedSerializableObject;
 
 import java.util.Collection;
@@ -47,7 +47,7 @@ import javax.annotation.Nullable;
 
 /**
  * An {@link ImmutableDataManipulator} for all information surrounding a
- * {@link MobSpawner} and {@link MinecartMobSpawner}. The data defined will
+ * {@link MobSpawner} and {@link MobSpawnerMinecart}. The data defined will
  * provide new {@link Entity} spawns with varying types and data.
  */
 public interface ImmutableMobSpawnerData extends ImmutableDataManipulator<ImmutableMobSpawnerData, MobSpawnerData> {

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/CommandData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/CommandData.java
@@ -30,7 +30,7 @@ import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.ImmutableCommandData;
 import org.spongepowered.api.data.value.mutable.OptionalValue;
 import org.spongepowered.api.data.value.mutable.Value;
-import org.spongepowered.api.entity.vehicle.minecart.MinecartCommandBlock;
+import org.spongepowered.api.entity.vehicle.minecart.CommandBlockMinecart;
 import org.spongepowered.api.text.Text;
 
 import java.util.Optional;
@@ -38,7 +38,7 @@ import java.util.Optional;
 /**
  * An {@link DataManipulator} handling all related {@link Value}s for command
  * related {@link DataHolder}s, such as {@link CommandBlock}s and
- * {@link MinecartCommandBlock}s.
+ * {@link CommandBlockMinecart}s.
  */
 public interface CommandData extends DataManipulator<CommandData, ImmutableCommandData> {
 

--- a/src/main/java/org/spongepowered/api/entity/vehicle/minecart/ChestMinecart.java
+++ b/src/main/java/org/spongepowered/api/entity/vehicle/minecart/ChestMinecart.java
@@ -27,6 +27,6 @@ package org.spongepowered.api.entity.vehicle.minecart;
 /**
  * Represents a minecart with a chest inside it.
  */
-public interface MinecartChest extends MinecartContainer {
+public interface ChestMinecart extends ContainerMinecart {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/vehicle/minecart/CommandBlockMinecart.java
+++ b/src/main/java/org/spongepowered/api/entity/vehicle/minecart/CommandBlockMinecart.java
@@ -29,6 +29,6 @@ import org.spongepowered.api.command.source.CommandBlockSource;
 /**
  * Represents a minecart with a command block inside it.
  */
-public interface MinecartCommandBlock extends Minecart, CommandBlockSource {
+public interface CommandBlockMinecart extends Minecart, CommandBlockSource {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/vehicle/minecart/ContainerMinecart.java
+++ b/src/main/java/org/spongepowered/api/entity/vehicle/minecart/ContainerMinecart.java
@@ -29,10 +29,10 @@ import org.spongepowered.api.item.inventory.type.CarriedInventory;
 
 /**
  * Represents a minecart with a container inside it. Common extensions
- * of this are: {@link MinecartChest} and {@link MinecartHopper}.
+ * of this are: {@link ChestMinecart} and {@link HopperMinecart}.
  */
-public interface MinecartContainer extends Minecart, Carrier {
+public interface ContainerMinecart extends Minecart, Carrier {
 
     @Override
-    CarriedInventory<MinecartContainer> getInventory();
+    CarriedInventory<ContainerMinecart> getInventory();
 }

--- a/src/main/java/org/spongepowered/api/entity/vehicle/minecart/FurnaceMinecart.java
+++ b/src/main/java/org/spongepowered/api/entity/vehicle/minecart/FurnaceMinecart.java
@@ -24,23 +24,26 @@
  */
 package org.spongepowered.api.entity.vehicle.minecart;
 
-import org.spongepowered.api.data.manipulator.mutable.tileentity.CooldownData;
-import org.spongepowered.api.item.inventory.ItemStack;
-
 /**
- * Represents a {@link Minecart} with a Hopper in it.
+ * Represents a minecart with a furnace inside it.
  */
-public interface MinecartHopper extends MinecartContainer {
+public interface FurnaceMinecart extends Minecart {
 
     /**
-     * Gets a copy of the {@link CooldownData}. The cooldown data represents
-     * the delay before this {@link MinecartHopper} will attempt to transfer
-     * an {@link ItemStack}.
+     * Gets the current fuel time in ticks.
+     * <p>Usually, the fuel time will decay until reaching 0. At
+     * zero, the fuel minecart will decelerate to a stop.</p>
      *
-     * @return A copy of the cooldown data
+     * @return The current fuel time in ticks
      */
-    default CooldownData getCooldownData() {
-        return get(CooldownData.class).get();
-    }
+    int getFuel();
 
+    /**
+     * Sets the fuel time in ticks.
+     * <p>Usually, the fuel time will decay until reaching 0. At
+     * zero, the fuel minecart will decelerate to a stop.</p>
+     *
+     * @param fuel The fuel time in ticks
+     */
+    void setFuel(int fuel);
 }

--- a/src/main/java/org/spongepowered/api/entity/vehicle/minecart/HopperMinecart.java
+++ b/src/main/java/org/spongepowered/api/entity/vehicle/minecart/HopperMinecart.java
@@ -24,13 +24,23 @@
  */
 package org.spongepowered.api.entity.vehicle.minecart;
 
-import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.data.manipulator.mutable.tileentity.CooldownData;
+import org.spongepowered.api.item.inventory.ItemStack;
 
 /**
- * Represents a minecart that is rideable by other entities, such
- * as {@link Player}.
+ * Represents a {@link Minecart} with a Hopper in it.
  */
-public interface MinecartRideable extends Minecart {
+public interface HopperMinecart extends ContainerMinecart {
 
+    /**
+     * Gets a copy of the {@link CooldownData}. The cooldown data represents
+     * the delay before this {@link HopperMinecart} will attempt to transfer
+     * an {@link ItemStack}.
+     *
+     * @return A copy of the cooldown data
+     */
+    default CooldownData getCooldownData() {
+        return get(CooldownData.class).get();
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/entity/vehicle/minecart/MobSpawnerMinecart.java
+++ b/src/main/java/org/spongepowered/api/entity/vehicle/minecart/MobSpawnerMinecart.java
@@ -29,7 +29,7 @@ import org.spongepowered.api.data.manipulator.mutable.MobSpawnerData;
 /**
  * Represents a Minecart with a MobSpawner inside it.
  */
-public interface MinecartMobSpawner extends Minecart {
+public interface MobSpawnerMinecart extends Minecart {
 
     /**
      * Gets a copy of the {@link MobSpawnerData}.

--- a/src/main/java/org/spongepowered/api/entity/vehicle/minecart/RideableMinecart.java
+++ b/src/main/java/org/spongepowered/api/entity/vehicle/minecart/RideableMinecart.java
@@ -24,26 +24,13 @@
  */
 package org.spongepowered.api.entity.vehicle.minecart;
 
+import org.spongepowered.api.entity.living.player.Player;
+
 /**
- * Represents a minecart with a furnace inside it.
+ * Represents a minecart that is rideable by other entities, such
+ * as {@link Player}.
  */
-public interface MinecartFurnace extends Minecart {
+public interface RideableMinecart extends Minecart {
 
-    /**
-     * Gets the current fuel time in ticks.
-     * <p>Usually, the fuel time will decay until reaching 0. At
-     * zero, the fuel minecart will decelerate to a stop.</p>
-     *
-     * @return The current fuel time in ticks
-     */
-    int getFuel();
 
-    /**
-     * Sets the fuel time in ticks.
-     * <p>Usually, the fuel time will decay until reaching 0. At
-     * zero, the fuel minecart will decelerate to a stop.</p>
-     *
-     * @param fuel The fuel time in ticks
-     */
-    void setFuel(int fuel);
 }

--- a/src/main/java/org/spongepowered/api/entity/vehicle/minecart/TNTMinecart.java
+++ b/src/main/java/org/spongepowered/api/entity/vehicle/minecart/TNTMinecart.java
@@ -29,6 +29,6 @@ import org.spongepowered.api.entity.explosive.IgnitableExplosive;
 /**
  * Represents a Minecart with a TNT block in it.
  */
-public interface MinecartTNT extends Minecart, IgnitableExplosive {
+public interface TNTMinecart extends Minecart, IgnitableExplosive {
 
 }


### PR DESCRIPTION
[**API**](https://github.com/SpongePowered/SpongeAPI/pull/1113) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/549)

This PR changes all of the Minecart entities to be appended with `Minecart` instead of pre-pended: `HopperMinecart` instead of `MinecartHopper`.
This is a difference compared to the rest of the API - for example: `Fireball` & `LargeFireball`, etc