### PR TITLE
Add API for handedness

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -551,6 +551,14 @@ public final class Keys {
 
     public static final Key<Value<Vector3d>> LEFT_ARM_ROTATION = KeyFactory.fake("LEFT_ARM_ROTATION");
 
+    /**
+     * Represents the {@link Key} for representing the dominant {@link HandType}
+     * of a {@link Living} entity.
+     *
+     * @see DominantHandData#dominantHand()
+     */
+    public static final Key<Value<HandType>> DOMINANT_HAND = KeyFactory.fake("DOMINANT_HAND");
+
     public static final Key<Value<Vector3d>> LEFT_LEG_ROTATION = KeyFactory.fake("LEFT_LEG_ROTATION");
 
     public static final Key<Value<String>> LOCK_TOKEN = KeyFactory.fake("LOCK_TOKEN");

--- a/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
@@ -49,6 +49,7 @@ import org.spongepowered.api.data.manipulator.mutable.entity.ChargedData;
 import org.spongepowered.api.data.manipulator.mutable.entity.CriticalHitData;
 import org.spongepowered.api.data.manipulator.mutable.entity.DamageableData;
 import org.spongepowered.api.data.manipulator.mutable.entity.DamagingData;
+import org.spongepowered.api.data.manipulator.mutable.entity.DominantHandData;
 import org.spongepowered.api.data.manipulator.mutable.entity.ElderData;
 import org.spongepowered.api.data.manipulator.mutable.entity.ExpOrbData;
 import org.spongepowered.api.data.manipulator.mutable.entity.ExperienceHolderData;
@@ -93,6 +94,7 @@ import org.spongepowered.api.data.manipulator.mutable.entity.VelocityData;
 import org.spongepowered.api.data.manipulator.mutable.entity.VillagerZombieData;
 import org.spongepowered.api.data.type.Art;
 import org.spongepowered.api.data.type.DyeColor;
+import org.spongepowered.api.data.type.HandType;
 import org.spongepowered.api.data.type.HorseColor;
 import org.spongepowered.api.data.type.HorseStyle;
 import org.spongepowered.api.data.type.HorseVariant;
@@ -234,6 +236,12 @@ public final class CatalogEntityData {
      * {@link Player}s and {@link Living} entities.
      */
     public static final Class<DisplayNameData> DISPLAY_NAME_DATA = DisplayNameData.class;
+    /**
+     * Represents the dominant {@link HandType} used by an entity for for "main"
+     * interactions such as such as tool use or block breaking. Usually
+     * applicable to {@link Living} entities.
+     */
+    public static final Class<DominantHandData> DOMINANT_HAND_DATA = DominantHandData.class;
     /**
      * Signifies that the entity can be dyed a specific {@link DyeColor}.
      * Usually applies to {@link Sheep}.

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableDominantHandData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableDominantHandData.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.data.manipulator.immutable.entity;
 
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.ImmutableVariantData;
 import org.spongepowered.api.data.manipulator.mutable.entity.DominantHandData;
 import org.spongepowered.api.data.type.HandType;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
@@ -39,7 +40,7 @@ import org.spongepowered.api.entity.living.Living;
  *     such as tool use or block breaking.
  * </p>
  */
-public interface ImmutableDominantHandData extends ImmutableDataManipulator<ImmutableDominantHandData, DominantHandData> {
+public interface ImmutableDominantHandData extends ImmutableVariantData<HandType, ImmutableDominantHandData, DominantHandData> {
 
     /**
      * Gets the {@link ImmutableValue} representing the dominant {@link HandType} of an

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableDominantHandData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableDominantHandData.java
@@ -27,16 +27,21 @@ package org.spongepowered.api.data.manipulator.immutable.entity;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.ImmutableVariantData;
 import org.spongepowered.api.data.manipulator.mutable.entity.DominantHandData;
+import org.spongepowered.api.data.property.entity.DominantHandProperty;
 import org.spongepowered.api.data.type.HandType;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.Living;
+import org.spongepowered.api.entity.living.player.Player;
 
 /**
  * A {@link ImmutableDataManipulator} representing the dominant {@link HandType}
  * of a {@link Living} entity.
  * <p>Handedness usually determines which hand is used for "main" interactions,
  * such as tool use or block placing/breaking.</p>
+ *
+ * <p><i>NOTE: </i> This does not apply to {@link Player}s, for Player
+ * entities see {@link DominantHandProperty}.</p>
  */
 public interface ImmutableDominantHandData extends ImmutableVariantData<HandType, ImmutableDominantHandData, DominantHandData> {
 

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableDominantHandData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableDominantHandData.java
@@ -35,10 +35,8 @@ import org.spongepowered.api.entity.living.Living;
 /**
  * A {@link ImmutableDataManipulator} representing the dominant {@link HandType}
  * of a {@link Living} entity.
- * <p>
- *     Handedness usually determines which hand is used for "main" interactions,
- *     such as tool use or block breaking.
- * </p>
+ * <p>Handedness usually determines which hand is used for "main" interactions,
+ * such as tool use or block placing/breaking.</p>
  */
 public interface ImmutableDominantHandData extends ImmutableVariantData<HandType, ImmutableDominantHandData, DominantHandData> {
 

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableDominantHandData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableDominantHandData.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.entity.DominantHandData;
+import org.spongepowered.api.data.type.HandType;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.Living;
+
+/**
+ * A {@link ImmutableDataManipulator} representing the dominant {@link HandType}
+ * of a {@link Living} entity.
+ * <p>
+ *     Handedness usually determines which hand is used for "main" interactions,
+ *     such as tool use or block breaking.
+ * </p>
+ */
+public interface ImmutableDominantHandData extends ImmutableDataManipulator<ImmutableDominantHandData, DominantHandData> {
+
+    /**
+     * Gets the {@link ImmutableValue} representing the dominant {@link HandType} of an
+     * {@link Entity}.
+     *
+     * @return The value for handedness
+     */
+    ImmutableValue<HandType> dominantHand();
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/DominantHandData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/DominantHandData.java
@@ -35,10 +35,8 @@ import org.spongepowered.api.entity.living.Living;
 /**
  * A {@link DataManipulator} representing the dominant {@link HandType} of a
  * {@link Living} entity.
- * <p>
- *     Handedness usually determines which hand is used for "main" interactions,
- *     such as tool use or block breaking.
- * </p>
+ * <p>Handedness usually determines which hand is used for "main" interactions,
+ * such as tool use or block placing/breaking.</p>
  */
 public interface DominantHandData extends VariantData<HandType, DominantHandData, ImmutableDominantHandData> {
 

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/DominantHandData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/DominantHandData.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.data.manipulator.mutable.entity;
 
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableDominantHandData;
+import org.spongepowered.api.data.manipulator.mutable.VariantData;
 import org.spongepowered.api.data.type.HandType;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.Entity;
@@ -39,7 +40,7 @@ import org.spongepowered.api.entity.living.Living;
  *     such as tool use or block breaking.
  * </p>
  */
-public interface DominantHandData extends DataManipulator<DominantHandData, ImmutableDominantHandData> {
+public interface DominantHandData extends VariantData<HandType, DominantHandData, ImmutableDominantHandData> {
 
     /**
      * Gets the {@link Value} representing the dominant {@link HandType} of an

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/DominantHandData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/DominantHandData.java
@@ -27,16 +27,21 @@ package org.spongepowered.api.data.manipulator.mutable.entity;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableDominantHandData;
 import org.spongepowered.api.data.manipulator.mutable.VariantData;
+import org.spongepowered.api.data.property.entity.DominantHandProperty;
 import org.spongepowered.api.data.type.HandType;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.Living;
+import org.spongepowered.api.entity.living.player.Player;
 
 /**
  * A {@link DataManipulator} representing the dominant {@link HandType} of a
  * {@link Living} entity.
  * <p>Handedness usually determines which hand is used for "main" interactions,
  * such as tool use or block placing/breaking.</p>
+ *
+ * <p><i>NOTE: </i> This does not apply to {@link Player}s, for Player
+ * entities see {@link DominantHandProperty}.</p>
  */
 public interface DominantHandData extends VariantData<HandType, DominantHandData, ImmutableDominantHandData> {
 

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/DominantHandData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/DominantHandData.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableDominantHandData;
+import org.spongepowered.api.data.type.HandType;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.Living;
+
+/**
+ * A {@link DataManipulator} representing the dominant {@link HandType} of a
+ * {@link Living} entity.
+ * <p>
+ *     Handedness usually determines which hand is used for "main" interactions,
+ *     such as tool use or block breaking.
+ * </p>
+ */
+public interface DominantHandData extends DataManipulator<DominantHandData, ImmutableDominantHandData> {
+
+    /**
+     * Gets the {@link Value} representing the dominant {@link HandType} of an
+     * {@link Entity}.
+     *
+     * @return The value for handedness
+     */
+    Value<HandType> dominantHand();
+
+}

--- a/src/main/java/org/spongepowered/api/data/property/entity/DominantHandProperty.java
+++ b/src/main/java/org/spongepowered/api/data/property/entity/DominantHandProperty.java
@@ -50,11 +50,11 @@ import javax.annotation.Nullable;
  */
 public class DominantHandProperty extends AbstractProperty<String, HandType> {
 
-    protected DominantHandProperty(@Nullable HandType value) {
+    public DominantHandProperty(@Nullable HandType value) {
         super(value);
     }
 
-    protected DominantHandProperty(@Nullable HandType value, @Nullable Operator op) {
+    public DominantHandProperty(@Nullable HandType value, @Nullable Operator op) {
         super(value, op);
     }
 

--- a/src/main/java/org/spongepowered/api/data/property/entity/DominantHandProperty.java
+++ b/src/main/java/org/spongepowered/api/data/property/entity/DominantHandProperty.java
@@ -38,15 +38,11 @@ import javax.annotation.Nullable;
 /**
  * Represents a {@link Property} for the dominant {@link HandType} of a {@link Player}.
  *
- * <p>
- *     Handedness usually determines which hand is used for "main" interactions,
- *     such as tool use or block breaking.
- * </p>
+ * <p>Handedness usually determines which hand is used for "main" interactions,
+ * such as tool use or block breaking.</p>
  *
- * <p>
- *     <i>NOTE: </i> This only applies to {@link Player}s, for {@link Living}
- *     entities see {@link DominantHandData}.
- * </p>
+ * <p><i>NOTE: </i> This only applies to {@link Player}s, for {@link Living}
+ * entities see {@link DominantHandData}.</p>
  */
 public class DominantHandProperty extends AbstractProperty<String, HandType> {
 

--- a/src/main/java/org/spongepowered/api/data/property/entity/DominantHandProperty.java
+++ b/src/main/java/org/spongepowered/api/data/property/entity/DominantHandProperty.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.property.entity;
+
+import org.spongepowered.api.data.Property;
+import org.spongepowered.api.data.manipulator.mutable.entity.DominantHandData;
+import org.spongepowered.api.data.property.AbstractProperty;
+import org.spongepowered.api.data.type.HandType;
+import org.spongepowered.api.data.type.HandTypes;
+import org.spongepowered.api.entity.living.Living;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.util.Coerce;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents a {@link Property} for the dominant {@link HandType} of a {@link Player}.
+ *
+ * <p>
+ *     Handedness usually determines which hand is used for "main" interactions,
+ *     such as tool use or block breaking.
+ * </p>
+ *
+ * <p>
+ *     <i>NOTE: </i> This only applies to {@link Player}s, for {@link Living}
+ *     entities see {@link DominantHandData}.
+ * </p>
+ */
+public class DominantHandProperty extends AbstractProperty<String, HandType> {
+
+    protected DominantHandProperty(@Nullable HandType value) {
+        super(value);
+    }
+
+    protected DominantHandProperty(@Nullable HandType value, @Nullable Operator op) {
+        super(value, op);
+    }
+
+    @Override
+    public int compareTo(@Nullable Property<?, ?> o) {
+        HandType other = Coerce.toPseudoEnum(o == null ? null : o.getValue(), HandType.class, HandTypes.class, HandTypes.RIGHT);
+        return this.getValue().getId().compareTo(o == null ? "" : other.getId());
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/type/HandType.java
+++ b/src/main/java/org/spongepowered/api/data/type/HandType.java
@@ -30,7 +30,8 @@ import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
- * Represents the "handedness" of a {@link Living} entity.
+ * Represents a hand of a {@link Living} entity. This usually specifies the hand
+ * used for interactions, such as tool use or block placing/breaking.
  */
 @CatalogedBy(HandTypes.class)
 public interface HandType extends CatalogType, Translatable {

--- a/src/main/java/org/spongepowered/api/data/type/HandType.java
+++ b/src/main/java/org/spongepowered/api/data/type/HandType.java
@@ -26,12 +26,13 @@ package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.entity.living.Living;
+import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
  * Represents the "handedness" of a {@link Living} entity.
  */
 @CatalogedBy(HandTypes.class)
-public interface HandType extends CatalogType {
+public interface HandType extends CatalogType, Translatable {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/HandType.java
+++ b/src/main/java/org/spongepowered/api/data/type/HandType.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.type;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.entity.living.Living;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
+/**
+ * Represents the "handedness" of a {@link Living} entity.
+ */
+@CatalogedBy(HandTypes.class)
+public interface HandType extends CatalogType {
+
+}

--- a/src/main/java/org/spongepowered/api/data/type/HandTypes.java
+++ b/src/main/java/org/spongepowered/api/data/type/HandTypes.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.type;
+
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+
+/**
+ * An enumeration of the various {@link HandType}s.
+ */
+public final class HandTypes {
+
+    public static final HandType LEFT = DummyObjectProvider.createFor(HandType.class, "LEFT");
+    public static final HandType RIGHT = DummyObjectProvider.createFor(HandType.class, "RIGHT");
+
+    private HandTypes() {
+    }
+
+}


### PR DESCRIPTION
*Continuation of #1121*
SpongePowered/SpongeCommon#630

This PR adds the ability for plugins to query the handedness of entities.

#### Players
Players are able to configure handedness through client settings. This is not configurable serverside, as such the implementation can get a player's handedness but will not be able to set it.

### Entities
Many living entities such as Skeletons or Zombies can have a dominant hand (Ghasts, for example, cannot). This is configurable with the `LeftHanded` NBT tag.

Implementation wise this will likely only be represented by a single boolean, with each value inversely toggling the it.
