### PR TITLE
Update MobSpawnerData for Archetypes

### DIFF
--- a/src/main/java/org/spongepowered/api/block/tileentity/MobSpawner.java
+++ b/src/main/java/org/spongepowered/api/block/tileentity/MobSpawner.java
@@ -27,9 +27,10 @@ package org.spongepowered.api.block.tileentity;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.mutable.MobSpawnerData;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.data.value.mutable.WeightedCollectionValue;
 import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.entity.EntitySnapshot;
+import org.spongepowered.api.entity.EntityArchetype;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.util.weighted.WeightedSerializableObject;
 
@@ -132,7 +133,7 @@ public interface MobSpawner extends TileEntity {
     }
 
     /**
-     * Gets the {@link org.spongepowered.api.data.manipulator.mutable.MobSpawnerData.NextEntityToSpawnValue}
+     * Gets the {@link Value}
      * for the overridden
      * {@link WeightedSerializableObject}{@code <EntitySnapshot>} to spawn
      * next. If possible, the next entity to spawn may be chosen from the
@@ -140,7 +141,7 @@ public interface MobSpawner extends TileEntity {
      *
      * @return The next possible entity to spawn
      */
-    default MobSpawnerData.NextEntityToSpawnValue nextEntityToSpawn() {
+    default Value<WeightedSerializableObject<EntityArchetype>> nextEntityToSpawn() {
         return getValue(Keys.SPAWNER_NEXT_ENTITY_TO_SPAWN).get();
     }
 
@@ -154,7 +155,7 @@ public interface MobSpawner extends TileEntity {
      *
      * @return The immutable weighted entity collection value of entities
      */
-    default WeightedCollectionValue<EntitySnapshot> possibleEntitiesToSpawn() {
+    default WeightedCollectionValue<EntityArchetype> possibleEntitiesToSpawn() {
         return getValue(Keys.SPAWNER_ENTITIES).get();
     }
 

--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -40,13 +40,13 @@ import org.spongepowered.api.data.value.mutable.*;
 import org.spongepowered.api.effect.potion.PotionEffect;
 import org.spongepowered.api.effect.potion.PotionEffectType;
 import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.EntityArchetype;
 import org.spongepowered.api.entity.EntitySnapshot;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.Item;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.projectile.arrow.Arrow;
-import org.spongepowered.api.util.RespawnLocation;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.entity.vehicle.minecart.CommandBlockMinecart;
 import org.spongepowered.api.entity.vehicle.minecart.Minecart;
@@ -62,7 +62,9 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.Axis;
 import org.spongepowered.api.util.Color;
 import org.spongepowered.api.util.Direction;
+import org.spongepowered.api.util.RespawnLocation;
 import org.spongepowered.api.util.rotation.Rotation;
+import org.spongepowered.api.util.weighted.WeightedSerializableObject;
 
 import java.time.Instant;
 import java.util.List;
@@ -838,7 +840,7 @@ public final class Keys {
 
     public static final Key<Value<EntityType>> SPAWNABLE_ENTITY_TYPE = KeyFactory.fake("SPAWNABLE_ENTITY_TYPE");
 
-    public static final Key<WeightedCollectionValue<EntitySnapshot>> SPAWNER_ENTITIES = KeyFactory.fake("SPAWNER_ENTITIES");
+    public static final Key<WeightedCollectionValue<EntityArchetype>> SPAWNER_ENTITIES = KeyFactory.fake("SPAWNER_ENTITIES");
 
     public static final Key<MutableBoundedValue<Short>> SPAWNER_MAXIMUM_DELAY = KeyFactory.fake("SPAWNER_MAXIMUM_DELAY");
 
@@ -846,7 +848,8 @@ public final class Keys {
 
     public static final Key<MutableBoundedValue<Short>> SPAWNER_MINIMUM_DELAY = KeyFactory.fake("SPAWNER_MINIMUM_DELAY");
 
-    public static final Key<MobSpawnerData.NextEntityToSpawnValue> SPAWNER_NEXT_ENTITY_TO_SPAWN = KeyFactory.fake("SPAWNER_NEXT_ENTITY_TO_SPAWN");
+    public static final Key<Value<WeightedSerializableObject<EntityArchetype>>> SPAWNER_NEXT_ENTITY_TO_SPAWN =
+            KeyFactory.fake("SPAWNER_NEXT_ENTITY_TO_SPAWN");
 
     public static final Key<MutableBoundedValue<Short>> SPAWNER_REMAINING_DELAY = KeyFactory.fake("SPAWNER_REMAINING_DELAY");
 

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableMobSpawnerData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutableMobSpawnerData.java
@@ -25,25 +25,18 @@
 package org.spongepowered.api.data.manipulator.immutable;
 
 import org.spongepowered.api.block.tileentity.MobSpawner;
-import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.MobSpawnerData;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.immutable.ImmutableWeightedCollectionValue;
-import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.entity.EntitySnapshot;
-import org.spongepowered.api.entity.EntityType;
+import org.spongepowered.api.entity.EntityArchetype;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.vehicle.minecart.MobSpawnerMinecart;
 import org.spongepowered.api.util.weighted.WeightedSerializableObject;
 
-import java.util.Collection;
 import java.util.Random;
-import java.util.function.Function;
-
-import javax.annotation.Nullable;
 
 /**
  * An {@link ImmutableDataManipulator} for all information surrounding a
@@ -117,14 +110,14 @@ public interface ImmutableMobSpawnerData extends ImmutableDataManipulator<Immuta
     ImmutableBoundedValue<Short> spawnRange();
 
     /**
-     * Gets the {@link ImmutableNextEntityToSpawnValue} for the overridden
-     * {@link WeightedSerializableObject} to spawn next. If possible, the next entity to
+     * Gets the {@link ImmutableValue} for the overridden
+     * {@link WeightedSerializableObject}{@code <EntityArchetype>} to spawn next. If possible, the next entity to
      * spawn may be chosen from the already provided
      * {@link #possibleEntitiesToSpawn()}.
      *
      * @return The next possible entity to spawn
      */
-    ImmutableNextEntityToSpawnValue nextEntityToSpawn();
+    ImmutableValue<WeightedSerializableObject<EntityArchetype>> nextEntityToSpawn();
 
     /**
      * Gets the {@link ImmutableWeightedCollectionValue} of all possible
@@ -135,38 +128,5 @@ public interface ImmutableMobSpawnerData extends ImmutableDataManipulator<Immuta
      *
      * @return The immutable weighted entity collection value of entities
      */
-    ImmutableWeightedCollectionValue<EntitySnapshot> possibleEntitiesToSpawn();
-
-    /**
-     * Represents a custom {@link Value} dealing with the next
-     * {@link WeightedSerializableObject} such that the next {@link Entity} to
-     * spawn may be pulled from the owning {@link #possibleEntitiesToSpawn()}
-     * with a default {@link Random}, or it may be custom defined on a case by
-     * case basis.
-     */
-    interface ImmutableNextEntityToSpawnValue extends ImmutableValue<WeightedSerializableObject<EntitySnapshot>> {
-
-        /**
-         * Creates a new {@link ImmutableNextEntityToSpawnValue} with the
-         * provided {@link EntityType} and {@link Collection} of
-         * {@link DataManipulator}s.
-         *
-         * @param type The type of {@link Entity}
-         * @param additionalProperties Any additional properties to spawn the
-         *     {@link Entity} with
-         * @return The new value, for chaining
-         */
-        ImmutableNextEntityToSpawnValue with(EntityType type, @Nullable Collection<DataManipulator<?, ?>> additionalProperties);
-
-        @Override
-        ImmutableNextEntityToSpawnValue with(WeightedSerializableObject<EntitySnapshot> value);
-
-        @Override
-        ImmutableNextEntityToSpawnValue transform(Function<WeightedSerializableObject<EntitySnapshot>,
-                WeightedSerializableObject<EntitySnapshot>> function);
-
-        @Override
-        MobSpawnerData.NextEntityToSpawnValue asMutable();
-    }
-
+    ImmutableWeightedCollectionValue<EntityArchetype> possibleEntitiesToSpawn();
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/MobSpawnerData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/MobSpawnerData.java
@@ -30,15 +30,11 @@ import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.data.value.mutable.WeightedCollectionValue;
 import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.entity.EntitySnapshot;
-import org.spongepowered.api.entity.EntityType;
+import org.spongepowered.api.entity.EntityArchetype;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.util.weighted.WeightedSerializableObject;
 
-import java.util.Collection;
 import java.util.Random;
-
-import javax.annotation.Nullable;
 
 /**
  * Represents the data associated with a mob spawner, including the spawn delay,
@@ -110,49 +106,25 @@ public interface MobSpawnerData extends DataManipulator<MobSpawnerData, Immutabl
     MutableBoundedValue<Short> spawnRange();
 
     /**
-     * Gets the {@link NextEntityToSpawnValue} for the overridden
-     * {@link WeightedSerializableObject}{@code <EntitySnapshot>} to spawn
+     * Gets the {@link Value} for the overridden
+     * {@link WeightedSerializableObject}{@code <EntityArchetype>} to spawn
      * next. If possible, the next entity to spawn may be chosen from the
      * already provided {@link #possibleEntitiesToSpawn()}.
      *
      * @return The next possible entity to spawn
      */
-    NextEntityToSpawnValue nextEntityToSpawn();
+    Value<WeightedSerializableObject<EntityArchetype>> nextEntityToSpawn();
 
     /**
      * Gets the {@link WeightedCollectionValue} of all possible
      * {@link Entity} instances that can be spawned by the spawner. As they
-     * are all {@link WeightedSerializableObject}{@code <EntitySnapshot>}
+     * are all {@link WeightedSerializableObject}{@code <EntityArchetype>}
      * instances, their weight is defined as a {@link Random} to determine
      * the next {@link Entity} that will be spawned, unless overriden by
      * {@link #nextEntityToSpawn()}.
      *
      * @return The immutable weighted entity collection value of entities
      */
-    WeightedCollectionValue<EntitySnapshot> possibleEntitiesToSpawn();
-
-    /**
-     * Represents a custom {@link Value} dealing with the next
-     * {@link WeightedSerializableObject}{@code <EntitySnapshot>} such that
-     * the next {@link Entity} to spawn may be pulled from the owning
-     * {@link #possibleEntitiesToSpawn()} with a default {@link Random},
-     * or it may be custom defined on a case by case basis.
-     */
-    interface NextEntityToSpawnValue extends Value<WeightedSerializableObject<EntitySnapshot>> {
-
-        /**
-         * Sets this value with the provided {@link EntityType} and
-         * {@link Collection} of {@link DataManipulator}s.
-         *
-         * @param type The type of {@link Entity}
-         * @param additionalProperties Any additional properties to spawn the
-         *     {@link Entity} with
-         * @return The new value, for chaining
-         */
-        NextEntityToSpawnValue set(EntityType type, @Nullable Collection<DataManipulator<?, ?>> additionalProperties);
-
-        @Override
-        ImmutableMobSpawnerData.ImmutableNextEntityToSpawnValue asImmutable();
-    }
+    WeightedCollectionValue<EntityArchetype> possibleEntitiesToSpawn();
 
 }

--- a/src/main/java/org/spongepowered/api/entity/EntityArchetype.java
+++ b/src/main/java/org/spongepowered/api/entity/EntityArchetype.java
@@ -46,6 +46,15 @@ public interface EntityArchetype extends Archetype<EntitySnapshot> {
     }
 
     /**
+     * Creates a new {@link EntityArchetype} with the specified {@link EntityType}.
+     * @param type Type of the entity
+     * @return An archetype of the given entity type
+     */
+    static EntityArchetype of(EntityType type) {
+        return builder().type(type).build();
+    }
+
+    /**
      * Gets the {@link EntityType} of the entity contained in this archetype.
      * 
      * @return The entity type

--- a/src/main/java/org/spongepowered/api/util/weighted/UnmodifiableWeightedTable.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/UnmodifiableWeightedTable.java
@@ -1,0 +1,233 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.util.weighted;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * Creates a WeightedTable that is completely immutable, but still is able to be changed via its proxy table.
+ * @param <T> Item type
+ */
+public class UnmodifiableWeightedTable<T> extends WeightedTable<T> {
+
+    private final WeightedTable<T> table;
+
+    public UnmodifiableWeightedTable(WeightedTable<T> table) {
+        super();
+        this.table = table;
+    }
+
+    public UnmodifiableWeightedTable(WeightedTable<T> table, int rolls) {
+        super(rolls);
+        this.table = table;
+    }
+
+    public UnmodifiableWeightedTable(WeightedTable<T> table, VariableAmount rolls) {
+        super(rolls);
+        this.table = table;
+    }
+
+    // FORBIDDEN METHODS
+
+    @Override
+    public boolean add(TableEntry<T> entry) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean add(T object, double weight) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends TableEntry<T>> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setRolls(VariableAmount rolls) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object entry) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeObject(Object entry) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super TableEntry<T>> filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    // PROXY METHODS
+
+    @Override
+    public Iterator<TableEntry<T>> iterator() {
+        Iterator<TableEntry<T>> it = this.table.iterator();
+        return new Iterator<TableEntry<T>>() {
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public TableEntry<T> next() {
+                return it.next();
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void forEachRemaining(Consumer<? super TableEntry<T>> action) {
+                it.forEachRemaining(action);
+            }
+        };
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return this.table.contains(o);
+    }
+
+    @Override
+    public VariableAmount getRolls() {
+        return this.table.getRolls();
+    }
+
+    @Override
+    public void setRolls(int rolls) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<T> get(Random rand) {
+        return this.table.get(rand);
+    }
+
+    @Override
+    public boolean containsObject(Object obj) {
+        return this.table.containsObject(obj);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return this.table.containsAll(c);
+    }
+
+    @Override
+    public boolean containsAllObjects(Collection<?> c) {
+        return this.table.containsAllObjects(c);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return this.table.equals(o);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.table.isEmpty();
+    }
+
+    @Override
+    public int hashCode() {
+        return this.table.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return this.table.toString();
+    }
+
+    @Override
+    public int size() {
+        return this.table.size();
+    }
+
+    @Override
+    public List<TableEntry<T>> getEntries() {
+        return this.table.getEntries();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return this.table.toArray();
+    }
+
+    @Override
+    public <R> R[] toArray(R[] a) {
+        return this.table.toArray(a);
+    }
+
+    @Override
+    public Spliterator<TableEntry<T>> spliterator() {
+        return this.table.spliterator();
+    }
+
+    @Override
+    public Stream<TableEntry<T>> stream() {
+        return this.table.stream();
+    }
+
+    @Override
+    public Stream<TableEntry<T>> parallelStream() {
+        return this.table.parallelStream();
+    }
+
+    @Override
+    public void forEach(Consumer<? super TableEntry<T>> action) {
+        this.table.forEach(action);
+    }
+}

--- a/src/main/java/org/spongepowered/api/world/gen/populator/Dungeon.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populator/Dungeon.java
@@ -26,17 +26,20 @@ package org.spongepowered.api.world.gen.populator;
 
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.manipulator.mutable.MobSpawnerData;
-import org.spongepowered.api.entity.EntitySnapshot;
+import org.spongepowered.api.entity.EntityArchetype;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.util.ResettableBuilder;
 import org.spongepowered.api.util.weighted.LootTable;
 import org.spongepowered.api.util.weighted.VariableAmount;
-import org.spongepowered.api.util.weighted.WeightedSerializableObject;
 import org.spongepowered.api.util.weighted.WeightedTable;
 import org.spongepowered.api.world.gen.Populator;
 
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
 /**
- * Represents a which places 'Dungeon's randomly underground. Each dungeon has
+ * Represents a {@link Populator} which places 'Dungeon's randomly underground. Each dungeon has
  * some associated MobSpawnerData, and data regarding the contents of any chests
  * generated within the dungeon.
  */
@@ -75,12 +78,50 @@ public interface Dungeon extends Populator {
     }
 
     /**
-     * Gets the {@link MobSpawnerData} which represents the MobSpawner which
-     * will be created within the dungeon.
-     * 
-     * @return The mob spawner data
+     * <p>Gets the {@link MobSpawnerData} which represents the MobSpawner which
+     * will be created within the dungeon.</p>
+     *
+     * <p><b>Note: </b> Only one of choices or mob spawner data
+     * will be present.</p>
+     *
+     * @return The mob spawner data, if present
      */
-    MobSpawnerData getSpawnerData();
+    Optional<MobSpawnerData> getMobSpawnerData();
+
+    /**
+     * <p>Sets {@link MobSpawnerData} which will be used to create the spawner
+     * within the dungeon.</p>
+     *
+     * <p><b>Note: </b> Only one of choices or mob spawner data
+     * will be present.</p>
+     * @param data MobSpawnerData to use
+     */
+    void setMobSpawnerData(MobSpawnerData data);
+
+    /**
+     * <p>Gets a weighted collection of possible
+     * {@link EntityArchetype}s that could be spawned. One type is chosen when
+     * creating the dungeon, for more complex spawners see
+     * {@link #getMobSpawnerData()}.</p>
+     *
+     * <p><b>Note: </b> Only one of choices or mob spawner data
+     * will be present.</p>
+     *
+     * @return Weighted table of possible types, if present
+     */
+    Optional<WeightedTable<EntityArchetype>> getChoices();
+
+    /**
+     * <p>Sets the possible {@link EntityArchetype}s that could be spawned.
+     * One type is chosen when creating the dungeon, for more complex
+     * spawners see {@link #setMobSpawnerData(MobSpawnerData)}</p>
+     *
+     * <p><b>Note: </b> Only one of choices or mob spawner data
+     * will be present.</p>
+     *
+     * @param choices Weighted table of possible types
+     */
+    void setChoices(WeightedTable<EntityArchetype> choices);
 
     /**
      * Gets a mutable weighted collection of possible contents of the chests.
@@ -117,89 +158,31 @@ public interface Dungeon extends Populator {
         }
 
         /**
-         * Sets the {@link MobSpawnerData} which represents the MobSpawner which
-         * will be created within the dungeon. Setting this directly will
-         * overwrite the related builder methods.
-         * 
-         * @param data The mob spawner data to use
+         * <p>Sets {@link MobSpawnerData} that will be used to create the spawner
+         * within the dungeon.</p>
+         *
+         * <p><b>Note: </b> Only one of choices or mob spawner data
+         * will be present.</p>
+         * @param data MobSpawnerData to use
          * @return This builder, for chaining
          */
         Builder mobSpawnerData(MobSpawnerData data);
 
         /**
-         * Sets the minimum delay between batches of monsters. <p> Each time the
-         * timer is reset the new delay is chosen randomly from between the
-         * minimum (inclusive) and maximum (exclusive) delays. </p>
+         * <p>Sets the possible {@link EntityArchetype}s that could be spawned.
+         * One type is chosen when creating the dungeon, for more complex
+         * spawners see {@link #mobSpawnerData(MobSpawnerData)}}</p>
          *
-         * @param delay The new minimum delay, in ticks
+         * <p>To use the default set of choices, pass <code>null</code> instead
+         * of a table.</p>
+         *
+         * <p><b>Note: </b> Only one of choices or mob spawner data
+         * will be present.</p>
+         *
+         * @param choices Weighted table of possible types
          * @return This builder, for chaining
          */
-        Builder minimumSpawnDelay(short delay);
-
-        /**
-         * Sets the maximum delay between batches of monsters. <p> Each time the
-         * timer is reset the new delay is chosen randomly from between the
-         * minimum (inclusive) and maximum (exclusive) delays. </p>
-         *
-         * @param delay The new maximum delay, in ticks
-         * @return This builder, for chaining
-         */
-        Builder maximumSpawnDelay(short delay);
-
-        /**
-         * Sets the number of monsters that will attempt to spawn in each batch.
-         *
-         * <p>The actual number of monsters spawned may be less than the
-         * attempted amount if the maximum number of entities allowed in the
-         * area is reached. </p>
-         *
-         * @param count The new count
-         * @return This builder, for chaining
-         */
-        Builder spawnCount(short count);
-
-        /**
-         * Sets the maximum amount of entities that may be within the spawn
-         * range. This monster spawner will cease spawning new entities if this
-         * cap is reached.
-         *
-         * @param count The new maximum amount of nearby entities
-         * @return This builder, for chaining
-         */
-        Builder maximumNearbyEntities(short count);
-
-        /**
-         * Sets the minimum range to the nearest player before this monster
-         * spawner will activate.
-         *
-         * @param range The new required range
-         * @return This builder, for chaining
-         */
-        Builder requiredPlayerRange(short range);
-
-        /**
-         * Sets the range within which the monsters from each batch will be
-         * spawned.
-         * 
-         * <p> The total region within which the monster may be spawned is
-         * defined by a cuboid with dimensions of
-         * {@code range*2+1 x 3 x range*2+1} centered around the monster
-         * spawner. </p>
-         *
-         * @param range The new range
-         * @return This builder, for chaining
-         */
-        Builder spawnRange(short range);
-
-        /**
-         * Defines a number of {@link WeightedSerializableObject}s from which
-         * the type of each batch will be randomly selected based on the
-         * weighting value.
-         *
-         * @param entities The possible entities
-         * @return This builder, for chaining
-         */
-        Builder possibleEntities(WeightedTable<EntitySnapshot> entities);
+        Builder choices(@Nullable WeightedTable<EntityArchetype> choices);
 
         /**
          * Defines a {@link LootTable} of {@link ItemStackSnapshot}s from which


### PR DESCRIPTION
**API** | [Common](https://github.com/SpongePowered/SpongeCommon/pull/710) | [Forge](https://github.com/SpongePowered/SpongeForge/pull/794)

Changes `MobSpawnerData` and `Dungeon` to use `EntityArchetype`s instead of `EntitySnapshot`s.

Updates `Dungeon` to have option of a table, as explained in the Common branch.

Adds a convenience method to `EntityArchetype` for creating an archetype based solely on an `EntityType`.

Also adds an immutable/unmodifiable version of `WeightedTable` to allow for wrapping of the default list of entities to use in a Dungeon. Without this, plugins could add/remove from this list potentially causing issues down the line. (if this is desired, maybe need to add better systems for doing so?)
