### PR TITLE
Refactor Block Change API

### DIFF
--- a/src/main/java/org/spongepowered/api/block/BlockSnapshot.java
+++ b/src/main/java/org/spongepowered/api/block/BlockSnapshot.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.data.DataView;
 import org.spongepowered.api.data.ImmutableDataBuilder;
 import org.spongepowered.api.data.LocatableSnapshot;
 import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+import org.spongepowered.api.world.BlockChangeFlag;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.storage.WorldProperties;
@@ -116,11 +117,11 @@ public interface BlockSnapshot extends LocatableSnapshot<BlockSnapshot> {
      *
      * @param force If true, forces block state to be set even if the
      *     {@link BlockType} does not match the snapshot one.
-     * @param notifyNeighbors If true, notifies neighboring blocks to update
-     *     physics
-     * @return true if the restore was successful, false otherwise
+     * @param flag The block change flags to determine whether neighbors are
+     *     notified, block physics performed, etc.
+     * @return True if the restore was successful, false otherwise
      */
-    boolean restore(boolean force, boolean notifyNeighbors);
+    boolean restore(boolean force, BlockChangeFlag flag);
 
     /**
      * Gets the {@link UUID}, if available, of the user who created this

--- a/src/main/java/org/spongepowered/api/data/value/mutable/CompositeValueStore.java
+++ b/src/main/java/org/spongepowered/api/data/value/mutable/CompositeValueStore.java
@@ -26,12 +26,15 @@ package org.spongepowered.api.data.value.mutable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.merge.MergeFunction;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.RespawnLocation;
+import org.spongepowered.api.world.extent.MutableBlockVolume;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -205,6 +208,57 @@ public interface CompositeValueStore<S extends CompositeValueStore<S, H>, H exte
     }
 
     /**
+     * Offers the given {@code value} as defined by the provided {@link Key}
+     * such that a {@link DataTransactionResult} is returned for any
+     * successful, rejected, and replaced {@link BaseValue}s from this
+     * {@link CompositeValueStore}.
+     *
+     * <p>Note that this differs from {@link #offer(ValueContainer, MergeFunction)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param key The key to the value to set
+     * @param value The value to set
+     * @param cause The cause to use in the events, if required
+     * @param <E> The type of value
+     * @return The transaction result
+     */
+    <E> DataTransactionResult offer(Key<? extends BaseValue<E>> key, E value, Cause cause);
+
+    /**
+     * Offers the given {@code value} as defined by the provided {@link Key}
+     * such that a {@link DataTransactionResult} is returned for any
+     * successful {@link BaseValue}s from this {@link CompositeValueStore}.
+     * Intentionally, however, this differs from {@link #offer(Key, Object)}
+     * as it will intentionally throw an exception if the result was a failure.
+     *
+     * <p>Note that this differs from {@link #offer(ValueContainer, MergeFunction)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param key The key to the value to set
+     * @param value The value to set
+     * @param cause The cause to use in the events, if required
+     * @param <E> The type of value
+     * @return The transaction result
+     * @throws IllegalArgumentException If the result is a failure likely due to
+     *     incompatibility
+     */
+    default <E> DataTransactionResult tryOffer(Key<? extends BaseValue<E>> key, E value, Cause cause) throws IllegalArgumentException {
+        final DataTransactionResult result = offer(key, value, cause);
+        if (!result.isSuccessful()) {
+            throw new IllegalArgumentException("Failed offer transaction!");
+        }
+        return result;
+    }
+
+    /**
      * Offers the given {@link BaseValue} as defined by the provided
      * {@link Key} such that a {@link DataTransactionResult} is returned for
      * any successful, rejected, and replaced {@link BaseValue}s from this
@@ -233,6 +287,57 @@ public interface CompositeValueStore<S extends CompositeValueStore<S, H>, H exte
      */
     default <E> DataTransactionResult tryOffer(BaseValue<E> value) throws IllegalArgumentException {
         final DataTransactionResult result = offer(value.getKey(), value.get());
+        if (!result.isSuccessful()) {
+            throw new IllegalArgumentException("Failed offer transaction!");
+        }
+        return result;
+    }
+
+    /**
+     * Offers the given {@link BaseValue} as defined by the provided
+     * {@link Key} such that a {@link DataTransactionResult} is returned for
+     * any successful, rejected, and replaced {@link BaseValue}s from this
+     * {@link CompositeValueStore}.
+     *
+     * <p>Note that this differs from {@link #offer(ValueContainer, MergeFunction)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param value The value to set
+     * @param cause The cause to use for any events if necessary
+     * @param <E> The type of the element wrapped by the value
+     * @return The transaction result
+     */
+    default <E> DataTransactionResult offer(BaseValue<E> value, Cause cause) {
+        return offer(value.getKey(), value.get(), cause);
+    }
+
+    /**
+     * Offers the given {@code value} as defined by the provided {@link Key}
+     * such that a {@link DataTransactionResult} is returned for any
+     * successful {@link BaseValue}s from this {@link CompositeValueStore}.
+     * Intentionally, however, this differs from {@link #offer(Key, Object)}
+     * as it will intentionally throw an exception if the result was a failure.
+     *
+     * <p>Note that this differs from {@link #offer(ValueContainer, MergeFunction)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param value The value to set
+     * @param cause The cause to use for any events if necessary
+     * @param <E> The type of value
+     * @return The transaction result
+     * @throws IllegalArgumentException If the result is a failure likely due to
+     *     incompatibility
+     */
+    default <E> DataTransactionResult tryOffer(BaseValue<E> value, Cause cause) throws IllegalArgumentException {
+        final DataTransactionResult result = offer(value.getKey(), value.get(), cause);
         if (!result.isSuccessful()) {
             throw new IllegalArgumentException("Failed offer transaction!");
         }
@@ -278,6 +383,32 @@ public interface CompositeValueStore<S extends CompositeValueStore<S, H>, H exte
      * {@link BaseValue}s from the given {@link ValueContainer} are offered
      * to this {@link CompositeValueStore}. The end result of the values
      * successfully offered, rejected, and replaced are stored in the returned
+     * {@link DataTransactionResult}.
+     *
+     * <p>Note that this differs from {@link #offer(ValueContainer, MergeFunction)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param valueContainer The value to set
+     * @param cause The cause to use for any events if necessary
+     * @return The transaction result
+     */
+    default DataTransactionResult offer(H valueContainer, Cause cause) {
+        final DataTransactionResult result = offer(valueContainer, MergeFunction.IGNORE_ALL, cause);
+        if (!result.isSuccessful()) {
+            throw new IllegalArgumentException("Failed offer transaction!");
+        }
+        return result;
+    }
+
+    /**
+     * Offers the given {@link ValueContainer} such that all of the available
+     * {@link BaseValue}s from the given {@link ValueContainer} are offered
+     * to this {@link CompositeValueStore}. The end result of the values
+     * successfully offered, rejected, and replaced are stored in the returned
      * {@link DataTransactionResult}. Any overlaps of data are merged via
      * the {@link MergeFunction}.
      *
@@ -310,6 +441,58 @@ public interface CompositeValueStore<S extends CompositeValueStore<S, H>, H exte
     }
 
     /**
+     * Offers the given {@link ValueContainer} such that all of the available
+     * {@link BaseValue}s from the given {@link ValueContainer} are offered
+     * to this {@link CompositeValueStore}. The end result of the values
+     * successfully offered, rejected, and replaced are stored in the returned
+     * {@link DataTransactionResult}. Any overlaps of data are merged via
+     * the {@link MergeFunction}.
+     *
+     * <p>Note that this differs from {@link #offer(ValueContainer, MergeFunction)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param valueContainer The value to set
+     * @param function The merge function
+     * @param cause The cause to use for any events if necessary
+     * @return The transaction result
+     */
+    DataTransactionResult offer(H valueContainer, MergeFunction function, Cause cause);
+
+    /**
+     * Offers the given {@link ValueContainer} such that all of the available
+     * {@link BaseValue}s from the given {@link ValueContainer} are offered
+     * to this {@link CompositeValueStore}. Any overlaps of data are merged via
+     * the {@link MergeFunction}. Intentionally, however, this differs
+     * from {@link #offer(ValueContainer)} as it will intentionally throw an
+     * exception if the result was a failure.
+     *
+     * <p>Note that this differs from {@link #offer(ValueContainer, MergeFunction)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param valueContainer The value to set
+     * @param function The merge function
+     * @param cause The cause to use for any events if necessary
+     * @return The transaction result
+     * @throws IllegalArgumentException If the result is a failure likely due to
+     *     incompatibility
+     */
+    default DataTransactionResult tryOffer(H valueContainer, MergeFunction function, Cause cause) throws IllegalArgumentException {
+        final DataTransactionResult result = offer(valueContainer, function, cause);
+        if (!result.isSuccessful()) {
+            throw new IllegalArgumentException("Failed offer transaction!");
+        }
+        return result;
+    }
+
+    /**
      * Offers all provided {@link ValueContainer}s to this
      * {@link CompositeValueStore} much like {@link #offer(ValueContainer)}
      * except all in a single batch. The end result of the values successfully
@@ -328,6 +511,28 @@ public interface CompositeValueStore<S extends CompositeValueStore<S, H>, H exte
      * {@link CompositeValueStore} much like {@link #offer(ValueContainer)}
      * except all in a single batch. The end result of the values successfully
      * offered, rejected, and replaced are stored in the returned
+     * {@link DataTransactionResult}.
+     *
+     * <p>Note that this differs from {@link #offer(ValueContainer, MergeFunction)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param valueContainers The values to set
+     * @param cause The cause to use for any events if necessary
+     * @return The transaction result
+     */
+    default DataTransactionResult offer(Iterable<H> valueContainers, Cause cause) {
+        return offer(valueContainers, MergeFunction.IGNORE_ALL, cause);
+    }
+
+    /**
+     * Offers all provided {@link ValueContainer}s to this
+     * {@link CompositeValueStore} much like {@link #offer(ValueContainer)}
+     * except all in a single batch. The end result of the values successfully
+     * offered, rejected, and replaced are stored in the returned
      * {@link DataTransactionResult}. Any merge conflicts are resolved through
      * the {@link MergeFunction}.
      *
@@ -339,6 +544,34 @@ public interface CompositeValueStore<S extends CompositeValueStore<S, H>, H exte
         final DataTransactionResult.Builder builder = DataTransactionResult.builder();
         for (H valueContainer : valueContainers) {
             builder.absorbResult(offer(valueContainer, function));
+        }
+        return builder.build();
+    }
+
+    /**
+     * Offers all provided {@link ValueContainer}s to this
+     * {@link CompositeValueStore} much like {@link #offer(ValueContainer)}
+     * except all in a single batch. The end result of the values successfully
+     * offered, rejected, and replaced are stored in the returned
+     * {@link DataTransactionResult}. Any merge conflicts are resolved through
+     * the {@link MergeFunction}.
+     *
+     * <p>Note that this differs from {@link #offer(ValueContainer, MergeFunction)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param valueContainers The values to set
+     * @param function The function to resolve the values
+     * @param cause The cause to use for any events if necessary
+     * @return The transaction result
+     */
+    default DataTransactionResult offer(Iterable<H> valueContainers, MergeFunction function, Cause cause) {
+        final DataTransactionResult.Builder builder = DataTransactionResult.builder();
+        for (H valueContainer : valueContainers) {
+            builder.absorbResult(offer(valueContainer, function, cause));
         }
         return builder.build();
     }

--- a/src/main/java/org/spongepowered/api/extra/modifier/skylands/SkylandsGrassPopulator.java
+++ b/src/main/java/org/spongepowered/api/extra/modifier/skylands/SkylandsGrassPopulator.java
@@ -34,6 +34,7 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.type.PlantType;
 import org.spongepowered.api.data.type.PlantTypes;
 import org.spongepowered.api.data.type.ShrubTypes;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.extent.ImmutableBiomeArea;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
@@ -67,6 +68,7 @@ public class SkylandsGrassPopulator implements GenerationPopulator {
     private final Voronoi flowerCells = new Voronoi();
     private final Voronoi flowerDensities = new Voronoi();
     private final RarityCurve flowerOdds = new RarityCurve();
+    private final Cause populatorCause = Cause.source(this).build();
 
     static {
         //noinspection ConstantConditions
@@ -136,9 +138,9 @@ public class SkylandsGrassPopulator implements GenerationPopulator {
                         }
                     }
                     if (flower != null) {
-                        buffer.setBlock(xx, yy + 1, zz, flower.getBlock());
+                        buffer.setBlock(xx, yy + 1, zz, flower.getBlock(), this.populatorCause);
                         if (flower.isDoubleHeight()) {
-                            buffer.setBlock(xx, yy + 2, zz, flower.getUpperBlock());
+                            buffer.setBlock(xx, yy + 2, zz, flower.getUpperBlock(), this.populatorCause);
                         }
                     } else if (value >= GRASS_ODDS) {
                         // if no flower, check if the value is greater than the grass odds
@@ -147,9 +149,9 @@ public class SkylandsGrassPopulator implements GenerationPopulator {
                             //buffer.setBlockType(xx, yy + 1, zz, BlockTypes.MELON_BLOCK);
                             //buffer.setBlockType(xx, yy + 2, zz, BlockTypes.MELON_BLOCK);
                             // TODO: fix double plants
-                            buffer.setBlock(xx, yy + 1, zz, TALL_GRASS);
+                            buffer.setBlock(xx, yy + 1, zz, TALL_GRASS, this.populatorCause);
                         } else {
-                            buffer.setBlock(xx, yy + 1, zz, TALL_GRASS);
+                            buffer.setBlock(xx, yy + 1, zz, TALL_GRASS, this.populatorCause);
                         }
                     }
                 }
@@ -163,7 +165,7 @@ public class SkylandsGrassPopulator implements GenerationPopulator {
                         // generate a new random value for the layer
                         final float value = SkylandsUtil.hashToFloat(xx, layerNumber, zz, seed);
                         if (value >= COVERED_GRASS_ODDS) {
-                            buffer.setBlock(xx, yy + 1, zz, TALL_GRASS);
+                            buffer.setBlock(xx, yy + 1, zz, TALL_GRASS, this.populatorCause);
                         }
                     }
                     layerNumber++;

--- a/src/main/java/org/spongepowered/api/extra/modifier/skylands/SkylandsGroundCoverPopulator.java
+++ b/src/main/java/org/spongepowered/api/extra/modifier/skylands/SkylandsGroundCoverPopulator.java
@@ -29,6 +29,7 @@ import com.flowpowered.noise.Noise;
 import com.flowpowered.noise.NoiseQuality;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.extent.ImmutableBiomeArea;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
@@ -45,6 +46,8 @@ public class SkylandsGroundCoverPopulator implements GenerationPopulator {
         new VariableGroundCoverLayer(BlockTypes.DIRT, 1, 4)
     };
     private static final double HOLE_THRESHOLD = 0.6;
+
+    private final Cause populatorCause = Cause.source(this).build();
 
     @Override
     public void populate(World world, MutableBlockVolume buffer, ImmutableBiomeArea biomes) {
@@ -83,7 +86,7 @@ public class SkylandsGroundCoverPopulator implements GenerationPopulator {
                                     break yIteration;
                                 }
                                 if (!buffer.getBlockType(xx, yy, zz).equals(BlockTypes.AIR)) {
-                                    buffer.setBlockType(xx, yy, zz, cover);
+                                    buffer.setBlockType(xx, yy, zz, cover, this.populatorCause);
                                 } else {
                                     break layerIteration;
                                 }

--- a/src/main/java/org/spongepowered/api/extra/modifier/skylands/SkylandsTerrainGenerator.java
+++ b/src/main/java/org/spongepowered/api/extra/modifier/skylands/SkylandsTerrainGenerator.java
@@ -35,6 +35,7 @@ import com.flowpowered.noise.module.modifier.ScalePoint;
 import com.flowpowered.noise.module.source.Perlin;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.extent.ImmutableBiomeArea;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
@@ -61,6 +62,7 @@ public class SkylandsTerrainGenerator implements GenerationPopulator {
     private final Perlin inputNoise = new Perlin();
     private final VerticalScaling outputNoise = new VerticalScaling();
     private final OreNoise[] oreNoises;
+    private final Cause generatorCause = Cause.source(this).build();
 
     /**
      * Constructs a new Skylands terrain generator.
@@ -133,11 +135,11 @@ public class SkylandsTerrainGenerator implements GenerationPopulator {
                     if (density >= THRESHOLD) {
                         for (OreNoise oreNoise : this.oreNoises) {
                             if (oreNoise.hasBlock(density, xx, yy, zz, intSeed)) {
-                                buffer.setBlockType(xx, yy, zz, oreNoise.getBlock());
+                                buffer.setBlockType(xx, yy, zz, oreNoise.getBlock(), this.generatorCause);
                                 continue xIteration;
                             }
                         }
-                        buffer.setBlockType(xx, yy, zz, BlockTypes.STONE);
+                        buffer.setBlockType(xx, yy, zz, BlockTypes.STONE, this.generatorCause);
                     }
                 }
             }

--- a/src/main/java/org/spongepowered/api/world/BlockChangeFlag.java
+++ b/src/main/java/org/spongepowered/api/world/BlockChangeFlag.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.world;
+
+import com.google.common.base.Objects;
+
+/**
+ * A flag of sorts that determines whether a block change will perform various
+ * interactions, such as notifying neighboring blocks, performing block phsyics
+ * on placement, etc.
+ */
+public enum BlockChangeFlag {
+
+    ALL(Flags.NEIGHBOR_MASK | Flags.PHYSICS_MASK),
+    NEIGHBOR(Flags.NEIGHBOR_MASK),
+    PHYSICS(Flags.PHYSICS_MASK),
+    NEIGHBOR_PHYSICS(Flags.NEIGHBOR_MASK | Flags.PHYSICS_MASK),
+    NONE()
+    ;
+
+    private final boolean updateNeighbors;
+    private final boolean performBlockPhysics;
+    private final int rawFlag;
+
+    BlockChangeFlag() {
+        this.updateNeighbors = false;
+        this.performBlockPhysics = false;
+        this.rawFlag = 0;
+    }
+
+    BlockChangeFlag(int flag) {
+        this.updateNeighbors = (flag & Flags.NEIGHBOR_MASK) != 0;
+        this.performBlockPhysics = (flag & Flags.PHYSICS_MASK) != 0;
+        this.rawFlag = flag;
+    }
+
+    /**
+     * Gets whether this flag defines that a block change should
+     * notify neighboring blocks.
+     *
+     * @return True if this is set to notify neighboring blocks
+     */
+    public boolean updateNeighbors() {
+        return this.updateNeighbors;
+    }
+
+    /**
+     * Gets whether this flag defines that a block change should
+     * perform block physics checks or not. If not, no checks
+     * are performed.
+     *
+     * @return True if this is set to perform block physics on placement
+     */
+    public boolean performBlockPhysics() {
+        return this.performBlockPhysics;
+    }
+
+
+    /**
+     * Gets the equivalent {@link BlockChangeFlag} of this flag with all
+     * other flags while having the desired {@code updateNeighbors}
+     * as defined by the parameter.
+     *
+     * @param updateNeighbors Whether to update neighboring blocks
+     * @return The relative flag with the desired update neighbors
+     */
+    public BlockChangeFlag setUpdateNeighbors(boolean updateNeighbors) {
+        if (this.updateNeighbors == updateNeighbors) {
+            return this;
+        }
+        final int maskedFlag = (updateNeighbors ? Flags.NEIGHBOR_MASK : 0)
+                               | (this.performBlockPhysics ? Flags.PHYSICS_MASK : 0);
+        for (BlockChangeFlag blockChangeFlag : values()) {
+            if (blockChangeFlag.rawFlag == maskedFlag) {
+                return blockChangeFlag;
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Gets the equivalent {@link BlockChangeFlag} of this flag
+     * with all other flags while having the desired {@code performBlockPhysics}
+     * as defined by the parameter.
+     *
+     * @param performBlockPhysics Whether to perform block physics
+     * @return The relative flag with the desired block physics
+     */
+    public BlockChangeFlag setPerformBlockPhysics(boolean performBlockPhysics) {
+        if (this.performBlockPhysics == performBlockPhysics) {
+            return this;
+        }
+        final int maskedFlag = (this.updateNeighbors ? Flags.NEIGHBOR_MASK : 0)
+                               | (performBlockPhysics ? Flags.PHYSICS_MASK : 0);
+
+        for (BlockChangeFlag blockChangeFlag : values()) {
+            if (blockChangeFlag.rawFlag == maskedFlag) {
+                return blockChangeFlag;
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("updateNeighbors", this.updateNeighbors)
+                .add("performBlockPhysics", this.performBlockPhysics)
+                .toString();
+    }
+
+    static final class Flags {
+        private static final int NEIGHBOR_MASK = 0b010;
+        private static final int PHYSICS_MASK = 0b100;
+    }
+
+
+
+}

--- a/src/main/java/org/spongepowered/api/world/Chunk.java
+++ b/src/main/java/org/spongepowered/api/world/Chunk.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.world;
 import com.flowpowered.math.vector.Vector3d;
 import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.api.world.extent.worker.MutableBiomeAreaWorker;
@@ -166,6 +167,6 @@ public interface Chunk extends Extent {
     MutableBiomeAreaWorker<? extends Chunk> getBiomeWorker();
 
     @Override
-    MutableBlockVolumeWorker<? extends Chunk> getBlockWorker();
+    MutableBlockVolumeWorker<? extends Chunk> getBlockWorker(Cause cause);
 
 }

--- a/src/main/java/org/spongepowered/api/world/Location.java
+++ b/src/main/java/org/spongepowered/api/world/Location.java
@@ -51,6 +51,7 @@ import org.spongepowered.api.data.merge.MergeFunction;
 import org.spongepowered.api.data.persistence.InvalidDataException;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.world.biome.BiomeType;
 import org.spongepowered.api.world.extent.Extent;
@@ -518,22 +519,24 @@ public final class Location<E extends Extent> implements DataHolder {
      * <p>This will remove any extended block data at the given position.</p>
      *
      * @param state The new block state
+     * @param cause The cause for the block change
+     * @return True if the block change was successful
      */
-    public void setBlock(BlockState state) {
-        getExtent().setBlock(getBlockPosition(), state);
+    public boolean setBlock(BlockState state, Cause cause) {
+        return getExtent().setBlock(getBlockPosition(), state, cause);
     }
 
     /**
      * Replace the block at this position with a new state.
      *
      * <p>This will remove any extended block data at the given position.</p>
-     *
-     * @param state The new block state
-     * @param notifyNeighbors Whether or not you want to notify neighboring
-     * blocks of this change. If true, this may cause blocks to change.
+     *  @param state The new block state
+     * @param flag The various change flags controlling some interactions
+     * @param cause The cause for the block change
+     * @return True if the block change was successful
      */
-    public void setBlock(BlockState state, boolean notifyNeighbors) {
-        getExtent().setBlock(getBlockPosition(), state, notifyNeighbors);
+    public boolean setBlock(BlockState state, BlockChangeFlag flag, Cause cause) {
+        return getExtent().setBlock(getBlockPosition(), state, flag, cause);
     }
 
     /**
@@ -542,22 +545,24 @@ public final class Location<E extends Extent> implements DataHolder {
      * <p>This will remove any extended block data at the given position.</p>
      *
      * @param type The new type
+     * @param cause The cause for the block change
+     * @return True if the block change was successful
      */
-    public void setBlockType(BlockType type) {
-        getExtent().setBlockType(getBlockPosition(), type);
+    public boolean setBlockType(BlockType type, Cause cause) {
+        return getExtent().setBlockType(getBlockPosition(), type, cause);
     }
 
     /**
      * Replace the block type at this position by a new type.
      *
      * <p>This will remove any extended block data at the given position.</p>
-     *
      * @param type The new type
-     * @param notifyNeighbors Whether or not you want to notify neighboring
-     * blocks of this change. If true, this may cause blocks to change.
+     * @param flag The various change flags controlling some interactions
+     * @param cause The cause for the block change
+     * @return True if the block change was successful
      */
-    public void setBlockType(BlockType type, boolean notifyNeighbors) {
-        getExtent().setBlockType(getBlockPosition(), type, notifyNeighbors);
+    public boolean setBlockType(BlockType type, BlockChangeFlag flag, Cause cause) {
+        return getExtent().setBlockType(getBlockPosition(), type, flag, cause);
     }
 
     /**
@@ -565,15 +570,15 @@ public final class Location<E extends Extent> implements DataHolder {
      *
      * <p>Changing the snapshot afterwards will not affect the block that has
      * been placed at this location.</p>
-     *
-     * @param snapshot The snapshot
+     *  @param snapshot The snapshot
      * @param force If true, forces block state to be set even if the
      * {@link BlockType} does not match the snapshot one.
-     * @param notifyNeighbors Whether or not you want to notify neighboring
-     * blocks of this change. If true, this may cause blocks to change.
+     * @param flag The various change flags controlling some interactions
+     * @param cause The cause for the block change
+     * @return True if the snapshot restore was successful
      */
-    public void restoreSnapshot(BlockSnapshot snapshot, boolean force, boolean notifyNeighbors) {
-        getExtent().restoreSnapshot(getBlockPosition(), snapshot, force, notifyNeighbors);
+    public boolean restoreSnapshot(BlockSnapshot snapshot, boolean force, BlockChangeFlag flag, Cause cause) {
+        return getExtent().restoreSnapshot(getBlockPosition(), snapshot, force, flag, cause);
     }
 
     /**
@@ -581,10 +586,12 @@ public final class Location<E extends Extent> implements DataHolder {
      * {@link BlockTypes#AIR}.
      *
      * <p>This will remove any extended block data at the given position.</p>
+     * @param cause The cause for the block change
+     * @return True if the block change was successful
      */
     @SuppressWarnings("ConstantConditions")
-    public void removeBlock() {
-        getExtent().setBlockType(getBlockPosition(), BlockTypes.AIR, true);
+    public boolean removeBlock(Cause cause) {
+        return getExtent().setBlockType(getBlockPosition(), BlockTypes.AIR, BlockChangeFlag.ALL, cause);
     }
 
     @Override
@@ -710,6 +717,11 @@ public final class Location<E extends Extent> implements DataHolder {
     }
 
     @Override
+    public <T> DataTransactionResult offer(Key<? extends BaseValue<T>> key, T value, Cause cause) {
+        return getExtent().offer(getBlockPosition(), key, value, cause);
+    }
+
+    @Override
     public DataTransactionResult offer(Iterable<DataManipulator<?, ?>> valueHolders) {
         return getExtent().offer(getBlockPosition(), valueHolders);
     }
@@ -732,6 +744,11 @@ public final class Location<E extends Extent> implements DataHolder {
     @Override
     public DataTransactionResult offer(DataManipulator<?, ?> valueContainer, MergeFunction function) {
         return getExtent().offer(getBlockPosition(), valueContainer, function);
+    }
+
+    @Override
+    public DataTransactionResult offer(DataManipulator<?, ?> valueContainer, MergeFunction function, Cause cause) {
+        return getExtent().offer(getBlockPosition(), valueContainer, function, cause);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -29,6 +29,7 @@ import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.effect.Viewer;
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.service.context.ContextSource;
 import org.spongepowered.api.text.channel.ChatTypeMessageReceiver;
 import org.spongepowered.api.text.channel.MessageReceiver;
@@ -313,7 +314,7 @@ public interface World extends Extent, WeatherUniverse, Viewer, ContextSource, M
     MutableBiomeAreaWorker<? extends World> getBiomeWorker();
 
     @Override
-    MutableBlockVolumeWorker<? extends World> getBlockWorker();
+    MutableBlockVolumeWorker<? extends World> getBlockWorker(Cause cause);
 
     /**
      * Instructs the world to save all data.

--- a/src/main/java/org/spongepowered/api/world/extent/BlockVolume.java
+++ b/src/main/java/org/spongepowered/api/world/extent/BlockVolume.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.world.extent;
 import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.util.PositionOutOfBoundsException;
 import org.spongepowered.api.world.extent.worker.BlockVolumeWorker;
@@ -211,7 +212,8 @@ public interface BlockVolume {
      * Gets a new block worker for this block volume.
      *
      * @return The block worker
+     * @param cause
      */
-    BlockVolumeWorker<? extends BlockVolume> getBlockWorker();
+    BlockVolumeWorker<? extends BlockVolume> getBlockWorker(Cause cause);
 
 }

--- a/src/main/java/org/spongepowered/api/world/extent/Extent.java
+++ b/src/main/java/org/spongepowered/api/world/extent/Extent.java
@@ -36,6 +36,7 @@ import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.util.Identifiable;
 import org.spongepowered.api.util.PositionOutOfBoundsException;
+import org.spongepowered.api.world.BlockChangeFlag;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.extent.worker.MutableBiomeAreaWorker;
 import org.spongepowered.api.world.extent.worker.MutableBlockVolumeWorker;
@@ -100,57 +101,28 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
     }
 
     /**
-     * Sets the block at the given position in the world.
-     *
-     * @param position The position
-     * @param block The block
-     * @param notifyNeighbors Whether or not you want to notify neighboring
-     *        blocks of this change. If true, this may cause blocks to change.
-     * @throws PositionOutOfBoundsException If the position is outside of the
-     *         bounds of the volume
-     */
-    default void setBlock(Vector3i position, BlockState block, boolean notifyNeighbors) {
-        setBlock(position.getX(), position.getY(), position.getZ(), block, notifyNeighbors);
-    }
-
-    /**
-     * Sets the block at the given position in the world.
-     *
-     * @param x The X position
-     * @param y The Y position
-     * @param z The Z position
-     * @param block The block
-     * @param notifyNeighbors Whether or not you want to notify neighboring
-     *        blocks of this change. If true, this may cause blocks to change.
-     * @throws PositionOutOfBoundsException If the position is outside of the
-     *         bounds of the volume
-     */
-    void setBlock(int x, int y, int z, BlockState block, boolean notifyNeighbors);
-
-    /**
      * Sets the block at the given position in the world with the provided
      * {@link Cause} will be used for any events thrown. Note that the
-     * difference between this an {@link #setBlock(Vector3i, BlockState)} is
+     * difference between this an {@link MutableBlockVolume#setBlock(Vector3i, BlockState, Cause)} is
      * that no block tracking chaining will take place. Note that there is
      * a requirement that the {@link PluginContainer} of the plugin calling
      * this method is <strong>REQUIRED</strong>.
      *
      * @param position The position
      * @param blockState The block
-     * @param notifyNeighbors Whether or not you want to notify neighboring
-     *        blocks of this change. If true, this may cause blocks to change.
+     * @param flag The various change flags controlling some interactions
      * @param cause The cause to use
      * @throws PositionOutOfBoundsException If the position is outside of the
      *         bounds of the volume
      */
-    default void setBlock(Vector3i position, BlockState blockState, boolean notifyNeighbors, Cause cause) {
-        setBlock(position.getX(), position.getY(), position.getZ(), blockState, notifyNeighbors, cause);
+    default boolean setBlock(Vector3i position, BlockState blockState, BlockChangeFlag flag, Cause cause) {
+        return setBlock(position.getX(), position.getY(), position.getZ(), blockState, flag, cause);
     }
 
     /**
      * Sets the block at the given position in the world with the provided
      * {@link Cause} will be used for any events thrown. Note that the
-     * difference between this an {@link #setBlock(Vector3i, BlockState)} is
+     * difference between this an {@link MutableBlockVolume#setBlock(Vector3i, BlockState, Cause)} is
      * that no block tracking chaining will take place. Note that there is
      * a requirement that the {@link PluginContainer} of the plugin calling
      * this method is <strong>REQUIRED</strong>.
@@ -159,72 +131,36 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
      * @param y The Y position
      * @param z The Z position
      * @param blockState The block
-     * @param notifyNeighbors Whether or not you want to notify neighboring
-     *        blocks of this change. If true, this may cause blocks to change.
+     * @param flag The various change flags controlling some interactions
      * @param cause The cause to use
      * @throws PositionOutOfBoundsException If the position is outside of the
      *         bounds of the volume
      */
-    void setBlock(int x, int y, int z, BlockState blockState, boolean notifyNeighbors, Cause cause);
-
-    /**
-     * Replace the block at this position by a new type.
-     *
-     * <p>This will remove any extended block data at the given position.</p>
-     *
-     * @param position The position of the block
-     * @param type The new type
-     * @param notifyNeighbors Whether or not you want to notify neighboring
-     *        blocks of this change. If true, this may cause blocks to change.
-     * @throws PositionOutOfBoundsException If the position is outside of the
-     *         bounds of the area
-     */
-    default void setBlockType(Vector3i position, BlockType type, boolean notifyNeighbors) {
-        setBlockType(position.getX(), position.getY(), position.getZ(), type, notifyNeighbors);
-    }
-
-    /**
-     * Replace the block at this position by a new type.
-     *
-     * <p>This will remove any extended block data at the given position.</p>
-     *
-     * @param x The X position
-     * @param y The Y position
-     * @param z The Z position
-     * @param type The new type
-     * @param notifyNeighbors Whether or not you want to notify neighboring
-     *        blocks. If true, this may cause blocks to change.
-     * @throws PositionOutOfBoundsException If the position is outside of the
-     *         bounds of the area
-     */
-    default void setBlockType(int x, int y, int z, BlockType type, boolean notifyNeighbors) {
-        setBlock(x, y, z, type.getDefaultState(), notifyNeighbors);
-    }
+    boolean setBlock(int x, int y, int z, BlockState blockState, BlockChangeFlag flag, Cause cause);
 
     /**
      * Sets the block at the given position in the world with the provided
      * {@link Cause} will be used for any events thrown. Note that the
-     * difference between this an {@link #setBlockType(Vector3i, BlockType)} is
+     * difference between this an {@link MutableBlockVolume#setBlockType(Vector3i, BlockType, Cause)} is
      * that no block tracking chaining will take place. Note that there is
      * a requirement that the {@link PluginContainer} of the plugin calling
      * this method is <strong>REQUIRED</strong>.
      *
      * @param position The position
      * @param type The block type
-     * @param notifyNeighbors Whether or not you want to notify neighboring
-     *        blocks of this change. If true, this may cause blocks to change.
+     * @param flag The various change flags controlling some interactions
      * @param cause The cause to use
      * @throws PositionOutOfBoundsException If the position is outside of the
      *         bounds of the volume
      */
-    default void setBlockType(Vector3i position, BlockType type, boolean notifyNeighbors, Cause cause) {
-        setBlock(position.getX(), position.getY(), position.getZ(), type.getDefaultState(), notifyNeighbors, cause);
+    default boolean setBlockType(Vector3i position, BlockType type, BlockChangeFlag flag, Cause cause) {
+        return setBlock(position.getX(), position.getY(), position.getZ(), type.getDefaultState(), flag, cause);
     }
 
     /**
      * Sets the block at the given position in the world with the provided
      * {@link Cause} will be used for any events thrown. Note that the
-     * difference between this an {@link #setBlockType(Vector3i, BlockType)} is
+     * difference between this an {@link MutableBlockVolume#setBlockType(Vector3i, BlockType, Cause)} is
      * that no block tracking chaining will take place. Note that there is
      * a requirement that the {@link PluginContainer} of the plugin calling
      * this method is <strong>REQUIRED</strong>.
@@ -233,14 +169,13 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
      * @param y The Y position
      * @param z The Z position
      * @param type The block
-     * @param notifyNeighbors Whether or not you want to notify neighboring
-     *        blocks of this change. If true, this may cause blocks to change.
+     * @param flag The various change flags controlling some interactions
      * @param cause The cause to use
      * @throws PositionOutOfBoundsException If the position is outside of the
      *         bounds of the volume
      */
-    default void setBlockType(int x, int y, int z, BlockType type, boolean notifyNeighbors, Cause cause) {
-        setBlock(x, y, z, type.getDefaultState(), notifyNeighbors, cause);
+    default boolean setBlockType(int x, int y, int z, BlockType type, BlockChangeFlag flag, Cause cause) {
+        return setBlock(x, y, z, type.getDefaultState(), flag, cause);
     }
 
     /**
@@ -282,11 +217,11 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
      * @param snapshot The snapshot
      * @param force If true, forces block state to be set even if the
      *        {@link BlockType} does not match the snapshot one.
-     * @param notifyNeighbors Whether or not you want to notify neighboring
-     *        blocks of this change. If true, this may cause blocks to change.
+     * @param flag The various change flags controlling some interactions
+     * @param cause The cause of the snapshot restore
      * @return true if the restore was successful, false otherwise
      */
-    boolean restoreSnapshot(BlockSnapshot snapshot, boolean force, boolean notifyNeighbors);
+    boolean restoreSnapshot(BlockSnapshot snapshot, boolean force, BlockChangeFlag flag, Cause cause);
 
     /**
      * Restores the {@link BlockSnapshot} at the given position.
@@ -301,12 +236,11 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
      * @param snapshot The snapshot
      * @param force If true, forces block state to be set even if the
      *        {@link BlockType} does not match the snapshot one.
-     * @param notifyNeighbors Whether or not you want to notify neighboring
-     *        blocks of this change. If true, this may cause blocks to change.
+     * @param flag The various change flags controlling some interactions
      * @return true if the restore was successful, false otherwise
      */
-    default boolean restoreSnapshot(Vector3i position, BlockSnapshot snapshot, boolean force, boolean notifyNeighbors) {
-        return restoreSnapshot(position.getX(), position.getY(), position.getZ(), snapshot, force, notifyNeighbors);
+    default boolean restoreSnapshot(Vector3i position, BlockSnapshot snapshot, boolean force, BlockChangeFlag flag, Cause cause) {
+        return restoreSnapshot(position.getX(), position.getY(), position.getZ(), snapshot, force, flag, cause);
     }
 
     /**
@@ -324,11 +258,11 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
      * @param snapshot The snapshot
      * @param force If true, forces block state to be set even if the
      *        {@link BlockType} does not match the snapshot one.
-     * @param notifyNeighbors Whether or not you want to notify neighboring
-     *        blocks of this change. If true, this may cause blocks to change.
+     * @param flag The various change flags controlling some interactions
+     * @param cause The cause of the snapshot restore
      * @return true if the restore was successful, false otherwise
      */
-    boolean restoreSnapshot(int x, int y, int z, BlockSnapshot snapshot, boolean force, boolean notifyNeighbors);
+    boolean restoreSnapshot(int x, int y, int z, BlockSnapshot snapshot, boolean force, BlockChangeFlag flag, Cause cause);
 
     /**
      * Gets a list of {@link ScheduledBlockUpdate}s on this block.
@@ -437,7 +371,7 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
     MutableBiomeAreaWorker<? extends Extent> getBiomeWorker();
 
     @Override
-    MutableBlockVolumeWorker<? extends Extent> getBlockWorker();
+    MutableBlockVolumeWorker<? extends Extent> getBlockWorker(Cause cause);
 
     /**
      * Gets the {@link UUID}, if available, of the user who created the

--- a/src/main/java/org/spongepowered/api/world/extent/ImmutableBlockVolume.java
+++ b/src/main/java/org/spongepowered/api/world/extent/ImmutableBlockVolume.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.world.extent;
 
 import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.util.PositionOutOfBoundsException;
 import org.spongepowered.api.world.extent.worker.BlockVolumeWorker;
@@ -79,6 +80,6 @@ public interface ImmutableBlockVolume extends UnmodifiableBlockVolume {
     }
 
     @Override
-    BlockVolumeWorker<? extends ImmutableBlockVolume> getBlockWorker();
+    BlockVolumeWorker<? extends ImmutableBlockVolume> getBlockWorker(Cause cause);
 
 }

--- a/src/main/java/org/spongepowered/api/world/extent/InteractableVolume.java
+++ b/src/main/java/org/spongepowered/api/world/extent/InteractableVolume.java
@@ -310,6 +310,6 @@ public interface InteractableVolume extends MutableBlockVolume {
     int getBlockDigTimeWith(int x, int y, int z, ItemStack itemStack, Cause cause);
 
     @Override
-    MutableBlockVolumeWorker<? extends InteractableVolume> getBlockWorker();
+    MutableBlockVolumeWorker<? extends InteractableVolume> getBlockWorker(Cause cause);
 
 }

--- a/src/main/java/org/spongepowered/api/world/extent/LocationCompositeValueStore.java
+++ b/src/main/java/org/spongepowered/api/world/extent/LocationCompositeValueStore.java
@@ -28,6 +28,7 @@ import static com.google.gson.internal.$Gson$Preconditions.checkNotNull;
 
 import com.flowpowered.math.vector.Vector3i;
 import com.google.common.collect.ImmutableSet;
+import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataTransactionResult;
@@ -37,7 +38,9 @@ import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.merge.MergeFunction;
 import org.spongepowered.api.data.persistence.InvalidDataException;
 import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.Location;
 
 import java.util.Collection;
@@ -465,6 +468,58 @@ public interface LocationCompositeValueStore {
     <E> DataTransactionResult offer(int x, int y, int z, Key<? extends BaseValue<E>> key, E value);
 
     /**
+     * Offers the given <code>E</code> value that is keyed by the provided
+     * {@link Key} to the block at the provided location.
+     *
+     * <p>If any data is rejected or existing data is replaced, the
+     * {@link DataTransactionResult} will retain the rejected and replaced
+     * data.</p>
+     *
+     * <p>Note that this differs from {@link #offer(Vector3i, Key, Object)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param coordinates The position of the block
+     * @param key The key for the data
+     * @param value The value to offer
+     * @param cause The cause to use for events if necessary
+     * @param <E> The type of data being offered
+     * @return The transaction result
+     */
+    default <E> DataTransactionResult offer(Vector3i coordinates, Key<? extends BaseValue<E>> key, E value, Cause cause) {
+        return offer(coordinates.getX(), coordinates.getY(), coordinates.getZ(), key, value, cause);
+    }
+
+    /**
+     * Offers the given <code>E</code> value that is keyed by the provided
+     * {@link Key} to the block at the provided location.
+     *
+     * <p>If any data is rejected or existing data is replaced, the
+     * {@link DataTransactionResult} will retain the rejected and replaced
+     * data.</p>
+     *
+     * <p>Note that this differs from {@link #offer(Vector3i, Key, Object)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param x The X position
+     * @param y The Y position
+     * @param z The Z position
+     * @param key The key for the data
+     * @param value The value to offer
+     * @param cause The cause to use for events if necessary
+     * @param <E> The type of data being offered
+     * @return The transaction result
+     */
+    <E> DataTransactionResult offer(int x, int y, int z, Key<? extends BaseValue<E>> key, E value, Cause cause);
+
+    /**
      * Offers the given {@link BaseValue} to the block at the given position.
      *
      * <p>If any data is rejected or existing data is replaced, the
@@ -496,6 +551,56 @@ public interface LocationCompositeValueStore {
      */
     default <E> DataTransactionResult offer(int x, int y, int z, BaseValue<E> value) {
         return offer(x, y, z, value.getKey(), value.get());
+    }
+
+    /**
+     * Offers the given {@link BaseValue} to the block at the given position.
+     *
+     * <p>If any data is rejected or existing data is replaced, the
+     * {@link DataTransactionResult} will retain the rejected and replaced
+     * data.</p>
+     *
+     * <p>Note that this differs from {@link #offer(Vector3i, Key, Object)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param coordinates The position of the block
+     * @param value The value to offer
+     * @param cause The cause to use for events if necessary
+     * @param <E> The type of the element wrapped by the value
+     * @return The transaction result
+     */
+    default <E> DataTransactionResult offer(Vector3i coordinates, BaseValue<E> value, Cause cause) {
+        return offer(coordinates.getX(), coordinates.getY(), coordinates.getZ(), value.getKey(), value.get(), cause);
+    }
+
+    /**
+     * Offers the given {@link BaseValue} to the block at the given position.
+     *
+     * <p>If any data is rejected or existing data is replaced, the
+     * {@link DataTransactionResult} will retain the rejected and replaced
+     * data.</p>
+     *
+     * <p>Note that this differs from {@link #offer(Vector3i, Key, Object)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param x The X position
+     * @param y The Y position
+     * @param z The Z position
+     * @param value The value to offer
+     * @param cause The cause to use for events if necessary
+     * @param <E> The type of the element wrapped by the value
+     * @return The transaction result
+     */
+    default <E> DataTransactionResult offer(int x, int y, int z, BaseValue<E> value, Cause cause) {
+        return offer(x, y, z, value.getKey(), value.get(), cause);
     }
 
     /**
@@ -540,6 +645,56 @@ public interface LocationCompositeValueStore {
      * {@link DataTransactionResult} will retain the rejected and replaced
      * data.</p>
      *
+     * <p>Note that this differs from {@link #offer(Vector3i, Key, Object)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param coordinates The position of the block
+     * @param manipulator The manipulator data to offer
+     * @param cause The cause to use for events if necessary
+     * @return The transaction result
+     */
+    default DataTransactionResult offer(Vector3i coordinates, DataManipulator<?, ?> manipulator, Cause cause) {
+        return offer(coordinates.getX(), coordinates.getY(), coordinates.getZ(), manipulator, MergeFunction.IGNORE_ALL, cause);
+    }
+
+    /**
+     * Offers the given {@link DataManipulator} to the block at the given
+     * position.
+     *
+     * <p>If any data is rejected or existing data is replaced, the
+     * {@link DataTransactionResult} will retain the rejected and replaced
+     * data.</p>
+     *
+     * <p>Note that this differs from {@link #offer(Vector3i, Key, Object)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param x The X position
+     * @param y The Y position
+     * @param z The Z position
+     * @param manipulator The manipulator data to offer
+     * @param cause The cause to use for events if necessary
+     * @return The transaction result
+     */
+    default DataTransactionResult offer(int x, int y, int z, DataManipulator<? ,?> manipulator, Cause cause) {
+        return offer(x, y, z, manipulator, MergeFunction.IGNORE_ALL, cause);
+    }
+
+    /**
+     * Offers the given {@link DataManipulator} to the block at the given
+     * position.
+     *
+     * <p>If any data is rejected or existing data is replaced, the
+     * {@link DataTransactionResult} will retain the rejected and replaced
+     * data.</p>
+     *
      * @param coordinates The position of the block
      * @param manipulator The manipulator data to offer
      * @param function The merge function to resolve conflicts
@@ -565,6 +720,56 @@ public interface LocationCompositeValueStore {
      * @return The transaction result
      */
     DataTransactionResult offer(int x, int y, int z, DataManipulator<?, ?> manipulator, MergeFunction function);
+
+    /**
+     * Offers the given {@link DataManipulator} to the block at the given
+     * position.
+     *
+     * <p>If any data is rejected or existing data is replaced, the
+     * {@link DataTransactionResult} will retain the rejected and replaced
+     * data.</p>
+     *
+     * <p>Note that this differs from {@link #offer(Vector3i, Key, Object)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param coordinates The position of the block
+     * @param manipulator The manipulator data to offer
+     * @param function The merge function to resolve conflicts
+     * @param cause The cause to use for events if necessary
+     * @return The transaction result
+     */
+    default DataTransactionResult offer(Vector3i coordinates, DataManipulator<?, ?> manipulator, MergeFunction function, Cause cause) {
+        return offer(coordinates.getX(), coordinates.getY(), coordinates.getZ(), manipulator, function, cause);
+    }
+
+    /**
+     * Offers the given {@link DataManipulator} to the block at the given
+     * position.
+     *
+     * <p>If any data is rejected or existing data is replaced, the
+     * {@link DataTransactionResult} will retain the rejected and replaced
+     * data.</p>
+     *
+     * <p>Note that this differs from {@link #offer(Vector3i, Key, Object)}
+     * as in that if a change is required to a
+     * {@link MutableBlockVolume#setBlock(int, int, int, BlockState, Cause)}
+     * or similar is performed, the provided {@link Cause} is used for the change
+     * in {@link BlockState}s. Traditional offer methods that do <strong>NOT</strong>
+     * take a {@link Cause} will fail if a block change is required.</p>
+     *
+     * @param x The X position
+     * @param y The Y position
+     * @param z The Z position
+     * @param manipulator The manipulator data to offer
+     * @param function The merge function to resolve conflicts
+     * @param cause The cause to use for events if necessary
+     * @return The transaction result
+     */
+    DataTransactionResult offer(int x, int y, int z, DataManipulator<?, ?> manipulator, MergeFunction function, Cause cause);
 
     /**
      * Offers the provided {@link DataManipulator}s to the block at the given

--- a/src/main/java/org/spongepowered/api/world/extent/MutableBlockVolume.java
+++ b/src/main/java/org/spongepowered/api/world/extent/MutableBlockVolume.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.world.extent;
 import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.util.PositionOutOfBoundsException;
 import org.spongepowered.api.world.extent.worker.MutableBlockVolumeWorker;
@@ -43,11 +44,12 @@ public interface MutableBlockVolume extends BlockVolume {
      *
      * @param position The position
      * @param block The block
+     * @param cause
      * @throws PositionOutOfBoundsException If the position is outside of the
      *         bounds of the volume
      */
-    default void setBlock(Vector3i position, BlockState block) {
-        setBlock(position.getX(), position.getY(), position.getZ(), block);
+    default boolean setBlock(Vector3i position, BlockState block, Cause cause) {
+        return setBlock(position.getX(), position.getY(), position.getZ(), block, cause);
     }
 
     /**
@@ -57,10 +59,11 @@ public interface MutableBlockVolume extends BlockVolume {
      * @param y The Y position
      * @param z The Z position
      * @param block The block
+     * @param cause
      * @throws PositionOutOfBoundsException If the position is outside of the
      *         bounds of the volume
      */
-    void setBlock(int x, int y, int z, BlockState block);
+    boolean setBlock(int x, int y, int z, BlockState block, Cause cause);
 
     /**
      * Replace the block at this position by a new type.
@@ -69,11 +72,12 @@ public interface MutableBlockVolume extends BlockVolume {
      *
      * @param position The position of the block
      * @param type The new type
+     * @param cause
      * @throws PositionOutOfBoundsException If the position is outside of the
      *         bounds of the area
      */
-    default void setBlockType(Vector3i position, BlockType type) {
-        setBlockType(position.getX(), position.getY(), position.getZ(), type);
+    default boolean setBlockType(Vector3i position, BlockType type, Cause cause) {
+        return setBlockType(position.getX(), position.getY(), position.getZ(), type, cause);
     }
 
     /**
@@ -85,11 +89,12 @@ public interface MutableBlockVolume extends BlockVolume {
      * @param y The Y position
      * @param z The Z position
      * @param type The new type
+     * @param cause
      * @throws PositionOutOfBoundsException If the position is outside of the
      *         bounds of the area
      */
-    default void setBlockType(int x, int y, int z, BlockType type) {
-        setBlock(x, y, z, type.getDefaultState());
+    default boolean setBlockType(int x, int y, int z, BlockType type, Cause cause) {
+        return setBlock(x, y, z, type.getDefaultState(), cause);
     }
 
     /**
@@ -129,6 +134,6 @@ public interface MutableBlockVolume extends BlockVolume {
     }
 
     @Override
-    MutableBlockVolumeWorker<? extends MutableBlockVolume> getBlockWorker();
+    MutableBlockVolumeWorker<? extends MutableBlockVolume> getBlockWorker(Cause cause);
 
 }

--- a/src/main/java/org/spongepowered/api/world/extent/TileEntityVolume.java
+++ b/src/main/java/org/spongepowered/api/world/extent/TileEntityVolume.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.world.extent;
 
 import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.block.tileentity.TileEntity;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.extent.worker.MutableBlockVolumeWorker;
 
 import java.util.Collection;
@@ -85,6 +86,6 @@ public interface TileEntityVolume extends MutableBlockVolume {
     Optional<TileEntity> getTileEntity(int x, int y, int z);
 
     @Override
-    MutableBlockVolumeWorker<? extends TileEntityVolume> getBlockWorker();
+    MutableBlockVolumeWorker<? extends TileEntityVolume> getBlockWorker(Cause cause);
 
 }

--- a/src/main/java/org/spongepowered/api/world/extent/UnmodifiableBlockVolume.java
+++ b/src/main/java/org/spongepowered/api/world/extent/UnmodifiableBlockVolume.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.world.extent;
 
 import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.util.PositionOutOfBoundsException;
 import org.spongepowered.api.world.extent.worker.BlockVolumeWorker;
@@ -79,6 +80,6 @@ public interface UnmodifiableBlockVolume extends BlockVolume {
     }
 
     @Override
-    BlockVolumeWorker<? extends UnmodifiableBlockVolume> getBlockWorker();
+    BlockVolumeWorker<? extends UnmodifiableBlockVolume> getBlockWorker(Cause cause);
 
 }

--- a/src/main/java/org/spongepowered/api/world/extent/worker/BlockVolumeWorker.java
+++ b/src/main/java/org/spongepowered/api/world/extent/worker/BlockVolumeWorker.java
@@ -53,7 +53,6 @@ public interface BlockVolumeWorker<V extends BlockVolume> {
     /**
      * Applies a mapping operation to all the blocks in the volume and saves the
      * results to the destination volume.
-     *
      * @param mapper The mapping operation
      * @param destination The destination volume
      */
@@ -62,7 +61,6 @@ public interface BlockVolumeWorker<V extends BlockVolume> {
     /**
      * Applies a merging operation to the blocks of the operating volume and an
      * external one. Saves the results to the destination volume.
-     *
      * @param second The volume to merge with
      * @param merger The merging operation
      * @param destination The destination volume

--- a/src/main/java/org/spongepowered/api/world/extent/worker/MutableBlockVolumeWorker.java
+++ b/src/main/java/org/spongepowered/api/world/extent/worker/MutableBlockVolumeWorker.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.world.extent.worker;
 
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.extent.BlockVolume;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
 import org.spongepowered.api.world.extent.worker.procedure.BlockVolumeFiller;
@@ -39,26 +40,24 @@ import org.spongepowered.api.world.extent.worker.procedure.BlockVolumeMerger;
 public interface MutableBlockVolumeWorker<V extends MutableBlockVolume> extends BlockVolumeWorker<V> {
 
     /**
-     * Similar to {@link BlockVolumeWorker#map(BlockVolumeMapper,
-     * MutableBlockVolume)} but uses the operating volume as the destination.
+     * Similar to {@link BlockVolumeWorker#map(BlockVolumeMapper, MutableBlockVolume)} but uses the operating volume as the destination.
      * Precautions must be taken as the volume is modified while the operation
      * is being performed, and so the surrounding blocks might not be the
      * original ones.
+     *  @param mapper The mapping operation
      *
-     * @param mapper The mapping operation
      */
     default void map(BlockVolumeMapper mapper) {
         map(mapper, getVolume());
     }
 
     /**
-     * Similar to {@link BlockVolumeWorker#merge(BlockVolume,
-     * BlockVolumeMerger, MutableBlockVolume)} but uses the operating volume as
+     * Similar to {@link BlockVolumeWorker#merge(BlockVolume, BlockVolumeMerger, MutableBlockVolume)} but uses the operating volume as
      * the destination. Precautions must be taken as the volume is modified
      * while the operation is being performed, and so the surrounding blocks
      * might not be the original ones.
+     *  @param merger The merging operation
      *
-     * @param merger The merging operation
      */
     default void merge(BlockVolume right, BlockVolumeMerger merger) {
         merge(right, merger, getVolume());
@@ -68,7 +67,8 @@ public interface MutableBlockVolumeWorker<V extends MutableBlockVolume> extends 
      * Applies a filler operation to the volume.
      *
      * @param filler The filler operation
+     * @param cause
      */
-    void fill(BlockVolumeFiller filler);
+    void fill(BlockVolumeFiller filler, Cause cause);
 
 }

--- a/src/main/java/org/spongepowered/api/world/gen/Populator.java
+++ b/src/main/java/org/spongepowered/api/world/gen/Populator.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.api.world.gen;
 
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.api.world.gen.populator.RandomObject;
@@ -40,6 +42,11 @@ import java.util.Random;
  * <p>Instead of directly implementing this interface, it may be easier to
  * implement {@link PopulatorObject} instead, and use the {@link RandomObject}
  * populator to get a populator that spawns that object.</p>
+ *
+ * <p>Note that while {@link Extent#setBlock(int, int, int, BlockState, Cause)}
+ * and other like minded methods take a {@link Cause}, blocks are not captured,
+ * nor are events thrown for block changes from a populator performing block
+ * changes.</p>
  *
  * @see PopulatorObject
  */


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/851) | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/770)

This is a more focused PR at dealing with several issues at once, but for the sake of having not had a decent PR description in a while, I'll rehash the conversational description that we used to have a while back.

#### So what's changing?

In short, if a plugin developer is calling any API method that changes something, an event should be thrown. Traditionally, we used to have the inability to throw events for virtually everything, however, at this point in time, it's well within our means to throw events for all `setBlock`, `createEntity`, `spawnEntity`, etc. 

#### But why force plugin developers to supply a `Cause`? Don't developers know to throw events to check for things before they make a change?

Yes and no. It's been useful for developers to throw "dummy" events to check for permissions or block modifications before finalizing a change, and for other cases, to throw dummy spawn events before an entity is indeed spawned into the world. The problem with all of this is that it's entirely up to the developer whether to throw the events, or not throw the events, and other plugins are none the wiser. This is especially complicated by the fact that Sponge has a very complex tracking system that performs various actions based on pre-defined expectations. The change resolves a great many event cause tracking determining aspects, such as a synchronous task set up by plugin X to make a tree due to player Y. 

#### Could you explain why this wasn't an issue in API 4.X?

The issue lies in the API and the implementation. Originally planned, the CauseTracker in 1.8.9 does a very good job at determining what is causing X, Y, and Z happening, when it's *expected*. Plugins that call our methods to spawn entities are bypassing the CauseTracker, but only to a limited extent, there's no `Cause` required or provided, and other plugins have no knowledge of why an entity was being spawned. Or for that matter, the CauseTracker can flip out if a multitude of block changes take place in a synchronized task, but this isn't the fault of the CauseTracker, more so our contracts we set forth in the API. If I had to pinpoint why the change is necessary, it's that the CauseTracker is more of a mechanism to determine causes for which things happen.

#### So what actually is changing API wise?

In short, any method that changes a block in a `World` (or `Extent`) will require a `Cause`. Virtually anything that touches changing blocks will now provide a `Cause` to the system, and the system will be able to apply that provided `Cause` to the ensuing `ChangeBlockEvent` (unless this is a populator, which can simply provide a recycled `Cause` as shown in the skylands populators and generators). Data API has gained an overloaded method that will provide a `Cause` for the cases that the `#offer(Key,Object,Cause)` will change a block in a `World`, however, normal offers that simply change data on a `TileEntity` can still use the traditional `#offer(Key,Object)` method. It is understandable at this point as well that the other `DataHolder` implementations may throw Data related events with the provided `Cause`.

#### What else? What's this `BlockChangeFlag`?

Ah, so that is a brainchild of the various `boolean` flags that we used to require plugin developers to provide, namely to show that there are various *options* to perform a block change. The reasoning for it is that previously, we could only allow developers to *NOT* notify neighboring blocks on a block change, but we didn't allow it to *NOT* perform block physics on placement. This caused issues with some `BlockSnapshot#restore`s, since the restore process would always perform block physics due to the nature of the implementation. At this point, instead of adding yet another `boolean` flag and set of overloads, it was simpler to use an object to determine whether neighbor notifications should take place, and if block physics should take place. In the future, more flags may be added as necessary, and this time without breaking the API ;).

#### With all of the `Cause` usage, why does this look like the implementation is leaking into the API?

It is and isn't. Due to the nature of our tracking system, this is the best way that we can achieve a proper API contract of "all your changes throw events". Likewise, this eliminates the issues of being able to deterministically resolve what is performing changes to the world, without some obscure `Cause` containing a `Task` and or a `PluginContainer`. This also eliminates any sort of tracking required on our part to *determine* what caused those changes. This ends up with the API being more contractually sound with the end result that plugins no longer have to throw dummy events and the implementation has no requirement to track and determine what is going on throughout different phases.

Any further questions can be asked below.