### PR TITLE
[WIP] Add ClientConnectionEvent.Handshake to let plugins handle client handshaking

### DIFF
--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -3982,6 +3982,34 @@ public class SpongeEventFactory {
     /**
      * AUTOMATICALLY GENERATED, DO NOT EDIT.
      * Creates a new instance of
+     * {@link org.spongepowered.api.event.network.ClientConnectionEvent.Handshake}.
+     * 
+     * @param cause The cause
+     * @param formatter The formatter
+     * @param gameProfile The game profile
+     * @param handshakeString The handshake string
+     * @param serverHostname The server hostname
+     * @param socketAddressHostname The socket address hostname
+     * @param failed The failed
+     * @param messageCancelled The message cancelled
+     * @return A new handshake client connection event
+     */
+    public static ClientConnectionEvent.Handshake createClientConnectionEventHandshake(Cause cause, MessageEvent.MessageFormatter formatter, Optional<GameProfile> gameProfile, String handshakeString, Optional<String> serverHostname, Optional<String> socketAddressHostname, boolean failed, boolean messageCancelled) {
+        HashMap<String, Object> values = new HashMap<>();
+        values.put("cause", cause);
+        values.put("formatter", formatter);
+        values.put("gameProfile", gameProfile);
+        values.put("handshakeString", handshakeString);
+        values.put("serverHostname", serverHostname);
+        values.put("socketAddressHostname", socketAddressHostname);
+        values.put("failed", failed);
+        values.put("messageCancelled", messageCancelled);
+        return SpongeEventFactoryUtils.createEventImpl(ClientConnectionEvent.Handshake.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
      * {@link org.spongepowered.api.event.network.ClientConnectionEvent.Join}.
      * 
      * @param cause The cause

--- a/src/main/java/org/spongepowered/api/event/network/ClientConnectionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/network/ClientConnectionEvent.java
@@ -42,6 +42,8 @@ import org.spongepowered.api.text.TextRepresentable;
 import org.spongepowered.api.world.World;
 
 import java.net.InetAddress;
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Represents an event fired during the login process.
@@ -60,6 +62,94 @@ import java.net.InetAddress;
  * with the player at well-defined moments during the connection process.
  */
 public interface ClientConnectionEvent extends Event {
+
+    /**
+     * Called when a client attempts to handshake against the server.
+     */
+    interface Handshake extends ClientConnectionEvent, MessageEvent, Cancellable {
+
+        /**
+         * Gets the original handshake string.
+         *
+         * @return The original handshake string
+         */
+        String getHandshakeString();
+
+        /**
+         * Gets the server hostname string.
+         *
+         * <p>This should not include the port.</p>
+         *
+         * @return The server hostname string if present, or {@link Optional#empty()}
+         */
+        Optional<String> getServerHostname();
+
+        /**
+         * Sets the server hostname string.
+         *
+         * <p>This should not include the port.</p>
+         *
+         * @param serverHostname The server hostname string
+         */
+        void setServerHostname(String serverHostname);
+
+        /**
+         * Gets the socket address hostname string.
+         *
+         * <p>This should not include the port.</p>
+         *
+         * @return The socket address hostname string if
+         *     present, or {@link Optional#empty()}
+         */
+        Optional<String> getSocketAddressHostname();
+
+        /**
+         * Sets the socket address hostname string.
+         *
+         * <p>This should not include the port.</p>
+         *
+         * @param socketAddressHostname The socket address hostname string
+         */
+        void setSocketAddressHostname(String socketAddressHostname);
+
+        /**
+         * Gets the resolved {@link GameProfile} of this client.
+         *
+         * @return The resolved profile if present, or {@link Optional#empty()}
+         */
+        Optional<GameProfile> getGameProfile();
+
+        /**
+         * Sets the resolved profile of this client.
+         *
+         * <p>The profile is used to retrieve the {@link UUID}
+         * and profile properties for this client.</p>
+         *
+         * @param profile The resolved profile
+         */
+        void setGameProfile(GameProfile profile);
+
+        /**
+         * Determines if the handshake failed.
+         *
+         * <p>When {@code true}, the client connecting will be disconnected
+         * with the {@link #getMessage()} () fail message}.</p>
+         *
+         * @return {@code true} if authentication failed, {@code false} otherwise
+         */
+        boolean isFailed();
+
+        /**
+         * Sets if the handshake failed and the client should be disconnected.
+         *
+         * <p>When {@code true}, the client connecting will be disconnected
+         * with the {@link #getMessage()} () fail message}.</p>
+         *
+         * @param failed {@code true} if authentication failed, {@code false}
+         *     otherwise
+         */
+        void setFailed(boolean failed);
+    }
 
     /**
      * Called asynchronously when the client attempts to authenticate against


### PR DESCRIPTION
[**API**](https://github.com/SpongePowered/SpongeAPI/pull/1182) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/649) | [Forge](https://github.com/SpongePowered/SpongeForge/pull/609)

This adds a new `ClientConnectionEvent.Handshake` event which is fired during a client `HANDSHAKE`. This event allows for more versatile handshaking to occur - the Sponge implementations are limited to BungeeCord-specific handshaking currently.

To replicate the BungeeCord-style handshaking:
```java
    @Listener
    public void handshake(final ClientConnectionEvent.Handshake event) {
        String[] split = event.getHandshakeString().split("\00");
        if (split.length == 3 || split.length == 4) {
            event.setServerHostname(split[0]);
            event.setSocketAddressHostname(split[1]);

            GameProfile profile = GameProfile.of(UUID.fromString(split[2].replaceFirst("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})", "$1-$2-$3-$4-$5")), null);

            if (split.length == 4) {
                ProfileProperty[] properties = GSON.fromJson(split[3], ProfileProperty[].class);
                for (ProfileProperty property : properties) {
                    profile.getPropertyMap().put(property.getName(), property);
                }
            }

            event.setGameProfile(profile);
        } else {
            event.setFailed(true);
        }
    }
```