### PR TITLE
Feature/loadingticket world

### DIFF
--- a/src/main/java/org/spongepowered/api/world/ChunkTicketManager.java
+++ b/src/main/java/org/spongepowered/api/world/ChunkTicketManager.java
@@ -189,7 +189,7 @@ public interface ChunkTicketManager {
         int getMaxNumChunks();
 
         /**
-         * Gets the world associated with this ticket during it's creation
+         * Gets the world associated with this ticket during its creation
          *
          * @return The world associated with this ticket
          */

--- a/src/main/java/org/spongepowered/api/world/ChunkTicketManager.java
+++ b/src/main/java/org/spongepowered/api/world/ChunkTicketManager.java
@@ -188,12 +188,12 @@ public interface ChunkTicketManager {
          */
         int getMaxNumChunks();
 
-		/**
-		 * Gets the world associated with this ticket during it's creation
-		 *
-		 * @return The world associated with this ticket
-		 */
-		World getWorld();
+        /**
+         * Gets the world associated with this ticket during it's creation
+         *
+         * @return The world associated with this ticket
+         */
+        World getWorld();
 
         // TODO: NBTTag getCustomData(); (Is saved with ticket information)
 

--- a/src/main/java/org/spongepowered/api/world/ChunkTicketManager.java
+++ b/src/main/java/org/spongepowered/api/world/ChunkTicketManager.java
@@ -188,6 +188,13 @@ public interface ChunkTicketManager {
          */
         int getMaxNumChunks();
 
+		/**
+		 * Gets the world associated with this ticket during it's creation
+		 *
+		 * @return The world associated with this ticket
+		 */
+		World getWorld();
+
         // TODO: NBTTag getCustomData(); (Is saved with ticket information)
 
         /**


### PR DESCRIPTION
The API currently does not provide a way for the ticket to provide the world from the ticket, despite having provided it during the creation of the ticket. Forge supports this, so this is essentially just adding to the completion of the Forge Chunk Manager wrapper.

This is paired with my SpongeForge pull request [#1248](https://github.com/SpongePowered/SpongeForge/pull/1248)