### PR TITLE
Virtual block changes

### DIFF
--- a/src/main/java/org/spongepowered/api/effect/Viewer.java
+++ b/src/main/java/org/spongepowered/api/effect/Viewer.java
@@ -24,11 +24,16 @@
  */
 package org.spongepowered.api.effect;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.flowpowered.math.vector.Vector3d;
+import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.effect.particle.ParticleEffect;
 import org.spongepowered.api.effect.sound.SoundType;
 import org.spongepowered.api.text.BookView;
 import org.spongepowered.api.text.title.Title;
+import org.spongepowered.api.world.World;
 
 /**
  * A Viewer is something that sees effects.
@@ -123,5 +128,57 @@ public interface Viewer {
      * @param bookView BookView to send
      */
     void sendBookView(BookView bookView);
+
+    /**
+     * Sends a client-only block change.
+     *
+     * <p>This will not change the {@link World} in any way.</p>
+     *
+     * @param vec The position
+     * @param state The block state
+     */
+    default void sendBlockChange(Vector3i vec, BlockState state) {
+        checkNotNull(vec, "vec");
+        this.sendBlockChange(vec.getX(), vec.getY(), vec.getZ(), state);
+    }
+
+    /**
+     * Sends a client-only block change.
+     *
+     * <p>This will not change the {@link World} in any way.</p>
+     *
+     * @param x The x position
+     * @param y The y position
+     * @param z The z position
+     * @param state The block state
+     */
+    void sendBlockChange(int x, int y, int z, BlockState state);
+
+    /**
+     * Resets the client's view of the provided position to what
+     * actually exists in the {@link World}.
+     *
+     * <p>This is useful for resetting what the client sees
+     * after sending a {@link #sendBlockChange block change}.</p>
+     *
+     * @param vec The position
+     */
+    default void resetBlockChange(Vector3i vec) {
+        checkNotNull(vec, "vec");
+        this.resetBlockChange(vec.getX(), vec.getY(), vec.getZ());
+    }
+
+    /**
+     * Resets the client's view of the provided position to what
+     * actually exists in the {@link World}.
+     *
+     * <p>This is useful for resetting what the client sees
+     * after sending a {@link #sendBlockChange block change}.</p>
+     *
+     * @param x The x position
+     * @param y The y position
+     * @param z The z position
+     */
+    void resetBlockChange(int x, int y, int z);
 
 }


### PR DESCRIPTION
[**API**](https://github.com/SpongePowered/SpongeAPI/pull/1144) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/591)

This adds the ability to send block changes to `Viewer`s without actually having the block change in the world.

Resolves https://github.com/SpongePowered/SpongeAPI/issues/619