### PR TITLE
Remove custom asset directories

### DIFF
--- a/src/ap/java/org/spongepowered/plugin/processor/PluginElement.java
+++ b/src/ap/java/org/spongepowered/plugin/processor/PluginElement.java
@@ -40,8 +40,6 @@ import org.spongepowered.plugin.meta.version.VersionRange;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.InvalidPathException;
-import java.nio.file.Paths;
 
 import javax.annotation.processing.Messager;
 import javax.lang.model.element.TypeElement;
@@ -120,23 +118,6 @@ final class PluginElement {
             }
         }
 
-        value = this.annotation.get().assets();
-        if (!value.isEmpty()) {
-            if (!isValidPath(value)) {
-                messager.printMessage(ERROR, "Invalid asset directory path: " + value, this.element, this.annotation.getMirror(),
-                        this.annotation.getValue("assets"));
-            }
-            SpongeExtension ext = new SpongeExtension();
-            ext.setAssetDirectory(value);
-            this.metadata.setExtension("sponge", ext);
-        } else {
-            SpongeExtension ext = this.metadata.getExtension("sponge");
-            if (ext != null && ext.getAssetDirectory() != null && !isValidPath(ext.getAssetDirectory())) {
-                messager.printMessage(ERROR, "Invalid asset directory path: " + value + " in extra metadata files", this.element,
-                        this.annotation.getMirror());
-            }
-        }
-
         String[] authors = this.annotation.get().authors();
         if (authors.length > 0) {
             this.metadata.getAuthors().clear();
@@ -200,15 +181,6 @@ final class PluginElement {
             new URL(url).toURI();
             return true;
         } catch (MalformedURLException | URISyntaxException ignored) {
-            return false;
-        }
-    }
-
-    private static boolean isValidPath(String path) {
-        try {
-            Paths.get(path);
-            return true;
-        } catch (InvalidPathException e) {
             return false;
         }
     }

--- a/src/main/java/org/spongepowered/api/asset/AssetManager.java
+++ b/src/main/java/org/spongepowered/api/asset/AssetManager.java
@@ -31,14 +31,8 @@ import java.util.Optional;
 
 /**
  * The AssetManager offers a convenient way to easily retrieve resources from
- * Sponge {@link Plugin}s. A {@link Plugin} may specify it's {@link Asset}
- * directory in it's annotation declaring class as well as in the plugin meta
- * file. If no directory is specified the manager will attempt to find the
- * asset of the specified name at:
- *
- * <p><code>assets/&lt;id&gt;</code> where 'ID' is the plugin's fully
- * qualified ID with all '.'s replaced with '/'s to more fit a directory
- * structure.</p>
+ * Sponge {@link Plugin}s. The asset manager will attempt to find the
+ * asset of the specified name at: <code>assets/&lt;plugin_id&gt;</code>
  */
 public interface AssetManager {
 

--- a/src/main/java/org/spongepowered/api/plugin/Plugin.java
+++ b/src/main/java/org/spongepowered/api/plugin/Plugin.java
@@ -96,16 +96,4 @@ public @interface Plugin {
      */
     String[] authors() default {};
 
-    /**
-     * The directory within the plugin's JAR file that contains this plugin's
-     * assets. This directory defaults to:
-     *
-     * <p><code>assets/&lt;id&gt;</code> where 'ID' is the plugin's fully
-     * qualified ID with all '.'s replaced with '/'s to more fit a directory
-     * structure.</p>
-     *
-     * @return Asset directory
-     */
-    String assets() default "";
-
 }

--- a/src/main/java/org/spongepowered/api/plugin/PluginContainer.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginContainer.java
@@ -114,15 +114,6 @@ public interface PluginContainer {
     }
 
     /**
-     * Gets the directory that contains this {@link Plugin}'s assets.
-     *
-     * @return Asset directory, or empty if none
-     */
-    default Optional<Path> getAssetDirectory() {
-        return Optional.empty();
-    }
-
-    /**
      * Retrieves the {@link Asset} of the specified name from the
      * {@link AssetManager} for this {@link Plugin}.
      *


### PR DESCRIPTION
The asset manager allows changing the directory where all plugin assets are stored. This was originally added for flexibility, but I can personally not see any usecases to change the asset directory. On the other hand, there are two reasons why it should **not** be changed:

- Assets in Vanilla Minecraft and Forge are always stored in the `assets/id` directory
- Changing the asset directory could cause problems with resource packs in future client-side plugins (since that requires assets to be stored in the default directory)

This PR removes the option to set custom asset directories. Unless someone has a usecase for the option I don't see any reason to keep it, since the default directory is always the best choice.