### PR TITLE
Update ZombieData for 1.10 features

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -909,7 +909,7 @@ public final class Keys {
 
     public static final Key<Value<Vector3d>> VELOCITY = KeyFactory.fake("VELOCITY");
 
-    public static final Key<Value<Profession>> VILLAGER_ZOMBIE_PROFESSION = KeyFactory.fake("VILLAGER_ZOMBIE_PROFESSION");
+    public static final Key<OptionalValue<Profession>> VILLAGER_ZOMBIE_PROFESSION = KeyFactory.fake("VILLAGER_ZOMBIE_PROFESSION");
 
     public static final Key<Value<Double>> WALKING_SPEED = KeyFactory.fake("WALKING_SPEED");
 
@@ -926,6 +926,8 @@ public final class Keys {
     public static final Key<Value<WireAttachmentType>> WIRE_ATTACHMENT_SOUTH = KeyFactory.fake("WIRE_ATTACHMENT_SOUTH");
 
     public static final Key<Value<WireAttachmentType>> WIRE_ATTACHMENT_WEST = KeyFactory.fake("WIRE_ATTACHMENT_WEST");
+
+    public static final Key<Value<ZombieType>> ZOMBIE_TYPE = KeyFactory.fake("ZOMBIE_TYPE");
 
     // SORTFIELDS:OFF
 

--- a/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
@@ -91,7 +91,7 @@ import org.spongepowered.api.data.manipulator.mutable.entity.StatisticData;
 import org.spongepowered.api.data.manipulator.mutable.entity.TameableData;
 import org.spongepowered.api.data.manipulator.mutable.entity.VehicleData;
 import org.spongepowered.api.data.manipulator.mutable.entity.VelocityData;
-import org.spongepowered.api.data.manipulator.mutable.entity.VillagerZombieData;
+import org.spongepowered.api.data.manipulator.mutable.entity.ZombieData;
 import org.spongepowered.api.data.type.Art;
 import org.spongepowered.api.data.type.DyeColor;
 import org.spongepowered.api.data.type.HandType;
@@ -480,10 +480,10 @@ public final class CatalogEntityData {
      */
     public static final Class<VelocityData> VELOCITY_DATA = VelocityData.class;
     /**
-     * Signifies that a {@link Zombie} is a "villager" zombie. Usually
-     * applicable to all {@link Zombie}s.
+     * Specifies the type of a {@link Zombie}, as well as its profession
+     * (if it has one).
      */
-    public static final Class<VillagerZombieData> VILLAGER_ZOMBIE_DATA = VillagerZombieData.class;
+    public static final Class<ZombieData> ZOMBIE_DATA = ZombieData.class;
     /**
      * Signifies that an entity is currently "wet". Usually applicable to
      * {@link Wolf} entities.

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableZombieData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableZombieData.java
@@ -22,25 +22,36 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.entity.living.monster;
+package org.spongepowered.api.data.manipulator.immutable.entity;
 
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.entity.ZombieData;
-import org.spongepowered.api.entity.ArmorEquipable;
-import org.spongepowered.api.entity.living.Ageable;
+import org.spongepowered.api.data.type.Profession;
+import org.spongepowered.api.data.type.ZombieType;
+import org.spongepowered.api.data.type.ZombieTypes;
+import org.spongepowered.api.data.value.immutable.ImmutableOptionalValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.entity.living.monster.Zombie;
+
+import java.util.Optional;
 
 /**
- * Represents a Zombie.
+ * Represents an {@link ImmutableDataManipulator} handling the type and
+ * profession of a {@link Zombie}.
  */
-public interface Zombie extends Monster, ArmorEquipable, Ageable {
+public interface ImmutableZombieData extends ImmutableDataManipulator<ImmutableZombieData, ZombieData> {
 
     /**
-     * Gets the {@link ZombieData} representing the type of the zombie, as well as its
-     * profession (if it has one).
-     *
-     * @return The zombie data
+     * Returns a value specifying Zombie's type
+     * @return Zombie's type
      */
-    default ZombieData getZombieData() {
-        return get(ZombieData.class).get();
-    }
+    ImmutableValue<ZombieType> type();
+
+    /**
+     * Value representing a zombie's {@link Profession}.
+     * .
+     * @return Profession of the zombie, or {@link Optional#empty()} if it has none
+     */
+    ImmutableOptionalValue<Profession> profession();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/ZombieData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/ZombieData.java
@@ -22,25 +22,36 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.entity.living.monster;
+package org.spongepowered.api.data.manipulator.mutable.entity;
 
-import org.spongepowered.api.data.manipulator.mutable.entity.ZombieData;
-import org.spongepowered.api.entity.ArmorEquipable;
-import org.spongepowered.api.entity.living.Ageable;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableZombieData;
+import org.spongepowered.api.data.type.Profession;
+import org.spongepowered.api.data.type.ZombieType;
+import org.spongepowered.api.data.type.ZombieTypes;
+import org.spongepowered.api.data.value.mutable.OptionalValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.entity.living.monster.Zombie;
+
+import java.util.Optional;
 
 /**
- * Represents a Zombie.
+ * Represents an {@link DataManipulator} handling the type and
+ * profession of a {@link Zombie}.
  */
-public interface Zombie extends Monster, ArmorEquipable, Ageable {
+public interface ZombieData extends DataManipulator<ZombieData, ImmutableZombieData> {
 
     /**
-     * Gets the {@link ZombieData} representing the type of the zombie, as well as its
-     * profession (if it has one).
-     *
-     * @return The zombie data
+     * Returns a value specifying Zombie's type
+     * @return Zombie's type
      */
-    default ZombieData getZombieData() {
-        return get(ZombieData.class).get();
-    }
+    Value<ZombieType> type();
+
+    /**
+     * Value representing a zombie's zombie's {@link Profession}.
+     * .
+     * @return Profession of the zombie, or {@link Optional#empty()} if it has none
+     */
+    OptionalValue<Profession> profession();
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/ZombieType.java
+++ b/src/main/java/org/spongepowered/api/data/type/ZombieType.java
@@ -22,19 +22,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.manipulator.mutable.entity;
+package org.spongepowered.api.data.type;
 
-import org.spongepowered.api.data.manipulator.DataManipulator;
-import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableVillagerZombieData;
-import org.spongepowered.api.data.manipulator.mutable.VariantData;
-import org.spongepowered.api.data.type.Profession;
-import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.entity.living.monster.Zombie;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
- * Signifies that a {@link Zombie} is a "villager" zombie, with a specific profession. Usually applicable
- * to all {@link Zombie}s.
+ * <p>
+ *     Represents the type of a {@link Zombie}.
+ * </p>
+ * <p>
+ *     Note that zombies with {@link ZombieTypes#VILLAGER} must also have an
+ *     associated {@link Profession}.
+ * </p>
  */
-public interface VillagerZombieData extends VariantData<Profession, VillagerZombieData, ImmutableVillagerZombieData> {
+@CatalogedBy(ZombieTypes.class)
+public interface ZombieType extends CatalogType {
 
 }

--- a/src/main/java/org/spongepowered/api/data/type/ZombieTypes.java
+++ b/src/main/java/org/spongepowered/api/data/type/ZombieTypes.java
@@ -22,19 +22,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.manipulator.immutable.entity;
+package org.spongepowered.api.data.type;
 
-import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
-import org.spongepowered.api.data.manipulator.immutable.ImmutableVariantData;
-import org.spongepowered.api.data.manipulator.mutable.entity.VillagerZombieData;
-import org.spongepowered.api.data.type.Profession;
-import org.spongepowered.api.data.value.immutable.ImmutableValue;
-import org.spongepowered.api.entity.living.monster.Zombie;
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
 
-/**
- * Represents an {@link ImmutableDataManipulator} handling the "villager
- * zombie" state of a {@link Zombie}.
- */
-public interface ImmutableVillagerZombieData extends ImmutableVariantData<Profession, ImmutableVillagerZombieData, VillagerZombieData> {
+public final class ZombieTypes {
+
+    // SORTFIELDS:ON
+
+    public static final ZombieType HUSK = DummyObjectProvider.createFor(ZombieType.class, "HUSK");
+
+    public static final ZombieType NORMAL = DummyObjectProvider.createFor(ZombieType.class, "NORMAL");
+
+    public static final ZombieType VILLAGER = DummyObjectProvider.createFor(ZombieType.class, "VILLAGER");
+
+    // SORTFIELDS:OFF
+
+    private ZombieTypes() {
+    }
 
 }


### PR DESCRIPTION
This changes VillagerZombieData to a composite DataManipulator.

The ZombieType specifies the kind of zombie, with Optional<Profession> specifying the profession only if it's a villager zombie.

This system allows mods to add new types of zombie villagers without requiring a matching zombie type (as is the current vanilla implementation).