### PR TITLE
Added stopRecord method to Jukebox.

### DIFF
--- a/src/main/java/org/spongepowered/api/block/tileentity/Jukebox.java
+++ b/src/main/java/org/spongepowered/api/block/tileentity/Jukebox.java
@@ -39,6 +39,11 @@ public interface Jukebox extends TileEntity {
     void playRecord();
 
     /**
+     * Stops the currently playing record, if any.
+     */
+    void stopRecord();
+
+    /**
      * Ejects the record item in this Jukebox into the world.
      */
     void ejectRecord();


### PR DESCRIPTION
[API](https://github.com/SpongePowered/SpongeAPI/pull/1478) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/1187)

This allows stopping a playing record, if one is currently playing.