### PR TITLE
Add support for virtual custom biomes

### DIFF
--- a/src/main/java/org/spongepowered/api/world/biome/BiomeGenerationSettings.java
+++ b/src/main/java/org/spongepowered/api/world/biome/BiomeGenerationSettings.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.api.world.biome;
 
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.util.ResettableBuilder;
 import org.spongepowered.api.world.gen.GenerationPopulator;
 import org.spongepowered.api.world.gen.Populator;
 
@@ -33,6 +35,15 @@ import java.util.List;
  * A representation of the biome-specific generation settings.
  */
 public interface BiomeGenerationSettings {
+
+    /**
+     * Gets a new builder for creating new BiomeGenerationSettings.
+     * 
+     * @return The builder
+     */
+    public static Builder builder() {
+        return Sponge.getRegistry().createBuilder(Builder.class);
+    }
 
     /**
      * Gets the minimum terrain height of this biome.
@@ -108,5 +119,92 @@ public interface BiomeGenerationSettings {
      * @return The populators
      */
     <T extends Populator> List<T> getPopulators(Class<T> type);
+
+    /**
+     * Returns a new biome generation settings which is a copy of this set of
+     * generation settings at this point in time.
+     * 
+     * @return The copy of these settings
+     */
+    BiomeGenerationSettings copy();
+
+    /**
+     * A builder for {@link BiomeGenerationSettings}s.
+     */
+    interface Builder extends ResettableBuilder<BiomeGenerationSettings, Builder> {
+
+        /**
+         * Sets the min height for the biome.
+         * 
+         * @param height The min height
+         * @return This builder, for chaining
+         */
+        Builder minHeight(float height);
+
+        /**
+         * Sets the max height for the biome.
+         * 
+         * @param height The max height
+         * @return This builder, for chaining
+         */
+        Builder maxHeight(float height);
+
+        /**
+         * Sets the ground cover layers.
+         * 
+         * @param coverLayers The ground cover layers
+         * @return This builder, for chaining
+         */
+        Builder groundCover(GroundCoverLayer... coverLayers);
+
+        /**
+         * Sets the ground cover layers.
+         * 
+         * @param coverLayers The ground cover layers
+         * @return This builder, for chaining
+         */
+        Builder groundCover(Iterable<GroundCoverLayer> coverLayers);
+
+        /**
+         * Sets the generation populators.
+         * 
+         * @param genpop The generation populators
+         * @return This builder, for chaining
+         */
+        Builder generationPopulators(GenerationPopulator... genpop);
+
+        /**
+         * Sets the generation populators.
+         * 
+         * @param genpop The generation populators
+         * @return This builder, for chaining
+         */
+        Builder generationPopulators(Iterable<GenerationPopulator> genpop);
+
+        /**
+         * Sets the populators.
+         * 
+         * @param populators The populators
+         * @return This builder, for chaining
+         */
+        Builder populators(Populator... populators);
+
+        /**
+         * Sets the populators.
+         * 
+         * @param populators The populators
+         * @return This builder, for chaining
+         */
+        Builder populators(Iterable<Populator> populators);
+
+        /**
+         * Creates a new set of {@link BiomeGenerationSettings}s.
+         * 
+         * @return The settings
+         * @throws IllegalStateException If any required values were left unset
+         */
+        BiomeGenerationSettings build() throws IllegalStateException;
+
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/world/biome/BiomeType.java
+++ b/src/main/java/org/spongepowered/api/world/biome/BiomeType.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.world.biome;
 
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
+import org.spongepowered.api.world.World;
 
 /**
  * Represents a biome.
@@ -46,5 +47,13 @@ public interface BiomeType extends CatalogType {
      * @return The humidity
      */
     double getHumidity();
+
+    /**
+     * Gets the default generation settings of this biome for the given world.
+     * 
+     * @param world The world the settings are being made for
+     * @return The default generation settings
+     */
+    BiomeGenerationSettings createDefaultGenerationSettings(World world);
 
 }

--- a/src/main/java/org/spongepowered/api/world/biome/VirtualBiomeType.java
+++ b/src/main/java/org/spongepowered/api/world/biome/VirtualBiomeType.java
@@ -1,0 +1,115 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.world.biome;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.util.ResettableBuilder;
+import org.spongepowered.api.world.World;
+
+import java.util.function.Function;
+
+/**
+ * A virtual biome is one which exists purely for generation and therefore
+ * requires no modifications to clients in order to use it. After generation for
+ * a chunk is complete the biome is persisted as its specified persisted biome
+ * type.
+ */
+public interface VirtualBiomeType extends BiomeType {
+
+    /**
+     * Gets a new builder for creating new VirtualBiomeTypes.
+     * 
+     * @return The builder
+     */
+    public static Builder builder() {
+        return Sponge.getRegistry().createBuilder(Builder.class);
+    }
+
+    /**
+     * Gets the biome type which this virtual biome is persisted as.
+     * 
+     * @return The persisted biome type
+     */
+    BiomeType getPersistedType();
+
+    /**
+     * A builder for {@link VirtualBiomeType}s.
+     */
+    interface Builder extends ResettableBuilder<VirtualBiomeType, Builder> {
+
+        /**
+         * Sets the name of the new virtual biome.
+         * 
+         * @param name The biome name
+         * @return This builder, for chaining
+         */
+        Builder name(String name);
+
+        /**
+         * Sets the temperature of the virtual biome.
+         * 
+         * @param temp The temperature
+         * @return This builder, for chaining
+         */
+        Builder temperature(double temp);
+
+        /**
+         * Sets the humidity of the virtual biome.
+         * 
+         * @param humidity The humidity
+         * @return This builder, for chaining
+         */
+        Builder humidity(double humidity);
+
+        /**
+         * Sets the {@link BiomeType} that this virtual biome is persisted as
+         * after generation is complete.
+         * 
+         * @param biome The persisted biome type
+         * @return This builder, for chaining
+         */
+        Builder persistedType(BiomeType biome);
+
+        /**
+         * Sets the function used for creating new
+         * {@link BiomeGenerationSettings}s for this virtual biome.
+         * 
+         * @param settingsBuilder The settings builder function
+         * @return This builder, for chaining
+         */
+        Builder settingsBuilder(Function<World, BiomeGenerationSettings> settingsBuilder);
+
+        /**
+         * Builds a new {@link VirtualBiomeType} with the given unique id.
+         * 
+         * @param id The biome id, must be unique
+         * @return The new virtual biome
+         * @throws IllegalStateException If any required fields were missing
+         */
+        VirtualBiomeType build(String id) throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/gen/Populator.java
+++ b/src/main/java/org/spongepowered/api/world/gen/Populator.java
@@ -28,6 +28,7 @@ import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.extent.Extent;
+import org.spongepowered.api.world.extent.ImmutableBiomeArea;
 import org.spongepowered.api.world.gen.populator.RandomObject;
 
 import java.util.Random;
@@ -70,13 +71,34 @@ public interface Populator {
     /**
      * Applies the populator to the given {@link Extent} volume. The entire area
      * of the given extent should be populated.
+     * 
+     * <p>Due to their transitive nature virtual biomes cannot be fetched from
+     * the given extent, instead your populator should override
+     * {@link #populate(World, Extent, Random, ImmutableBiomeArea)} to make use
+     * of the ImmutableBiomeArea which does contain virtual biome types.</p>
      *
      * @param world The World within which the generation in happening
      * @param volume The volume to be populated
      * @param random A random number generator. This random number generator is
      *        based on the world seed and the chunk position. It is shared with
-     *        with other populators.
+     *        with other populators
      */
     void populate(World world, Extent volume, Random random);
+
+    /**
+     * Applies the populator to the given {@link Extent} volume. The entire area
+     * of the given extent should be populated.
+     *
+     * @param world The World within which the generation in happening
+     * @param volume The volume to be populated
+     * @param random A random number generator. This random number generator is
+     *        based on the world seed and the chunk position. It is shared with
+     *        with other populators
+     * @param virtualBiomes A biome area for the extent being populated which
+     *        includes any virtual biomes not persisted to the world
+     */
+    default void populate(World world, Extent volume, Random random, ImmutableBiomeArea virtualBiomes) {
+        populate(world, volume, random);
+    }
 
 }


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/928) | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/900)

This adds support for creating custom biomes which exist only during generation, afterwards they are stored as an existing non-virtual biome. This can be used to support more varied generation easier without creating full blown custom biomes which would require client modifications as well.