### PR TITLE
Make the potion effect in ChangeEntityPotionEffect.Gain mutable

### DIFF
--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -1295,16 +1295,18 @@ public class SpongeEventFactory {
      * {@link org.spongepowered.api.event.entity.ChangeEntityPotionEffectEvent.Gain}.
      * 
      * @param cause The cause
-     * @param currentEffects The current effects
+     * @param originalPotionEffect The original potion effect
      * @param potionEffect The potion effect
+     * @param currentEffects The current effects
      * @param targetEntity The target entity
      * @return A new gain change entity potion effect event
      */
-    public static ChangeEntityPotionEffectEvent.Gain createChangeEntityPotionEffectEventGain(Cause cause, List<PotionEffect> currentEffects, PotionEffect potionEffect, Entity targetEntity) {
+    public static ChangeEntityPotionEffectEvent.Gain createChangeEntityPotionEffectEventGain(Cause cause, PotionEffect originalPotionEffect, PotionEffect potionEffect, List<PotionEffect> currentEffects, Entity targetEntity) {
         HashMap<String, Object> values = new HashMap<>();
         values.put("cause", cause);
-        values.put("currentEffects", currentEffects);
+        values.put("originalPotionEffect", originalPotionEffect);
         values.put("potionEffect", potionEffect);
+        values.put("currentEffects", currentEffects);
         values.put("targetEntity", targetEntity);
         return SpongeEventFactoryUtils.createEventImpl(ChangeEntityPotionEffectEvent.Gain.class, values);
     }

--- a/src/main/java/org/spongepowered/api/event/entity/ChangeEntityPotionEffectEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/ChangeEntityPotionEffectEvent.java
@@ -51,7 +51,22 @@ public interface ChangeEntityPotionEffectEvent extends TargetEntityEvent, Cancel
     /**
      * An event where the {@link PotionEffect} is being added.
      */
-    interface Gain extends ChangeEntityPotionEffectEvent { }
+    interface Gain extends ChangeEntityPotionEffectEvent {
+        
+        /**
+         * Gets the original potion effect involved in this event.
+         *
+         * @return The original potion effect involved in this event
+         */
+        PotionEffect getOriginalPotionEffect();
+        
+        /**
+         * Sets the potion effect to be used in this event.
+         *
+         * @param effect The potion effect to be used in this event
+         */
+        void setPotionEffect(PotionEffect effect);
+    }
 
     /**
      * An event where the {@link PotionEffect} is being removed.


### PR DESCRIPTION
This targets bleeding because the existing getPotionEffect() method would return the changed effect, and does not currently.
