### PR TITLE
Add "simple" custom data API

### DIFF
--- a/src/main/java/org/spongepowered/api/data/manipulator/SimpleCustomData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/SimpleCustomData.java
@@ -1,0 +1,43 @@
+package org.spongepowered.api.data.manipulator;
+
+import com.google.common.reflect.TypeToken;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.persistence.DataContentUpdater;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.util.ResettableBuilder;
+
+import java.util.Set;
+
+public interface SimpleCustomData<T> {
+
+    Key<Value<T>> getKey();
+
+    String getName();
+
+    String getID();
+
+    int getContentVersion();
+
+    Set<DataContentUpdater> getContentUpdaters();
+
+    static Builder builder() {
+        return Sponge.getRegistry().createBuilder(Builder.class);
+    }
+
+    interface Builder extends ResettableBuilder<SimpleCustomData, Builder> {
+
+        Builder contentVersion(int version);
+
+        Builder contentUpdaters(Iterable<DataContentUpdater> updaters);
+
+        Builder name(String name);
+
+        Builder id(String id);
+
+        <T> SimpleCustomData<T> build();
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/util/CollectionUtils.java
+++ b/src/main/java/org/spongepowered/api/util/CollectionUtils.java
@@ -26,11 +26,17 @@ package org.spongepowered.api.util;
 
 import com.google.common.collect.Maps;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collector;
 
 public final class CollectionUtils {
 
@@ -62,7 +68,18 @@ public final class CollectionUtils {
         }
     }
 
-
+    /**
+     * Returns a Collector which will collect all values in a stream,
+     * and return an {@link Collections#unmodifiableSet(Set)}.
+     * @param <T> Value type of stream
+     * @return A {@link Collector} for building an immutable set
+     */
+    public static <T> Collector<T, Set<T>, Set<T>> immutableSetCollector() {
+        return Collector.of(HashSet::new, Set::add, (left, right) -> {
+            left.addAll(right);
+            return left;
+        }, Collections::unmodifiableSet);
+    }
 
     private CollectionUtils() {
     }


### PR DESCRIPTION
**API** | [Common](https://github.com/SpongePowered/SpongeCommon/pull/988)

I'll put it bluntly - implementing the current data API system is tedious. Say you want to save a string to an entity. You need to implement two `DataManipulator`s with keys, values, register everything, and a `DataManipulatorBuilder` too if you want it persisted.

That's a tonne of work for just a string, especially for someone new to plugin development or to sponge.

At the heart of this PR, there is still the bells and whistles of the data API. You use keys to access values, but the rest of the implementation work is done behind the scenes - all you need to do is register and you're good to go.

It still supports the forwards compatibility with `DataContentUpdater`s too, but that's an optional feature that can be left out if desired - the version will just default to `1`.

We'll still keep around the current system for those that want more control over their data, or providing a better interface to other plugins. But this will really ease the learning curve for those that don't care for the details (yet).

So instead of implementing and registering multiple classes to access your string data, you just do this:

``` java
SimpleCustomData<String> custom = SimpleCustomData.builder()
            .id("my-plugin:my_string")
            .name("My String")
            .build();

myEntity.offer(custom.getKey(), "Hello World!");
```

**Super simple to register, super simple to use.**
