### PR TITLE
Rework Explosives API for implementation

### DIFF
--- a/src/main/java/org/spongepowered/api/data/DataTransactionResult.java
+++ b/src/main/java/org/spongepowered/api/data/DataTransactionResult.java
@@ -362,7 +362,7 @@ public final class DataTransactionResult {
          * Adds the provided {@link ImmutableValue} to the {@link List} of
          * "replaced" {@link ImmutableValue}s. The replaced values are always
          * copied for every {@link DataTransactionResult} for referencing. It is
-         * also possible ot retrieve these replaced {@link ImmutableValue}s to
+         * also possible to retrieve these replaced {@link ImmutableValue}s to
          * {@link DataHolder#undo(DataTransactionResult)} at a later point in
          * the lifespan of the {@link DataHolder}.
          *

--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -62,8 +62,6 @@ import org.spongepowered.api.util.Axis;
 import org.spongepowered.api.util.Color;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.util.rotation.Rotation;
-import org.spongepowered.api.world.Location;
-import org.spongepowered.api.world.World;
 
 import java.time.Instant;
 import java.util.List;
@@ -310,7 +308,7 @@ public final class Keys {
 
     public static final Key<MutableBoundedValue<Integer>> EXPIRATION_TICKS = KeyFactory.fake("EXPIRATION_TICKS");
 
-    public static final Key<MutableBoundedValue<Integer>> EXPLOSIVE_RADIUS = KeyFactory.fake("EXPLOSIVE_RADIUS");
+    public static final Key<OptionalValue<Integer>> EXPLOSION_RADIUS = KeyFactory.fake("EXPLOSION_RADIUS");
 
     /**
      * Represents the {@link Key} for representing the {@link BigMushroomType}
@@ -382,7 +380,7 @@ public final class Keys {
 
     public static final Key<MutableBoundedValue<Integer>> FOOD_LEVEL = KeyFactory.fake("FOOD_LEVEL");
 
-    public static final Key<MutableBoundedValue<Integer>> FUSE_DURATION = KeyFactory.fake("FUSE_DURATION");
+    public static final Key<Value<Integer>> FUSE_DURATION = KeyFactory.fake("FUSE_DURATION");
 
     public static final Key<Value<GameMode>> GAME_MODE = KeyFactory.fake("GAME_MODE");
 
@@ -854,6 +852,8 @@ public final class Keys {
     public static final Key<Value<Vector3d>> TARGETED_LOCATION = KeyFactory.fake("TARGETED_LOCATION");
 
     public static final Key<MutableBoundedValue<Integer>> TOTAL_EXPERIENCE = KeyFactory.fake("TOTAL_EXPERIENCE");
+
+    public static final Key<Value<Integer>> TICKS_REMAINING = KeyFactory.fake("TICKS_REMAINING");
 
     public static final Key<Value<Boolean>> TRACKS_OUTPUT = KeyFactory.fake("TRACKS_OUTPUT");
 

--- a/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
@@ -53,7 +53,7 @@ import org.spongepowered.api.data.manipulator.mutable.entity.ElderData;
 import org.spongepowered.api.data.manipulator.mutable.entity.ExpOrbData;
 import org.spongepowered.api.data.manipulator.mutable.entity.ExperienceHolderData;
 import org.spongepowered.api.data.manipulator.mutable.entity.ExpirableData;
-import org.spongepowered.api.data.manipulator.mutable.entity.ExplosiveRadiusData;
+import org.spongepowered.api.data.manipulator.mutable.entity.ExplosionRadiusData;
 import org.spongepowered.api.data.manipulator.mutable.entity.FallingBlockData;
 import org.spongepowered.api.data.manipulator.mutable.entity.FlyingData;
 import org.spongepowered.api.data.manipulator.mutable.entity.FoodData;
@@ -259,7 +259,7 @@ public final class CatalogEntityData {
      * Represents the "explosion radius" that an entity will have upon
      * detonation. Usually applies to all {@link Explosive}s.
      */
-    public static final Class<ExplosiveRadiusData> EXPLOSIVE_RADIUS_DATA = ExplosiveRadiusData.class;
+    public static final Class<ExplosionRadiusData> EXPLOSIVE_RADIUS_DATA = ExplosionRadiusData.class;
     /**
      * Represents a falling block that can deal damage upon landing.
      * Applies to {@link FallingBlock}s.

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableExplosionRadiusData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableExplosionRadiusData.java
@@ -25,31 +25,22 @@
 package org.spongepowered.api.data.manipulator.immutable.entity;
 
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
-import org.spongepowered.api.data.manipulator.mutable.entity.FuseData;
-import org.spongepowered.api.data.value.immutable.ImmutableValue;
-import org.spongepowered.api.entity.explosive.FusedExplosive;
+import org.spongepowered.api.data.manipulator.mutable.entity.ExplosionRadiusData;
+import org.spongepowered.api.data.value.immutable.ImmutableOptionalValue;
 
 /**
- * Represents information about a {@link FusedExplosive}'s fuse.
+ * Represents the radius of an explosion.
  */
-public interface ImmutableFuseData extends ImmutableDataManipulator<ImmutableFuseData, FuseData> {
+public interface ImmutableExplosionRadiusData extends ImmutableDataManipulator<ImmutableExplosionRadiusData, ExplosionRadiusData> {
 
     /**
-     * The amount of ticks before the {@link FusedExplosive} detonates when
-     * primed.
+     * The radius in blocks that the explosion will affect. This value may be
+     * missing if the explosion radius is unknown such as when it is generated
+     * randomly on detonation. Setting this value on such explosives will
+     * override that behavior.
      *
-     * @return Amount of ticks before detonation when primed
+     * @return Explosion radius
      */
-    ImmutableValue<Integer> fuseDuration();
-
-    /**
-     * The amount of ticks before {@link FusedExplosive} detonates. This value
-     * may be zero if the {@link FusedExplosive} is not currently primed nor
-     * will setting this value have any effect if the {@link FusedExplosive} is
-     * not primed.
-     *
-     * @return Amount of ticks before impending detonation
-     */
-    ImmutableValue<Integer> ticksRemaining();
+    ImmutableOptionalValue<Integer> explosionRadius();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/ExplosionRadiusData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/ExplosionRadiusData.java
@@ -22,23 +22,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.entity.explosive;
+package org.spongepowered.api.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableExplosionRadiusData;
+import org.spongepowered.api.data.value.mutable.OptionalValue;
 
 /**
- * Represents an ignitable entity that has a fuse.
+ * Represents the radius of an explosion.
  */
-public interface IgnitableExplosive extends FusedExplosive {
+public interface ExplosionRadiusData extends DataManipulator<ExplosionRadiusData, ImmutableExplosionRadiusData> {
 
     /**
-     * Ignites this explosive to detonate after some fuse duration in ticks.
-     */
-    void ignite();
-
-    /**
-     * Ignites this explosive to detonate after the given fuse ticks.
+     * The radius in blocks that the explosion will affect. This value may be
+     * missing if the explosion radius is unknown such as when it is generated
+     * randomly on detonation. Setting this value on such explosives will
+     * override that behavior.
      *
-     * @param fuseTicks The ticks to set the fuse
+     * @return Explosion radius
      */
-    void ignite(int fuseTicks);
+    OptionalValue<Integer> explosionRadius();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/FuseData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/FuseData.java
@@ -26,21 +26,33 @@ package org.spongepowered.api.data.manipulator.mutable.entity;
 
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableFuseData;
-import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.explosive.FusedExplosive;
 
 /**
- * An {@link DataManipulator} handling the "fuse" duration remaining
- * for an {@link FusedExplosive}. Normal mechanics dictate that once the fuse
- * reduces to 0, the explosive will explode.
+ * Represents information about a {@link FusedExplosive}'s fuse.
  */
 public interface FuseData extends DataManipulator<FuseData, ImmutableFuseData> {
 
     /**
-     * Gets the {@link MutableBoundedValue} for the remaining fuse duration.
+     * The amount of ticks before the {@link FusedExplosive} detonates when
+     * primed.
      *
-     * @return The fuse duration
+     * @return Amount of ticks before detonation when primed
      */
-    MutableBoundedValue<Integer> getFuseDuration();
+    Value<Integer> fuseDuration();
+
+    /**
+     * The amount of ticks before {@link FusedExplosive} detonates. Setting
+     * this value has no effect if the explosive is not currently
+     * primed and is set to an arbitrary value that differs from explosive to
+     * explosive when not-primed. Therefore, this value should be ignored when
+     * the explosive is not primed. Instead, set the fuse duration of the
+     * explosive which is the value used to initialize this value when the
+     * explosive is primed.
+     *
+     * @return Amount of ticks before impending detonation
+     */
+    Value<Integer> ticksRemaining();
 
 }

--- a/src/main/java/org/spongepowered/api/entity/EnderCrystal.java
+++ b/src/main/java/org/spongepowered/api/entity/EnderCrystal.java
@@ -24,9 +24,11 @@
  */
 package org.spongepowered.api.entity;
 
+import org.spongepowered.api.entity.explosive.Explosive;
+
 /**
  * Represents an ender crystal.
  */
-public interface EnderCrystal extends Entity {
+public interface EnderCrystal extends Explosive {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/explosive/Explosive.java
+++ b/src/main/java/org/spongepowered/api/entity/explosive/Explosive.java
@@ -25,9 +25,10 @@
 package org.spongepowered.api.entity.explosive;
 
 import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.data.manipulator.mutable.entity.ExplosiveRadiusData;
-import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.data.manipulator.mutable.entity.ExplosionRadiusData;
+import org.spongepowered.api.data.value.mutable.OptionalValue;
 import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.cause.Cause;
 
 /**
  * Represents an explosive entity that explodes.
@@ -35,29 +36,31 @@ import org.spongepowered.api.entity.Entity;
 public interface Explosive extends Entity {
 
     /**
-     * Detonates this explosive immediately.
-     */
-    void detonate();
-
-    /**
-     * Gets a copy of the {@link ExplosiveRadiusData} used by this
-     * {@link Explosive} entity.
+     * Returns the {@link ExplosionRadiusData} for this explosive.
      *
-     * @return A copy of the explosive radius data
+     * @return Explosion radius data
      */
-    default ExplosiveRadiusData getExplosiveRadiusData() {
-        return get(ExplosiveRadiusData.class).get();
+    default ExplosionRadiusData getExplosionRadiusData() {
+        return get(ExplosionRadiusData.class).get();
     }
 
     /**
-     * Gets the {@link Value} for the explosive radius of the {@link Explosive}.
+     * The radius in blocks that the explosion will affect. This value may be
+     * missing if the explosion radius is unknown such as when it is generated
+     * randomly on detonation. Setting this value on such explosives will
+     * override that behavior.
      *
-     * <p>The explosion radius may be affected by other data manipulators.</p>
-     *
-     * @return The explosion radius of the entity
+     * @return Explosion radius
      */
-    default Value<Integer> explosiveRadius() {
-        return getValue(Keys.EXPLOSIVE_RADIUS).get();
+    default OptionalValue<Integer> explosionRadius() {
+        return getValue(Keys.EXPLOSION_RADIUS).get();
     }
+
+    /**
+     * Detonates this explosive as soon as possible.
+     *
+     * @param cause The cause of detonation
+     */
+    void detonate(Cause cause);
 
 }

--- a/src/main/java/org/spongepowered/api/entity/explosive/FusedExplosive.java
+++ b/src/main/java/org/spongepowered/api/entity/explosive/FusedExplosive.java
@@ -26,7 +26,7 @@ package org.spongepowered.api.entity.explosive;
 
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.mutable.entity.FuseData;
-import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.event.cause.Cause;
 
 /**
  * Represents an explosive that detonates after its fuse has expired.
@@ -35,22 +35,36 @@ import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 public interface FusedExplosive extends Explosive {
 
     /**
-     * Gets a copy of the {@link FuseData} representing the fuse
-     * for this {@link FusedExplosive} entity.
+     * Returns the {@link FuseData} for this explosive.
      *
-     * @return A copy of the fuse data
+     * @return FuseData
      */
     default FuseData getFuseData() {
         return get(FuseData.class).get();
     }
 
     /**
-     * Gets the {@link MutableBoundedValue} for the remaining fuse duration.
+     * Returns true if this explosive is currently primed.
      *
-     * @return The fuse duration
+     * @return True if primed
      */
-    default MutableBoundedValue<Integer> fuseDuration() {
-        return getValue(Keys.FUSE_DURATION).get();
-    }
+    boolean isPrimed();
+
+    /**
+     * Primes this explosive to detonate after the amount of ticks that
+     * this entity explodes in defined by {@link Keys#FUSE_DURATION}.
+     *
+     * @param cause The cause of this primed entity
+     * @throws IllegalStateException if explosive already primed
+     */
+    void prime(Cause cause);
+
+    /**
+     * Cancels an actively primed explosive.
+     *
+     * @param cause The cause for diffusion
+     * @throws IllegalStateException if explosive is not primed
+     */
+    void defuse(Cause cause);
 
 }

--- a/src/main/java/org/spongepowered/api/entity/living/monster/Creeper.java
+++ b/src/main/java/org/spongepowered/api/entity/living/monster/Creeper.java
@@ -26,12 +26,12 @@ package org.spongepowered.api.entity.living.monster;
 
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.mutable.Value;
-import org.spongepowered.api.entity.explosive.IgnitableExplosive;
+import org.spongepowered.api.entity.explosive.FusedExplosive;
 
 /**
  * Represents a Creeper.
  */
-public interface Creeper extends Monster, IgnitableExplosive {
+public interface Creeper extends Monster, FusedExplosive {
 
     default Value<Boolean> charged() {
         return getValue(Keys.CREEPER_CHARGED).get();

--- a/src/main/java/org/spongepowered/api/entity/living/monster/Wither.java
+++ b/src/main/java/org/spongepowered/api/entity/living/monster/Wither.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.entity.living.monster;
 
+import org.spongepowered.api.entity.explosive.FusedExplosive;
 import org.spongepowered.api.entity.living.Aerial;
 import org.spongepowered.api.entity.living.Agent;
 import org.spongepowered.api.entity.living.Living;
@@ -34,7 +35,7 @@ import java.util.List;
 /**
  * Represents the Wither.
  */
-public interface Wither extends Monster, ProjectileSource, Boss, Aerial {
+public interface Wither extends Monster, ProjectileSource, Boss, Aerial, FusedExplosive {
 
     /**
      * Gets the list of {@link Living} targets that this wither is targeting.

--- a/src/main/java/org/spongepowered/api/entity/projectile/Arrow.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/Arrow.java
@@ -25,28 +25,13 @@
 package org.spongepowered.api.entity.projectile;
 
 import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.data.manipulator.mutable.entity.DamagingData;
 import org.spongepowered.api.data.manipulator.mutable.entity.KnockbackData;
-import org.spongepowered.api.data.value.mutable.MapValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.entity.EntityType;
-import org.spongepowered.api.entity.living.Living;
 
 /**
  * Represents an Arrow.
  */
-public interface Arrow extends Projectile {
-
-    /**
-     * Gets a copy of the current {@link DamagingData} that this arrow will
-     * deal on an {@link Entity} when hit.
-     *
-     * @return A copy of the damaging data
-     */
-    default DamagingData getDamagingData() {
-        return get(DamagingData.class).get();
-    }
+public interface Arrow extends DamagingProjectile {
 
     /**
      * Gets a copy of the current {@link KnockbackData} that this arrow
@@ -56,30 +41,6 @@ public interface Arrow extends Projectile {
      */
     default KnockbackData getKnockbackData() {
         return get(KnockbackData.class).get();
-    }
-
-    /**
-     * Gets the damage this projectile will deal to a {@link Living}
-     * if hit.
-     *
-     * @return The damage to deal
-     */
-    default MutableBoundedValue<Double> damage() {
-        return getValue(Keys.ATTACK_DAMAGE).get();
-    }
-
-    /**
-     * Gets the {@link MapValue} for representing the custom damage
-     * values to use if the owner strikes an entity of that type.
-     *
-     * <p>Note that in events, the damage defined for the provided
-     * {@link EntityType} will take priority over the "default" damage as
-     * defined from {@link #damage()}.</p>
-     *
-     * @return The immutable map value for the entity damage values
-     */
-    default MapValue<EntityType, Double> damageForEntity() {
-        return getValue(Keys.DAMAGE_ENTITY_MAP).get();
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/projectile/DamagingProjectile.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/DamagingProjectile.java
@@ -22,7 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.entity.projectile.explosive;
+package org.spongepowered.api.entity.projectile;
 
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.mutable.entity.DamagingData;
@@ -30,17 +30,15 @@ import org.spongepowered.api.data.value.mutable.MapValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntityType;
-import org.spongepowered.api.entity.explosive.Explosive;
 import org.spongepowered.api.entity.living.Living;
-import org.spongepowered.api.entity.projectile.Projectile;
 
 /**
- * Represents a {@link Projectile} which is also an {@link Explosive}.
+ * Represents a {@link Projectile} that inflicts damage.
  */
-public interface ExplosiveProjectile extends Projectile, Explosive {
+public interface DamagingProjectile extends Projectile {
 
     /**
-     * Gets the damaging data for this {@link ExplosiveProjectile}.
+     * Gets the damaging data for this {@link DamagingProjectile}.
      *
      * <p>The damaging data defines how much damage the projectile will deal
      * upon hitting an {@link Entity}, before the explosion.</p>

--- a/src/main/java/org/spongepowered/api/entity/projectile/Egg.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/Egg.java
@@ -24,50 +24,9 @@
  */
 package org.spongepowered.api.entity.projectile;
 
-import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.data.manipulator.mutable.entity.DamagingData;
-import org.spongepowered.api.data.value.mutable.MapValue;
-import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.entity.EntityType;
-import org.spongepowered.api.entity.living.Living;
-
 /**
  * Represents a thrown egg.
  */
-public interface Egg extends Projectile {
+public interface Egg extends DamagingProjectile {
 
-    /**
-     * Gets a copy of the current {@link DamagingData} that this egg will
-     * deal on an {@link Entity} when hit.
-     *
-     * @return A copy of the damaging data
-     */
-    default DamagingData getDamagingData() {
-        return get(DamagingData.class).get();
-    }
-
-    /**
-     * Gets the damage this projectile will deal to a {@link Living}
-     * if hit.
-     *
-     * @return The damage to deal
-     */
-    default MutableBoundedValue<Double> damage() {
-        return getValue(Keys.ATTACK_DAMAGE).get();
-    }
-
-    /**
-     * Gets the {@link MapValue} for representing the custom damage
-     * values to use if the owner strikes an entity of that type.
-     *
-     * <p>Note that in events, the damage defined for the provided
-     * {@link EntityType} will take priority over the "default" damage as
-     * defined from {@link #damage()}.</p>
-     *
-     * @return The immutable map value for the entity damage values
-     */
-    default MapValue<EntityType, Double> damageForEntity() {
-        return getValue(Keys.DAMAGE_ENTITY_MAP).get();
-    }
 }

--- a/src/main/java/org/spongepowered/api/entity/projectile/EnderPearl.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/EnderPearl.java
@@ -24,50 +24,9 @@
  */
 package org.spongepowered.api.entity.projectile;
 
-import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.data.manipulator.mutable.entity.DamagingData;
-import org.spongepowered.api.data.value.mutable.MapValue;
-import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.entity.EntityType;
-import org.spongepowered.api.entity.living.Living;
-
 /**
  * Represents an Ender Pearl.
  */
-public interface EnderPearl extends Projectile {
+public interface EnderPearl extends DamagingProjectile {
 
-    /**
-     * Gets a copy of the current {@link DamagingData} that this ender pearl
-     * will deal on an {@link Entity} when hit.
-     *
-     * @return A copy of the damaging data
-     */
-    default DamagingData getDamagingData() {
-        return get(DamagingData.class).get();
-    }
-
-    /**
-     * Gets the damage this projectile will deal to a {@link Living}
-     * if hit.
-     *
-     * @return The damage to deal
-     */
-    default MutableBoundedValue<Double> damage() {
-        return getValue(Keys.ATTACK_DAMAGE).get();
-    }
-
-    /**
-     * Gets the {@link MapValue} for representing the custom damage
-     * values to use if the owner strikes an entity of that type.
-     *
-     * <p>Note that in events, the damage defined for the provided
-     * {@link EntityType} will take priority over the "default" damage as
-     * defined from {@link #damage()}.</p>
-     *
-     * @return The immutable map value for the entity damage values
-     */
-    default MapValue<EntityType, Double> damageForEntity() {
-        return getValue(Keys.DAMAGE_ENTITY_MAP).get();
-    }
 }

--- a/src/main/java/org/spongepowered/api/entity/projectile/Snowball.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/Snowball.java
@@ -24,50 +24,9 @@
  */
 package org.spongepowered.api.entity.projectile;
 
-import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.data.manipulator.mutable.entity.DamagingData;
-import org.spongepowered.api.data.value.mutable.MapValue;
-import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.entity.EntityType;
-import org.spongepowered.api.entity.living.Living;
-
 /**
  * Represents a Snowball.
  */
-public interface Snowball extends Projectile {
+public interface Snowball extends DamagingProjectile {
 
-    /**
-     * Gets a copy of the current {@link DamagingData} that this snowball will
-     * deal on an {@link Entity} when hit.
-     *
-     * @return A copy of the damaging data
-     */
-    default DamagingData getDamagingData() {
-        return get(DamagingData.class).get();
-    }
-
-    /**
-     * Gets the damage this projectile will deal to a {@link Living}
-     * if hit.
-     *
-     * @return The damage to deal
-     */
-    default MutableBoundedValue<Double> damage() {
-        return getValue(Keys.ATTACK_DAMAGE).get();
-    }
-
-    /**
-     * Gets the {@link MapValue} for representing the custom damage
-     * values to use if the owner strikes an entity of that type.
-     *
-     * <p>Note that in events, the damage defined for the provided
-     * {@link EntityType} will take priority over the "default" damage as
-     * defined from {@link #damage()}.</p>
-     *
-     * @return The immutable map value for the entity damage values
-     */
-    default MapValue<EntityType, Double> damageForEntity() {
-        return getValue(Keys.DAMAGE_ENTITY_MAP).get();
-    }
 }

--- a/src/main/java/org/spongepowered/api/entity/projectile/explosive/WitherSkull.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/explosive/WitherSkull.java
@@ -24,9 +24,12 @@
  */
 package org.spongepowered.api.entity.projectile.explosive;
 
+import org.spongepowered.api.entity.explosive.Explosive;
+import org.spongepowered.api.entity.projectile.DamagingProjectile;
+
 /**
  * Represents a Wither Skull.
  */
-public interface WitherSkull extends ExplosiveProjectile {
+public interface WitherSkull extends DamagingProjectile, Explosive {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/projectile/explosive/fireball/Fireball.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/explosive/fireball/Fireball.java
@@ -24,11 +24,11 @@
  */
 package org.spongepowered.api.entity.projectile.explosive.fireball;
 
-import org.spongepowered.api.entity.projectile.explosive.ExplosiveProjectile;
+import org.spongepowered.api.entity.projectile.DamagingProjectile;
 
 /**
  * Represents an abstract fireball, such as {@link SmallFireball}.
  */
-public interface Fireball extends ExplosiveProjectile {
+public interface Fireball extends DamagingProjectile {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/projectile/explosive/fireball/LargeFireball.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/explosive/fireball/LargeFireball.java
@@ -24,9 +24,11 @@
  */
 package org.spongepowered.api.entity.projectile.explosive.fireball;
 
+import org.spongepowered.api.entity.explosive.Explosive;
+
 /**
  * Represents a Ghast fireball.
  */
-public interface LargeFireball extends Fireball {
+public interface LargeFireball extends Fireball, Explosive {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/vehicle/minecart/TNTMinecart.java
+++ b/src/main/java/org/spongepowered/api/entity/vehicle/minecart/TNTMinecart.java
@@ -24,11 +24,11 @@
  */
 package org.spongepowered.api.entity.vehicle.minecart;
 
-import org.spongepowered.api.entity.explosive.IgnitableExplosive;
+import org.spongepowered.api.entity.explosive.FusedExplosive;
 
 /**
  * Represents a Minecart with a TNT block in it.
  */
-public interface TNTMinecart extends Minecart, IgnitableExplosive {
+public interface TNTMinecart extends Minecart, FusedExplosive {
 
 }

--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -59,6 +59,8 @@ import org.spongepowered.api.entity.Item;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.entity.ai.Goal;
 import org.spongepowered.api.entity.ai.task.AITask;
+import org.spongepowered.api.entity.explosive.Explosive;
+import org.spongepowered.api.entity.explosive.FusedExplosive;
 import org.spongepowered.api.entity.living.Ageable;
 import org.spongepowered.api.entity.living.Agent;
 import org.spongepowered.api.entity.living.Humanoid;
@@ -114,6 +116,11 @@ import org.spongepowered.api.event.entity.TameEntityEvent;
 import org.spongepowered.api.event.entity.TargetEntityEvent;
 import org.spongepowered.api.event.entity.UnleashEntityEvent;
 import org.spongepowered.api.event.entity.ai.AITaskEvent;
+import org.spongepowered.api.event.entity.explosive.DefuseExplosiveEvent;
+import org.spongepowered.api.event.entity.explosive.DetonateExplosiveEvent;
+import org.spongepowered.api.event.entity.explosive.PrimeExplosiveEvent;
+import org.spongepowered.api.event.entity.explosive.TargetExplosiveEvent;
+import org.spongepowered.api.event.entity.explosive.TargetFusedExplosiveEvent;
 import org.spongepowered.api.event.entity.item.ItemMergeItemEvent;
 import org.spongepowered.api.event.entity.item.TargetItemEvent;
 import org.spongepowered.api.event.entity.living.TargetAgentEvent;
@@ -2361,6 +2368,154 @@ public class SpongeEventFactory {
         values.put("task", task);
         values.put("priority", priority);
         return SpongeEventFactoryUtils.createEventImpl(AITaskEvent.Remove.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.entity.explosive.DefuseExplosiveEvent}.
+     * 
+     * @param cause The cause
+     * @param targetEntity The target entity
+     * @return A new defuse explosive event
+     */
+    public static DefuseExplosiveEvent createDefuseExplosiveEvent(Cause cause, FusedExplosive targetEntity) {
+        HashMap<String, Object> values = new HashMap<>();
+        values.put("cause", cause);
+        values.put("targetEntity", targetEntity);
+        return SpongeEventFactoryUtils.createEventImpl(DefuseExplosiveEvent.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.entity.explosive.DefuseExplosiveEvent.Post}.
+     * 
+     * @param cause The cause
+     * @param targetEntity The target entity
+     * @return A new post defuse explosive event
+     */
+    public static DefuseExplosiveEvent.Post createDefuseExplosiveEventPost(Cause cause, FusedExplosive targetEntity) {
+        HashMap<String, Object> values = new HashMap<>();
+        values.put("cause", cause);
+        values.put("targetEntity", targetEntity);
+        return SpongeEventFactoryUtils.createEventImpl(DefuseExplosiveEvent.Post.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.entity.explosive.DefuseExplosiveEvent.Pre}.
+     * 
+     * @param cause The cause
+     * @param targetEntity The target entity
+     * @return A new pre defuse explosive event
+     */
+    public static DefuseExplosiveEvent.Pre createDefuseExplosiveEventPre(Cause cause, FusedExplosive targetEntity) {
+        HashMap<String, Object> values = new HashMap<>();
+        values.put("cause", cause);
+        values.put("targetEntity", targetEntity);
+        return SpongeEventFactoryUtils.createEventImpl(DefuseExplosiveEvent.Pre.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.entity.explosive.DetonateExplosiveEvent}.
+     * 
+     * @param cause The cause
+     * @param explosionBuilder The explosion builder
+     * @param originalExplosion The original explosion
+     * @param targetEntity The target entity
+     * @return A new detonate explosive event
+     */
+    public static DetonateExplosiveEvent createDetonateExplosiveEvent(Cause cause, Explosion.Builder explosionBuilder, Explosion originalExplosion, Explosive targetEntity) {
+        HashMap<String, Object> values = new HashMap<>();
+        values.put("cause", cause);
+        values.put("explosionBuilder", explosionBuilder);
+        values.put("originalExplosion", originalExplosion);
+        values.put("targetEntity", targetEntity);
+        return SpongeEventFactoryUtils.createEventImpl(DetonateExplosiveEvent.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.entity.explosive.PrimeExplosiveEvent}.
+     * 
+     * @param cause The cause
+     * @param targetEntity The target entity
+     * @return A new prime explosive event
+     */
+    public static PrimeExplosiveEvent createPrimeExplosiveEvent(Cause cause, FusedExplosive targetEntity) {
+        HashMap<String, Object> values = new HashMap<>();
+        values.put("cause", cause);
+        values.put("targetEntity", targetEntity);
+        return SpongeEventFactoryUtils.createEventImpl(PrimeExplosiveEvent.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.entity.explosive.PrimeExplosiveEvent.Post}.
+     * 
+     * @param cause The cause
+     * @param targetEntity The target entity
+     * @return A new post prime explosive event
+     */
+    public static PrimeExplosiveEvent.Post createPrimeExplosiveEventPost(Cause cause, FusedExplosive targetEntity) {
+        HashMap<String, Object> values = new HashMap<>();
+        values.put("cause", cause);
+        values.put("targetEntity", targetEntity);
+        return SpongeEventFactoryUtils.createEventImpl(PrimeExplosiveEvent.Post.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.entity.explosive.PrimeExplosiveEvent.Pre}.
+     * 
+     * @param cause The cause
+     * @param targetEntity The target entity
+     * @return A new pre prime explosive event
+     */
+    public static PrimeExplosiveEvent.Pre createPrimeExplosiveEventPre(Cause cause, FusedExplosive targetEntity) {
+        HashMap<String, Object> values = new HashMap<>();
+        values.put("cause", cause);
+        values.put("targetEntity", targetEntity);
+        return SpongeEventFactoryUtils.createEventImpl(PrimeExplosiveEvent.Pre.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.entity.explosive.TargetExplosiveEvent}.
+     * 
+     * @param cause The cause
+     * @param targetEntity The target entity
+     * @return A new target explosive event
+     */
+    public static TargetExplosiveEvent createTargetExplosiveEvent(Cause cause, Explosive targetEntity) {
+        HashMap<String, Object> values = new HashMap<>();
+        values.put("cause", cause);
+        values.put("targetEntity", targetEntity);
+        return SpongeEventFactoryUtils.createEventImpl(TargetExplosiveEvent.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.entity.explosive.TargetFusedExplosiveEvent}.
+     * 
+     * @param cause The cause
+     * @param targetEntity The target entity
+     * @return A new target fused explosive event
+     */
+    public static TargetFusedExplosiveEvent createTargetFusedExplosiveEvent(Cause cause, FusedExplosive targetEntity) {
+        HashMap<String, Object> values = new HashMap<>();
+        values.put("cause", cause);
+        values.put("targetEntity", targetEntity);
+        return SpongeEventFactoryUtils.createEventImpl(TargetFusedExplosiveEvent.class, values);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/event/entity/explosive/DefuseExplosiveEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/explosive/DefuseExplosiveEvent.java
@@ -22,34 +22,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.manipulator.immutable.entity;
+package org.spongepowered.api.event.entity.explosive;
 
-import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
-import org.spongepowered.api.data.manipulator.mutable.entity.FuseData;
-import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.entity.explosive.FusedExplosive;
+import org.spongepowered.api.event.Cancellable;
 
 /**
- * Represents information about a {@link FusedExplosive}'s fuse.
+ * Event called when a primed {@link FusedExplosive} is defused.
  */
-public interface ImmutableFuseData extends ImmutableDataManipulator<ImmutableFuseData, FuseData> {
+public interface DefuseExplosiveEvent extends TargetFusedExplosiveEvent {
 
     /**
-     * The amount of ticks before the {@link FusedExplosive} detonates when
-     * primed.
-     *
-     * @return Amount of ticks before detonation when primed
+     * Event called immediately before a primed {@link FusedExplosive} is
+     * defused.
      */
-    ImmutableValue<Integer> fuseDuration();
+    interface Pre extends DefuseExplosiveEvent, Cancellable {}
 
     /**
-     * The amount of ticks before {@link FusedExplosive} detonates. This value
-     * may be zero if the {@link FusedExplosive} is not currently primed nor
-     * will setting this value have any effect if the {@link FusedExplosive} is
-     * not primed.
-     *
-     * @return Amount of ticks before impending detonation
+     * Event called after a primed {@link FusedExplosive} has been defused.
      */
-    ImmutableValue<Integer> ticksRemaining();
+    interface Post extends DefuseExplosiveEvent {}
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/explosive/DetonateExplosiveEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/explosive/DetonateExplosiveEvent.java
@@ -22,34 +22,31 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.manipulator.immutable.entity;
+package org.spongepowered.api.event.entity.explosive;
 
-import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
-import org.spongepowered.api.data.manipulator.mutable.entity.FuseData;
-import org.spongepowered.api.data.value.immutable.ImmutableValue;
-import org.spongepowered.api.entity.explosive.FusedExplosive;
+import org.spongepowered.api.entity.explosive.Explosive;
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.world.explosion.Explosion;
 
 /**
- * Represents information about a {@link FusedExplosive}'s fuse.
+ * Event called immediately before an {@link Explosive} explodes.
  */
-public interface ImmutableFuseData extends ImmutableDataManipulator<ImmutableFuseData, FuseData> {
+public interface DetonateExplosiveEvent extends TargetExplosiveEvent, Cancellable {
 
     /**
-     * The amount of ticks before the {@link FusedExplosive} detonates when
-     * primed.
+     * Returns the explosion of the vanilla behavior that this event was
+     * initialized with.
      *
-     * @return Amount of ticks before detonation when primed
+     * @return Original explosion
      */
-    ImmutableValue<Integer> fuseDuration();
+    Explosion getOriginalExplosion();
 
     /**
-     * The amount of ticks before {@link FusedExplosive} detonates. This value
-     * may be zero if the {@link FusedExplosive} is not currently primed nor
-     * will setting this value have any effect if the {@link FusedExplosive} is
-     * not primed.
+     * Returns the {@link Explosion.Builder} that will be used to build the
+     * explosion for the impending detonation.
      *
-     * @return Amount of ticks before impending detonation
+     * @return Explosion builder for detonation
      */
-    ImmutableValue<Integer> ticksRemaining();
+    Explosion.Builder getExplosionBuilder();
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/explosive/PrimeExplosiveEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/explosive/PrimeExplosiveEvent.java
@@ -22,34 +22,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.manipulator.immutable.entity;
+package org.spongepowered.api.event.entity.explosive;
 
-import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
-import org.spongepowered.api.data.manipulator.mutable.entity.FuseData;
-import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.entity.explosive.FusedExplosive;
+import org.spongepowered.api.event.Cancellable;
 
 /**
- * Represents information about a {@link FusedExplosive}'s fuse.
+ * Event called when a {@link FusedExplosive} is primed for detonation.
  */
-public interface ImmutableFuseData extends ImmutableDataManipulator<ImmutableFuseData, FuseData> {
+public interface PrimeExplosiveEvent extends TargetFusedExplosiveEvent {
 
     /**
-     * The amount of ticks before the {@link FusedExplosive} detonates when
-     * primed.
-     *
-     * @return Amount of ticks before detonation when primed
+     * Event called immediately before a {@link FusedExplosive} is primed for
+     * detonation.
      */
-    ImmutableValue<Integer> fuseDuration();
+    interface Pre extends PrimeExplosiveEvent, Cancellable {}
 
     /**
-     * The amount of ticks before {@link FusedExplosive} detonates. This value
-     * may be zero if the {@link FusedExplosive} is not currently primed nor
-     * will setting this value have any effect if the {@link FusedExplosive} is
-     * not primed.
-     *
-     * @return Amount of ticks before impending detonation
+     * Event called after a {@link FusedExplosive} has been primed for
+     * detonation.
      */
-    ImmutableValue<Integer> ticksRemaining();
+    interface Post extends PrimeExplosiveEvent {}
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/explosive/TargetExplosiveEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/explosive/TargetExplosiveEvent.java
@@ -22,26 +22,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.manipulator.mutable.entity;
+package org.spongepowered.api.event.entity.explosive;
 
-import org.spongepowered.api.data.manipulator.DataManipulator;
-import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableExplosiveRadiusData;
-import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.explosive.Explosive;
+import org.spongepowered.api.event.entity.TargetEntityEvent;
 
 /**
- * A {@link DataManipulator} for handling the "explosive radius" of an
- * {@link Explosive}.
+ * Represents an event regarding an {@link Explosive}.
  */
-public interface ExplosiveRadiusData extends DataManipulator<ExplosiveRadiusData, ImmutableExplosiveRadiusData> {
+public interface TargetExplosiveEvent extends TargetEntityEvent {
 
-    /**
-     * Gets the {@link Value} for the explosive radius of the {@link Explosive}.
-     *
-     * <p>The explosion radius may be affected by other data manipulators.</p>
-     *
-     * @return The explosion radius of the entity
-     */
-    Value<Integer> explosiveRadius();
+    @Override
+    Explosive getTargetEntity();
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/explosive/TargetFusedExplosiveEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/explosive/TargetFusedExplosiveEvent.java
@@ -22,25 +22,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.manipulator.immutable.entity;
+package org.spongepowered.api.event.entity.explosive;
 
-import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
-import org.spongepowered.api.data.manipulator.mutable.entity.ExplosiveRadiusData;
-import org.spongepowered.api.data.value.immutable.ImmutableValue;
-import org.spongepowered.api.entity.explosive.Explosive;
+import org.spongepowered.api.entity.explosive.FusedExplosive;
 
 /**
- * An {@link ImmutableDataManipulator} for the "explosive radius" of an
- * {@link Explosive}.
+ * Represents an event regarding a {@link FusedExplosive}.
  */
-public interface ImmutableExplosiveRadiusData extends ImmutableDataManipulator<ImmutableExplosiveRadiusData, ExplosiveRadiusData> {
+public interface TargetFusedExplosiveEvent extends TargetExplosiveEvent {
 
-    /**
-     * Gets the {@link ImmutableValue} for the explosive radius of the
-     * {@link Explosive}.
-     *
-     * @return The explosion radius of the entity
-     */
-    ImmutableValue<Integer> explosiveRadius();
+    @Override
+    FusedExplosive getTargetEntity();
 
 }


### PR DESCRIPTION
[**API**](https://github.com/SpongePowered/SpongeAPI/pull/1164) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/620)

[Test plugin](https://gist.github.com/windy1/adfd334770ef12c13dba9a348f9570dc)

This PR completes the Explosives API and adds two new events: `ExplosiveEntityEvent.Prime` and `ExplosiveEntityEvent.Detonate`.

Signed-off-by: Walker Crouse <walkercrouse@hotmail.com>