### PR TITLE
BlockCarriers

### DIFF
--- a/src/main/java/org/spongepowered/api/item/inventory/BlockCarrier.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/BlockCarrier.java
@@ -22,22 +22,36 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.block.tileentity.carrier;
+package org.spongepowered.api.item.inventory;
 
-import org.spongepowered.api.block.tileentity.TileEntity;
-import org.spongepowered.api.item.inventory.BlockCarrier;
-import org.spongepowered.api.item.inventory.Carrier;
-import org.spongepowered.api.item.inventory.type.TileEntityInventory;
+import org.spongepowered.api.util.Direction;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
+
+import java.util.Optional;
 
 /**
- * Represents a {@link TileEntity} that is a carrier of 
- * {@link TileEntityInventory}.
- *
- * <p>Additional information regarding the {@link TileEntityCarrier} is
- * dependent on the {@link TileEntity} itself.</p>
+ * Represents a Block that is a carrier of an Inventory
+ * e.g. An Anvil
  */
-public interface TileEntityCarrier extends TileEntity, BlockCarrier {
+public interface BlockCarrier extends Carrier {
 
-    @Override
-    TileEntityInventory<TileEntityCarrier> getInventory();
+    /**
+     * Returns the Location of the Block.
+     *
+     * @return The Location of the Block
+     */
+    Location<World> getLocation();
+
+    /**
+     * Returns the Inventory owned by this Carrier and accessible from given direction.
+     *
+     * <p>e.g. A Furnace accessed from {@link Direction#DOWN} will return its Fuel Slot</p>
+     *
+     * <p>When no inventory is accessible a {@link EmptyInventory} is returned</p>
+     *
+     * @param from The Direction
+     * @return The inventory at the location when accessed from given direction
+     */
+    Inventory getInventory(Direction from);
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/MultiBlockCarrier.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/MultiBlockCarrier.java
@@ -22,22 +22,46 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.block.tileentity.carrier;
+package org.spongepowered.api.item.inventory;
 
-import org.spongepowered.api.block.tileentity.TileEntity;
-import org.spongepowered.api.item.inventory.BlockCarrier;
-import org.spongepowered.api.item.inventory.Carrier;
-import org.spongepowered.api.item.inventory.type.TileEntityInventory;
+import org.spongepowered.api.util.Direction;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
- * Represents a {@link TileEntity} that is a carrier of 
- * {@link TileEntityInventory}.
- *
- * <p>Additional information regarding the {@link TileEntityCarrier} is
- * dependent on the {@link TileEntity} itself.</p>
+ * Represents Multiple Blocks that are the Carrier for an Inventory.
+ * e.g. A DoubleChest Inventory carried by two blocks
  */
-public interface TileEntityCarrier extends TileEntity, BlockCarrier {
+public interface MultiBlockCarrier extends BlockCarrier {
 
-    @Override
-    TileEntityInventory<TileEntityCarrier> getInventory();
+    /**
+     * Returns the Locations of the Blocks
+     *
+     * @return The Locations of the Blocks
+     */
+    List<Location<World>> getLocations();
+
+    /**
+     * Returns the Inventory at given location if owned by this Carrier
+     *
+     * @param at The location
+     * @return The inventory at given location
+     */
+    Optional<Inventory> getInventory(Location<World> at);
+
+    /**
+     * Returns the Inventory at given location if owned by this Carrier and
+     * accessible from given direction.
+     *
+     * e.g. A Furnace accessed from {@link Direction#DOWN} will return its Fuel Slot
+     *
+     * @param at The Location
+     * @param from The Direction
+     * @return The inventory at the location when accessed from given direction
+     */
+    Optional<Inventory> getInventory(Location<World> at, Direction from);
+
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/SingleBlockCarrier.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/SingleBlockCarrier.java
@@ -22,22 +22,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.block.tileentity.carrier;
-
-import org.spongepowered.api.block.tileentity.TileEntity;
-import org.spongepowered.api.item.inventory.BlockCarrier;
-import org.spongepowered.api.item.inventory.Carrier;
-import org.spongepowered.api.item.inventory.type.TileEntityInventory;
+package org.spongepowered.api.item.inventory;
 
 /**
- * Represents a {@link TileEntity} that is a carrier of 
- * {@link TileEntityInventory}.
- *
- * <p>Additional information regarding the {@link TileEntityCarrier} is
- * dependent on the {@link TileEntity} itself.</p>
+ * Represents a Block that is a carrier of an Inventory
+ * e.g. An Anvil
  */
-public interface TileEntityCarrier extends TileEntity, BlockCarrier {
+public interface SingleBlockCarrier extends BlockCarrier {
 
-    @Override
-    TileEntityInventory<TileEntityCarrier> getInventory();
+
 }


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1494) | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1640)

Adds Interfaces for Carrier that are Blocks or multiple Blocks
also adds access for inventories that can be accessed from a particular direction.