### PR TITLE
Add `getExtendedDescription` to the `CommandSpec` class.

### DIFF
--- a/src/main/java/org/spongepowered/api/command/spec/CommandSpec.java
+++ b/src/main/java/org/spongepowered/api/command/spec/CommandSpec.java
@@ -61,7 +61,7 @@ public final class CommandSpec implements CommandCallable {
     private final CommandElement args;
     private final CommandExecutor executor;
     private final Optional<Text> description;
-    @Nullable private final Text extendedDescription;
+    private final Optional<Text> extendedDescription;
     @Nullable private final String permission;
     private final InputTokenizer argumentParser;
 
@@ -71,7 +71,7 @@ public final class CommandSpec implements CommandCallable {
         this.executor = executor;
         this.permission = permission;
         this.description = Optional.ofNullable(description);
-        this.extendedDescription = extendedDescription;
+        this.extendedDescription = Optional.ofNullable(extendedDescription);
         this.argumentParser = parser;
     }
 
@@ -354,6 +354,15 @@ public final class CommandSpec implements CommandCallable {
     }
 
     /**
+     * Gets the extended description used with this command if any is present
+     *
+     * @return the extended description.
+     */
+    public Optional<Text> getExtendedDescription(CommandSource source) {
+        return this.extendedDescription;
+    }
+
+    /**
      * Gets the usage for this command appropriate for the provided command
      * source.
      *
@@ -378,14 +387,9 @@ public final class CommandSpec implements CommandCallable {
     public Optional<Text> getHelp(CommandSource source) {
         checkNotNull(source, "source");
         Text.Builder builder = Text.builder();
-        Optional<Text> desc = getShortDescription(source);
-        if (desc.isPresent()) {
-            builder.append(desc.get(), Text.NEW_LINE);
-        }
+        this.getShortDescription(source).ifPresent((a) -> builder.append(a, Text.NEW_LINE));
         builder.append(getUsage(source));
-        if (this.extendedDescription != null) {
-            builder.append(Text.NEW_LINE, this.extendedDescription);
-        }
+        this.getExtendedDescription(source).ifPresent((a) -> builder.append(Text.NEW_LINE, a));
         return Optional.of(builder.build());
     }
 


### PR DESCRIPTION
Basically a Quality of Life thing, I guess. I found it annoying that the only way to access the `extendedDescription` for a `CommandSpec` was from the `getHelp` method, and as such worked this up.

(Previously, was adding it to the `CommandCallable` interface, but @kashike redirected me to just implement it for the `CommandSpec` class.)
