### PR TITLE
Get the world from a LoadingTicket

### DIFF
--- a/src/main/java/org/spongepowered/api/world/ChunkTicketManager.java
+++ b/src/main/java/org/spongepowered/api/world/ChunkTicketManager.java
@@ -190,6 +190,13 @@ public interface ChunkTicketManager {
         int getMaxNumChunks();
 
         /**
+         * Gets the world passed when creating this ticket
+         *
+         * @return The World object given to this ticket upon its creation
+         */
+        World getWorld();
+
+        /**
          * Gets the companion data stored in a {@link DataContainer}. Note that
          * the provided {@link DataContainer} is modifiable, but a copy of the
          * internal container, and as such may need to be


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1480) | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1190) | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/1252)

The SpongeAPI has no means currently to get a world from a LoadingTicket; given that the world is passed to the ticket for storage upon creation and called back when the server starts, it makes sense that you should be able to retrieve it again from a LoadingTicket object.