### PR TITLE
Expose slot ordinal via interface

### DIFF
--- a/src/main/java/org/spongepowered/api/item/inventory/Slot.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Slot.java
@@ -38,4 +38,11 @@ public interface Slot extends Inventory {
      */
     int getStackSize();
 
+	/**
+     * Gets the ordinal of a slot.
+     *
+     * @return the slot's ordinal
+     */
+    int getOrdinal();
+
 }


### PR DESCRIPTION
No need to update sponge common 
https://github.com/SpongePowered/SpongeCommon/blob/bleeding/src/main/java/org/spongepowered/common/item/inventory/adapter/impl/slots/SlotAdapter.java

Slot adapter already has the member, this pr just adds needed method into the Slot interface which allows us to access the ordinal number of a slot.

If anyone want to access slot's id, or whatever you call it, now the only possible way is to add spongevanilla/forge into your dependencies and typecast to slotadapter. Which is annoing to do.