### PR TITLE
Update BlockRay Filters to Filter Instead of stopping the Block Ray

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -1228,7 +1228,7 @@ public final class GenericArguments {
                 yStr = split[1];
                 zStr = split[2];
             } else if (xStr.equals("#target") && source instanceof Entity) {
-                Optional<BlockRayHit<World>> hit = BlockRay.from(((Entity) source)).filter(BlockRay.onlyAirFilter()).build().end();
+                Optional<BlockRayHit<World>> hit = BlockRay.from(((Entity) source)).stopWhen(BlockRay.onlyAirFilter()).build().end();
                 if (!hit.isPresent()) {
                     throw args.createError(t("No target block is available! Stop stargazing!"));
                 }

--- a/src/main/java/org/spongepowered/api/util/blockray/BlockRay.java
+++ b/src/main/java/org/spongepowered/api/util/blockray/BlockRay.java
@@ -367,6 +367,7 @@ public class BlockRay<E extends Extent> implements Iterator<BlockRayHit<E>> {
             return false;
         }
 
+        // Check if the end predicate is satisfied.
         if (!this.endPredicate.test(hit)) {
             throw new NoSuchElementException("End predicate satisfied");
         }


### PR DESCRIPTION
Currently, BlockRay filters do not filter Block hits, instead when the filter predicate is true, the BlockRay stops. This really doesn't reflect a true "filter" and instead reflects more of a stopping predicate.

This misconception is shared by other plugin developers in the community: https://forums.spongepowered.org/t/how-to-get-the-location-the-player-is-looking-at-from-an-entity-location-and-rotation/8906

This PR switches filters to filter blocks and continue hitting. The previous functionality has been preserved in a "stopWhen" call.

Here is a test plugin with three test commands: https://gist.github.com/m0pt0pmatt/79ce98dbeaf08f692f3425f8ffc12e4b

1. The first command prints the first block the player is looking at which isn't AIR.
2. The second command prints the last block between the player and a COAL_BLOCK.
3. And the last one stops prints the last block between the player and a given Location.

Note that I've tested that the first command works, but haven't put the time to test the other two personally. However, I'm fairly confident in them.

Also note that, just life the previous filter implementation, the final block is not included when the stopWhen predicates are true. I also believe this is incorrect, but I wanted to wait on input from others.