### PR TITLE
Added World#getHighestLocationAt(Vector2i). Fixes SpongeAPI #1375

### DIFF
--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -84,14 +84,14 @@ public interface World extends Extent, WeatherUniverse, Viewer, ContextSource, M
     }
 
     /**
-     * Get the {@link Location} of the lowest block that sunlight can reach in the given column.
+     * Get the {@link Location} where sunlight reaches in the given column.
      *
      * <p>This method ignores all transparent blocks, providing the highest opaque block.</p>
      *
      * @param position The column position
      * @return The highest opaque block
      */
-    Location<World> getHighestLocationAt(Vector2i position);
+    Location<World> getHighestBlockAt(Vector2i position);
 
     /**
      * Get the loaded chunk at the given block coordinate position.

--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.world;
 
+import com.flowpowered.math.vector.Vector2i;
 import com.flowpowered.math.vector.Vector3d;
 import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.Sponge;
@@ -81,6 +82,16 @@ public interface World extends Extent, WeatherUniverse, Viewer, ContextSource, M
     default Location<World> getLocation(double x, double y, double z) {
         return getLocation(new Vector3d(x, y, z));
     }
+
+    /**
+     * Get the {@link Location} of the lowest block that sunlight can reach in the given column.
+     *
+     * <p>This method ignores all transparent blocks, providing the highest opaque block.</p>
+     *
+     * @param position The column position
+     * @return The highest opaque block
+     */
+    Location<World> getHighestLocationAt(Vector2i position);
 
     /**
      * Get the loaded chunk at the given block coordinate position.


### PR DESCRIPTION
As per https://github.com/SpongePowered/SpongeAPI/issues/1375, this PR adds a method to retrieve the highest block in a column, using the internal chunk heightmaps. This retrieves the highest opaque block, which is also the lowest block sunlight can reach.

The method name is up for debate.
