### PR TITLE
Clarify some parts of the PermissionService documentation

### DIFF
--- a/src/main/java/org/spongepowered/api/service/permission/PermissionService.java
+++ b/src/main/java/org/spongepowered/api/service/permission/PermissionService.java
@@ -64,6 +64,11 @@ public interface PermissionService extends ContextualService<Subject> {
      * subject is at the root of all inheritance trees, above even subject type-specific
      * defaults, meaning it has the lowest priority when all other weighting is equal.
      *
+     * <p>Note: This data should be persisted, so plugins that add permissions to this subject
+     * must take care to not override permissions already set or modified. It is also
+     * recommended to use {@link Subject#getTransientSubjectData()} where possible to
+     * avoid persisting unnecessary data.
+     *
      * @return The default subject data
      */
     Subject getDefaults();

--- a/src/main/java/org/spongepowered/api/service/permission/SubjectCollection.java
+++ b/src/main/java/org/spongepowered/api/service/permission/SubjectCollection.java
@@ -92,7 +92,14 @@ public interface SubjectCollection {
     Map<Subject, Boolean> getAllWithPermission(Set<Context> contexts, String permission);
 
     /**
-     * Get the subject that provides defaults for subjects of this type. This subject is placed at the root of any inheritance tree involving subjects of this type.
+     * Get the subject holding data that is applied by default for subjects of this type.
+     * This subject is placed at the root of any inheritance tree involving subjects of
+     * this type, but has a higher priority than {@link PermissionService#getDefaults()}.
+     *
+     * <p>Note: This data may be persisted, so plugins that add permissions to this subject
+     * must take care to not override permissions already set or modified. It is also
+     * recommended to use {@link Subject#getTransientSubjectData()} where possible to
+     * avoid persisting unnecessary data.
      *
      * @return The subject holding defaults
      */

--- a/src/main/java/org/spongepowered/api/service/permission/SubjectData.java
+++ b/src/main/java/org/spongepowered/api/service/permission/SubjectData.java
@@ -179,7 +179,7 @@ public interface SubjectData {
      * Clear all options in the given context combination.
      *
      * @param contexts The context combination
-     * @return Whether the operation was successful (any options were remowed)
+     * @return Whether the operation was successful (any options were removed)
      */
     boolean clearOptions(Set<Context> contexts);
 


### PR DESCRIPTION
This PR attempts to clarify some of the ambiguities in PermissionService, as raised in #1383.

As far as I know, the added javadocs do not conflict with existing intended behaviours, rather just clarifies them. 

Possibly relevant: some of the issues were also briefly discussed here: https://forums.spongepowered.org/t/luckperms-an-advanced-permissions-system/14274/118