### PR TITLE
Add DataSerializer API for Java Objects not able to implement DataSerializable

### DIFF
--- a/src/main/java/org/spongepowered/api/data/DataManager.java
+++ b/src/main/java/org/spongepowered/api/data/DataManager.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulatorBuilder;
 import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.data.persistence.DataContentUpdater;
+import org.spongepowered.api.data.persistence.DataSerializer;
 
 import java.util.Optional;
 
@@ -185,5 +186,23 @@ public interface DataManager {
      */
     <T extends DataManipulator<T, I>, I extends ImmutableDataManipulator<I, T>>
         Optional<DataManipulatorBuilder<T, I>> getImmutableManipulatorBuilder(Class<I> immutableManipulatorClass);
+
+    /**
+     * Registers a {@link DataSerializer} for the desired class.
+     *
+     * @param objectClass The class of the object type being managed
+     * @param serializer The serializer for the desired class object
+     * @param <T> The type of object
+     */
+    <T> void registerSerializer(Class<T> objectClass, DataSerializer<T> serializer);
+
+    /**
+     * Gets the desired {@link DataSerializer} for the provided class.
+     *
+     * @param objectclass The class of the object
+     * @param <T> The type of object
+     * @return The data serializer, if available
+     */
+    <T> Optional<DataSerializer<T>> getSerializer(Class<T> objectclass);
 
 }

--- a/src/main/java/org/spongepowered/api/data/DataView.java
+++ b/src/main/java/org/spongepowered/api/data/DataView.java
@@ -270,6 +270,30 @@ public interface DataView {
     Optional<Boolean> getBoolean(DataQuery path);
 
     /**
+     * Gets the {@link Short} by path, if available.
+     *
+     * <p>If a {@link Short} does not exist, or the data residing at
+     * the path is not an instance of a {@link Short}, an absent is
+     * returned.</p>
+     *
+     * @param path The path of the value to get
+     * @return The boolean, if available
+     */
+    Optional<Short> getShort(DataQuery path);
+
+    /**
+     * Gets the {@link Byte} by path, if available.
+     *
+     * <p>If a {@link Byte} does not exist, or the data residing at
+     * the path is not an instance of a {@link Byte}, an absent is
+     * returned.</p>
+     *
+     * @param path The path of the value to get
+     * @return The boolean, if available
+     */
+    Optional<Byte> getByte(DataQuery path);
+
+    /**
      * Gets the {@link Integer} by path, if available.
      *
      * <p>If a {@link Integer} does not exist, or the data residing at
@@ -292,6 +316,18 @@ public interface DataView {
      * @return The long, if available
      */
     Optional<Long> getLong(DataQuery path);
+
+    /**
+     * Gets the {@link Float} by path, if available.
+     *
+     * <p>If a {@link Float} does not exist, or the data residing at
+     * the path is not an instance of a {@link Float}, an absent is
+     * returned.</p>
+     *
+     * @param path The path of the value to get
+     * @return The boolean, if available
+     */
+    Optional<Float> getFloat(DataQuery path);
 
     /**
      * Gets the {@link Double} by path, if available.
@@ -498,6 +534,10 @@ public interface DataView {
      * @return The deserialized objects in a list, if available
      */
     <T extends DataSerializable> Optional<List<T>> getSerializableList(DataQuery path, Class<T> clazz);
+
+    <T> Optional<T> getObject(DataQuery path, Class<T> objectClass);
+
+    <T> Optional<List<T>> getObjectList(DataQuery path, Class<T> objectclass);
 
     /**
      * Gets the {@link CatalogType} object by path, if available.

--- a/src/main/java/org/spongepowered/api/data/Queries.java
+++ b/src/main/java/org/spongepowered/api/data/Queries.java
@@ -84,6 +84,10 @@ public final class Queries {
     // RespawnLocation
     public static final DataQuery FORCED_SPAWN = of("ForcedSpawn");
 
+    // UUID
+    public static final DataQuery UUID_LEAST = of("UuidLeast");
+    public static final DataQuery UUID_MOST = of("UuidMost");
+
     private Queries() {
     }
 

--- a/src/main/java/org/spongepowered/api/data/persistence/DataSerializer.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/DataSerializer.java
@@ -24,52 +24,44 @@
  */
 package org.spongepowered.api.data.persistence;
 
+import com.google.common.reflect.TypeToken;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataQuery;
+import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.DataView;
+import org.spongepowered.api.data.MemoryDataView;
+
+import java.util.Optional;
 
 /**
- * An exception that occurs when a {@link DataBuilder} or
- * {@link DataSource} is unable to handle an operation, which can include:
- * {@link DataBuilder#build(DataView)}, {@link DataSource#()},
- * etc.
+ * A compatibility object to serialize and deserialize any type of
+ * {@link Object} that is not a {@link DataSerializable}. Natively,
+ * {@link MemoryDataView} will attempt to locate a {@code DataSerializer}
+ * during {@link DataView#set(DataQuery, Object)}.
+ *
+ * @param <T> The type of object that this serializer and handle
  */
-public class InvalidDataException extends UnsupportedOperationException {
+public interface DataSerializer<T> {
 
-    private static final long serialVersionUID = -754482190837922531L;
-
-    /**
-     * Constructs a new {@link InvalidDataException}.
-     */
-    public InvalidDataException() {
-        super();
-    }
+    TypeToken<T> getToken();
 
     /**
-     * Constructs a new {@link InvalidDataException} with a message.
+     * Attempts to deserialize the {@code T} object from the provided
+     * {@link DataView}.
      *
-     * @param message The message to display with the exception
+     * @param view The data view to deserialize the object from
+     * @return The object, deserialized, if available
+     * @throws InvalidDataException If the dataview contained invalid data
      */
-    public InvalidDataException(String message) {
-        super(message);
-    }
+    Optional<T> deserialize(DataView view) throws InvalidDataException;
 
     /**
-     * Constructs a new {@link InvalidDataException} with the specified message and
-     * cause.
+     * Serializes the provided object to a {@link DataContainer}.
      *
-     * @param message The exception message
-     * @param cause The cause of this exception
+     * @param obj The object to serialize
+     * @return The object serialized to a container
+     * @throws InvalidDataException If the desired object is not supported
+     *     for any reason
      */
-    public InvalidDataException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    /**
-     * Constructs a new {@link InvalidDataException} with the specified cause and a
-     * null message.
-     *
-     * @param cause The cause of this exception
-     */
-    public InvalidDataException(Throwable cause) {
-        super(cause);
-    }
+    DataContainer serialize(T obj) throws InvalidDataException;
 }

--- a/src/test/java/org/spongepowered/api/data/MemoryDataTest.java
+++ b/src/test/java/org/spongepowered/api/data/MemoryDataTest.java
@@ -253,6 +253,7 @@ public class MemoryDataTest {
         mockStatic(Sponge.class);
         when(Sponge.getDataManager()).thenReturn(service);
         Mockito.stub(service.getBuilder(SimpleData.class)).toReturn(Optional.of(builder));
+        Mockito.stub(service.getSerializer(Mockito.any())).toReturn(Optional.empty());
 
         List<String> myList = ImmutableList.of("foo", "bar", "baz");
 
@@ -273,6 +274,7 @@ public class MemoryDataTest {
         mockStatic(Sponge.class);
         when(Sponge.getDataManager()).thenReturn(service);
         Mockito.stub(service.getBuilder(SimpleData.class)).toReturn(Optional.of(builder));
+        Mockito.stub(service.getSerializer(Mockito.any())).toReturn(Optional.empty());
 
         List<SimpleData> list = Lists.newArrayList();
         for (int i = 0; i < 1000; i++) {


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/634)

Plainly, this adds the ability for POJOs to reactively be serialized appropriately without creating `DataContainer`s for the various objects.

The default implementation in SpongeCommon contains registration for the following:
- `java.util.UUID`
- `com.flowpowered.math.vector.Vector2i`
- `com.flowpowered.math.vector.Vector2l`
- `com.flowpowered.math.vector.Vector2d`
- `com.flowpowered.math.vector.Vector2f`
- `com.flowpowered.math.vector.Vector3i`
- `com.flowpowered.math.vector.Vector3l`
- `com.flowpowered.math.vector.Vector3d`
- `com.flowpowered.math.vector.Vector3f`
- `com.flowpowered.math.vector.Vector4i`
- `com.flowpowered.math.vector.Vector4l`
- `com.flowpowered.math.vector.Vector4d`
- `com.flowpowered.math.vector.Vector4f`
- `com.flowpowered.math.imaginary.Complexd`
- `com.flowpowered.math.imaginary.Complexf`
- `com.flowpowered.math.imaginary.Quaterniond`
- `com.flowpowered.math.imaginary.Quaternionf`
- `java.time.LocalDate`
- `java.time.LocalTime`
- `java.time.LocalDateTime`
- `java.time.ZonedDateTime`
- `java.time.Instant`

Any additional objects/types that should be considered default serialized? Please reply below! Note that we will not accept serializing abstract classes or interfaces!