### PR TITLE
EnumValueElement#getValue case fix

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -940,9 +940,7 @@ public final class GenericArguments {
 
         @Override
         protected Iterable<String> getChoices(CommandSource source) {
-            return Arrays.stream(this.type.getEnumConstants())
-                .map(Enum::name)
-                .collect(Collectors.toList());
+            return this.values.keySet();
         }
 
         @Override

--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -929,14 +929,14 @@ public final class GenericArguments {
 
         @Override
         protected Iterable<String> getChoices(CommandSource source) {
-            return Arrays.asList(this.type.getEnumConstants()).stream()
-                .map(input -> input == null ? null : input.name())
+            return Arrays.stream(this.type.getEnumConstants())
+                .map(Enum::name)
                 .collect(Collectors.toList());
         }
 
         @Override
         protected Object getValue(String choice) throws IllegalArgumentException {
-            return Enum.valueOf(this.type, choice.toUpperCase());
+            return Enum.valueOf(this.type, choice);
         }
     }
 

--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -930,7 +930,7 @@ public final class GenericArguments {
             this.values = Arrays.stream(type.getEnumConstants())
                     .collect(Collectors.toMap(
                             value -> value.name().toLowerCase(),
-                            value -> value,
+                            Function.identity(),
                             (value, value2) -> {
                                 throw new UnsupportedOperationException(type.getCanonicalName() + " contains more than one enum constant " +
                                         "with the same name, only differing by capitalization, which is unsupported.");

--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -927,11 +927,10 @@ public final class GenericArguments {
         EnumValueElement(Text key, Class<T> type) {
             super(key);
             this.type = type;
-            this.values = Arrays.stream(type.getFields())
-                    .filter(Field::isEnumConstant)
+            this.values = Arrays.stream(type.getEnumConstants())
                     .collect(Collectors.toMap(
-                            field -> field.getName().toLowerCase(),
-                            field -> Enum.valueOf(type, field.getName()),
+                            value -> value.name().toLowerCase(),
+                            value -> value,
                             (value, value2) -> {
                                 throw new UnsupportedOperationException(type.getCanonicalName() + " contains more than one enum constant " +
                                         "with the same name, only differing by capitalization, which is unsupported.");


### PR DESCRIPTION
This is a fix to https://github.com/SpongePowered/SpongeAPI/issues/1396

At the moment, using EnumValueElement#getValue(String) only works when the enum field is all uppercase, this fixes that, making the search case sensitive.