### PR TITLE
Pattern.quote input strings in PatternMatchingCommandElement

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/PatternMatchingCommandElement.java
+++ b/src/main/java/org/spongepowered/api/command/args/PatternMatchingCommandElement.java
@@ -80,7 +80,7 @@ public abstract class PatternMatchingCommandElement extends CommandElement {
 
     Pattern getFormattedPattern(String input) {
         if (!input.startsWith("^")) { // Anchor matches to the beginning -- this lets us use find()
-            input = "^" + input;
+            input = "^" + Pattern.quote(input); // Quote input to avoid syntax errors caused by characters such as '['
         }
         return Pattern.compile(input, Pattern.CASE_INSENSITIVE);
 


### PR DESCRIPTION
Some input strings can cause PatternSyntaxException's to be thrown when compiling the regex pattern due to them containing certain characters.

For example, compiling the user input for a blockstate `minecraft:stone[` fails due to the open bracket: [log snippet](https://gist.github.com/dags-/a6cdb24a4b1605c013d456f33fed154e)

Pattern.quote()'ing the input string resolves this in my tests.