### PR TITLE
Overhaul chunk pre-generation

### DIFF
--- a/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
+++ b/src/main/java/org/spongepowered/api/event/SpongeEventFactory.java
@@ -28,6 +28,7 @@ import com.flowpowered.math.vector.Vector3d;
 import com.flowpowered.math.vector.Vector3i;
 import com.google.common.base.Preconditions;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -177,6 +178,7 @@ import org.spongepowered.api.event.user.PardonUserEvent;
 import org.spongepowered.api.event.user.TargetUserEvent;
 import org.spongepowered.api.event.world.ChangeWorldGameRuleEvent;
 import org.spongepowered.api.event.world.ChangeWorldWeatherEvent;
+import org.spongepowered.api.event.world.ChunkPreGenerationEvent;
 import org.spongepowered.api.event.world.ConstructPortalEvent;
 import org.spongepowered.api.event.world.ConstructWorldPropertiesEvent;
 import org.spongepowered.api.event.world.ExplosionEvent;
@@ -212,6 +214,7 @@ import org.spongepowered.api.util.Tristate;
 import org.spongepowered.api.util.Tuple;
 import org.spongepowered.api.util.ban.Ban;
 import org.spongepowered.api.world.Chunk;
+import org.spongepowered.api.world.ChunkPreGenerate;
 import org.spongepowered.api.world.ChunkTicketManager;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.PortalAgent;
@@ -3973,6 +3976,86 @@ public class SpongeEventFactory {
         values.put("initialWeather", initialWeather);
         values.put("targetWorld", targetWorld);
         return SpongeEventFactoryUtils.createEventImpl(ChangeWorldWeatherEvent.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.world.ChunkPreGenerationEvent.Cancelled}.
+     * 
+     * @param cause The cause
+     * @param chunkPreGenerate The chunk pre generate
+     * @param targetWorld The target world
+     * @return A new cancelled chunk pre generation event
+     */
+    public static ChunkPreGenerationEvent.Cancelled createChunkPreGenerationEventCancelled(Cause cause, ChunkPreGenerate chunkPreGenerate, World targetWorld) {
+        HashMap<String, Object> values = new HashMap<>();
+        values.put("cause", cause);
+        values.put("chunkPreGenerate", chunkPreGenerate);
+        values.put("targetWorld", targetWorld);
+        return SpongeEventFactoryUtils.createEventImpl(ChunkPreGenerationEvent.Cancelled.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.world.ChunkPreGenerationEvent.Complete}.
+     * 
+     * @param cause The cause
+     * @param chunkPreGenerate The chunk pre generate
+     * @param targetWorld The target world
+     * @return A new complete chunk pre generation event
+     */
+    public static ChunkPreGenerationEvent.Complete createChunkPreGenerationEventComplete(Cause cause, ChunkPreGenerate chunkPreGenerate, World targetWorld) {
+        HashMap<String, Object> values = new HashMap<>();
+        values.put("cause", cause);
+        values.put("chunkPreGenerate", chunkPreGenerate);
+        values.put("targetWorld", targetWorld);
+        return SpongeEventFactoryUtils.createEventImpl(ChunkPreGenerationEvent.Complete.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.world.ChunkPreGenerationEvent.Post}.
+     * 
+     * @param cause The cause
+     * @param chunkPreGenerate The chunk pre generate
+     * @param targetWorld The target world
+     * @param timeTakenForStep The time taken for step
+     * @param chunksGeneratedThisStep The chunks generated this step
+     * @param chunksSkippedThisStep The chunks skipped this step
+     * @return A new post chunk pre generation event
+     */
+    public static ChunkPreGenerationEvent.Post createChunkPreGenerationEventPost(Cause cause, ChunkPreGenerate chunkPreGenerate, World targetWorld, Duration timeTakenForStep, int chunksGeneratedThisStep, int chunksSkippedThisStep) {
+        HashMap<String, Object> values = new HashMap<>();
+        values.put("cause", cause);
+        values.put("chunkPreGenerate", chunkPreGenerate);
+        values.put("targetWorld", targetWorld);
+        values.put("timeTakenForStep", timeTakenForStep);
+        values.put("chunksGeneratedThisStep", chunksGeneratedThisStep);
+        values.put("chunksSkippedThisStep", chunksSkippedThisStep);
+        return SpongeEventFactoryUtils.createEventImpl(ChunkPreGenerationEvent.Post.class, values);
+    }
+
+    /**
+     * AUTOMATICALLY GENERATED, DO NOT EDIT.
+     * Creates a new instance of
+     * {@link org.spongepowered.api.event.world.ChunkPreGenerationEvent.Pre}.
+     * 
+     * @param cause The cause
+     * @param chunkPreGenerate The chunk pre generate
+     * @param targetWorld The target world
+     * @param skipStep The skip step
+     * @return A new pre chunk pre generation event
+     */
+    public static ChunkPreGenerationEvent.Pre createChunkPreGenerationEventPre(Cause cause, ChunkPreGenerate chunkPreGenerate, World targetWorld, boolean skipStep) {
+        HashMap<String, Object> values = new HashMap<>();
+        values.put("cause", cause);
+        values.put("chunkPreGenerate", chunkPreGenerate);
+        values.put("targetWorld", targetWorld);
+        values.put("skipStep", skipStep);
+        return SpongeEventFactoryUtils.createEventImpl(ChunkPreGenerationEvent.Pre.class, values);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/event/world/ChunkPreGenerationEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/ChunkPreGenerationEvent.java
@@ -1,0 +1,115 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.world;
+
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.world.ChunkPreGenerate;
+
+import java.time.Duration;
+
+/**
+ * Base event for when a {@link ChunkPreGenerate} task
+ * is underway.
+ */
+public interface ChunkPreGenerationEvent extends TargetWorldEvent {
+
+    /**
+     * The object that contains the progress information for the
+     * current {@link ChunkPreGenerate}
+     *
+     * @return The {@link ChunkPreGenerate}
+     */
+    ChunkPreGenerate getChunkPreGenerate();
+
+    /**
+     * Event fired when chunks are about to be generated. Cancelling this task
+     * will cancel the entire pre-generation.
+     */
+    interface Pre extends ChunkPreGenerationEvent, Cancellable {
+
+        /**
+         * Returns whether the chunk generator will skip generation this time
+         * around. This only prevents the next step from being performed.
+         *
+         * <p>Use {@link #isCancelled()} to check for cancellation of the
+         * entire generation task.</p>
+         *
+         * @return {@code true} if the next step will be skipped.
+         */
+        boolean getSkipStep();
+
+        /**
+         * Sets whether the next step should be skipped.
+         *
+         * <p>Use {@link #setCancelled(boolean)} to cancel the entire pre
+         * generation task.</p>
+         *
+         * @param skipStep If set to {@code true}, the next step will be
+         *                 skipped.
+         */
+        void setSkipStep(boolean skipStep);
+
+    }
+
+    /**
+     * Event fired when a step has completed. Cancelling this task
+     * will cancel the entire pre-generation.
+     */
+    interface Post extends ChunkPreGenerationEvent, Cancellable {
+
+        /**
+         * The number of chunks generated during the previous step.
+         *
+         * @return The number of chunks that were generated.
+         */
+        int getChunksGeneratedThisStep();
+
+        /**
+         * The number of chunks generated that did not need to be generated and
+         * were skipped over
+         *
+         * @return The number of chunks that were generated.
+         */
+        int getChunksSkippedThisStep();
+
+        /**
+         * The {@link Duration} of the previous step.
+         *
+         * @return The {@link Duration}
+         */
+        Duration getTimeTakenForStep();
+
+    }
+
+    /**
+     * Event fired when the pre generation has been completed.
+     */
+    interface Complete extends ChunkPreGenerationEvent {}
+
+    /**
+     * Event fired when the pre generation has been cancelled.
+     */
+    interface Cancelled extends ChunkPreGenerationEvent {}
+}

--- a/src/main/java/org/spongepowered/api/world/ChunkPreGenerate.java
+++ b/src/main/java/org/spongepowered/api/world/ChunkPreGenerate.java
@@ -1,0 +1,201 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.world;
+
+import com.flowpowered.math.vector.Vector3d;
+import org.slf4j.Logger;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.event.world.ChunkPreGenerationEvent;
+import org.spongepowered.api.scheduler.Scheduler;
+import org.spongepowered.api.util.ResettableBuilder;
+import org.spongepowered.api.world.storage.WorldProperties;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents an ongoing chunk pre-generation.
+ */
+public interface ChunkPreGenerate {
+
+    /**
+     * The {@link WorldProperties} of the world that this task is operating on.
+     *
+     * @return The {@link WorldProperties}
+     */
+    WorldProperties getWorldProperties();
+
+    /**
+     * The total number of chunks generated during this generation.
+     *
+     * @return The number of chunks.
+     */
+    int getTotalGeneratedChunks();
+
+    /**
+     * The total number of chunks skipped during this generation.
+     *
+     * @return The number of chunks.
+     */
+    int getTotalSkippedChunks();
+
+    /**
+     * The target number of chunks that will be generated or skipped
+     * during this generation. This includes chunks already generated
+     * or skipped.
+     *
+     * @return The total number of chunks to be generated.
+     */
+    int getTargetTotalChunks();
+
+    /**
+     * Gets the total wall clock time it has taken (so far) to generate
+     * chunks.
+     *
+     * @return A {@link Duration} representing the amount of time taken
+     *         so far.
+     */
+    Duration getTotalTime();
+
+    /**
+     * Gets whether the task for this world has been cancelled
+     * (or completed).
+     *
+     * @return True if cancelled.
+     */
+    boolean isCancelled();
+
+    /**
+     * Cancels this pre-generation if it is still running.
+     */
+    void cancel();
+
+    /**
+     * A builder for submitting a task to pre-generate chunks.
+     *
+     * <p>The task is synchronous and repeating with a given interval and either
+     * a target number of chunks per ticks and/or a percentage of the tick
+     * time.</p>
+     *
+     * <p>Chunk order is not defined but a proper implementation should use and
+     * "inside-out" strategy for better results if the task is cancelled.</p>
+     *
+     * @see WorldBorder#newChunkPreGenerate(World)
+     * @see World#newChunkPreGenerate(Vector3d, double)
+     */
+    interface Builder extends ResettableBuilder<ChunkPreGenerate, Builder> {
+
+        /**
+         * Sets the owner of the resulting task.
+         *
+         * <p>Mandatory.</p>
+         *
+         * @param plugin The owner plugin
+         * @return This for chained calls
+         */
+        Builder owner(Object plugin);
+
+        /**
+         * Adds a logger for logging generator efforts.
+         *
+         * <p>Optional. No effect if null is passed.</p>
+         *
+         * @param logger A logger for the generator
+         * @return This for chained calls
+         */
+        Builder logger(@Nullable Logger logger);
+
+        /**
+         * Sets the number of ticks between generation runs.
+         *
+         * <p>Must be greater than 0.</p>
+         *
+         * <p>Optional.</p>
+         *
+         * <p>Default is 4.</p>
+         *
+         * @param tickInterval The tick interval
+         * @return This for chained calls
+         */
+        Builder tickInterval(int tickInterval);
+
+        /**
+         * Sets maximum number of chunks per tick to generate.
+         *
+         * <p>Use a value smaller or equal to 0 to disable.</p>
+         *
+         * <p>Optional if {@link #tickPercentLimit(float)} is used.</p>
+         *
+         * <p>Default is disabled.</p>
+         *
+         * @param chunkCount The maximum number of chunks to generate
+         * @return This for chained calls
+         */
+        Builder chunksPerTick(int chunkCount);
+
+        /**
+         * Sets the limit of tick time that can be used to generate chunks as a
+         * percentage of {@link Scheduler#getPreferredTickInterval()}. The
+         * percentage must be a value in the range (0, 1]. No estimation is
+         * used to decide when to stop so the actual value will always be
+         * somewhere above the given percentage.
+         *
+         * <p>Use a value smaller or equal to 0 to disable.</p>
+         *
+         * <p>Optional if {@link #chunksPerTick(int)} is used.</p>
+         *
+         * <p>Default is 80%.</p>
+         *
+         * @param tickPercent The maximum percentage of the tick time to use
+         *                    for this generation pass.
+         * @return This for chained calls
+         */
+        Builder tickPercentLimit(float tickPercent);
+
+        /**
+         * Adds a {@link ChunkPreGenerationEvent} listener callback that will be
+         * called for this, and only this, pre-generation routine. Note that
+         * this does not change whether the various {@link ChunkPreGenerationEvent}
+         * events will be called, this is a convenience method to simply setup
+         * a listener bound to this pre-generation.
+         *
+         * @param listener The {@link Consumer} that will handle the events.
+         *
+         * @return This for chained calls
+         */
+        Builder addListener(Consumer<ChunkPreGenerationEvent> listener);
+
+        /**
+         * Schedules the task with the {@link Game#getScheduler()}.
+         *
+         * @return The resulting {@link ChunkPreGenerate} that can be used
+         *         obtain progress
+         */
+        ChunkPreGenerate start();
+
+    }
+}

--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -207,9 +207,9 @@ public interface World extends Extent, WeatherUniverse, Viewer, ContextSource, M
      * @param center The center of the border
      * @param diameter The diameter of the border
      * @return The builder for the chunk pre-generate task
-     * @see WorldBorder.ChunkPreGenerate
+     * @see ChunkPreGenerate
      */
-    WorldBorder.ChunkPreGenerate newChunkPreGenerate(Vector3d center, double diameter);
+    ChunkPreGenerate.Builder newChunkPreGenerate(Vector3d center, double diameter);
 
     /**
      * Returns the {@link Dimension} of this world.

--- a/src/main/java/org/spongepowered/api/world/WorldBorder.java
+++ b/src/main/java/org/spongepowered/api/world/WorldBorder.java
@@ -25,13 +25,6 @@
 package org.spongepowered.api.world;
 
 import com.flowpowered.math.vector.Vector3d;
-import org.slf4j.Logger;
-import org.spongepowered.api.Game;
-import org.spongepowered.api.scheduler.Scheduler;
-import org.spongepowered.api.scheduler.Task;
-import org.spongepowered.api.util.ResettableBuilder;
-
-import javax.annotation.Nullable;
 
 /**
  * A world border is a square boundary, extending through the entire y-axis.
@@ -214,97 +207,5 @@ public interface WorldBorder {
      * @return The builder for the chunk pre-generate task
      * @see ChunkPreGenerate
      */
-    ChunkPreGenerate newChunkPreGenerate(World world);
-
-    /**
-     * A builder for submitting a task to pre-generate chunks inside a world
-     * border.
-     *
-     * <p>The task is synchronous and repeating with a given interval and either
-     * a target number of chunks per ticks and/or a percentage of the tick
-     * time.</p>
-     *
-     * <p>Chunk order is not defined but a proper implementation should use and
-     * "inside-out" strategy for better results if the task is cancelled.</p>
-     *
-     * @see WorldBorder#newChunkPreGenerate(World)
-     * @see World#newChunkPreGenerate(Vector3d, double)
-     */
-    interface ChunkPreGenerate extends ResettableBuilder<Task, ChunkPreGenerate> {
-
-        /**n
-         * Sets the owner of the resulting task.
-         *
-         * <p>Mandatory.</p>
-         *
-         * @param plugin The owner plugin
-         * @return This for chained calls
-         */
-        ChunkPreGenerate owner(Object plugin);
-
-        /**
-         * Sets the logger for logging generator efforts.
-         *
-         * <p>Optional.</p>
-         *
-         * @param logger A logger for the generator
-         * @return This for chained calls
-         */
-        ChunkPreGenerate logger(@Nullable Logger logger);
-
-        /**
-         * Sets the interval between generation runs.
-         *
-         * <p>Must be greater than 0.</p>
-         *
-         * <p>Optional.</p>
-         *
-         * <p>Default is 10.</p>
-         *
-         * @param tickInterval The tick interval
-         * @return This for chained calls
-         */
-        ChunkPreGenerate tickInterval(int tickInterval);
-
-        /**
-         * Sets maximum number of chunks per tick to generate.
-         *
-         * <p>Use a value smaller or equal to 0 to disable.</p>
-         *
-         * <p>Optional if {@link #tickPercentLimit(float)} is used.</p>
-         *
-         * <p>Default is disabled.</p>
-         *
-         * @param chunkCount The maximum number of chunks to generate
-         * @return This for chained calls
-         */
-        ChunkPreGenerate chunksPerTick(int chunkCount);
-
-        /**
-         * Sets the limit of tick time that can be used to generate chunks as a
-         * percentage of {@link Scheduler#getPreferredTickInterval()}. The
-         * percentage should be a value in the range (0, 1]. No estimation is
-         * used to decide when to stop so the actual value will always be
-         * somewhere above the given percentage.
-         *
-         * <p>Use a value smaller or equal to 0 to disable.</p>
-         *
-         * <p>Optional if {@link #chunksPerTick(int)} is used.</p>
-         *
-         * <p>Default is 15%.</p>
-         *
-         * @param tickPercent The
-         * @return This for chained calls
-         */
-        ChunkPreGenerate tickPercentLimit(float tickPercent);
-
-        /**
-         * Schedules the task with the {@link Game#getScheduler()}.
-         *
-         * @return The resulting task
-         */
-        Task start();
-
-    }
-
+    ChunkPreGenerate.Builder newChunkPreGenerate(World world);
 }

--- a/src/test/java/org/spongepowered/api/event/SpongeEventFactoryTest.java
+++ b/src/test/java/org/spongepowered/api/event/SpongeEventFactoryTest.java
@@ -57,6 +57,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -241,6 +242,8 @@ public class SpongeEventFactoryTest {
             return Locale.ROOT;
         } else if (paramType == Text.class) {
             return Text.of();
+        } else if (paramType == Duration.class) {
+            return Duration.ZERO;
         } else {
             return mock(paramType, withSettings().defaultAnswer(EVENT_MOCKING_ANSWER));
         }


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1149)

This PR is designed to open up the World PreGeneration code to allow plugins to effectively monitor and manipulate the pregeneration. This PR contains breaking changes that allow this to happen, so should not target anything but bleeding. This is based off my experience with NucleusMixins, and should allow all plugins to control the pre generation more effectively - and I'm offering this after being asked by @bloodmc to do so in https://github.com/NucleusPowered/Nucleus/issues/528

Discussion of the internals are discussed on the Common PR.

**Movement of API**

Prior to this, the pre-gen builder code was a sub interface to `WorldBorder.ChunkPreGenerate`. This seems to indicate that the pre-generation is related to the world border - it is not. Further, as the builder now returns a custom `ChunkPreGenerate` object, it made sense to move this all to it's own class. This does not affect how to get a builder.

The builder is subinterface to the `ChunkPreGenerate` interface, in line with other builders.

**Introduction of `ChunkPreGenerate`**

This interface is the base of the pre-gen system, and contains information about how the pre-generation is going - number of chunks generated, number skipped (that is, not required to be generated), etc. This is now returned from the `ChunkPreGenerate.Builder`, rather than just a `Task` - and plugins should now cancel pre-generation through this interface rather than the `Task`.

(It might be nice to add cancellation routines to the `Task` system, where code could be run if a task is cancelled, but that's out of the scope of this PR)

**Events**

There are now four events in the lifecycle of pre-generation, all in the `ChunkPreGenerationEvent` interface. They all return the `WorldProperties` and `ChunkPreGenerate` objects for proper progress reporting.

* **Pre**: fired before a pregeneration step is taken. If cancelled, cancels the entire pre generation. If `setSkipStep` is set to true, then that pre-generation step is skipped, but will try again when it is next scheduled to do so.
* **Post**: fired after a pregeneration step is taken. Contains stats about what has just been generated. If cancelled, cancels the entire pre generation.
* **Cancelled**: fired if the pregeneration is cancelled using `ChunkPreGenerate#cancel`.
* **Complete**: fired if the pregeneration is completed.

**Builder changes and additions**

* `Builder#addListener` adds a event listener for `ChunkPreGenerationEvent` to this specific task. This works in broadly the same way as the Custom Inventory listener methods.
* `Builder#logger` now adds the logger by adding a listener that fires on `ChunkPreGenerationEvent.Post` and `ChunkPreGenerationEvent.Complete`
* `from` now accepts a `ChunkPreGenerate` object, rather than a `Task` object.
* `start` returns the `ChunkPreGenerate` object now.

**Thoughts and notes**

* The `Pre/Post` events, if cancelled, will cancel the entire generation. Is this right? Should it be limited to `Pre`, and then only skip a step?
* Docmentation might need a few improvements!
* I think I caught everything in the style, but I've probably missed something!

**Test code & log results**

I will try to add more later - for now, this tests the listeners work as expected - both single task listeners, and global listeners.

https://gist.github.com/dualspiral/2664950914056f5a3ce005fba78811c8