### PR TITLE
Clarify Inventory#query/contains behaviour + new versions for any amount

### DIFF
--- a/src/main/java/org/spongepowered/api/item/inventory/Inventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Inventory.java
@@ -271,13 +271,27 @@ public interface Inventory extends Iterable<Inventory>, Nameable {
     boolean hasChildren();
 
     /**
-     * Checks for whether the given stack is contained in this Inventory. This
-     * is equivalent to calling <code>!inv.query(stack).hasChildren();</code>
+     * Checks whether the stacks quantity or more of given stack is
+     * contained in this Inventory. This is equivalent to calling
+     * <code>!inv.query(stack).hasChildren();</code> To check if an
+     * inventory contains any amount use {@link #containsAny(ItemStack)}.
      *
      * @param stack The stack to check for
-     * @return True if the stack is present in this list
+     * @return True if there are at least the given stack's amount of items
+     *      present in this inventory.
      */
     boolean contains(ItemStack stack);
+
+    /**
+     * Checks whether the given stack is contained in this Inventory.
+     * The stack size is ignored. Note this will return true if any amount
+     * of the supplied stack is found. To check if an inventory contains at
+     * least an amount use {@link #contains(ItemStack)}.
+     *
+     * @param stack The stack to check for
+     * @return True if the stack is present in this inventory
+     */
+    boolean containsAny(ItemStack stack);
 
     /**
      * Checks for whether there is a stack in this Inventory with the given
@@ -389,20 +403,34 @@ public interface Inventory extends Iterable<Inventory>, Nameable {
     <T extends Inventory> T query(ItemType... types);
 
     /**
-     * Query this inventory for inventories containing any stacks which match
-     * the supplied stack operands. This query operates directly on {@link Slot}
+     * Query this inventory for inventories containing stacks which match the
+     * supplied stack operand. This query operates directly on {@link Slot}
      * leaf nodes in the inventory and will always return a collection
-     * containing only {@link Slot} instances. Logical <code>OR</code> is
-     * applied between operands.
+     * containing only {@link Slot} instances.
+     * To query for stacks of any size use {@link #queryAny(ItemStack...)}.
      *
-     * @param types items to query for, the size of the stacks is ignored if the
-     *      stack size is set to -1, otherwise the stack sizes must match the
-     *      supplied stacks exactly
+     * @param types items to query for, stack sizes must match the supplied stack exactly
      * @param <T> expected inventory type, specified as generic to allow easy
      *      pseudo-duck-typing
      * @return the query result
      */
     <T extends Inventory> T query(ItemStack... types);
+
+    /**
+     * Query this inventory for inventories containing any stacks which match
+     * the supplied stack operands ignoring its quantity. This query operates
+     * directly on {@link Slot} leaf nodes in the inventory and will always
+     * return a collection containing only {@link Slot} instances. Logical
+     * <code>OR</code> is applied between operands.
+     * This ignores stack sizes. To query for stacks of a specific size use
+     * {@link #query(ItemStack...)}.
+     *
+     * @param types items to query for, the size of the stacks is always ignored
+     * @param <T> expected inventory type, specified as generic to allow easy
+     *      pseudo-duck-typing
+     * @return the query result
+     */
+    <T extends Inventory> T queryAny(ItemStack... types);
 
     /**
      * Query this inventory for inventories which match any of the supplied


### PR DESCRIPTION
[API](https://github.com/SpongePowered/SpongeAPI/pull/1437) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/1095)

With Minecraft 1.11 it is no longer possible to create -1 sized ItemStacks.
Additionally the current query method never actually cared about stack sizes.

This claryfies the javadocs on the existing query/contains methods
and adds a new one to query for ItemStacks matching any size
and one to check for inventories containing any amount.