### PR TITLE
Return created type from Archetype#apply, Fixes #1423

### DIFF
--- a/src/main/java/org/spongepowered/api/block/tileentity/TileEntityArchetype.java
+++ b/src/main/java/org/spongepowered/api/block/tileentity/TileEntityArchetype.java
@@ -42,7 +42,7 @@ import org.spongepowered.api.world.World;
  * Represents the data of a {@link TileEntity} which does not exist in the world
  * and may be used to create new {@link TileEntity}s with the same data.
  */
-public interface TileEntityArchetype extends Archetype<BlockSnapshot> {
+public interface TileEntityArchetype extends Archetype<BlockSnapshot, TileEntity> {
 
     /**
      * Creates a {@link Builder} to get {@link TileEntityArchetype}s.

--- a/src/main/java/org/spongepowered/api/data/Archetype.java
+++ b/src/main/java/org/spongepowered/api/data/Archetype.java
@@ -28,21 +28,23 @@ import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
+import java.util.Optional;
+
 /**
  * A {@link DataHolder} which has no attachment to any particular world allowing
  * it to be used as a blueprint to create multiple copies of its containing
  * data.
  */
-public interface Archetype<S extends LocatableSnapshot<S>> extends DataHolder {
+public interface Archetype<S extends LocatableSnapshot<S>, E> extends DataHolder {
 
     /**
      * Creates a new instance based on this archetype at the given location.
      * 
      * @param location The location to create the new instance at
      * @param cause The cause of the creation
-     * @return Whether the creation was successful
+     * @return The created type, if successful
      */
-    boolean apply(Location<World> location, Cause cause);
+    Optional<E> apply(Location<World> location, Cause cause);
 
     /**
      * Creates a new immutable snapshot based on this archetype.

--- a/src/main/java/org/spongepowered/api/entity/EntityArchetype.java
+++ b/src/main/java/org/spongepowered/api/entity/EntityArchetype.java
@@ -34,7 +34,7 @@ import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.data.persistence.InvalidDataException;
 import org.spongepowered.api.data.value.BaseValue;
 
-public interface EntityArchetype extends Archetype<EntitySnapshot> {
+public interface EntityArchetype extends Archetype<EntitySnapshot, Entity> {
 
     /**
      * Creates a {@link Builder} to get {@link EntityArchetype}s.


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1246)

A small change to allow a plugin to access the newly created type from applying an archetype.