### PR TITLE
Add glowing API

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -403,6 +403,14 @@ public final class Keys {
 
     public static final Key<MutableBoundedValue<Integer>> GENERATION = KeyFactory.fake("GENERATION");
 
+    /**
+     * Represents the {@link Key} for representing whether an entity has a
+     * glowing outline.
+     *
+     * @see GlowingData#glowing()
+     */
+    public static final Key<Value<Boolean>> GLOWING = KeyFactory.fake("GLOWING");
+
     public static final Key<Value<GoldenApple>> GOLDEN_APPLE_TYPE = KeyFactory.fake("GOLDEN_APPLE_TYPE");
 
     /**

--- a/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
@@ -60,6 +60,7 @@ import org.spongepowered.api.data.manipulator.mutable.entity.FlyingData;
 import org.spongepowered.api.data.manipulator.mutable.entity.FoodData;
 import org.spongepowered.api.data.manipulator.mutable.entity.FuseData;
 import org.spongepowered.api.data.manipulator.mutable.entity.GameModeData;
+import org.spongepowered.api.data.manipulator.mutable.entity.GlowingData;
 import org.spongepowered.api.data.manipulator.mutable.entity.GriefingData;
 import org.spongepowered.api.data.manipulator.mutable.entity.HealingSourceData;
 import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
@@ -144,6 +145,7 @@ import org.spongepowered.api.entity.projectile.arrow.Arrow;
 import org.spongepowered.api.entity.projectile.EyeOfEnder;
 import org.spongepowered.api.entity.projectile.Firework;
 import org.spongepowered.api.entity.projectile.Projectile;
+import org.spongepowered.api.entity.projectile.Snowball;
 import org.spongepowered.api.entity.vehicle.minecart.Minecart;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.inventory.ItemStack;
@@ -303,6 +305,12 @@ public final class CatalogEntityData {
      * {@link Player}s.
      */
     public static final Class<GameModeData> GAME_MODE_DATA = GameModeData.class;
+    /**
+     * Represents that an entity has a glowing outline. Few entities, such
+     * as {@link Snowball}, do not show this glow.
+     * <!-- TODO: Find all non-effected entities -->
+     */
+    public static final Class<GlowingData> GLOWING_DATA = GlowingData.class;
     /**
      * Signifies that an entity can modify blocks in the world. Usually applies
      * to {@link Enderman} and {@link Humanoid}s.

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableGlowingData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableGlowingData.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.entity.GlowingData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.entity.Entity;
+
+/**
+ * An {@link ImmutableDataManipulator} for representing something glowing. Usually applies
+ * to an {@link Entity} to give a glowing outline.
+ */
+public interface ImmutableGlowingData extends ImmutableDataManipulator<ImmutableGlowingData, GlowingData> {
+
+    /**
+     * Gets the {@link Value} representing whether something is glowing.
+     * @return The value for glowing
+     */
+    ImmutableValue<Boolean> glowing();
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/GlowingData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/GlowingData.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableGlowingData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.entity.Entity;
+
+/**
+ * A {@link DataManipulator} for representing something glowing. Usually applies
+ * to an {@link Entity} to give a glowing outline.
+ */
+public interface GlowingData extends DataManipulator<GlowingData, ImmutableGlowingData> {
+
+    /**
+     * Gets the {@link Value} representing whether an entity is glowing.
+     * @return The value for glowing
+     */
+    Value<Boolean> glowing();
+
+}


### PR DESCRIPTION
*Continuation of #1121*

Spectral arrows can give an entity glow potion effect temporarily. You can also apply it permanently with `Glowing` NBT tag. This exposes this to SpongeAPI.

I've added a TODO in one of the javadocs - basically a couple entities do not show the glow, will need to do some testing when possible to work out exactly which entities do not do this.