### PR TITLE
Add the SpongeAPI dependency to the annotation processor.

### DIFF
--- a/api-revision.gradle
+++ b/api-revision.gradle
@@ -1,0 +1,15 @@
+// This task attempts to execute 'git rev-parse --short HEAD' on the SpongeAPI
+// submodule to resolve the current API revision short hash. If successful, it
+// will append it to the SpongeAPI version included in the implementation
+// jar files.
+task('resolveApiRevision') << {
+    def process = ['git', 'rev-parse', '--short', 'HEAD'].execute(null as String[], projectDir)
+
+    def result = process.waitFor()
+    if (result == 0) {
+        version += '-' + process.inputStream.readLines().first().trim()
+    } else {
+        logger.warn('Failed to resolve API revision (Process returned error code {})', result)
+        return
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ buildscript {
 
 version = '4.1.0-SNAPSHOT'
 
+apply from: file('api-revision.gradle')
+
 // Include shared Gradle configuration
 ext.api = project
 apply from: 'gradle/sponge.gradle'

--- a/gradle/sponge.gradle
+++ b/gradle/sponge.gradle
@@ -50,10 +50,15 @@ test {
 
 // Set manifest entries
 jar {
+    dependsOn api.resolveApiRevision
     manifest {
         attributes(
                 'Built-By': System.properties['user.name'],
                 'Created-By': "${System.properties['java.vm.version']} (${System.properties['java.vm.vendor']})",
+
+                'Specification-Title': api.name,
+                'Specification-Version': api.version,
+                'Specification-Vendor': api.url,
 
                 'Implementation-Title': project.name,
                 'Implementation-Vendor': project.url
@@ -156,4 +161,9 @@ apply from: api.file('gradle/deploy.gradle')
 // Gradle version used for generating the Gradle wrapper
 task wrapper(type: Wrapper) {
     gradleVersion = '2.12'
+}
+
+// Append API revision to the SpongeAPI version
+api.resolveApiRevision << {
+    jar.manifest.attributes('Specification-Version': api.version)
 }

--- a/src/main/java/org/spongepowered/api/Platform.java
+++ b/src/main/java/org/spongepowered/api/Platform.java
@@ -27,12 +27,33 @@ package org.spongepowered.api;
 import org.spongepowered.api.plugin.PluginContainer;
 
 import java.util.Map;
+import java.util.Optional;
+
+import com.google.common.base.Objects;
 
 /**
  * Represents a possible platform or implementation a {@link Game} could be
  * running on.
  */
 public interface Platform {
+
+    /**
+     * The {@linkplain PluginContainer#getId() plugin ID} of the {@linkplain
+     * #getApi() SpongeAPI plugin container}.
+     */
+    String API_ID = "spongeapi";
+
+    /**
+     * The {@linkplain PluginContainer#getName() name} of the {@linkplain
+     * #getApi() SpongeAPI plugin container}.
+     */
+    String API_NAME = Objects.firstNonNull(Platform.class.getPackage().getSpecificationTitle(), "SpongeAPI");
+
+    /**
+     * The {@linkplain PluginContainer#getVersion() version} of the {@linkplain
+     * #getApi() SpongeAPI plugin container}.
+     */
+    Optional<String> API_VERSION = Optional.ofNullable(Platform.class.getPackage().getSpecificationVersion());
 
     /**
      * Retrieves the current {@link Type} this platform is running on.


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/687) | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/622) | [SpongeVanilla](https://github.com/SpongePowered/SpongeVanilla/pull/238)

Allows SpongePowered/Ore#95 to be added without giving (most) plugin developers any additional work. This uses a dependency version range, so it will work with any SpongeAPI version that's guaranteed to be compatible.