### PR TITLE
Add methods to require data from a CompositeValueStore/ValueContainer

### DIFF
--- a/src/main/java/org/spongepowered/api/data/value/ValueContainer.java
+++ b/src/main/java/org/spongepowered/api/data/value/ValueContainer.java
@@ -34,6 +34,7 @@ import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValueStore;
 import org.spongepowered.api.data.value.mutable.CompositeValueStore;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 
@@ -68,6 +69,26 @@ public interface ValueContainer<C extends ValueContainer<C>> {
      * @return The value, if available
      */
     <E> Optional<E> get(Key<? extends BaseValue<E>> key);
+
+    /**
+     * Attempts to get the underlying value backed by a {@link BaseValue}
+     * linked to the provided {@link Key}.
+     *
+     * <p>If the {@link Key} is not supported or
+     * available, {@link NoSuchElementException} will be thrown.</p>
+     *
+     * @param key The key
+     * @param <E> The type of value
+     * @return The value
+     * @throws NoSuchElementException If the value is not supported or present
+     */
+    default <E> E require(Key<? extends BaseValue<E>> key) {
+        final Optional<E> optional = this.get(key);
+        if (optional.isPresent()) {
+            return optional.get();
+        }
+        throw new NoSuchElementException(String.format("Could not retrieve value for key '%s'", key.getId()));
+    }
 
     /**
      * Attempts to get the underlying value if available and supported. If the

--- a/src/main/java/org/spongepowered/api/data/value/mutable/CompositeValueStore.java
+++ b/src/main/java/org/spongepowered/api/data/value/mutable/CompositeValueStore.java
@@ -37,6 +37,7 @@ import org.spongepowered.api.util.RespawnLocation;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
 
 import java.util.Collection;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -94,6 +95,26 @@ public interface CompositeValueStore<S extends CompositeValueStore<S, H>, H exte
      * @return The value container, if available
      */
     <T extends H> Optional<T> get(Class<T> containerClass);
+
+    /**
+     * Gets the desired {@link ValueContainer} of type <code>H</code> if the
+     * {@link ValueContainer} is compatible.
+     *
+     * <p>If the container class is not supported or
+     * available, {@link NoSuchElementException} will be thrown.</p>
+     *
+     * @param containerClass The container class
+     * @param <T> The type of {@link ValueContainer}
+     * @return The value
+     * @throws NoSuchElementException If the value is not supported or present
+     */
+    default <T extends H> T require(Class<T> containerClass) {
+        final Optional<T> optional = this.get(containerClass);
+        if (optional.isPresent()) {
+            return optional.get();
+        }
+        throw new NoSuchElementException(String.format("Could not retrieve value for container class '%s'", containerClass.getName()));
+    }
 
     /**
      * Gets the desired {@link ValueContainer} of type <code>H</code> if the


### PR DESCRIPTION
This adds the following methods:
- `org.spongepowered.api.data.value.ValueContainer#require`
- `org.spongepowered.api.data.value.mutable.CompositeValueStore#require`

which simply call the associated `get` method and, if the value is not present, throws `NoSuchElementException`.