### PR TITLE
Arrow pickup rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,7 @@ sortClassFields {
     add 'main', 'org.spongepowered.api.data.type.LogAxes'
     add 'main', 'org.spongepowered.api.data.type.NotePitches'
     add 'main', 'org.spongepowered.api.data.type.OcelotTypes'
+    add 'main', 'org.spongepowered.api.data.type.PickupRules'
     add 'main', 'org.spongepowered.api.data.type.PistonTypes'
     add 'main', 'org.spongepowered.api.data.type.PlantTypes'
     add 'main', 'org.spongepowered.api.data.type.PortionTypes'

--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -44,6 +44,7 @@ import org.spongepowered.api.entity.EntitySnapshot;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.projectile.arrow.Arrow;
 import org.spongepowered.api.util.RespawnLocation;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.entity.vehicle.minecart.CommandBlockMinecart;
@@ -610,6 +611,13 @@ public final class Keys {
     public static final Key<ListValue<EntitySnapshot>> PASSENGERS = KeyFactory.fake("PASSENGERS");
 
     public static final Key<Value<Boolean>> PERSISTS = KeyFactory.fake("PERSISTS");
+
+    /**
+     * Represents the {@link Key} for the "pickup rule" of an {@link Arrow}.
+     *
+     * @see PickupRuleData#rule()
+     */
+    public static final Key<Value<PickupRule>> PICKUP_RULE = KeyFactory.fake("PICKUP_RULE");
 
     public static final Key<Value<Boolean>> PIG_SADDLE = KeyFactory.fake("PIG_SADDLE");
 

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutablePickupRuleData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutablePickupRuleData.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.ImmutableVariantData;
+import org.spongepowered.api.data.manipulator.mutable.entity.PickupRuleData;
+import org.spongepowered.api.data.type.PickupRule;
+import org.spongepowered.api.entity.projectile.arrow.Arrow;
+
+/**
+ * An {@link ImmutableDataManipulator} for the "pickup" rule of an
+ * {@link Arrow}.
+ */
+public interface ImmutablePickupRuleData extends ImmutableVariantData<PickupRule, ImmutablePickupRuleData, PickupRuleData> {
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/PickupRuleData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/PickupRuleData.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutablePickupRuleData;
+import org.spongepowered.api.data.manipulator.mutable.VariantData;
+import org.spongepowered.api.data.type.PickupRule;
+import org.spongepowered.api.entity.projectile.arrow.Arrow;
+
+/**
+ * A {@link DataManipulator} for the "pickup" rule of an
+ * {@link Arrow}.
+ */
+public interface PickupRuleData extends VariantData<PickupRule, PickupRuleData, ImmutablePickupRuleData> {
+
+}

--- a/src/main/java/org/spongepowered/api/data/type/PickupRule.java
+++ b/src/main/java/org/spongepowered/api/data/type/PickupRule.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.type;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.entity.projectile.arrow.Arrow;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
+/**
+ * Represents a pickup rule used by {@link Arrow}s.
+ */
+@CatalogedBy(PickupRules.class)
+public interface PickupRule extends CatalogType {
+
+}

--- a/src/main/java/org/spongepowered/api/data/type/PickupRules.java
+++ b/src/main/java/org/spongepowered/api/data/type/PickupRules.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.type;
+
+import org.spongepowered.api.entity.projectile.arrow.Arrow;
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+
+/**
+ * An enumeration of the vanilla pickup rules for an {@link Arrow}.
+ */
+public final class PickupRules {
+
+    // SORTFIELDS:ON
+
+    public static final PickupRule ALLOWED = dummy("ALLOWED");
+
+    public static final PickupRule CREATIVE_ONLY = dummy("CREATIVE_ONLY");
+
+    public static final PickupRule DISALLOWED = dummy("DISALLOWED");
+
+    // SORTFIELDS:OFF
+
+    private PickupRules() {
+    }
+
+    private static PickupRule dummy(String fieldName) {
+        return DummyObjectProvider.createFor(PickupRule.class, fieldName);
+    }
+
+}


### PR DESCRIPTION
[**API**](https://github.com/SpongePowered/SpongeAPI/pull/1218) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/693)
Supersedes #1193 
This adds an API to control an `Arrow`s pickup rule.