### PR TITLE
Change populators to take an extent for the area to be populated

### DIFF
--- a/src/main/java/org/spongepowered/api/world/gen/Populator.java
+++ b/src/main/java/org/spongepowered/api/world/gen/Populator.java
@@ -24,8 +24,8 @@
  */
 package org.spongepowered.api.world.gen;
 
-import com.flowpowered.math.vector.Vector3i;
-import org.spongepowered.api.world.Chunk;
+import org.spongepowered.api.world.World;
+import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.api.world.gen.populator.RandomObject;
 
 import java.util.Random;
@@ -61,59 +61,15 @@ public interface Populator {
     PopulatorType getType();
 
     /**
-     * Applies the populator to the given chunk. The chunks at
-     * {@code (chunkX + 1, chunkZ)}, {@code (chunkX, chunkZ + 1)} and
-     * {@code (chunkX + 1, chunkZ + 1)} will at least have been generated
-     * (although they do not have to be populated) to allow
-     * {@link PopulatorObject}s to overlap across chunk boundaries.
+     * Applies the populator to the given {@link Extent} volume. The entire area
+     * of the given extent should be populated.
      *
-     * <p>This means that there are only four chunks guaranteed to be loaded.
-     * Other chunks in the world may or may not be loaded. Avoid touching those
-     * chunks, trying to get/set a block there may cause the chunk to be loaded,
-     * which is a bad thing during terrain population.</p>
-     *
-     * <p>Those four chunks form an area of 32x32 columns that you can populate,
-     * from {@code (block x, block z) (chunkX * 16, chunkZ * 16)} to
-     * {@code (chunkX * 16 + 31, chunkZ * 16 + 31)}. See <b>Figure 1</b>. To
-     * effectively use this area, it is recommend to make sure the centers of
-     * all objects are placed from
-     * {@code (block x, block z) (chunkX * 16 + 8, chunkZ * 16 + 8)} to
-     * {@code (chunkX * 16 + 23, chunkZ * 16 + 23)}. This ensures both that each
-     * object can extend 8 blocks on the x and z axis from its center and that
-     * every area in the world is populated exactly once.</p>
-     *
-     * <pre>
-     *       +----------+----------+ . . The chunk provided as a parameter
-     *       |          |          | . . to this method.
-     *       |          |          |
-     *       |     #####|#####     | ### The area you should populate.
-     *       |     #####|#####     | ###
-     *       +----------+----------+
-     *       | . . #####|#####     |
-     *       | . . #####|#####     |
-     *       | . . . . .|          |
-     *       | . . . . .|          |
-     *       +----------+----------+
-     * </pre>
-     * 
-     * <p><b>Figure 1</b> <i>The four chunks guanteed to be loaded, along with
-     * the area you are allowed to populate.</i></p>
-     *
-     * <p>The following code guantantees that the center of your object is
-     * placed with its center in the recommend area:
-     * 
-     * <pre>
-     *  {@link Vector3i} chunkStartBlockPos = chunk.getPosition().mul(16);
-     *  Vector3i populationAreaStartBlockPos = chunkStartBlockPos.add(8, 0, 8);
-     *  Vector3i objectCenterBlockPos = populationAreaStart.add(
-     *          random.nextInt(16), justSomeValueForY, random.nextInt(16));
-     * </pre>
-     *
-     * @param chunk The provided chunk.
+     * @param world The World within which the generation in happening
+     * @param volume The volume to be populated
      * @param random A random number generator. This random number generator is
      *        based on the world seed and the chunk position. It is shared with
      *        with other populators.
      */
-    void populate(Chunk chunk, Random random);
+    void populate(World world, Extent volume, Random random);
 
 }

--- a/src/main/java/org/spongepowered/api/world/gen/populator/BigMushroom.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populator/BigMushroom.java
@@ -28,8 +28,8 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.util.ResettableBuilder;
 import org.spongepowered.api.util.weighted.VariableAmount;
 import org.spongepowered.api.util.weighted.WeightedTable;
-import org.spongepowered.api.world.Chunk;
 import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.api.world.gen.Populator;
 import org.spongepowered.api.world.gen.PopulatorObject;
 
@@ -105,7 +105,7 @@ public interface BigMushroom extends Populator {
      * 
      * @return The supplier override
      */
-    Optional<Function<Location<Chunk>, PopulatorObject>> getSupplierOverride();
+    Optional<Function<Location<Extent>, PopulatorObject>> getSupplierOverride();
 
     /**
      * Sets the overriding supplier. If the supplier is present then it is used
@@ -114,7 +114,7 @@ public interface BigMushroom extends Populator {
      * 
      * @param override The new supplier override, or null
      */
-    void setSupplierOverride(@Nullable Function<Location<Chunk>, PopulatorObject> override);
+    void setSupplierOverride(@Nullable Function<Location<Extent>, PopulatorObject> override);
 
     /**
      * Clears the supplier override to force the weighted table to be used
@@ -181,7 +181,7 @@ public interface BigMushroom extends Populator {
          * @param override The new supplier override, or null
          * @return This builder, for chaining
          */
-        Builder supplier(Function<Location<Chunk>, PopulatorObject> override);
+        Builder supplier(Function<Location<Extent>, PopulatorObject> override);
 
         /**
          * Builds a new instance of a {@link BigMushroom} populator with the

--- a/src/main/java/org/spongepowered/api/world/gen/populator/DoublePlant.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populator/DoublePlant.java
@@ -29,8 +29,8 @@ import org.spongepowered.api.data.type.DoublePlantType;
 import org.spongepowered.api.util.ResettableBuilder;
 import org.spongepowered.api.util.weighted.VariableAmount;
 import org.spongepowered.api.util.weighted.WeightedTable;
-import org.spongepowered.api.world.Chunk;
 import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.api.world.gen.Populator;
 
 import java.util.Optional;
@@ -100,7 +100,7 @@ public interface DoublePlant extends Populator {
      * 
      * @return The supplier override
      */
-    Optional<Function<Location<Chunk>, DoublePlantType>> getSupplierOverride();
+    Optional<Function<Location<Extent>, DoublePlantType>> getSupplierOverride();
 
     /**
      * Sets the overriding supplier. If the supplier is present then it is used
@@ -109,7 +109,7 @@ public interface DoublePlant extends Populator {
      * 
      * @param override The new supplier override, or null
      */
-    void setSupplierOverride(@Nullable Function<Location<Chunk>, DoublePlantType> override);
+    void setSupplierOverride(@Nullable Function<Location<Extent>, DoublePlantType> override);
 
     /**
      * Clears the supplier override to force the weighted table to be used
@@ -175,7 +175,7 @@ public interface DoublePlant extends Populator {
          * @param override The new supplier override, or null
          * @return This builder, for chaining
          */
-        Builder supplier(@Nullable Function<Location<Chunk>, DoublePlantType> override);
+        Builder supplier(@Nullable Function<Location<Extent>, DoublePlantType> override);
 
         /**
          * Builds a new instance of a {@link DoublePlant} populator with the

--- a/src/main/java/org/spongepowered/api/world/gen/populator/Flower.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populator/Flower.java
@@ -29,8 +29,8 @@ import org.spongepowered.api.data.type.PlantType;
 import org.spongepowered.api.util.ResettableBuilder;
 import org.spongepowered.api.util.weighted.VariableAmount;
 import org.spongepowered.api.util.weighted.WeightedTable;
-import org.spongepowered.api.world.Chunk;
 import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.api.world.gen.Populator;
 
 import java.util.Optional;
@@ -101,7 +101,7 @@ public interface Flower extends Populator {
      * 
      * @return The supplier override
      */
-    Optional<Function<Location<Chunk>, PlantType>> getSupplierOverride();
+    Optional<Function<Location<Extent>, PlantType>> getSupplierOverride();
 
     /**
      * Sets the overriding supplier. If the supplier is present then it is used
@@ -109,7 +109,7 @@ public interface Flower extends Populator {
      * 
      * @param override The new supplier override, or null
      */
-    void setSupplierOverride(@Nullable Function<Location<Chunk>, PlantType> override);
+    void setSupplierOverride(@Nullable Function<Location<Extent>, PlantType> override);
 
     /**
      * Clears the supplier override to force the weighted table to be used
@@ -177,7 +177,7 @@ public interface Flower extends Populator {
          * @param override The new supplier override, or null
          * @return This builder, for chaining
          */
-        Builder supplier(Function<Location<Chunk>, PlantType> override);
+        Builder supplier(Function<Location<Extent>, PlantType> override);
 
         /**
          * Builds a new instance of a {@link Flower} populator with the settings

--- a/src/main/java/org/spongepowered/api/world/gen/populator/Forest.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populator/Forest.java
@@ -28,8 +28,8 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.util.ResettableBuilder;
 import org.spongepowered.api.util.weighted.VariableAmount;
 import org.spongepowered.api.util.weighted.WeightedTable;
-import org.spongepowered.api.world.Chunk;
 import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.api.world.gen.Populator;
 import org.spongepowered.api.world.gen.PopulatorObject;
 import org.spongepowered.api.world.gen.type.BiomeTreeType;
@@ -95,7 +95,7 @@ public interface Forest extends Populator {
      * 
      * @return The supplier override
      */
-    Optional<Function<Location<Chunk>, PopulatorObject>> getSupplierOverride();
+    Optional<Function<Location<Extent>, PopulatorObject>> getSupplierOverride();
 
     /**
      * Sets the overriding supplier. If the supplier is present then it is used
@@ -104,7 +104,7 @@ public interface Forest extends Populator {
      * 
      * @param override The new supplier override, or null
      */
-    void setSupplierOverride(@Nullable Function<Location<Chunk>, PopulatorObject> override);
+    void setSupplierOverride(@Nullable Function<Location<Extent>, PopulatorObject> override);
 
     /**
      * Clears the supplier override to force the weighted table to be used
@@ -163,7 +163,7 @@ public interface Forest extends Populator {
          * @param override The new supplier override, or null
          * @return This builder, for chaining
          */
-        Builder supplier(@Nullable Function<Location<Chunk>, PopulatorObject> override);
+        Builder supplier(@Nullable Function<Location<Extent>, PopulatorObject> override);
 
         /**
          * Builds a new instance of a {@link Forest} populator with the settings

--- a/src/main/java/org/spongepowered/api/world/gen/populator/Mushroom.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populator/Mushroom.java
@@ -28,8 +28,8 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.util.ResettableBuilder;
 import org.spongepowered.api.util.weighted.ChanceTable;
 import org.spongepowered.api.util.weighted.VariableAmount;
-import org.spongepowered.api.world.Chunk;
 import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.api.world.gen.Populator;
 import org.spongepowered.api.world.gen.type.MushroomType;
 import org.spongepowered.api.world.gen.type.MushroomTypes;
@@ -108,7 +108,7 @@ public interface Mushroom extends Populator {
      * 
      * @return The supplier override
      */
-    Optional<Function<Location<Chunk>, MushroomType>> getSupplierOverride();
+    Optional<Function<Location<Extent>, MushroomType>> getSupplierOverride();
 
     /**
      * Sets the overriding supplier. If the supplier is present then it is used
@@ -117,7 +117,7 @@ public interface Mushroom extends Populator {
      * 
      * @param override The new supplier override, or null
      */
-    void setSupplierOverride(@Nullable Function<Location<Chunk>, MushroomType> override);
+    void setSupplierOverride(@Nullable Function<Location<Extent>, MushroomType> override);
 
     /**
      * Clears the supplier override to force the chance table to be used
@@ -184,7 +184,7 @@ public interface Mushroom extends Populator {
          * @param override The new supplier override, or null
          * @return This builder, for chaining
          */
-        Builder supplier(@Nullable Function<Location<Chunk>, MushroomType> override);
+        Builder supplier(@Nullable Function<Location<Extent>, MushroomType> override);
 
         /**
          * Builds a new instance of a {@link Mushroom} populator with the

--- a/src/main/java/org/spongepowered/api/world/gen/populator/Shrub.java
+++ b/src/main/java/org/spongepowered/api/world/gen/populator/Shrub.java
@@ -29,8 +29,8 @@ import org.spongepowered.api.data.type.ShrubType;
 import org.spongepowered.api.util.ResettableBuilder;
 import org.spongepowered.api.util.weighted.VariableAmount;
 import org.spongepowered.api.util.weighted.WeightedTable;
-import org.spongepowered.api.world.Chunk;
 import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.api.world.gen.Populator;
 
 import java.util.Optional;
@@ -93,7 +93,7 @@ public interface Shrub extends Populator {
      * 
      * @return The supplier override
      */
-    Optional<Function<Location<Chunk>, ShrubType>> getSupplierOverride();
+    Optional<Function<Location<Extent>, ShrubType>> getSupplierOverride();
 
     /**
      * Sets the overriding supplier. If the supplier is present then it is used
@@ -101,7 +101,7 @@ public interface Shrub extends Populator {
      * 
      * @param override The new supplier override, or null
      */
-    void setSupplierOverride(@Nullable Function<Location<Chunk>, ShrubType> override);
+    void setSupplierOverride(@Nullable Function<Location<Extent>, ShrubType> override);
 
     /**
      * Clears the supplier override to force the weighted table to be used
@@ -160,7 +160,7 @@ public interface Shrub extends Populator {
          * @param override The new supplier override, or null
          * @return This builder, for chaining
          */
-        Builder supplier(@Nullable Function<Location<Chunk>, ShrubType> override);
+        Builder supplier(@Nullable Function<Location<Extent>, ShrubType> override);
 
         /**
          * Builds a new instance of a {@link Shrub} populator with the settings


### PR DESCRIPTION
[Forge](https://github.com/SpongePowered/SpongeForge/pull/627) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/715) | Api

This makes a small change to `Populator#populate` in order to give it an extent view of the area needing population rather than relying on the plugin to offset to the correct location, this also allows much more flexibility for implementations who wish to use a different pattern for population.

A major usecase for this change is the ability to populate a non offset area to allow a single chunk to be regenerated for #574.