### PR TITLE
Add ability to get/set state of CommandContext, update GenericArguments.firstParsing to discard parsed arguments

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/CommandContext.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandContext.java
@@ -158,4 +158,29 @@ public final class CommandContext {
     public boolean hasAny(Text key) {
         return hasAny(ArgUtils.textToArgKey(key));
     }
+
+    /**
+     * Return this arguments object's current state. Can be used to reset with the {@link #setState(Object)} method.
+     *
+     * @return The current state
+     */
+    public Object getState() {
+        return ArrayListMultimap.create(this.parsedArgs);
+    }
+
+    /**
+     * Restore the arguments object's state to a state previously used.
+     *
+     * @param state the previous state
+     */
+    @SuppressWarnings("unchecked")
+    public void setState(Object state) {
+        // Check that the object we get back also only has String keys.
+        if (!(state instanceof Multimap) || !((Multimap<?, ?>) state).keySet().stream().allMatch(String.class::isInstance)) {
+            throw new IllegalArgumentException("Provided state was not of appropriate format returned by getState!");
+        }
+
+        this.parsedArgs.clear();
+        this.parsedArgs.putAll((Multimap)state);
+    }
 }

--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -417,13 +417,15 @@ public final class GenericArguments {
         public void parse(CommandSource source, CommandArgs args, CommandContext context) throws ArgumentParseException {
             ArgumentParseException lastException = null;
             for (CommandElement element : this.elements) {
-                Object startState = args.getState();
+                Object argsStartState = args.getState();
+                Object contextStartState = context.getState();
                 try {
                     element.parse(source, args, context);
                     return;
                 } catch (ArgumentParseException ex) {
                     lastException = ex;
-                    args.setState(startState);
+                    args.setState(argsStartState);
+                    context.setState(contextStartState);
                 }
             }
             if (lastException != null) {

--- a/src/test/java/org/spongepowered/api/command/args/GenericArgumentsTest.java
+++ b/src/test/java/org/spongepowered/api/command/args/GenericArgumentsTest.java
@@ -131,6 +131,20 @@ public class GenericArgumentsTest {
     }
 
     @Test
+    public void testFirstParsingWithSequence() throws ArgumentParseException {
+        CommandElement el = firstParsing(seq(string(untr("val1")), string(untr("val2"))), string(untr("val3")));
+        CommandContext context = parseForInput("word", el);
+        assertFalse(context.getOne("val1").isPresent());
+        assertFalse(context.getOne("val2").isPresent());
+        assertEquals("word", context.getOne("val3").get());
+
+        context = parseForInput("word 42", el);
+        assertFalse(context.getOne("val3").isPresent());
+        assertEquals("word", context.getOne("val1").get());
+        assertEquals("42", context.getOne("val2").get());
+    }
+
+    @Test
     public void testOptional() throws ArgumentParseException {
         CommandElement el = optional(string(untr("val")));
         CommandContext context = parseForInput("", el);


### PR DESCRIPTION
Pinging @zml2008 as the commands guru!

When using `GenericArguments.firstParsing()` with a sequence of arguments, for example:

```java
GenericArguments.firstParsing(
    GenericArguments.seq(
        GenericArguments.string(Text.of("test1")),
        GenericArguments.string(Text.of("test2"))
    ),

    GenericArguments.string(Text.of("test3"))
)
```

if we run the command `/test test`, both variables "test1" and "test3" will be added to the `CommandContext` as "test", which is incorrect. This is because the state of the `CommandArgs` object is saved, but the `CommandContext` is not.

This PR adds the ability to save the state of the `CommandContext` in the same way that the `CommandArgs` object is saved, so that using the first parsing argument with a sequence of arguments will not have their parsed arguments bleed into each other.

A unit test has been added to verify this behaviour, and the code used to test this behaviour, along with output, is in the included gist.

https://gist.github.com/dualspiral/0ac16d62f265e45222c1a22784cc2831

I have targeted master/API 4.2.x as this is a bugfix that does not break any API methods.