### PR TITLE
Add AssetManager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0'
         classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
         classpath 'org.spongepowered:event-impl-gen:1.1.0'
-        classpath 'org.spongepowered:spongegradle:0.3.1-SNAPSHOT'
+        classpath 'org.spongepowered:spongegradle:0.4-SNAPSHOT'
     }
 }
 

--- a/src/ap/java/org/spongepowered/plugin/processor/PluginElement.java
+++ b/src/ap/java/org/spongepowered/plugin/processor/PluginElement.java
@@ -39,6 +39,8 @@ import org.spongepowered.plugin.meta.version.VersionRange;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Paths;
 
 import javax.annotation.processing.Messager;
 import javax.lang.model.element.TypeElement;
@@ -119,6 +121,20 @@ final class PluginElement {
             }
         }
 
+        value = this.annotation.get().assets();
+        if (!value.isEmpty()) {
+            if (!isValidPath(value)) {
+                messager.printMessage(ERROR, "Invalid asset directory path: " + value, this.element, this.annotation.getMirror(),
+                        this.annotation.getValue("assets"));
+            }
+            this.metadata.setAssetDirectory(value);
+        } else if ((value = this.metadata.getAssetDirectory()) != null) {
+            if (!isValidPath(value)) {
+                messager.printMessage(ERROR, "Invalid asset directory path: " + value + " in extra metadata files", this.element,
+                        this.annotation.getMirror());
+            }
+        }
+
         String[] authors = this.annotation.get().authors();
         if (authors.length > 0) {
             this.metadata.getAuthors().clear();
@@ -186,6 +202,15 @@ final class PluginElement {
         }
     }
 
+    private static boolean isValidPath(String path) {
+        try {
+            Paths.get(path);
+            return true;
+        } catch (InvalidPathException e) {
+            return false;
+        }
+    }
+
     static void applyMeta(PluginMetadata meta, PluginMetadata other, Messager messager) {
         checkArgument(meta.getId().equals(other.getId()), "Plugin meta IDs don't match");
 
@@ -200,6 +225,9 @@ final class PluginElement {
         }
         if (other.getUrl() != null) {
             meta.setUrl(other.getUrl());
+        }
+        if (other.getAssetDirectory() != null) {
+            meta.setAssetDirectory(other.getAssetDirectory());
         }
 
         // TODO: Dependencies

--- a/src/main/java/org/spongepowered/api/Game.java
+++ b/src/main/java/org/spongepowered/api/Game.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api;
 
+import org.spongepowered.api.asset.AssetManager;
 import org.spongepowered.api.command.CommandManager;
 import org.spongepowered.api.config.ConfigManager;
 import org.spongepowered.api.data.DataManager;
@@ -75,6 +76,13 @@ public interface Game {
      * @return The event manager
      */
     EventManager getEventManager();
+
+    /**
+     * Gets the {@link AssetManager}.
+     *
+     * @return The asset manager
+     */
+    AssetManager getAssetManager();
 
     /**
      * Gets the {@link GameRegistry}.

--- a/src/main/java/org/spongepowered/api/Sponge.java
+++ b/src/main/java/org/spongepowered/api/Sponge.java
@@ -26,6 +26,7 @@ package org.spongepowered.api;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import org.spongepowered.api.asset.AssetManager;
 import org.spongepowered.api.command.CommandManager;
 import org.spongepowered.api.data.DataManager;
 import org.spongepowered.api.event.EventManager;
@@ -53,6 +54,10 @@ public final class Sponge {
 
     public static EventManager getEventManager() {
         return getGame().getEventManager();
+    }
+
+    public static AssetManager getAssetManager() {
+        return getGame().getAssetManager();
     }
 
     public static Scheduler getScheduler() {

--- a/src/main/java/org/spongepowered/api/asset/Asset.java
+++ b/src/main/java/org/spongepowered/api/asset/Asset.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.asset;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.io.ByteStreams;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.plugin.PluginContainer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Represents an {@link Asset} within Sponge that belongs to a {@link Plugin}.
+ */
+public interface Asset {
+
+    /**
+     * Returns the original {@link Plugin} owner of this Asset.
+     *
+     * @return Original owner of asset
+     */
+    PluginContainer getOwner();
+
+    /**
+     * Returns the {@link URL} to this Asset.
+     *
+     * @return URL to asset
+     */
+    URL getUrl();
+
+    /**
+     * Copies this Asset to the specified 'output' {@link Path}.
+     *
+     * @param output Path to copy to
+     * @throws IOException
+     */
+    default void copyToFile(Path output) throws IOException {
+        checkNotNull(output, "output");
+        InputStream in = getUrl().openStream();
+        Files.copy(in, output);
+        in.close();
+    }
+
+    /**
+     * Reads this Asset in it's entirety as a {@link String} and returns the
+     * result.
+     *
+     * @return String representation of Asset
+     * @throws IOException
+     */
+    default String readString() throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(getUrl().openStream()));
+        StringBuilder result = new StringBuilder();
+        String ln;
+        while ((ln = reader.readLine()) != null) {
+            result.append(ln).append('\n');
+        }
+        reader.close();
+        return result.toString();
+    }
+
+    /**
+     * Reads this Asset in it's entirety as a byte array and returns the
+     * result.
+     *
+     * @return Byte array representation of Asset
+     * @throws IOException
+     */
+    default byte[] readBytes() throws IOException {
+        InputStream in = getUrl().openStream();
+        byte[] bytes = ByteStreams.toByteArray(in);
+        in.close();
+        return bytes;
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/asset/AssetManager.java
+++ b/src/main/java/org/spongepowered/api/asset/AssetManager.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.asset;
+
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.plugin.PluginContainer;
+
+import java.util.Optional;
+
+/**
+ * The AssetManager offers a convenient way to easily retrieve resources from
+ * Sponge {@link Plugin}s. A {@link Plugin} may specify it's {@link Asset}
+ * directory in it's annotation declaring class as well as in the plugin meta
+ * file. If no directory is specified the manager will attempt to find the
+ * asset of the specified name at:
+ *
+ * <p><code>assets/&lt;id&gt;</code> where 'ID' is the plugin's fully
+ * qualified ID with all '.'s replaced with '/'s to more fit a directory
+ * structure.</p>
+ */
+public interface AssetManager {
+
+    /**
+     * Returns the {@link Asset} of the specified name for the specified
+     * {@link Plugin} instance.
+     *
+     * @param plugin Plugin instance
+     * @param name Name of resource to retrieve
+     * @return Asset if present, empty otherwise
+     */
+    Optional<Asset> getAsset(Object plugin, String name);
+
+    /**
+     * Returns the {@link Asset} of the specified name within the domain of the
+     * implementation. This method will typically call
+     * {@link #getAsset(Object, String)} using a dummy
+     * {@link PluginContainer} for the SpongeAPI implementation.
+     *
+     * @param name Name of resource to retrieve
+     * @return Asset if present, empty otherwise
+     */
+    Optional<Asset> getAsset(String name);
+
+}

--- a/src/main/java/org/spongepowered/api/plugin/Plugin.java
+++ b/src/main/java/org/spongepowered/api/plugin/Plugin.java
@@ -96,4 +96,16 @@ public @interface Plugin {
      */
     String[] authors() default {};
 
+    /**
+     * The directory within the plugin's JAR file that contains this plugin's
+     * assets. This directory defaults to:
+     *
+     * <p><code>assets/&lt;id&gt;</code> where 'ID' is the plugin's fully
+     * qualified ID with all '.'s replaced with '/'s to more fit a directory
+     * structure.</p>
+     *
+     * @return Asset directory
+     */
+    String assets() default "";
+
 }

--- a/src/main/java/org/spongepowered/api/plugin/PluginContainer.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginContainer.java
@@ -27,6 +27,9 @@ package org.spongepowered.api.plugin;
 import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.asset.Asset;
+import org.spongepowered.api.asset.AssetManager;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -117,6 +120,26 @@ public interface PluginContainer {
      */
     default List<String> getAuthors() {
         return ImmutableList.of();
+    }
+
+    /**
+     * Gets the directory that contains this {@link Plugin}'s assets.
+     *
+     * @return Asset directory, or empty if none
+     */
+    default Optional<Path> getAssetDirectory() {
+        return Optional.empty();
+    }
+
+    /**
+     * Retrieves the {@link Asset} of the specified name from the
+     * {@link AssetManager} for this {@link Plugin}.
+     *
+     * @param name Name of asset
+     * @return Asset if present, empty otherwise
+     */
+    default Optional<Asset> getAsset(String name) {
+        return Sponge.getAssetManager().getAsset(this, name);
     }
 
     /**


### PR DESCRIPTION
[**API**](https://github.com/SpongePowered/SpongeAPI/pull/1126) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/558) | [Forge](https://github.com/SpongePowered/SpongeForge/pull/562) | [Vanilla](https://github.com/SpongePowered/SpongeVanilla/pull/230) | [Gradle](https://github.com/SpongePowered/SpongeGradle/pull/3) | [plugin-meta](https://github.com/Minecrell/plugin-meta/pull/1)

This PR adds the `AssetManager` class to Sponge. It allows for easy retrieval of plugin resources as well as adds a `assets` plugin meta attribute to allow developers to declare a custom asset directory.

Signed-off-by: Walker Crouse <walkercrouse@hotmail.com>