### PR TITLE
Expose Caffeine to plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ dependencies {
     // Dependency injection
     compile 'com.google.inject:guice:4.0'
 
+    // Java 8 high performance cache (+ wrapper for Guava)
+    compile 'com.github.ben-manes.caffeine:caffeine:2.3.2'
+    compile 'com.github.ben-manes.caffeine:guava:2.3.2'
+
     // Plugin meta
     compile 'org.spongepowered:plugin-meta:0.1.1'
 


### PR DESCRIPTION
Since we now bundle [Caffeine](https://github.com/ben-manes/caffeine) with SpongeCommon we can also expose it to plugins so they can use it without having to bundle it together with the plugin.

Additional to Caffeine I've also added the Guava adaptors which may be useful for some plugins that are still using Guava caches right now.