### PR TITLE
Annotation-based commands

### DIFF
--- a/src/main/java/org/spongepowered/api/command/AbstractCommandModule.java
+++ b/src/main/java/org/spongepowered/api/command/AbstractCommandModule.java
@@ -1,0 +1,366 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import org.slf4j.Logger;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.annotation.Command;
+import org.spongepowered.api.command.annotation.PlainDescription;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.command.args.parsing.InputTokenizer;
+import org.spongepowered.api.command.binding.Binder;
+import org.spongepowered.api.command.binding.BindingBuilder;
+import org.spongepowered.api.command.binding.BindingKey;
+import org.spongepowered.api.command.binding.ReadOnlyDelegateBinder;
+import org.spongepowered.api.command.binding.simple.SimpleBinder;
+import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.text.serializer.TextSerializer;
+import org.spongepowered.api.text.serializer.TextSerializers;
+import org.spongepowered.api.text.translation.TextFunction;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+/**
+ * A command module contributes configuration information to commands, and
+ * registers commands with a {@link CommandManager}.
+ *
+ * <p>A command module is <b>not</b> re-usable.</p>
+ */
+public abstract class AbstractCommandModule {
+
+    private Binder binder = new SimpleBinder();
+    @SuppressWarnings("NullableProblems")
+    private PluginContainer plugin;
+    @SuppressWarnings("NullableProblems")
+    private CommandManager manager;
+    private InputTokenizer inputTokenizer = InputTokenizer.quotedStrings(false);
+    private TextSerializer textSerializer = TextSerializers.FORMATTING_CODE;
+    @Nullable private CommandThrowableProcessor throwableProcessor;
+    @Nullable private TextFunction textFunction;
+    private CommandAuthorizer authorizer = CommandAuthorizer.CALLABLE;
+    private boolean configured;
+    private boolean registered;
+
+    protected AbstractCommandModule() {
+    }
+
+    /**
+     * Contributes bindings and other configurations for this module to {@code binder}.
+     *
+     * @param plugin The plugin
+     * @param manager The command manager
+     */
+    @SuppressWarnings("ConstantConditions")
+    public final void configure(PluginContainer plugin, CommandManager manager) {
+        checkState(this.manager == null, "Re-entry is not allowed.");
+        this.plugin = checkNotNull(plugin, "plugin");
+        this.manager = checkNotNull(manager, "manager");
+        this.preConfigure();
+        this.configure();
+        // Create a delegating read-only binder
+        this.binder = new ReadOnlyDelegateBinder(this.binder);
+        this.configured = true;
+    }
+
+    private void preConfigure() {
+        // Register a few of the most common arguments by default
+        this.bind(CommandSource.class).toProvider((source, args, modifiers) -> source);
+        this.bind(CommandArgs.class).toProvider((source, args, modifiers) -> args);
+        this.bind(Game.class).toProvider((source, args, modifiers) -> Sponge.getGame());
+        this.bind(Logger.class).toProvider((source, args, modifiers) -> this.plugin.getLogger());
+    }
+
+    private void noChangingRegistration(String what) {
+        checkState(!this.registered, "The %s cannot be changed after commands have been registered", what);
+    }
+
+    /**
+     * Determines if this command module can be installed or configured
+     * through a {@link CommandManager}.
+     *
+     * @param install {@code true} if we should check if this module
+     *     can be installed
+     * @return {@code true} if this command module can be installed
+     *     or configured
+     */
+    @SuppressWarnings("ConstantConditions")
+    public final boolean canBeInstalledOrConfigured(boolean install) {
+        return install ? (this.plugin == null && this.manager == null && !this.configured) : !this.configured;
+    }
+
+    /**
+     * Configure this command module.
+     *
+     * <p>You <b>must</b> {@link #register(Object) register commands} <i>after</i>
+     * you have configured any bindings, input tokenizer, etc.</p>
+     */
+    @SuppressWarnings("WeakerAccess")
+    protected abstract void configure();
+
+    /**
+     * Create a binding builder from a class type.
+     *
+     * @param clazz The class
+     * @param <T> The bound type
+     * @return A binding builder
+     */
+    protected final <T> BindingBuilder<T> bind(Class<T> clazz) {
+        this.noChangingRegistration("bindings");
+        return this.binder.bind(clazz);
+    }
+
+    /**
+     * Create a binding builder from a binding key.
+     *
+     * @param key The binding key
+     * @param <T> The bound type
+     * @return A binding builder
+     */
+    protected final <T> BindingBuilder<T> bind(BindingKey<T> key) {
+        this.noChangingRegistration("bindings");
+        return this.binder.bind(key);
+    }
+
+    /**
+     * Registers all found {@link Command annotation commands}.
+     *
+     * <p>You <b>must</b> register commands <i>after</i> you have
+     * configured any bindings, input tokenizer, etc.</p>
+     *
+     * @param object The object to register commands from
+     */
+    protected final void register(Object object) {
+        this.registered = true;
+        this.manager.register(this, object);
+    }
+
+    /**
+     * Register a given command using the given list of aliases.
+     *
+     * <p>You <b>must</b> register commands <i>after</i> you have
+     * configured any bindings, input tokenizer, etc.</p>
+     *
+     * <p>If there is a conflict with one of the aliases (i.e. that alias
+     * is already assigned to another command), then the alias will be skipped.
+     * It is possible for there to be no alias to be available out of
+     * the provided list of aliases, which would mean that the command would not
+     * be assigned to any aliases.</p>
+     *
+     * <p>The first non-conflicted alias becomes the "primary alias."</p>
+     *
+     * @param callable The command
+     * @param alias An array of aliases
+     * @return The registered command mapping, unless no aliases could be registered
+     * @throws IllegalArgumentException Thrown if {@code plugin} is not a plugin instance
+     * @see CommandManager#register(Object, CommandCallable, String...)
+     */
+    protected final Optional<CommandMapping> register(CommandCallable callable, String... alias) {
+        return this.register(callable, Arrays.asList(alias));
+    }
+
+    /**
+     * Register a given command using the given list of aliases.
+     *
+     * <p>You <b>must</b> register commands <i>after</i> you have
+     * configured any bindings, input tokenizer, etc.</p>
+     *
+     * <p>If there is a conflict with one of the aliases (i.e. that alias
+     * is already assigned to another command), then the alias will be skipped.
+     * It is possible for there to be no alias to be available out of
+     * the provided list of aliases, which would mean that the command would not
+     * be assigned to any aliases.</p>
+     *
+     * <p>The first non-conflicted alias becomes the "primary alias."</p>
+     *
+     * @param callable The command
+     * @param aliases A list of aliases
+     * @return The registered command mapping, unless no aliases could be registered
+     * @throws IllegalArgumentException Thrown if {@code plugin} is not a plugin instance
+     * @see CommandManager#register(Object, CommandCallable, List)
+     */
+    protected final Optional<CommandMapping> register(CommandCallable callable, List<String> aliases) {
+        return this.register(callable, aliases, Function.identity());
+    }
+
+    /**
+     * Register a given command using a given list of aliases.
+     *
+     * <p>You <b>must</b> register commands <i>after</i> you have
+     * configured any bindings, input tokenizer, etc.</p>
+     *
+     * <p>The provided callback function will be called with a list of aliases
+     * that are not taken (from the list of aliases that were requested) and
+     * it should return a list of aliases to actually register. Aliases may be
+     * removed, and if no aliases remain, then the command will not be
+     * registered. It may be possible that no aliases are available, and thus
+     * the callback would receive an empty list. New aliases should not be added
+     * to the list in the callback as this may cause
+     * {@link IllegalArgumentException} to be thrown.</p>
+     *
+     * <p>The first non-conflicted alias becomes the "primary alias."</p>
+     *
+     * @param callable The command
+     * @param aliases A list of aliases
+     * @param callback The callback
+     * @return The registered command mapping, unless no aliases could be registered
+     * @throws IllegalArgumentException Thrown if new conflicting aliases are added in the callback
+     * @throws IllegalArgumentException Thrown if {@code plugin} is not a plugin instance
+     * @see CommandManager#register(Object, CommandCallable, List, Function)
+     */
+    protected final Optional<CommandMapping> register(CommandCallable callable, List<String> aliases, Function<List<String>, List<String>> callback) {
+        this.registered = true;
+        return this.manager.register(this, callable, aliases, callback);
+    }
+
+    /**
+     * Gets the plugin container associated with this command module.
+     *
+     * @return The associated plugin container
+     */
+    public final PluginContainer getPlugin() {
+        return this.plugin;
+    }
+
+    /**
+     * Gets the binder for this dispatcher.
+     *
+     * @return The binder
+     */
+    public final Binder getBinder() {
+        return this.binder;
+    }
+
+    /**
+     * Gets the input tokenizer used for commands registered through
+     * this command module.
+     *
+     * @return The input tokenizer
+     */
+    public final InputTokenizer getInputTokenizer() {
+        return this.inputTokenizer;
+    }
+
+    /**
+     * Sets the input tokenizer used for commands registered through
+     * this command module.
+     *
+     * @param tokenizer The input tokenizer
+     */
+    protected final void setInputTokenizer(InputTokenizer tokenizer) {
+        this.noChangingRegistration("input tokenizer");
+        this.inputTokenizer = checkNotNull(tokenizer, "tokenizer");
+    }
+
+    /**
+     * Gets the text serializer used for commands registered through
+     * this command module that use {@link PlainDescription}.
+     *
+     * @return The text serializer
+     */
+    public final TextSerializer getTextSerializer() {
+        return this.textSerializer;
+    }
+
+    /**
+     * Sets the text serializer used for commands registered through
+     * this command module that use {@link PlainDescription}.
+     *
+     * @param serializer The text serializer
+     */
+    protected final void setTextSerializer(TextSerializer serializer) {
+        this.noChangingRegistration("text serializer");
+        this.textSerializer = checkNotNull(serializer, "serializer");
+    }
+
+    /**
+     * Gets the throwable processor used for commands registered through
+     * this command module that use {@link PlainDescription}.
+     *
+     * @return The throwable processor
+     */
+    public final Optional<CommandThrowableProcessor> getThrowableProcessor() {
+        return Optional.ofNullable(this.throwableProcessor);
+    }
+
+    /**
+     * Sets the throwable processor used for commands registered through
+     * this command module that use {@link PlainDescription}.
+     *
+     * @param processor The throwable processor
+     */
+    protected final void setThrowableProcessor(CommandThrowableProcessor processor) {
+        this.throwableProcessor = processor;
+    }
+
+    /**
+     * Gets the text function used for commands registered through
+     * this command module that use {@link PlainDescription}.
+     *
+     * @return The text function, if present, {@link Optional#empty()} otherwise
+     */
+    public final Optional<TextFunction> getTextFunction() {
+        return Optional.ofNullable(this.textFunction);
+    }
+
+    /**
+     * Sets the text function used for commands registered through
+     * this command module that use {@link PlainDescription}.
+     *
+     * @param function The text function
+     */
+    protected final void setTextFunction(TextFunction function) {
+        this.textFunction = function;
+    }
+
+    /**
+     * Gets the authorizer used for commands registered through
+     * this command module that use {@link PlainDescription}.
+     *
+     * @return The authorizer
+     */
+    public final CommandAuthorizer getAuthorizer() {
+        return this.authorizer;
+    }
+
+    /**
+     * Sets the authorizer used for commands registered through
+     * this command module that use {@link PlainDescription}.
+     *
+     * @param authorizer The authorizer
+     */
+    protected final void setAuthorizer(CommandAuthorizer authorizer) {
+        this.authorizer = checkNotNull(authorizer, "authorizer");
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/command/CommandAuthorizer.java
+++ b/src/main/java/org/spongepowered/api/command/CommandAuthorizer.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command;
+
+import java.util.function.BiPredicate;
+
+/**
+ * A command authorization checker.
+ */
+public interface CommandAuthorizer extends BiPredicate<CommandSource, CommandCallable> {
+
+    /**
+     * A command authorizer which asks the {@link CommandCallable} if
+     * the {@link CommandSource} has permissions.
+     */
+    CommandAuthorizer CALLABLE = (source, callable) -> callable.testPermission(source);
+
+    /**
+     * Determine if a command source has permission to execute a command callable
+     *
+     * @param source The command source
+     * @param callable The command callable
+     * @return {@code true} if the command source has permission to execute
+     *     the command callable
+     */
+    @Override
+    boolean test(CommandSource source, CommandCallable callable);
+
+}

--- a/src/main/java/org/spongepowered/api/command/CommandCallable.java
+++ b/src/main/java/org/spongepowered/api/command/CommandCallable.java
@@ -30,7 +30,6 @@ import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
 import java.util.List;
-import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -41,7 +40,7 @@ import javax.annotation.Nullable;
  * <p>Implementations are not required to implement a sane
  * {@link Object#equals(Object)} but really should.</p>
  */
-public interface CommandCallable {
+public interface CommandCallable extends CommandDescription {
 
     /**
      * Execute the command based on input arguments.
@@ -83,45 +82,4 @@ public interface CommandCallable {
      * @return Whether permission is (probably) granted
      */
     boolean testPermission(CommandSource source);
-
-    /**
-     * Gets a short one-line description of this command.
-     *
-     * <p>The help system may display the description in the command list.</p>
-     *
-     * @param source The source of the help request
-     * @return A description
-     */
-    Optional<Text> getShortDescription(CommandSource source);
-
-    /**
-     * Gets a longer formatted help message about this command.
-     *
-     * <p>It is recommended to use the default text color and style. Sections
-     * with text actions (e.g. hyperlinks) should be underlined.</p>
-     *
-     * <p>Multi-line messages can be created by separating the lines with
-     * {@code \n}.</p>
-     *
-     * <p>The help system may display this message when a source requests
-     * detailed information about a command.</p>
-     *
-     * @param source The source of the help request
-     * @return A help text
-     */
-    Optional<Text> getHelp(CommandSource source);
-
-    /**
-     * Gets the usage string of this command.
-     *
-     * <p>A usage string may look like
-     * {@code [-w &lt;world&gt;] &lt;var1&gt; &lt;var2&gt;}.</p>
-     *
-     * <p>The string must not contain the command alias.</p>
-     *
-     * @param source The source of the help request
-     * @return A usage string
-     */
-    Text getUsage(CommandSource source);
-
 }

--- a/src/main/java/org/spongepowered/api/command/CommandDescription.java
+++ b/src/main/java/org/spongepowered/api/command/CommandDescription.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command;
+
+import org.spongepowered.api.text.Text;
+
+import java.util.Optional;
+
+/**
+ * Provides descriptive information about a command.
+ */
+public interface CommandDescription {
+
+    /**
+     * Get a short one-line description of this command.
+     *
+     * <p>The help system may display the description in the command list.</p>
+     *
+     * @param source The source of the help request
+     * @return A description
+     */
+    Optional<Text> getShortDescription(CommandSource source);
+
+    /**
+     * Get a longer formatted help message about this command.
+     *
+     * <p>It is recommended to use the default text color and style. Sections
+     * with text actions (e.g. hyperlinks) should be underlined.</p>
+     *
+     * <p>Multi-line messages can be created by separating the lines with
+     * {@code \n}.</p>
+     *
+     * <p>The help system may display this message when a source requests
+     * detailed information about a command.</p>
+     *
+     * @param source The source of the help request
+     * @return A help text
+     */
+    Optional<Text> getHelp(CommandSource source);
+
+    /**
+     * Get the usage string of this command.
+     *
+     * <p>A usage string may look like
+     * {@code [-w &lt;world&gt;] &lt;var1&gt; &lt;var2&gt;}.</p>
+     *
+     * <p>The string must not contain the command alias.</p>
+     *
+     * @param source The source of the help request
+     * @return A usage string
+     */
+    Text getUsage(CommandSource source);
+
+}

--- a/src/main/java/org/spongepowered/api/command/CommandException.java
+++ b/src/main/java/org/spongepowered/api/command/CommandException.java
@@ -36,9 +36,12 @@ public class CommandException extends TextMessageException {
     private static final long serialVersionUID = 4626722485860074825L;
 
     private final boolean includeUsage;
+    private final boolean friendly;
 
     /**
      * Constructs a new {@link CommandException} with the given message.
+     *
+     * <p>This exception is "friendly", and can be displayed to users.</p>
      *
      * @param message The detail message
      */
@@ -49,6 +52,8 @@ public class CommandException extends TextMessageException {
     /**
      * Constructs a new {@link CommandException} with the given message and
      * the given cause.
+     *
+     * <p>This exception is "friendly", and can be displayed to users.</p>
      *
      * @param message The detail message
      * @param cause The cause
@@ -64,8 +69,21 @@ public class CommandException extends TextMessageException {
      * @param includeUsage Whether to include usage in the exception
      */
     public CommandException(Text message, boolean includeUsage) {
+        this(message, includeUsage, true);
+    }
+
+    /**
+     * Constructs a new {@link CommandException} with the given message.
+     *
+     * @param message The detail message
+     * @param includeUsage If the command usage should be included
+     * @param friendly If this exception is friendly and can
+     *     be displayed to users
+     */
+    public CommandException(Text message, boolean includeUsage, boolean friendly) {
         super(message);
         this.includeUsage = includeUsage;
+        this.friendly = friendly;
     }
 
     /**
@@ -77,8 +95,23 @@ public class CommandException extends TextMessageException {
      * @param includeUsage Whether to include the usage in the exception
      */
     public CommandException(Text message, Throwable cause, boolean includeUsage) {
+        this(message, cause, includeUsage, true);
+    }
+
+    /**
+     * Constructs a new {@link CommandException} with the given message and
+     * the given cause.
+     *
+     * @param message The detail message
+     * @param cause The cause
+     * @param includeUsage If the command usage should be included
+     * @param friendly If this exception is friendly and can
+     *     be displayed to users
+     */
+    public CommandException(Text message, Throwable cause, boolean includeUsage, boolean friendly) {
         super(message, cause);
         this.includeUsage = includeUsage;
+        this.friendly = friendly;
     }
 
     /**
@@ -90,4 +123,14 @@ public class CommandException extends TextMessageException {
     public boolean shouldIncludeUsage() {
         return this.includeUsage;
     }
+
+    /**
+     * Gets if this exception is "friendly".
+     *
+     * @return If this exception is friendly.
+     */
+    public boolean isFriendly() {
+        return this.friendly;
+    }
+
 }

--- a/src/main/java/org/spongepowered/api/command/CommandManager.java
+++ b/src/main/java/org/spongepowered/api/command/CommandManager.java
@@ -24,8 +24,9 @@
  */
 package org.spongepowered.api.command;
 
-import org.spongepowered.api.command.dispatcher.Dispatcher;
+import org.spongepowered.api.command.annotation.Command;
 import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.command.dispatcher.Dispatcher;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
@@ -110,6 +111,50 @@ public interface CommandManager extends Dispatcher {
      *     plugin instance
      */
     Optional<CommandMapping> register(Object plugin, CommandCallable callable, List<String> aliases, Function<List<String>, List<String>> callback);
+
+    /**
+     * Installs a {@link AbstractCommandModule} into this command manager.
+     *
+     * @param plugin The plugin instance
+     * @param module The command module
+     */
+    void install(Object plugin, AbstractCommandModule module);
+
+    /**
+     * Registers all found {@link Command annotation commands}.
+     *
+     * <p>This is an internal method and should <b>not</b> be called
+     * manually - it is called from within {@link AbstractCommandModule}.</p>
+     *
+     * @param module The command module we're registering for
+     * @param object The object to register commands from
+     */
+    void register(AbstractCommandModule module, Object object);
+
+    /**
+     * Register a given command using a given list of aliases.
+     *
+     * <p>This is an internal method and should <b>not</b> be called
+     * manually - it is called from within {@link AbstractCommandModule}.</p>
+     *
+     * <p>The provided callback function will be called with a list of aliases
+     * that are not taken (from the list of aliases that were requested) and
+     * it should return a list of aliases to actually register. Aliases may be
+     * removed, and if no aliases remain, then the command will not be
+     * registered. It may be possible that no aliases are available, and thus
+     * the callback would receive an empty list. New aliases should not be added
+     * to the list in the callback as this may cause
+     * {@link IllegalArgumentException} to be thrown.</p>
+     *
+     * <p>The first non-conflicted alias becomes the "primary alias."</p>
+     *
+     * @param callable The command
+     * @param aliases A list of aliases
+     * @param callback The callback
+     * @return The registered command mapping, unless no aliases could be registered
+     * @throws IllegalArgumentException Thrown if new conflicting aliases are added in the callback
+     */
+    Optional<CommandMapping> register(AbstractCommandModule module, CommandCallable callable, List<String> aliases, Function<List<String>, List<String>> callback);
 
     /**
      * Remove a command identified by the given mapping.

--- a/src/main/java/org/spongepowered/api/command/CommandThrowableProcessor.java
+++ b/src/main/java/org/spongepowered/api/command/CommandThrowableProcessor.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command;
+
+/**
+ * A {@link CommandCallable} {@link Throwable} processor.
+ */
+public interface CommandThrowableProcessor {
+
+    /**
+     * A helper to forward processing to the implementation.
+     */
+    CommandThrowableProcessor NOT_PROCESSED = (source, mapping, throwable) -> false;
+
+    /**
+     * Attempts to process a caught {@link Throwable} while processing a
+     * {@link CommandCallable}.
+     *
+     * <p>When {@code false} is returned, the throwable will be handled
+     * internally by the implementation.</p>
+     *
+     * @param source The command source
+     * @param mapping The command that was executed
+     * @param throwable The throwable
+     * @return {@code true} if the throwable was processed, {@code false} otherwise
+     */
+    boolean processCommandThrowable(CommandSource source, CommandMapping mapping, Throwable throwable);
+
+}

--- a/src/main/java/org/spongepowered/api/command/ImmutableCommandMapping.java
+++ b/src/main/java/org/spongepowered/api/command/ImmutableCommandMapping.java
@@ -36,7 +36,7 @@ import java.util.Set;
  * An immutable command mapping instance that returns the same objects that
  * this instance is constructed with.
  */
-public final class ImmutableCommandMapping implements CommandMapping {
+public class ImmutableCommandMapping implements CommandMapping {
 
     private final String primary;
     private final Set<String> aliases;

--- a/src/main/java/org/spongepowered/api/command/ImmutableModuleCommandMapping.java
+++ b/src/main/java/org/spongepowered/api/command/ImmutableModuleCommandMapping.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command;
+
+import java.util.Collection;
+
+public class ImmutableModuleCommandMapping extends ImmutableCommandMapping implements ModuleCommandMapping {
+
+    private final AbstractCommandModule module;
+
+    public ImmutableModuleCommandMapping(AbstractCommandModule module, CommandCallable callable, String primary, String... alias) {
+        super(callable, primary, alias);
+        this.module = module;
+    }
+
+    public ImmutableModuleCommandMapping(AbstractCommandModule module, CommandCallable callable, String primary, Collection<String> aliases) {
+        super(callable, primary, aliases);
+        this.module = module;
+    }
+
+    @Override
+    public AbstractCommandModule getModule() {
+        return this.module;
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/command/ModuleCommandMapping.java
+++ b/src/main/java/org/spongepowered/api/command/ModuleCommandMapping.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command;
+
+/**
+ * An extension of {@link CommandMapping} which provides
+ * the {@link AbstractCommandModule} this mapping was registered with.
+ */
+public interface ModuleCommandMapping extends CommandMapping {
+
+    /**
+     * Gets the module which created this mapping.
+     *
+     * @return The command module
+     */
+    AbstractCommandModule getModule();
+
+}

--- a/src/main/java/org/spongepowered/api/command/annotation/Classifier.java
+++ b/src/main/java/org/spongepowered/api/command/annotation/Classifier.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.annotation;
+
+import org.spongepowered.api.command.binding.BindingKey;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks another annotation as a "classifier".
+ *
+ * @see BindingKey
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface Classifier {
+
+}

--- a/src/main/java/org/spongepowered/api/command/annotation/Command.java
+++ b/src/main/java/org/spongepowered/api/command/annotation/Command.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.annotation;
+
+import org.spongepowered.api.command.CommandResult;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a method which should be registered as a command.
+ *
+ * <p>The return value of the method must be {@link CommandResult}.</p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Command {
+
+    /**
+     * Gets all aliases for this command.
+     *
+     * <p>The first element is the name of this command.</p>
+     *
+     * @return The command aliases
+     */
+    String[] value();
+
+}

--- a/src/main/java/org/spongepowered/api/command/annotation/Completion.java
+++ b/src/main/java/org/spongepowered/api/command/annotation/Completion.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+/**
+ * Marks a method that is to be used to provide command suggestions.
+ *
+ * <p>The return value of the method must be a {@link List} of {@link String}.</p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Completion {
+
+    /**
+     * Gets the command name parts for this completer.
+     *
+     * @return The command name parts
+     */
+    String[] value();
+
+}

--- a/src/main/java/org/spongepowered/api/command/annotation/Default.java
+++ b/src/main/java/org/spongepowered/api/command/annotation/Default.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a method that should be used as the default/fallback method.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Default {
+
+    /**
+     * Gets if the annotated method should only be used as a default method.
+     *
+     * <p>When this is set to <code>false</code> the method will also be registered
+     * as if it were a normal command, but will also be marked as the default.</p>
+     *
+     * @return if the method annotated should only be used as a default method
+     */
+    boolean defaultOnly() default false;
+
+}

--- a/src/main/java/org/spongepowered/api/command/annotation/Parent.java
+++ b/src/main/java/org/spongepowered/api/command/annotation/Parent.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a {@link Command} method which should be part of a parent.
+ *
+ * <p>This annotation can be repeated to assign multiple parents.</p>
+ *
+ * <p>When using {@link Parent}, additionally annotate with
+ * {@link Standalone} to register with no parent.</p>
+ */
+@Repeatable(Parent.Parents.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Parent {
+
+    /**
+     * Gets an array of parts which make up this group.
+     *
+     * @return An array of group parts
+     */
+    String[] value();
+
+    /**
+     * A holder of {@link Parent}s.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @interface Parents {
+
+        /**
+         * Gets an array of parents.
+         *
+         * @return An array of parents
+         */
+        Parent[] value();
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/command/annotation/Permission.java
+++ b/src/main/java/org/spongepowered/api/command/annotation/Permission.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.annotation;
+
+import org.spongepowered.api.command.CommandSource;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a a {@link Command} method that requires a permission, or a
+ * list of permissions, to be satisfied by the {@link CommandSource}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Permission {
+
+    /**
+     * Gets a list of permissions.
+     *
+     * <p>All permissions specified must be satisfied
+     * by the {@link CommandSource}.</p>
+     *
+     * @return An array of permissions
+     */
+    String[] value();
+
+}

--- a/src/main/java/org/spongepowered/api/command/annotation/PlainDescription.java
+++ b/src/main/java/org/spongepowered/api/command/annotation/PlainDescription.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.annotation;
+
+import org.spongepowered.api.text.Text;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a {@link Command} method which has plaintext descriptions.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface PlainDescription {
+
+    /**
+     * Gets the description of this command.
+     *
+     * <p>The value is converted to a {@link Text}
+     * using {@link Text#of(String)}.</p>
+     *
+     * @return The command description
+     */
+    String description();
+
+    /**
+     * Gets the usage for this command.
+     *
+     * <p>The value is converted to a {@link Text}
+     * using {@link Text#of(String)}.</p>
+     *
+     * @return The command usage
+     */
+    String usage();
+
+    /**
+     * Gets the help for this command.
+     *
+     * <p>The value is converted to a {@link Text}
+     * using {@link Text#of(String)}.</p>
+     *
+     * @return The command help
+     */
+    String help();
+
+}

--- a/src/main/java/org/spongepowered/api/command/annotation/Standalone.java
+++ b/src/main/java/org/spongepowered/api/command/annotation/Standalone.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a a {@link Command} method that should be
+ * registered outside of a parent.
+ *
+ * <p>This annotation should be used with {@link Parent}.</p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Standalone {
+
+}

--- a/src/main/java/org/spongepowered/api/command/annotation/TranslatableDescription.java
+++ b/src/main/java/org/spongepowered/api/command/annotation/TranslatableDescription.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a {@link Command} method which has translatable descriptions.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface TranslatableDescription {
+
+    /**
+     * Gets the translation key for the description of this command.
+     *
+     * @return The command description
+     */
+    String description();
+
+    /**
+     * Gets the translation key for the usage for this command.
+     *
+     * @return The command usage
+     */
+    String usage();
+
+    /**
+     * Gets the translation key for the help for this command.
+     *
+     * @return The command help
+     */
+    String help();
+
+}

--- a/src/main/java/org/spongepowered/api/command/annotation/package-info.java
+++ b/src/main/java/org/spongepowered/api/command/annotation/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.api.command.annotation;

--- a/src/main/java/org/spongepowered/api/command/args/ChildCommandElementExecutor.java
+++ b/src/main/java/org/spongepowered/api/command/args/ChildCommandElementExecutor.java
@@ -71,6 +71,15 @@ public class ChildCommandElementExecutor extends CommandElement implements Comma
     }
 
     /**
+     * Gets the dispatcher used by this child command executor.
+     *
+     * @return The dispatcher
+     */
+    public SimpleDispatcher getDispatcher() {
+        return this.dispatcher;
+    }
+
+    /**
      * Register a child command for a given set of aliases.
      *
      * @param callable The command to register

--- a/src/main/java/org/spongepowered/api/command/binding/Binder.java
+++ b/src/main/java/org/spongepowered/api/command/binding/Binder.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.binding;
+
+import org.spongepowered.api.command.provider.Provider;
+
+import java.util.Optional;
+
+/**
+ * A {@link Binding} manager.
+ */
+public interface Binder {
+
+    /**
+     * Gets the binding for the given binding key.
+     *
+     * @param key The binding key
+     * @param <T> The bound type
+     * @return The binding, or {@link Optional#empty()} if one was not found
+     */
+    <T> Optional<Binding<T>> getBinding(BindingKey<T> key);
+
+    /**
+     * Gets the binding for the given class.
+     *
+     * @param clazz The class
+     * @param <T> The bound type
+     * @return The binding, or {@link Optional#empty()} if one was not found
+     */
+    default <T> Optional<Binding<T>> getBinding(Class<T> clazz) {
+        return this.getBinding(BindingKey.of(clazz));
+    }
+
+    /**
+     * Gets the provider for the given binding key.
+     *
+     * @param key The binding key
+     * @param <T> The provided type
+     * @return The provider, or {@link Optional#empty()} if one was not found
+     */
+    <T> Optional<Provider<T>> getProvider(BindingKey<T> key);
+
+    /**
+     * Gets the provider for the given binding key.
+     *
+     * @param clazz The class
+     * @param <T> The provided type
+     * @return The provider, or {@link Optional#empty()} if one was not found
+     */
+    default <T> Optional<Provider<T>> getProvider(Class<T> clazz) {
+        return this.getProvider(BindingKey.of(clazz));
+    }
+
+    /**
+     * Create a binding builder from a class type.
+     *
+     * @param clazz The class
+     * @param <T> The bound type
+     * @return A binding builder
+     */
+    default <T> BindingBuilder<T> bind(Class<T> clazz) {
+        return this.bind(BindingKey.of(clazz));
+    }
+
+    /**
+     * Create a binding builder from a binding key.
+     *
+     * @param key The binding key
+     * @param <T> The bound type
+     * @return A binding builder
+     */
+    <T> BindingBuilder<T> bind(BindingKey<T> key);
+
+}

--- a/src/main/java/org/spongepowered/api/command/binding/Binding.java
+++ b/src/main/java/org/spongepowered/api/command/binding/Binding.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.binding;
+
+import org.spongepowered.api.command.provider.Provider;
+
+/**
+ * A mapping from a binding key (type and optional annotation) to the
+ * provider for getting instances of the {@link T type}.
+ *
+ * @param <T> The bound type
+ */
+public interface Binding<T> extends Comparable<Binding<?>> {
+
+    /**
+     * Gets the key representing the type.
+     *
+     * @return The key
+     */
+    BindingKey<T> getKey();
+
+    /**
+     * Gets the provider.
+     *
+     * @return The provider
+     */
+    Provider<T> getProvider();
+
+}

--- a/src/main/java/org/spongepowered/api/command/binding/BindingBuilder.java
+++ b/src/main/java/org/spongepowered/api/command/binding/BindingBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.binding;
+
+import org.spongepowered.api.command.provider.Provider;
+
+import java.lang.annotation.Annotation;
+
+import javax.annotation.Nullable;
+
+/**
+ * A binding builder.
+ *
+ * @param <T> The bound type
+ */
+public interface BindingBuilder<T> {
+
+    /**
+     * Sets the classifier the binding will listen for.
+     *
+     * @param annotation The classifier annotation class
+     * @return This builder
+     */
+    BindingBuilder<T> annotatedWith(@Nullable Class<? extends Annotation> annotation);
+
+    /**
+     * Creates a binding that is provided by the given provider class.
+     * @param provider The provider
+     */
+    void toProvider(Provider<T> provider);
+
+    /**
+     * Creates a binding that is provided by the given static instance.
+     *
+     * @param instance The instance to provide
+     */
+    void toInstance(T instance);
+
+}

--- a/src/main/java/org/spongepowered/api/command/binding/BindingKey.java
+++ b/src/main/java/org/spongepowered/api/command/binding/BindingKey.java
@@ -1,0 +1,156 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.binding;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Objects;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+
+/**
+ * A binding key consists of an injection type and an optional annotation.
+ *
+ * @param <T> The bound type
+ */
+public final class BindingKey<T> implements Comparable<BindingKey<?>>, Predicate<BindingKey<?>> {
+
+    private final Type type;
+    @Nullable private final Class<? extends Annotation> classifier;
+
+    /**
+     * Creates a binding key from the provided class.
+     *
+     * @param clazz The class
+     * @param <T> The bound type
+     * @return A binding key
+     */
+    public static <T> BindingKey<T> of(Class<T> clazz) {
+        return new BindingKey<>(clazz, null);
+    }
+
+    /**
+     * Creates a binding key from the provided class and classifier.
+     *
+     * @param clazz The class
+     * @param classifier The classifier annotation
+     * @param <T> The bound type
+     * @return A binding key
+     */
+    public static <T> BindingKey<T> of(Class<T> clazz, @Nullable Class<? extends Annotation> classifier) {
+        return new BindingKey<>(clazz, classifier);
+    }
+
+    /**
+     * Creates a binding key from the provided type.
+     *
+     * @param type The type
+     * @param <T> The bound type
+     * @return A binding key
+     */
+    public static <T> BindingKey<T> of(Type type) {
+        return new BindingKey<>(type, null);
+    }
+
+    /**
+     * Creates a binding key from the provided type and classifier.
+     *
+     * @param type The type
+     * @param classifier The classifier annotation
+     * @param <T> The bound type
+     * @return A binding key
+     */
+    public static <T> BindingKey<T> of(Type type, @Nullable Class<? extends Annotation> classifier) {
+        return new BindingKey<>(type, classifier);
+    }
+
+    /**
+     * Creates a binding key
+     *
+     * @param type The type
+     * @param classifier The classifier annotation
+     */
+    private BindingKey(Type type, @Nullable Class<? extends Annotation> classifier) {
+        this.type = checkNotNull(type, "type");
+        this.classifier = classifier;
+    }
+
+    /**
+     * Gets the type.
+     *
+     * @return The type
+     */
+    public Type getType() {
+        return this.type;
+    }
+
+    /**
+     * Gets the classifier annotation.
+     *
+     * @return The classifier annotation
+     */
+    public Optional<Class<? extends Annotation>> getClassifier() {
+        return Optional.ofNullable(this.classifier);
+    }
+
+    /**
+     * Sets the annotation classifier.
+     *
+     * @param classifier The classifier annotation
+     * @return A new binding key
+     */
+    public BindingKey<T> setClassifier(@Nullable Class<? extends Annotation> classifier) {
+        return new BindingKey<>(this.type, classifier);
+    }
+
+    /**
+     * Determines if another binding key matches this binding key.
+     *
+     * @param that The other binding key
+     * @return {@code true} if the other binding key matches, {@code false} otherwise
+     */
+    @Override
+    public boolean test(BindingKey<?> that) {
+        checkNotNull(that, "that");
+        return Objects.equal(this.type, that.type) && Objects.equal(this.classifier, that.classifier);
+    }
+
+    @Override
+    public int compareTo(BindingKey<?> that) {
+        if (this.classifier != null && that.classifier == null) {
+            return -1;
+        } else if (this.classifier == null && that.classifier != null) {
+            return 1;
+        }
+
+        return 0;
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/command/binding/ReadOnlyDelegateBinder.java
+++ b/src/main/java/org/spongepowered/api/command/binding/ReadOnlyDelegateBinder.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.binding;
+
+import org.spongepowered.api.command.provider.Provider;
+
+import java.util.Optional;
+
+/**
+ * A read-only delegating {@link Binder}.
+ *
+ * <p>Attempting to write to this binder will result in
+ * an {@link UnsupportedOperationException}.</p>
+ */
+public final class ReadOnlyDelegateBinder implements Binder {
+
+    private final Binder binder;
+
+    public ReadOnlyDelegateBinder(Binder binder) {
+        this.binder = binder;
+    }
+
+    @Override
+    public <T> Optional<Binding<T>> getBinding(BindingKey<T> key) {
+        return this.binder.getBinding(key);
+    }
+
+    @Override
+    public <T> Optional<Provider<T>> getProvider(BindingKey<T> key) {
+        return this.binder.getProvider(key);
+    }
+
+    @Override
+    public <T> BindingBuilder<T> bind(BindingKey<T> key) {
+        throw new UnsupportedOperationException("This binder is read-only.");
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/command/binding/package-info.java
+++ b/src/main/java/org/spongepowered/api/command/binding/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.api.command.binding;

--- a/src/main/java/org/spongepowered/api/command/binding/simple/SimpleBinder.java
+++ b/src/main/java/org/spongepowered/api/command/binding/simple/SimpleBinder.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.binding.simple;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import org.spongepowered.api.command.binding.Binder;
+import org.spongepowered.api.command.binding.Binding;
+import org.spongepowered.api.command.binding.BindingBuilder;
+import org.spongepowered.api.command.binding.BindingKey;
+import org.spongepowered.api.command.provider.Provider;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+/**
+ * A simple implementation of {@link Binder}.
+ */
+public final class SimpleBinder implements Binder {
+
+    private final Multimap<Type, Binding<?>> bindings = Multimaps.newMultimap(Maps.newHashMap(), Sets::newTreeSet);
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Optional<Binding<T>> getBinding(BindingKey<T> key) {
+        for (Binding<?> binding : this.bindings.get(key.getType())) {
+            if (binding.getKey().test(key)) {
+                return Optional.of((Binding<T>) binding);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Add a provider binding.
+     *
+     * @param key The binding key
+     * @param provider The provider
+     * @param <T> The bound type
+     */
+    <T> void addBinding(BindingKey<T> key, Provider<T> provider) {
+        this.bindings.put(key.getType(), new SimpleBinding<>(key, provider));
+    }
+
+    @Override
+    public <T> Optional<Provider<T>> getProvider(BindingKey<T> key) {
+        return this.getBinding(key).map(Binding::getProvider);
+    }
+
+    @Override
+    public <T> BindingBuilder<T> bind(BindingKey<T> key) {
+        return new SimpleBindingBuilder<>(this, key);
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/command/binding/simple/SimpleBinding.java
+++ b/src/main/java/org/spongepowered/api/command/binding/simple/SimpleBinding.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.binding.simple;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.command.binding.Binding;
+import org.spongepowered.api.command.binding.BindingKey;
+import org.spongepowered.api.command.provider.Provider;
+
+/**
+ * A simple implementation of {@link Binding}.
+ *
+ * @param <T> The bound type
+ */
+final class SimpleBinding<T> implements Binding<T> {
+
+    private final BindingKey<T> key;
+    private final Provider<T> provider;
+
+    /**
+     * Constructs a new simple binding.
+     *
+     * @param key The binding key
+     * @param provider The provider
+     */
+    SimpleBinding(BindingKey<T> key, Provider<T> provider) {
+        this.key = checkNotNull(key, "key");
+        this.provider = checkNotNull(provider, "provider");
+    }
+
+    @Override
+    public BindingKey<T> getKey() {
+        return this.key;
+    }
+
+    @Override
+    public Provider<T> getProvider() {
+        return this.provider;
+    }
+
+    @Override
+    public int compareTo(Binding<?> that) {
+        return this.getKey().compareTo(that.getKey());
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/command/binding/simple/SimpleBindingBuilder.java
+++ b/src/main/java/org/spongepowered/api/command/binding/simple/SimpleBindingBuilder.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.binding.simple;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.command.annotation.Classifier;
+import org.spongepowered.api.command.binding.BindingBuilder;
+import org.spongepowered.api.command.binding.BindingKey;
+import org.spongepowered.api.command.provider.Provider;
+import org.spongepowered.api.command.provider.StaticProvider;
+
+import java.lang.annotation.Annotation;
+
+import javax.annotation.Nullable;
+
+/**
+ * A simple implementation of {@link BindingBuilder}.
+ *
+ * @param <T> The bound type
+ */
+final class SimpleBindingBuilder<T> implements BindingBuilder<T> {
+
+    private final SimpleBinder binder;
+    private BindingKey<T> key;
+
+    /**
+     * Constructs a new binding builder.
+     *
+     * @param binder The binder
+     * @param key The binding key
+     */
+    SimpleBindingBuilder(SimpleBinder binder, BindingKey<T> key) {
+        this.binder = checkNotNull(binder, "binder");
+        this.key = checkNotNull(key, "key");
+    }
+
+    @Override
+    public BindingBuilder<T> annotatedWith(@Nullable Class<? extends Annotation> annotation) {
+        if (annotation != null) {
+            checkArgument(annotation.getAnnotation(Classifier.class) != null, "The '@%s' annotation must be decorated with '@%s' to be used as a "
+                    + "classifier", annotation.getName(), Classifier.class.getName());
+        }
+
+        this.key = this.key.setClassifier(annotation);
+        return this;
+    }
+
+    @Override
+    public void toProvider(Provider<T> provider) {
+        this.binder.addBinding(this.key, checkNotNull(provider, "provider"));
+    }
+
+    @Override
+    public void toInstance(T instance) {
+        this.toProvider(new StaticProvider<>(instance));
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/command/binding/simple/package-info.java
+++ b/src/main/java/org/spongepowered/api/command/binding/simple/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.api.command.binding.simple;

--- a/src/main/java/org/spongepowered/api/command/provider/Provider.java
+++ b/src/main/java/org/spongepowered/api/command/provider/Provider.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.provider;
+
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandArgs;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+
+/**
+ * An object capable of providing instances of type {@link T}.
+ *
+ * @param <T> The type of object this provider provides
+ */
+public interface Provider<T> {
+
+    /**
+     * Provides an instance of {@link T}.
+     *
+     * @param source The command source
+     * @param args The command arguments
+     * @param modifiers The annotation modifiers
+     * @return An instance of {@link T}
+     * @throws ProvisionException If an instance could not be provided
+     */
+    T get(CommandSource source, CommandArgs args, Collection<? extends Annotation> modifiers) throws ProvisionException;
+
+}

--- a/src/main/java/org/spongepowered/api/command/provider/ProvisionException.java
+++ b/src/main/java/org/spongepowered/api/command/provider/ProvisionException.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.provider;
+
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.text.Text;
+
+/**
+ * An exception indicating that there was a failure while providing
+ * an instance from a {@link Provider}.
+ */
+public class ProvisionException extends CommandException {
+
+    /**
+     * Constructs a new provision exception with a message.
+     *
+     * @param message The message
+     */
+    public ProvisionException(Text message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new provision exception with a message and cause.
+     *
+     * @param message The message
+     * @param cause The cause
+     */
+    public ProvisionException(Text message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/command/provider/StaticProvider.java
+++ b/src/main/java/org/spongepowered/api/command/provider/StaticProvider.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.provider;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandArgs;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+
+/**
+ * A provider which provides a static instance.
+ *
+ * @param <T> The type of object this provider provides
+ */
+public final class StaticProvider<T> implements Provider<T> {
+
+    private final T instance;
+
+    /**
+     * Constructs a new static provider.
+     *
+     * @param instance The instance to provide
+     */
+    public StaticProvider(T instance) {
+        this.instance = checkNotNull(instance, "instance");
+    }
+
+    @Override
+    public T get(CommandSource source, CommandArgs args, Collection<? extends Annotation> modifiers) {
+        return this.instance;
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/command/provider/package-info.java
+++ b/src/main/java/org/spongepowered/api/command/provider/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.api.command.provider;

--- a/src/main/java/org/spongepowered/api/text/translation/TextFunction.java
+++ b/src/main/java/org/spongepowered/api/text/translation/TextFunction.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.text.translation;
+
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.channel.MessageReceiver;
+
+import java.util.function.BiFunction;
+
+/**
+ * A text function takes a message receiver and string key, and provides
+ * a {@link Text} to be used.
+ */
+public interface TextFunction extends BiFunction<MessageReceiver, String, Text> {
+
+    @Override
+    Text apply(MessageReceiver receiver, String key);
+
+}


### PR DESCRIPTION
[**API**](https://github.com/SpongePowered/SpongeAPI/pull/1201) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/675)
Implements #1171 

---

This PR adds an annotation-based command API to SpongeAPI.

Example:

``` java
    @Listener
    public void starting(final GameStartingServerEvent event) {
        this.game.getCommandManager().install(this, new AbstractCommandModule() {
            @Override
            protected void configure() {
                // Here I bind any commands registered through this command module who has `Logger` in the signature
                // to `MiserableTest.this.logger` which, in this case, is the Logger of my test plugin.
                this.bind(Logger.class).toProvider((args, modifiers) -> MiserableTest.this.logger);
                // Here I bind any commands registered through this command module who has `World` in the signature
                // to the first world found using the iterator which, in this case, is the Logger of my test plugin.
                this.bind(World.class).toProvider((args, modifiers) -> Sponge.getServer().getWorlds().iterator().next());
                this.register(new ExampleCommands());
            }
        });
    }

    public static class ExampleCommands {

        /*
         * /kittens actions
         * /cats actions
         */
        // @formatter:off
        @Parent("kittens")
        @Parent("cats")
        @Command("actions")
        @Permission({
            "example.kittens",
            "example.kittens.actions"
        })
        @PlainDescription(
            description = "Display a listing of actions",
            usage = "/kittens pet",
            help = ""
        )
        @Default(defaultOnly = true)
        // @formatter:on
        public CommandResult actions(CommandSource source) {
            source.sendMessage(Text.of("Actions"));
            return CommandResult.success();
        }

        /*
         * /kittens actions pet
         * /cats actions pet
         */
        // @formatter:off
        @Parent({"kittens", "actions"})
        @Parent({"cats", "actions"})
        @Command("pet")
        @Permission({
            "example.kittens",
            "example.kittens.actions",
            "example.kittens.actions.pet"
        })
        // The description, usage, and help texts are static.
        @PlainDescription(
            description = "Pet the kitty",
            usage = "/kittens pet",
            help = "how2helppet?"
        )
        // @formatter:on
        public CommandResult pet(Logger logger, CommandSource source) {
            source.sendMessage(Text.of("Success from pet"));
            logger.info("Meow.");
            return CommandResult.success();
        }
    }
```

---

Thanks to @jamierocks for his initial work on #1186 
