### PR TITLE
Provide implementations for mutable and immutable CatalogRegistryModules

### DIFF
--- a/src/main/java/org/spongepowered/api/registry/AdditionalCatalogRegistryModule.java
+++ b/src/main/java/org/spongepowered/api/registry/AdditionalCatalogRegistryModule.java
@@ -26,8 +26,23 @@ package org.spongepowered.api.registry;
 
 import org.spongepowered.api.CatalogType;
 
+/**
+ * Registry module that is used to maintain a list of catalog types of a certain
+ * type. This module also accepts catalog type instances that are created by
+ * plugins.
+ *
+ * @param <T> The type of catalog type that is maintained by this module
+ */
 public interface AdditionalCatalogRegistryModule<T extends CatalogType> extends CatalogRegistryModule<T> {
 
-    void registerAdditionalCatalog(T extraCatalog);
+    /**
+     * Registers the given catalog type instance in this registry module. The
+     * ids that can be used to access this instance are chosen automatically.
+     *
+     * @param extraCatalog The catalog type to register
+     * @throws IllegalArgumentException If there is an id conflict with the
+     *         given type and an existing type
+     */
+    void registerAdditionalCatalog(T extraCatalog) throws IllegalArgumentException;
 
 }

--- a/src/main/java/org/spongepowered/api/registry/AlternateCatalogRegistryModule.java
+++ b/src/main/java/org/spongepowered/api/registry/AlternateCatalogRegistryModule.java
@@ -25,10 +25,28 @@
 package org.spongepowered.api.registry;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.registry.util.RegisterCatalog;
 
 import java.util.Map;
 
+/**
+ * Registry module that is used to maintain a list of catalog types of a certain
+ * type. Implementations must also annotate the class or a field in the class
+ * with the {@link RegisterCatalog} annotation, to indicate which catalog type
+ * pseudo enum class should be populated with the given values. The
+ * {@link #provideCatalogMap()} method takes precedence before any fields
+ * annotated with the {@link RegisterCatalog} annotation.
+ *
+ * @param <T> The type of catalog type that is maintained by this module
+ */
 public interface AlternateCatalogRegistryModule<T extends CatalogType> extends CatalogRegistryModule<T> {
 
+    /**
+     * Returns a view of the internal id to instance mapping that can be used to
+     * populate the catalog type pseudo enums.
+     *
+     * @return The map that should be used to populate the pseudo enums.
+     */
     Map<String, T> provideCatalogMap();
+
 }

--- a/src/main/java/org/spongepowered/api/registry/CatalogRegistryModule.java
+++ b/src/main/java/org/spongepowered/api/registry/CatalogRegistryModule.java
@@ -29,10 +29,29 @@ import org.spongepowered.api.CatalogType;
 import java.util.Collection;
 import java.util.Optional;
 
+/**
+ * Registry module that is used to maintain a list of catalog types of a certain
+ * type.
+ *
+ * @param <T> The type of catalog type that is maintained by this module
+ */
 public interface CatalogRegistryModule<T extends CatalogType> extends RegistryModule {
 
+    /**
+     * Gets the registered catalog type with the given id or an equivalent.
+     *
+     * @param id The id of the catalog type to search
+     * @return The catalog type if a matching one is found
+     */
     Optional<T> getById(String id);
 
+    /**
+     * Gets a duplicate free collection of all registered catalog type instances
+     * of this type. The order of the contained elements should be considered
+     * random.
+     *
+     * @return A collection containing all registered catalog types
+     */
     Collection<T> getAll();
 
 }

--- a/src/main/java/org/spongepowered/api/registry/ImmutableCatalogRegistryModule.java
+++ b/src/main/java/org/spongepowered/api/registry/ImmutableCatalogRegistryModule.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.registry;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.spongepowered.api.CatalogType;
+
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Simple implementation of the {@link CatalogRegistryModule} that does not
+ * allow custom types to be added.
+ *
+ * @param <T> The type of catalog type that is maintained by this module
+ */
+public abstract class ImmutableCatalogRegistryModule<T extends CatalogType> implements AlternateCatalogRegistryModule<T> {
+
+    private final Map<String, T> typesById;
+    private final Set<T> types;
+
+    /**
+     * Creates a new instance with the given id to type mappings. All keys will
+     * be stored in lower case.
+     *
+     * @param typesById The map containing all registered ids for all catalog
+     *        types
+     */
+    protected ImmutableCatalogRegistryModule(Map<String, T> typesById) {
+        checkNotNull(typesById, "typesById");
+        ImmutableMap.Builder<String, T> builder = ImmutableMap.builder();
+        typesById.forEach((key, value) -> builder.put(toLowerCase(key), checkNotNull(value, "value for key: %s", key)));
+        this.typesById = builder.build();
+        this.types = ImmutableSet.copyOf(typesById.values());
+    }
+
+    @Override
+    public final Optional<T> getById(String id) {
+        return Optional.ofNullable(this.typesById.get(toLowerCase(id)));
+    }
+
+    @Override
+    public final Collection<T> getAll() {
+        return this.types;
+    }
+
+    @Override
+    public Map<String, T> provideCatalogMap() {
+        return this.typesById;
+    }
+
+    // Registration needs to take place in the constructor
+    @Override
+    public final void registerDefaults() {
+    }
+
+    /**
+     * Checks and converts the given key to its lower case equivalent, that can
+     * be used to get a type from the key map.
+     *
+     * @param id The key to check and convert
+     * @return The checked lower case key
+     * @see #provideCatalogMap()
+     */
+    protected static String toLowerCase(String id) {
+        return checkNotNull(id, "key").toLowerCase(Locale.ENGLISH);
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/registry/MutableCatalogRegistryModule.java
+++ b/src/main/java/org/spongepowered/api/registry/MutableCatalogRegistryModule.java
@@ -1,0 +1,162 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.registry;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableSet;
+import org.spongepowered.api.CatalogType;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+/**
+ * Simple implementation of the {@link CatalogRegistryModule} that allows plugin
+ * created types to be registered.
+ *
+ * @param <T> The type of catalog type that is maintained by this module
+ */
+public abstract class MutableCatalogRegistryModule<T extends CatalogType> implements AdditionalCatalogRegistryModule<T>, AlternateCatalogRegistryModule<T> {
+
+    private final Map<String, T> typesById = new LinkedHashMap<>();
+    @Nullable private Set<T> types;
+
+    @Override
+    public final Optional<T> getById(String id) {
+        return Optional.ofNullable(this.typesById.get(toLowerCase(id)));
+    }
+
+    @Override
+    public final Collection<T> getAll() {
+        if (this.types == null) {
+            this.types = ImmutableSet.copyOf(this.types);
+        }
+        return this.types;
+    }
+
+    @Override
+    public Map<String, T> provideCatalogMap() {
+        return Collections.unmodifiableMap(this.typesById);
+    }
+
+    /**
+     * Checks and converts the given id to its lower case equivalent, that can
+     * be used to get a type from the catalog map.
+     *
+     * @param id The id to check and convert
+     * @return The checked lower case id
+     * @see #provideCatalogMap()
+     */
+    protected static String toLowerCase(String id) {
+        return checkNotNull(id, "id").toLowerCase(Locale.ENGLISH);
+    }
+
+    /**
+     * Helper method to get a collection of calculated alias ids that will be
+     * used to register additional ids for the given {@link CatalogType}
+     * instance. This method is not required to return all possible ids that can
+     * be used to obtain the type, but it should return all common ids.
+     * Special/alias ids might be registered through
+     * {@link #register(String, CatalogType)}.
+     *
+     * <p>This instance might return ids that are stripped of their prefix or
+     * are enriched with a default prefix. Example: minecraft:sandStone -&gt
+     * sandstone, sand_stone, minecraft:sand_stone.</p>
+     *
+     * @param type The catalog type instance to get the ids for
+     * @return A collection containing the ids that uniquely map to the given
+     *         type
+     */
+    protected Collection<String> aliasIdsForType(T type) {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public final void registerAdditionalCatalog(T extraCatalog) {
+        checkNotNull(extraCatalog, "extraCatalog");
+        String id = toLowerCase(extraCatalog.getId());
+        checkArgument(!this.typesById.containsKey(id), "Cannot register %s because the id %s is already registered.", id);
+        Collection<String> aliasIds = checkNotNull(aliasIdsForType(extraCatalog), "idsForType");
+        boolean foundConflict = aliasIds.stream()
+                .map(aliasId -> toLowerCase(aliasId))
+                .anyMatch(this.typesById::containsKey);
+        checkArgument(!foundConflict, "Cannot register %s because the at least one of these alias ids is already registered: %s!", aliasIds,
+                extraCatalog);
+        this.typesById.put(id, extraCatalog);
+        aliasIds.forEach(aliasId -> this.typesById.put(toLowerCase(aliasId), extraCatalog));
+        this.types = null;
+    }
+
+    /**
+     * Register an additional id to access the given type. This should only be
+     * called during {@link #registerDefaults()}.
+     *
+     * @param id The new id to register
+     * @param type The type to register the id for
+     */
+    protected final void register(String id, T type) {
+        id = toLowerCase(id);
+        checkArgument(!this.typesById.containsKey(id), "Cannot register %s because the id %s is already registered!", type, id);
+        this.typesById.put(id, checkNotNull(type, "type"));
+        this.types = null;
+    }
+
+    /**
+     * Register an additional alias id to access the type that is already
+     * registered with the other id.
+     *
+     * @param oldId The old id the type is already registered for
+     * @param newId The new alias id to register
+     */
+    protected final void registerAlias(String oldId, String newId) {
+        checkNotNull(oldId, "oldId");
+        checkNotNull(newId, "newId");
+        final T type = getById(oldId).orElseThrow(() -> new IllegalStateException("Could not find instance for id: " + oldId));
+        register(newId, type);
+    }
+
+    /**
+     * Forcefully register the given id for the given type. Great care should be
+     * taken, when using this method as it will replace the given id to the
+     * target, but others might still point to that instance.
+     *
+     * @param id The id to register
+     * @param type The type to register the key for.
+     */
+    // TODO: Is such a method needed at all?
+    protected final void forceRegister(String id, T type) {
+        this.typesById.put(toLowerCase(id), checkNotNull(type, "type"));
+        this.types = null;
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/registry/util/RegisterCatalog.java
+++ b/src/main/java/org/spongepowered/api/registry/util/RegisterCatalog.java
@@ -42,7 +42,7 @@ import java.util.Map;
  * first one is used.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.TYPE})
 public @interface RegisterCatalog {
 
     /**

--- a/src/main/java/org/spongepowered/api/registry/util/RegisterCatalog.java
+++ b/src/main/java/org/spongepowered/api/registry/util/RegisterCatalog.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.registry.util;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.registry.AlternateCatalogRegistryModule;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -34,9 +35,11 @@ import java.util.Map;
 
 /**
  * An annotation to mark a {@link Map} where it's of type
- * {@code Map<String, CatalogType>} such that it is used with a helper to
+ * {@code Map<String, CatalogType>} or an implementation of
+ * {@link AlternateCatalogRegistryModule} such that it is used with a helper to
  * register the static fields of various pseudo enum classes containing
- * "default" {@link CatalogType}s.
+ * "default" {@link CatalogType}s. If multiple fields are annotated only the
+ * first one is used.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)


### PR DESCRIPTION
Description is WIP. The implementation is ready for review.

# The issue
Currently there are multiple issues with more than a few existing implementations of `CatalogRegistryModule`s.

Currently there are 100 implemented `CatalogRegistryModule`s. 
From those 33 are not visible in `CatalogTypes` fields.

Issue | Affected
------------ | -------------
Exception instead of `Optional#empty()` in `#getById(String)` | 2
`#getById(String)` returns `Optional#empty()` for registered ids | 31
`#getById(String)` does not handle case properly | 2
Inconsistent handling of "sponge:" and "minecraft:" prefixes in `#getById()` | 30
Expensive deep copy in `getAll()` | 95
Duplicates in `getAll()` | 6
Incomplete/lacking `#registerAdditionalCatalog(CatalogType)` implemenations | 24 / 28 (86%)

Some of these issues are also mentioned in https://github.com/SpongePowered/SpongeCommon/issues/739.

# TestPlugin

* [Plugin](https://dl.dropboxusercontent.com/u/16999313/Sponge/CatalogRegistryModuleTest.jar)
* [Source](https://dl.dropboxusercontent.com/u/16999313/Sponge/CatalogRegistryModuleTest.zip)
* [Result](http://pastebin.com/ASr7D8LD)

# The solution
Provide simple to use implementations that reduce the implementation work to just the default registration and thus reduce the error potential.

(This implementation alone cannot fix the inconsistent prefix handling though)

# Usage

````java
@RegisterCatalog(GoalTypes.class)
public final class GoalTypeModule extends MutableCatalogRegistryModule<GoalType> {

    @Override
    protected Collection<String> aliasIdsForType(GoalType type) {
        // Also register without prefix
        if (type.getId().startsWith("minecraft:")) {
            return Collections.singletonList(type.getId().substring(10));
        }
        return Collections.emptyList();
    }

    @Override
    public void registerDefaults() {
        createGoalType(SpongeImpl.getMinecraftPlugin(), "normal", "Normal");
        createGoalType(SpongeImpl.getMinecraftPlugin(), "target", "Target");
    }

    public GoalType createGoalType(PluginContainer pluginContainer , String id, String name) {
        String combinedId = pluginContainer.getId().toLowerCase(Locale.ENGLISH) + ":" + id;
        GoalType newType = new SpongeGoalType(combinedId, name, EntityAITasks.class);
        registerAdditionalCatalog(newType);
        return newType;
    }

}
````

------------------------

I also offer my help to rewrite those modules to use these implemenations.