### PR TITLE
Fix Abstract(Indirect)EntityDamageSource generics and expose some fields.

### DIFF
--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractEntityDamageSource.java
@@ -93,9 +93,8 @@ public abstract class AbstractEntityDamageSource implements EntityDamageSource {
     }
 
     @SuppressWarnings("unchecked")
-    public static abstract class AbstractEntityDamageSourceBuilder<T extends EntityDamageSource, B extends AbstractEntityDamageSourceBuilder<T, B>>
-        extends AbstractDamageSourceBuilder<T, B>
-    implements EntityDamageSourceBuilder<T, B> {
+    public static abstract class AbstractEntityDamageSourceBuilder<T extends EntityDamageSource, B extends EntityDamageSource.EntityDamageSourceBuilder<T, B>>
+            extends AbstractDamageSourceBuilder<T, B> implements EntityDamageSourceBuilder<T, B> {
 
         protected Entity source;
 

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSource.java
@@ -101,12 +101,11 @@ public abstract class AbstractIndirectEntityDamageSource implements IndirectEnti
     }
 
     @SuppressWarnings("unchecked")
-    public static abstract class AbstractIndirectEntityDamageSourceBuilder<T extends IndirectEntityDamageSource, B extends AbstractIndirectEntityDamageSourceBuilder<T, B>>
-        extends AbstractEntityDamageSource.AbstractEntityDamageSourceBuilder<T,
-        B> implements IndirectEntityDamageSource.AbstractBuilder<T, B> {
+    public static abstract class AbstractIndirectEntityDamageSourceBuilder<T extends IndirectEntityDamageSource, B extends IndirectEntityDamageSource.AbstractBuilder<T, B>>
+            extends AbstractEntityDamageSource.AbstractEntityDamageSourceBuilder<T, B> implements IndirectEntityDamageSource.AbstractBuilder<T, B> {
 
-        Entity source;
-        Entity indirect;
+        protected Entity source;
+        protected Entity indirect;
 
         @Override
         public B entity(Entity entity) {


### PR DESCRIPTION
This following example is currently impossible to make, you have to insert the builder interface type in the `AbstractEntityDamageSourceBuilder` generics, but they only allow `AbstractEntityDamageSourceBuilder`s, and the generics of the `CustomEntityDamageSource.Builder` specify that you want a `CustomEntityDamageSource.Builder` as return value. This causes a conflict and breaks the `CustomEntityDamageSourceBuilderImpl`.
This is the same case for the `AbstractIndirectEntityDamageSource`.
And exposed some fields to allow some null checks in the build method.

```java
public interface CustomEntityDamageSource extends EntityDamageSource {

    public interface Builder extends EntityDamageSource.EntityDamageSourceBuilder<CustomEntityDamageSource, Builder> {
    
    }
}
```
```java
public class CustomEntityDamageSourceImpl extends AbstractEntityDamageSource implements CustomEntityDamageSource {

    protected CustomEntityDamageSourceImpl(CustomEntityDamageSourceBuilder builder) {
        super(builder);
    }
}
```

```java
public class CustomEntityDamageSourceBuilderImpl extends AbstractEntityDamageSource.AbstractEntityDamageSourceBuilder<CustomEntityDamageSource, CustomEntityDamageSource.Builder>
        implements CustomEntityDamageSource.Builder {

    @Override
    public CustomEntityDamageSource build() throws IllegalStateException {
        checkState(this.damageType != null, "The damage type must be set");
        checkState(this.source != null, "The entity must be set");
        return new CustomEntityDamageSourceImpl(this);
    }
}
```