### PR TITLE
Expose RemainingJoinedStrings raw mode.

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -904,6 +904,17 @@ public final class GenericArguments {
         return new RemainingJoinedStringsCommandElement(key, false);
     }
 
+    /**
+     * Require one or more strings, without any processing, which are combined into a single, space-separated string.
+     * Gives values of type {@link String}.
+     *
+     * @param key The key to store the parsed argument under
+     * @return the element to match the input
+     */
+    public static CommandElement remainingRawJoinedStrings(Text key) {
+        return new RemainingJoinedStringsCommandElement(key, true);
+    }
+
     private static class RemainingJoinedStringsCommandElement extends KeyElement {
         private final boolean raw;
 


### PR DESCRIPTION
@zml2008 @mcmonkey4eva 

@mcmonkey4eva mentioned in IRC that remainingJoinedStrings still had some form of processing being applied, @zml2008 said that there was already a raw option exposed.

I looked, saw that it was limited to private visibility, presumably because it was added later and not thought about.