### PR TITLE
ItemStack isEmpty

### DIFF
--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
@@ -40,6 +40,7 @@ import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.text.translation.Translatable;
 
 import java.util.Map;
@@ -78,6 +79,14 @@ public interface ItemStack extends DataHolder, Translatable {
         return builder().itemType(itemType).quantity(quantity).build();
     }
 
+    /**
+     * Returns an empty {@link ItemStack}
+     *
+     * @return The empty ItemStack
+     */
+    static ItemStack empty() {
+        return builder().itemType(ItemTypes.NONE).build();
+    }
 
     /**
      * Gets the {@link ItemType} of this {@link ItemStack}.
@@ -134,6 +143,16 @@ public interface ItemStack extends DataHolder, Translatable {
      * @return True if this equals the ItemStack
      */
     boolean equalTo(ItemStack that);
+
+    /**
+     * Returns true if {@link #getQuantity()} is zero and therefore this
+     * ItemStack is empty.
+     *
+     * <p>In Vanilla empty ItemStacks are not rendered by the client.</p>
+     *
+     * @return True if this ItemStack is empty
+     */
+    boolean isEmpty();
 
     @Override
     ItemStack copy();

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackSnapshot.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackSnapshot.java
@@ -57,6 +57,14 @@ public interface ItemStackSnapshot extends ImmutableDataHolder<ItemStackSnapshot
     int getCount();
 
     /**
+     * Returns true if {@link #getCount()} is zero and therefore this
+     * ItemStackSnapshot is empty.
+     *
+     * @return True if this ItemStackSnapshot is empty
+     */
+    boolean isEmpty();
+
+    /**
      * Creates a new {@link ItemStack} with all the data currently available
      * on this {@link ItemStackSnapshot}.
      *


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1487) | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1205)

Adds an isEmpty Method to ItemStacks