### PR TITLE
Add a get method for a world's sea level

### DIFF
--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -428,6 +428,13 @@ public interface World extends Extent, WeatherUniverse, Viewer, ContextSource, M
      */
     PortalAgent getPortalAgent();
 
+    /**
+     * Gets the sea level of the world.
+     *
+     * @return The sea level
+     */
+    int getSeaLevel();
+
     @Override
     MutableBiomeVolumeWorker<World> getBiomeWorker();
 


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1335)

At the moment this is still hardcoded in some locations throughout Minecraft and does not seem to be saved with the world anyway, so I feel it is best to just have a method to get it right now and not set it.

Hopefully Mojang will make it more flexible as time goes on so we can add a setter method as well. At that point it would probably move to `WorldArchetype` too. 

This can be useful for generation logic and more.

Example plugin:

![image](https://cloud.githubusercontent.com/assets/18372958/25768792/baac9252-31d0-11e7-9434-92a9f1a5effd.png)

![image](https://cloud.githubusercontent.com/assets/18372958/25768788/af4078d4-31d0-11e7-91ad-f22bff604d20.png)

Fixes https://github.com/SpongePowered/SpongeAPI/issues/1371