### PR TITLE
Add required dependency on SpongeAPI for plugins

### DIFF
--- a/src/main/java/org/spongepowered/api/Platform.java
+++ b/src/main/java/org/spongepowered/api/Platform.java
@@ -34,6 +34,8 @@ import java.util.Map;
  */
 public interface Platform {
 
+    String API_ID = "spongeapi";
+
     /**
      * Retrieves the current {@link Type} this platform is running on.
      *


### PR DESCRIPTION
Using these changes the annotation processor will add a required dependency on SpongeAPI which allows identifying Sponge plugins based on their `mcmod.info` file.

The dependency version is set to the SpongeAPI version the plugin is compiled against. Without additional restrictions the dependency version will just represent the "recommended version" for the dependency.

While plugins will continue to load using newer or older API versions, these changes allow the implementation to issue a warning if a plugin was designed for an older or newer API version.

SpongeVanilla implementation: https://github.com/SpongePowered/SpongeVanilla/pull/269
SpongeForge implementation: https://github.com/SpongePowered/SpongeForge/pull/907

**Note:** This is similar to https://github.com/SpongePowered/SpongeAPI/pull/1214 but is implemented using a recommended API version instead of a required minimum version.

Fixes #1212 