### PR TITLE
Add support for ordinal block offsets in Direction

### DIFF
--- a/src/main/java/org/spongepowered/api/util/Direction.java
+++ b/src/main/java/org/spongepowered/api/util/Direction.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.util;
 import com.flowpowered.math.GenericMath;
 import com.flowpowered.math.TrigMath;
 import com.flowpowered.math.vector.Vector3d;
+import com.flowpowered.math.vector.Vector3i;
 
 /**
  * Represent the 16 main and secondary cardinal directions plus up and down.
@@ -79,7 +80,8 @@ public enum Direction {
     private static final Direction[] CARDINAL_SET = {
             NORTH, EAST, SOUTH, WEST
     };
-    private final Vector3d direction;
+    private final Vector3d offset;
+    private final Vector3i blockOffset;
     private final Division division;
     private Direction opposite;
 
@@ -109,13 +111,14 @@ public enum Direction {
         SOUTH_SOUTHWEST.opposite = NORTH_NORTHEAST;
     }
 
-    Direction(Vector3d vector3d, Division division) {
-        if (vector3d.lengthSquared() == 0) {
+    Direction(Vector3d direction, Division division) {
+        if (direction.lengthSquared() == 0) {
             // Prevent normalization of the zero direction
-            this.direction = vector3d;
+            this.offset = direction;
         } else {
-            this.direction = vector3d.normalize();
+            this.offset = direction.normalize();
         }
+        this.blockOffset = direction.round().toInt();
         this.division = division;
     }
 
@@ -314,9 +317,35 @@ public enum Direction {
      * Get the Vector3d.
      *
      * @return The Vector3d
+     * @deprecated Use {@link #asOffset()} instead. Will be removed in 5.0.
      */
+    @Deprecated
     public Vector3d toVector3d() {
-        return this.direction;
+        return this.offset;
+    }
+
+    /**
+     * Returns the direction as a unit offset vector.
+     * This vector is also suitable as a unit direction vector.
+     *
+     * @return The direction as an offset
+     */
+    public Vector3d asOffset() {
+        return this.offset;
+    }
+
+    /**
+     * Returns the direction as a block offset vector.
+     * For secondary ordinals the results are approximated to the nearest
+     * block.
+     *
+     * <p>The difference between this offset and {@link #asOffset()} is that
+     * a block offset has unit components instead of unit length.</p>
+     *
+     * @return The direction as a block offset
+     */
+    public Vector3i asBlockOffset() {
+        return this.blockOffset;
     }
 
     private interface C {

--- a/src/main/java/org/spongepowered/api/world/Location.java
+++ b/src/main/java/org/spongepowered/api/world/Location.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.world;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -331,6 +332,17 @@ public final class Location<E extends Extent> implements DataHolder {
     }
 
     /**
+     * Subtract another Vector3i to the position on this instance, returning
+     * a new Location instance.
+     *
+     * @param v The vector to subtract
+     * @return A new instance
+     */
+    public Location<E> sub(Vector3i v) {
+        return sub(v.getX(), v.getY(), v.getZ());
+    }
+
+    /**
      * Subtract vector components to the position on this instance, returning a
      * new Location instance.
      *
@@ -351,6 +363,17 @@ public final class Location<E extends Extent> implements DataHolder {
      * @return A new instance
      */
     public Location<E> add(Vector3d v) {
+        return add(v.getX(), v.getY(), v.getZ());
+    }
+
+    /**
+     * Add another Vector3i to the position on this instance, returning a new
+     * Location instance.
+     *
+     * @param v The vector to add
+     * @return A new instance
+     */
+    public Location<E> add(Vector3i v) {
         return add(v.getX(), v.getY(), v.getZ());
     }
 
@@ -412,13 +435,31 @@ public final class Location<E extends Extent> implements DataHolder {
     }
 
     /**
-     * Gets the location next to this one in the give direction.
+     * Gets the location next to this one in the given direction.
+     * Always moves by a unit amount, even diagonally.
      *
-     * @param direction The direction to look in
-     * @return The block in that direction
+     * @param direction The direction to move in
+     * @return The location in that direction
      */
     public Location<E> getRelative(Direction direction) {
-        return add(direction.toVector3d());
+        return add(direction.asOffset());
+    }
+
+    /**
+     * Gets the location next to this one in the given direction.
+     * Always moves by a block amount, even diagonally.
+     *
+     * {@link Direction.Division#SECONDARY_ORDINAL} directions are not a valid
+     * argument. These will throw an exception.
+     *
+     * @param direction The direction to move in
+     * @return The location in that direction
+     * @throws IllegalArgumentException If the direction is a
+     * {@link Direction.Division#SECONDARY_ORDINAL}
+     */
+    public Location<E> getBlockRelative(Direction direction) {
+        checkArgument(!direction.isSecondaryOrdinal(), "Secondary cardinal directions can't be used here");
+        return add(direction.asBlockOffset());
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/world/storage/ChunkLayout.java
+++ b/src/main/java/org/spongepowered/api/world/storage/ChunkLayout.java
@@ -338,7 +338,7 @@ public interface ChunkLayout {
     default Optional<Vector3i> moveToChunk(Vector3i chunkCoords, Direction direction, int steps) {
         checkNotNull(direction, "direction");
         checkArgument(!direction.isSecondaryOrdinal(), "Secondary cardinal directions can't be used here");
-        return addToChunk(chunkCoords, direction.toVector3d().ceil().toInt().mul(steps));
+        return addToChunk(chunkCoords, direction.asBlockOffset().mul(steps));
     }
 
     /**


### PR DESCRIPTION
Fixes #1291

Common https://github.com/SpongePowered/SpongeCommon/pull/822

Forge https://github.com/SpongePowered/SpongeForge/pull/722

@bloodmc 

Output should now be correct:

    > acee world.getLocation(0, 0, 0).getBlockRelative(Direction.SOUTHEAST)
    [13:50:15] [Server thread/INFO]: [ACE] Type: org.spongepowered.api.world.Location<CAP#1 extends org.spongepowered.api.world.extent.Extent> Value: Location{(1.0, 0.0, 1.0) in net.minecraft.world.WorldServer@1fafeaa9}
    > acee world.getLocation(0, 0, 0).getRelative(Direction.SOUTHEAST)
    [13:50:33] [Server thread/INFO]: [ACE] Type: org.spongepowered.api.world.Location<CAP#1 extends org.spongepowered.api.world.extent.Extent> Value: Location{(0.7071067811865475, 0.0, 0.7071067811865475) in net.minecraft.world.WorldServer@1fafeaa9}