### PR TITLE
Various command fixes and some additions.

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/CommandArgs.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandArgs.java
@@ -122,6 +122,10 @@ public final class CommandArgs {
         return this.args;
     }
 
+    void setArgs(List<SingleArg> args) {
+        this.args = args;
+    }
+
     /**
      * Return this arguments object's current state. Can be used to reset with the {@link #setState(Object)} method.
      *
@@ -153,6 +157,20 @@ public final class CommandArgs {
     }
 
     /**
+     * Insert an {@link Iterable} of args as the next args to be
+     * returned by {@link #next()}.
+     *
+     * @param values The arguments to insert
+     */
+    public void insertArgs(Iterable<String> values) {
+        int index = this.index < 0 ? 0 : this.args.get(this.index).getEndIdx();
+        int pos = this.index;
+        for (String value : values) {
+            this.args.add(++pos, new SingleArg(value, index, index));
+        }
+    }
+
+    /**
      * Insert an arg as the next arg to be returned by {@link #next()}.
      *
      * @param value The argument to insert
@@ -163,12 +181,29 @@ public final class CommandArgs {
     }
 
     /**
+     * Remove the arguments parsed at the state.
+     *
+     * @param state The state
+     */
+    public void removeArg(Object state) {
+        if (!(state instanceof Integer)) {
+            throw new IllegalArgumentException("The provided state was not of the correct type!");
+        }
+        int index = (Integer) state;
+        if (this.index > index) {
+            this.index--;
+        }
+        this.args.remove(index);
+    }
+
+    /**
      * Remove the arguments parsed between startState and endState.
      *
      * @param startState The starting state
      * @param endState The ending state
+     * @return The removed arguments
      */
-    public void removeArgs(Object startState, Object endState) {
+    public List<String> removeArgs(Object startState, Object endState) {
         if (!(startState instanceof Integer) || !(endState instanceof Integer)) {
             throw new IllegalArgumentException("One of the states provided was not of the correct type!");
         }
@@ -181,9 +216,11 @@ public final class CommandArgs {
                 this.index -= (endIdx - startIdx) + 1;
             }
         }
+        final List<String> args = new ArrayList<>();
         for (int i = startIdx; i <= endIdx; ++i) {
-            this.args.remove(startIdx);
+            args.add(this.args.remove(startIdx).getValue());
         }
+        return args;
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/command/args/CommandContext.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandContext.java
@@ -46,7 +46,13 @@ public final class CommandContext {
     /**
      * The argument key for a target block position that may be present during tab completion, of type {@link Location Location&lt;World>}
      */
-    public static final String TARGET_BLOCK_ARG = "targetblock-pos048658"; // Random junk afterwards so we don't accidentally conflict with other args
+    public static final String TARGET_BLOCK_ARG = "target-block-pos-048658"; // Random junk afterwards so we don't accidentally conflict with other args
+
+    /**
+     * The argument key which represents that a command context is being used
+     * for tab completation.
+     */
+    public static final String TAB_COMPLETION_CONTEXT = "tab-completion-context-963485";
 
     private final Multimap<String, Object> parsedArgs;
 
@@ -55,6 +61,10 @@ public final class CommandContext {
      */
     public CommandContext() {
         this.parsedArgs = ArrayListMultimap.create();
+    }
+
+    Multimap<String, Object> getParsedArgs() {
+        return this.parsedArgs;
     }
 
     /**
@@ -118,6 +128,7 @@ public final class CommandContext {
      * @param value the value for this argument
      */
     public void putArg(String key, Object value) {
+        checkNotNull(key, "key");
         checkNotNull(value, "value");
         this.parsedArgs.put(key, value);
     }
@@ -130,6 +141,49 @@ public final class CommandContext {
      */
     public void putArg(Text key, Object value) {
         putArg(ArgUtils.textToArgKey(key), value);
+    }
+
+    /**
+     * Removes all the arguments with the specified
+     * key from this context.
+     *
+     * @param key the key the args are stored under
+     */
+    public void removeArgs(String key) {
+        checkNotNull(key, "key");
+        this.parsedArgs.removeAll(key);
+    }
+
+    /**
+     * Removes all the arguments with the specified
+     * key from this context.
+     *
+     * @param key the key the args are stored under
+     */
+    public void removeArgs(Text key) {
+        removeArgs(ArgUtils.textToArgKey(key));
+    }
+
+    /**
+     * Removes an argument from this context.
+     *
+     * @param key the key the arg is stored under
+     * @param value the value of the argument
+     */
+    public void removeArg(String key, Object value) {
+        checkNotNull(key, "key");
+        checkNotNull(value, "value");
+        this.parsedArgs.remove(key, value);
+    }
+
+    /**
+     * Removes an argument from this context.
+     *
+     * @param key the key the arg is stored under
+     * @param value the value of the argument
+     */
+    public void removeArg(Text key, Object value) {
+        removeArg(ArgUtils.textToArgKey(key), value);
     }
 
     /**
@@ -164,4 +218,5 @@ public final class CommandContext {
     public boolean hasAny(Text key) {
         return hasAny(ArgUtils.textToArgKey(key));
     }
+
 }

--- a/src/main/java/org/spongepowered/api/command/args/CommandElement.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandElement.java
@@ -24,13 +24,12 @@
  */
 package org.spongepowered.api.command.args;
 
-import org.spongepowered.api.text.Text;
 import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.TranslatableText;
 
-import java.util.List;
-
 import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * Represents a command argument element.
@@ -81,6 +80,10 @@ public abstract class CommandElement {
      */
     public void parse(CommandSource source, CommandArgs args, CommandContext context) throws ArgumentParseException {
         Object val = parseValue(source, args);
+        this.store(context, val);
+    }
+
+    void store(CommandContext context, @Nullable Object val) {
         String key = getUntranslatedKey();
         if (key != null && val != null) {
             if (val instanceof Iterable<?>) {

--- a/src/main/java/org/spongepowered/api/command/args/NullCompletionList.java
+++ b/src/main/java/org/spongepowered/api/command/args/NullCompletionList.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.args;
+
+import com.google.common.collect.ForwardingList;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents a {@code null} {@link List} that can be returned by tab completions,
+ * which is used for cases where the completions may be overridden by the next
+ * command argument.
+ */
+public final class NullCompletionList extends ForwardingList<String> {
+
+    public static final NullCompletionList INSTANCE = new NullCompletionList();
+
+    private NullCompletionList() {
+    }
+
+    @Override
+    protected List<String> delegate() {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/org/spongepowered/api/command/dispatcher/SimpleDispatcher.java
+++ b/src/main/java/org/spongepowered/api/command/dispatcher/SimpleDispatcher.java
@@ -340,7 +340,7 @@ public final class SimpleDispatcher implements Dispatcher {
     public List<String> getSuggestions(CommandSource src, final String arguments, @Nullable Location<World> targetPosition) throws CommandException {
         final String[] argSplit = arguments.split(" ", 2);
         Optional<CommandMapping> cmdOptional = get(argSplit[0], src);
-        if (argSplit.length == 1) {
+        if (argSplit.length == 1 && !arguments.endsWith(" ")) {
             return filterCommands(src).stream().filter(new StartsWithPredicate(argSplit[0])).collect(GuavaCollectors.toImmutableList());
         } else if (!cmdOptional.isPresent()) {
             return ImmutableList.of();

--- a/src/main/java/org/spongepowered/api/command/spec/CommandSpec.java
+++ b/src/main/java/org/spongepowered/api/command/spec/CommandSpec.java
@@ -339,6 +339,7 @@ public final class CommandSpec implements CommandCallable {
         if (targetPos != null) {
             ctx.putArg(CommandContext.TARGET_BLOCK_ARG, targetPos);
         }
+        ctx.putArg(CommandContext.TAB_COMPLETION_CONTEXT, true);
         return complete(source, args, ctx);
     }
 


### PR DESCRIPTION
- Added the ColorCommandElement
- Allow Vector3d and Location<World> elements to be completed through targeted blocks
- Fixed tab completion behaviour of in command optionals and flags that aren't at the end, for example: `/tp [<target>] <destination>|[-world:-w <world>] <coordinates>`
- Fixed a error caused by the WorldPropertiesElement when there are disabled properties present
- Completely reset the CommandArgs state after parsing every FirstParsingCommandElement entry
- Some other small bug fixes