### PR TITLE
Add StringDataFormat that allows reading/writing data from text I/O

### DIFF
--- a/src/main/java/org/spongepowered/api/data/persistence/DataFormats.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/DataFormats.java
@@ -33,9 +33,9 @@ public final class DataFormats {
 
     // SORTFIELDS:ON
 
-    public static final DataFormat HOCON = DummyObjectProvider.createFor(DataFormat.class, "HOCON");
+    public static final StringDataFormat HOCON = DummyObjectProvider.createFor(StringDataFormat.class, "HOCON");
 
-    public static final DataFormat JSON = DummyObjectProvider.createFor(DataFormat.class, "JSON");
+    public static final StringDataFormat JSON = DummyObjectProvider.createFor(StringDataFormat.class, "JSON");
 
     public static final DataFormat NBT = DummyObjectProvider.createFor(DataFormat.class, "NBT");
 

--- a/src/main/java/org/spongepowered/api/data/persistence/StringDataFormat.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/StringDataFormat.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.persistence;
+
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataView;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+
+/**
+ * Represents a {@link DataFormat} that reads and writes data from/to a string.
+ */
+public interface StringDataFormat extends DataFormat {
+
+    /**
+     * Creates a new {@link DataContainer} from the contents of the given
+     * {@link String}.
+     *
+     * @param input The string to parse
+     * @return A data container representing the parsed contents of the string
+     * @throws InvalidDataException If the data in the string was not a
+     *         supported format
+     * @throws IOException If there was an error reading from the string
+     */
+    DataContainer read(String input) throws InvalidDataException, IOException;
+
+    /**
+     * Creates a new {@link DataContainer} from the contents of the given
+     * {@link Reader}.
+     *
+     * @param input The reader
+     * @return A data container representing the parsed contents of the reader
+     * @throws InvalidDataException If the data in the reader was not a
+     *         supported format
+     * @throws IOException If there was an error reading from the reader
+     */
+    DataContainer readFrom(Reader input) throws InvalidDataException, IOException;
+
+    /**
+     * Serializes the given {@link DataView} to a {@link String} using
+     * the format specified by this {@link DataFormat}.
+     *
+     * @param data The DataView to write
+     * @throws IOException If there was an error serializing the data
+     */
+    String write(DataView data) throws IOException;
+
+    /**
+     * Writes the given {@link DataView} to the given {@link Writer} using
+     * the format specified by this {@link DataFormat}.
+     *
+     * @param output The writer to write the data to
+     * @param data The DataView to write to the writer
+     * @throws IOException If there was an error writing to the writer
+     */
+    void writeTo(Writer output, DataView data) throws IOException;
+
+}


### PR DESCRIPTION
Adds an extended `StringDataFormat` interface for `DataFormat` that allows reading/writing data for text formats like HOCON or JSON much more efficiently directly from/to a string or a reader/writer instead of always going through a binary `InputStream`.

Not entirely sure about the naming, open for alternative suggestions for the interface and/or the new methods.

Implementation PR: https://github.com/SpongePowered/SpongeCommon/pull/1318