### PR TITLE
Improve the block ray filters

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -1228,7 +1228,11 @@ public final class GenericArguments {
                 yStr = split[1];
                 zStr = split[2];
             } else if (xStr.equals("#target") && source instanceof Entity) {
-                Optional<BlockRayHit<World>> hit = BlockRay.from(((Entity) source)).filter(BlockRay.onlyAirFilter()).build().end();
+                Optional<BlockRayHit<World>> hit = BlockRay
+                        .from(((Entity) source))
+                        .stopFilter(BlockRay.continueAfterFilter(BlockRay.onlyAirFilter(), 1))
+                        .build()
+                        .end();
                 if (!hit.isPresent()) {
                     throw args.createError(t("No target block is available! Stop stargazing!"));
                 }


### PR DESCRIPTION
In response to: https://github.com/SpongePowered/SpongeAPI/pull/1342

This adds a `skipFilter` to ignore blocks that match a predicate. The previous filter functionality gets renamed to `stopFilter`.

Also, based off of feedback from @Deamon5550, I changed the block limit into a distance limit. Since the filter is now built-in it was removed as a stand-alone.

Finally I fixed the `GenericArguments` `#target` functionality not returning the target block, but the air block just before it. 

I've fixed Cookbook/Smite and I'll merge those changes if the PR is accepted.

@m0pt0pmatt