### PR TITLE
Added GravityData and removed gravity from ArmorStandData

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -96,8 +96,6 @@ public final class Keys {
 
     public static final Key<Value<Boolean>> ARMOR_STAND_HAS_BASE_PLATE = KeyFactory.fake("ARMOR_STAND_HAS_BASE_PLATE");
 
-    public static final Key<Value<Boolean>> ARMOR_STAND_HAS_GRAVITY = KeyFactory.fake("ARMOR_STAND_HAS_GRAVITY");
-
     public static final Key<Value<Boolean>> ARMOR_STAND_IS_SMALL = KeyFactory.fake("ARMOR_STAND_IS_SMALL");
 
     public static final Key<Value<Boolean>> ARMOR_STAND_MARKER = KeyFactory.fake("ARMOR_STAND_MARKER");
@@ -421,6 +419,8 @@ public final class Keys {
      * @see GrowthData#growthStage()
      */
     public static final Key<MutableBoundedValue<Integer>> GROWTH_STAGE = KeyFactory.fake("GROWTH_STAGE");
+
+    public static final Key<Value<Boolean>> HAS_GRAVITY = KeyFactory.fake("HAS_GRAVITY");
 
     public static final Key<Value<Vector3d>> HEAD_ROTATION = KeyFactory.fake("HEAD_ROTATION");
 

--- a/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
@@ -60,6 +60,7 @@ import org.spongepowered.api.data.manipulator.mutable.entity.FoodData;
 import org.spongepowered.api.data.manipulator.mutable.entity.FuseData;
 import org.spongepowered.api.data.manipulator.mutable.entity.GameModeData;
 import org.spongepowered.api.data.manipulator.mutable.entity.GlowingData;
+import org.spongepowered.api.data.manipulator.mutable.entity.GravityData;
 import org.spongepowered.api.data.manipulator.mutable.entity.GriefingData;
 import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
 import org.spongepowered.api.data.manipulator.mutable.entity.HorseData;
@@ -307,6 +308,11 @@ public final class CatalogEntityData {
      * <!-- TODO: Find all non-effected entities -->
      */
     public static final Class<GlowingData> GLOWING_DATA = GlowingData.class;
+    /**
+     * Signifies that an entity will ignore gravity. Usually applies to all
+     * known types of entities.
+     */
+    public static final Class<GravityData> GRAVITY_DATA = GravityData.class;
     /**
      * Signifies that an entity can modify blocks in the world. Usually applies
      * to {@link Enderman} and {@link Humanoid}s.

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableGravityData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableGravityData.java
@@ -25,33 +25,22 @@
 package org.spongepowered.api.data.manipulator.immutable.entity;
 
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
-import org.spongepowered.api.data.manipulator.mutable.entity.ArmorStandData;
+import org.spongepowered.api.data.manipulator.mutable.entity.GravityData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.entity.Entity;
 
-public interface ImmutableArmorStandData extends ImmutableDataManipulator<ImmutableArmorStandData, ArmorStandData> {
-
-    ImmutableValue<Boolean> marker();
-
-    /**
-     * Returns whether this armor stand is a small armor stand or not.
-     *
-     * @return Whether this is a small armor stand
-     */
-    ImmutableValue<Boolean> small();
+/**
+ * An {@link ImmutableDataManipulator} for the gravity state. If the value is
+ * true, the {@link Entity} will have gravity.
+ */
+public interface ImmutableGravityData extends ImmutableDataManipulator<ImmutableGravityData, GravityData> {
 
     /**
-     * Returns whether this armor stand shows arms or not.
-     * <p>Arms that do not show may also not show an item in hand.</p>
+     * Gets the {@link ImmutableValue} of the gravity of an {@link Entity}.
+     * Returns true when the {@link Entity} has gravity.
      *
-     * @return Whether this armor stand shows its arms
+     * @return The immutable value of the gravity
      */
-    ImmutableValue<Boolean> arms();
-
-    /**
-     * Gets whether this armor stand has a visible base plate or not.
-     *
-     * @return Whether this armor stand has a visible base plate
-     */
-    ImmutableValue<Boolean> basePlate();
+    ImmutableValue<Boolean> gravity();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/ArmorStandData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/ArmorStandData.java
@@ -40,13 +40,6 @@ public interface ArmorStandData extends DataManipulator<ArmorStandData, Immutabl
     Value<Boolean> small();
 
     /**
-     * Returns whether this armor stand is affected by gravity or not.
-     *
-     * @return Whether this armor stand is affected by gravity or not
-     */
-    Value<Boolean> gravity();
-
-    /**
      * Returns whether this armor stand shows arms or not.
      * <p>Arms that do not show may also not show an item in hand.</p>
      *

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/GravityData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/GravityData.java
@@ -22,36 +22,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.manipulator.immutable.entity;
+package org.spongepowered.api.data.manipulator.mutable.entity;
 
-import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
-import org.spongepowered.api.data.manipulator.mutable.entity.ArmorStandData;
-import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableGravityData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.entity.Entity;
 
-public interface ImmutableArmorStandData extends ImmutableDataManipulator<ImmutableArmorStandData, ArmorStandData> {
-
-    ImmutableValue<Boolean> marker();
-
-    /**
-     * Returns whether this armor stand is a small armor stand or not.
-     *
-     * @return Whether this is a small armor stand
-     */
-    ImmutableValue<Boolean> small();
+/**
+ * A {@link DataManipulator} for gravity. If the value is true, the
+ * {@link Entity} will have gravity.
+ */
+public interface GravityData extends DataManipulator<GravityData, ImmutableGravityData> {
 
     /**
-     * Returns whether this armor stand shows arms or not.
-     * <p>Arms that do not show may also not show an item in hand.</p>
+     * Gets the {@link Value} of the gravity of an {@link Entity}. Returns true
+     * when the {@link Entity} has gravity.
      *
-     * @return Whether this armor stand shows its arms
+     * @return The value of the gravity
      */
-    ImmutableValue<Boolean> arms();
-
-    /**
-     * Gets whether this armor stand has a visible base plate or not.
-     *
-     * @return Whether this armor stand has a visible base plate
-     */
-    ImmutableValue<Boolean> basePlate();
+    Value<Boolean> gravity();
 
 }

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -34,6 +34,7 @@ import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.mutable.TargetedLocationData;
+import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSource; 
 import org.spongepowered.api.text.translation.Translatable;
@@ -549,5 +550,14 @@ public interface Entity extends Identifiable, Locatable, DataHolder, DataSeriali
      * @return The created archetype for re-creating this entity
      */
     EntityArchetype createArchetype();
+
+    /**
+     * Returns whether this entity has gravity.
+     *
+     * @return True if this entity has gravity
+     */
+    default Value<Boolean> gravity() {
+        return getValue(Keys.HAS_GRAVITY).get();
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/entity/living/ArmorStand.java
+++ b/src/main/java/org/spongepowered/api/entity/living/ArmorStand.java
@@ -90,18 +90,6 @@ public interface ArmorStand extends Living, ArmorEquipable {
     }
 
     /**
-     * Gets the {@link Boolean} {@link Value} of whether this
-     * {@link ArmorStand} reacts to "gravity". If
-     * {@code true}, the armor stand will naturally obey the laws
-     * of physics and fall.
-     *
-     * @return The value for the gravity state
-     */
-    default Value<Boolean> gravity() {
-        return getValue(Keys.ARMOR_STAND_HAS_GRAVITY).get();
-    }
-
-    /**
      * Gets the {@link ArmorStandData} for this armor stand.
      *
      * @return The data manipulator for this armorstand


### PR DESCRIPTION
**[API](https://github.com/SpongePowered/SpongeAPI/pull/1301)** | [Common](https://github.com/SpongePowered/SpongeCommon/pull/828)

Adds `GravityData` and removes gravity from `ArmorStandData`. This is due to a change in Minecraft  1.10 that allows all entities, not just armor stands, to be affected by the `NoGravity` tag.

Resolves #1300. 

```java
@Listener
public void onPlayerJoin(ClientConnectionEvent.Join event) {
    Player player = event.getTargetEntity();
    // Prints the current value
    System.out.println(player.get(Keys.ENTITY_HAS_GRAVITY).get());
    // Turns off gravity for the player
    player.offer(Keys.ENTITY_HAS_GRAVITY, false);

    // Test the DataManipulator
    Optional<GravityData> optional = player.get(GravityData.class);
    if(optional.isPresent()) {
        Value<Boolean> value = optional.get().gravity();
        // Prints the current value (false)
        System.out.println(value.get());
        // Turns gravity back on for the player
        player.offer(optional.get().set(value.set(true)));
    }
}
```