### PR TITLE
Update TeleportHelper to allow plugin controlled safe teleports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,6 +210,7 @@ sortClassFields {
     add 'main', 'org.spongepowered.api.world.gen.PopulatorObjects'
     add 'main', 'org.spongepowered.api.world.gen.PopulatorTypes'
     add 'main', 'org.spongepowered.api.world.gen.WorldGeneratorModifiers'
+    add 'main', 'org.spongepowered.api.world.teleport.TeleportHelperFilters'
     add 'main', 'org.spongepowered.api.world.weather.Weathers'
     add 'main', 'org.spongepowered.api.util.TypeTokens'
 }

--- a/src/main/java/org/spongepowered/api/world/TeleportHelper.java
+++ b/src/main/java/org/spongepowered/api/world/TeleportHelper.java
@@ -25,13 +25,21 @@
 package org.spongepowered.api.world;
 
 import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.api.world.teleport.TeleportHelperFilter;
+import org.spongepowered.api.world.teleport.TeleportHelperFilters;
 
 import java.util.Optional;
 
 /**
  * Finds safe {@link Location}s for {@link Entity}s (typically ones that won't
  * hurt them).
+ *
+ * <p>Typically, the teleport helper will first determine whether the requested
+ * location is a safe one. If not, it will investigate locations close by,
+ * favouring spots closer, and favouring a location above or below over the
+ * x-z plane if two locations are equidistant.</p>
  */
 @NonnullByDefault
 public interface TeleportHelper {
@@ -40,13 +48,19 @@ public interface TeleportHelper {
     int DEFAULT_HEIGHT = 3;
     /** The default width radius to scan for safe locations. */
     int DEFAULT_WIDTH = 9;
+    /**
+     * The default distance to check for a suitable floor below any candidate
+     * location
+     * */
+    int DEFAULT_FLOOR_CHECK_DISTANCE = 2;
 
     /**
      * Gets the next safe {@link Location} around the given location.
      *
      * <p>Safe entails that the returned location will not be somewhere that
      * would harm an {@link Entity}. This method will use the default height and
-     * width for a search area.</p>
+     * width for a search area, and will check for a suitable floor up to two
+     * blocks below any selected block.</p>
      *
      * <p>It's possible the same location will be returned that was passed in.
      * This means it was safe.</p>
@@ -56,7 +70,97 @@ public interface TeleportHelper {
      *         location if it is deemed safe. If no safe location can be found,
      *         {@link Optional#empty()} will be returned.
      */
-    Optional<Location<World>> getSafeLocation(Location<World> location);
+    default Optional<Location<World>> getSafeLocation(Location<World> location) {
+        return getSafeLocation(location, DEFAULT_HEIGHT, DEFAULT_WIDTH, DEFAULT_FLOOR_CHECK_DISTANCE, TeleportHelperFilters.DEFAULT);
+    }
+
+    /**
+     * Gets the next safe {@link Location} around the given location with a
+     * given tolerance and search radius.
+     *
+     * <p>Safe entails that the returned location will not be somewhere that
+     * would harm an {@link Entity}.</p>
+     *
+     * <p>It's possible the same location will be returned that was passed in.
+     * This means it was safe.</p>
+     *
+     * <p>This method will check for a suitable floor up to two blocks below
+     * any selected block.</p>
+     *
+     * <p>This method will use the default {@link TeleportHelperFilter}</p>
+     *
+     * @param location The location to search nearby.
+     * @param height The radius of blocks on the y-axis to search.
+     * @param width The radius of blocks on the x and z-axis to search.
+     * @return A safe location near the original location or the original
+     *         location if it is deemed safe. If no safe location can be found,
+     *         {@link Optional#empty()} will be returned
+     */
+    default Optional<Location<World>> getSafeLocation(Location<World> location, int height, int width) {
+        return getSafeLocation(location, height, width, DEFAULT_FLOOR_CHECK_DISTANCE, TeleportHelperFilters.DEFAULT);
+    }
+
+    /**
+     * Gets the next safe {@link Location} around the given location with a
+     * given tolerance and search radius.
+     *
+     * <p>Safe entails that the returned location will not be somewhere that
+     * would harm an {@link Entity}.</p>
+     *
+     * <p>It's possible the same location will be returned that was passed in.
+     * This means it was safe.</p>
+     *
+     * <p>This method will use the default {@link TeleportHelperFilter} and will
+     * respect the blacklist.</p>
+     *
+     * @param location The location to search nearby.
+     * @param height The radius of blocks on the y-axis to search.
+     * @param width The radius of blocks on the x and z-axis to search.
+     * @param floorDistance The number of blocks below a selected block to
+     *                      search for a suitable floor, that is, the
+     *                      maximum distance to a floor that the selected
+     *                      point can be. If this is zero or negative, a floor
+     *                      check will not be performed.
+     * @return A safe location near the original location or the original
+     *         location if it is deemed safe. If no safe location can be found,
+     *         {@link Optional#empty()} will be returned
+     */
+    default Optional<Location<World>> getSafeLocation(Location<World> location, int height, int width, int floorDistance) {
+        return getSafeLocation(location, height, width, floorDistance, TeleportHelperFilters.DEFAULT, TeleportHelperFilters.CONFIG);
+    }
+
+    /**
+     * Gets the next safe {@link Location} around the given location with a
+     * given tolerance and search radius.
+     *
+     * <p>Safe entails that the returned location will not be somewhere that
+     * would harm an {@link Entity}.</p>
+     *
+     * <p>It's possible the same location will be returned that was passed in.
+     * This means it was safe.</p>
+     *
+     * <p>This method will use the defined blacklist, effectively an equivalent
+     * to adding {@link TeleportHelperFilters#CONFIG} to the filter set.</p>
+     *
+     * @param location The location to search nearby.
+     * @param height The radius of blocks on the y-axis to search.
+     * @param width The radius of blocks on the x and z-axis to search.
+     * @param floorDistance The number of blocks below a selected block to
+     *                      search for a suitable floor, that is, the
+     *                      maximum distance to a floor that the selected
+     *                      point can be. If this is zero or negative, a floor
+     *                      check will not be performed.
+     * @param filters The {@link TeleportHelperFilter}s to check, in addition
+     *                to {@link TeleportHelperFilters#CONFIG}. All filters must
+     *                match for a location to be marked as safe.
+     * @return A safe location near the original location or the original
+     *         location if it is deemed safe. If no safe location can be found,
+     *         {@link Optional#empty()} will be returned
+     */
+    default Optional<Location<World>> getSafeLocationWithBlacklist(Location<World> location, int height, int width, int floorDistance,
+            TeleportHelperFilter... filters) {
+        return getSafeLocation(location, height, width, floorDistance, TeleportHelperFilters.CONFIG, filters);
+    }
 
     /**
      * Gets the next safe {@link Location} around the given location with a
@@ -71,9 +175,21 @@ public interface TeleportHelper {
      * @param location The location to search nearby.
      * @param height The radius of blocks on the y-axis to search.
      * @param width The radius of blocks on the x and z-axis to search.
+     * @param floorDistance The number of blocks below a selected block to
+     *                      search for a suitable floor, that is, the
+     *                      maximum distance to a floor that the selected
+     *                      point can be. If this is zero or negative, a floor
+     *                      check will not be performed.
+     * @param filter The {@link TeleportHelperFilter} to use to determine if a
+     *               location is safe.
+     * @param additionalFilters Additional {@link TeleportHelperFilter}s to
+     *                          check. All filters must match for a location to
+     *                          be marked as safe.
      * @return A safe location near the original location or the original
      *         location if it is deemed safe. If no safe location can be found,
      *         {@link Optional#empty()} will be returned
      */
-    Optional<Location<World>> getSafeLocation(Location<World> location, int height, int width);
+    Optional<Location<World>> getSafeLocation(Location<World> location, int height, int width, int floorDistance, TeleportHelperFilter filter,
+            TeleportHelperFilter... additionalFilters);
+
 }

--- a/src/main/java/org/spongepowered/api/world/teleport/TeleportHelperFilter.java
+++ b/src/main/java/org/spongepowered/api/world/teleport/TeleportHelperFilter.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.world.teleport;
+
+import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.util.ResettableBuilder;
+import org.spongepowered.api.util.Tristate;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+import org.spongepowered.api.world.TeleportHelper;
+import org.spongepowered.api.world.World;
+
+/**
+ * A {@link TeleportHelperFilter} contains routines to determine whether a
+ * location is a suitable candidate for teleporting to safely.
+ */
+@CatalogedBy(TeleportHelperFilters.class)
+public interface TeleportHelperFilter extends CatalogType {
+
+    /**
+     * Tests whether the location in question is valid, regardless of whether
+     * the block is safe or not. This is <em>only</em> intended to be used by
+     * kernels that blacklist/whitelist certain locations, and any block checks
+     * should be performed by {@link #isSafeFloorMaterial(BlockState)} and
+     * {@link #isSafeBodyMaterial(BlockState)} instead, to obtain the full
+     * benefits of the {@link TeleportHelper}.
+     *
+     * <ul>
+     *     <li>Returning {@link Tristate#UNDEFINED} denotes that the filter
+     *     does not regard the location as valid or otherwise, and that the
+     *     helper should determine if the location is suitable using the
+     *     {@link #isSafeBodyMaterial(BlockState)} and
+     *     {@link #isSafeFloorMaterial(BlockState)} methods. Implementations
+     *     should generally return this result.</li>
+     *
+     *     <li>Returning {@link Tristate#TRUE} marks the location as valid and
+     *     will causes the parent {@link TeleportHelper} to return this
+     *     location. No checks using {@link #isSafeBodyMaterial(BlockState)}
+     *     and {@link #isSafeFloorMaterial(BlockState)} will be performed.</li>
+     *
+     *     <li>Returning {@link Tristate#FALSE} marks the location as invalid
+     *     and causes the parent {@link TeleportHelper} to move onto the next
+     *     block to check, regardless of whether it would have otherwise been
+     *     marked as safe.</li>
+     * </ul>
+     *
+     * <p>This method has a default implementation of always returning
+     * {@link Tristate#UNDEFINED}, that is, such a filter is not location
+     * specific.</p>
+     *
+     * <p>This will be called before any other check on the target location is
+     * performed, this is the first check performed when investigating a
+     * location.</p>
+     *
+     * @param world The {@link World} to check.
+     * @param position The {@link Vector3i} (block position) to check.
+     * @return A {@link Tristate}.
+     */
+    default Tristate isValidLocation(World world, Vector3i position) {
+        return Tristate.UNDEFINED;
+    }
+
+    /**
+     * Tests whether a {@link BlockState} should be considered a safe block
+     * to land on.
+     *
+     * @param blockState The {@link BlockState} to check
+     * @return <code>true</code> if the material should be safe to land on.
+     */
+    boolean isSafeFloorMaterial(BlockState blockState);
+
+    /**
+     * Tests whether a {@link BlockState} should be considered a safe block
+     * for the body to be inside of.
+     *
+     * <p>Generally, you want this to be a passable block!</p>
+     *
+     * @param blockState The {@link BlockState} to check
+     * @return <code>true</code> if the material should be safe for the body to
+     *         be inside of.
+     */
+    boolean isSafeBodyMaterial(BlockState blockState);
+
+}

--- a/src/main/java/org/spongepowered/api/world/teleport/TeleportHelperFilters.java
+++ b/src/main/java/org/spongepowered/api/world/teleport/TeleportHelperFilters.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.world.teleport;
+
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+
+public final class TeleportHelperFilters {
+
+    private TeleportHelperFilters() {}
+
+    // SORTFIELDS:ON
+
+    /**
+     * Designed to be combined with other filters, this filter determines if a
+     * block is in the config blacklist and returns the appropriate result.
+     */
+    public final static TeleportHelperFilter CONFIG = DummyObjectProvider.createFor(TeleportHelperFilter.class, "CONFIG");
+
+    /**
+     * The default behavior for safe teleportation, this filter attempts to
+     * find a location to teleport to that has the following characteristics:
+     *
+     * <ul>
+     *     <li>The two blocks that the player would occupy (the target and the
+     *     block above) are passable.</li>
+     *     <li>The floor is a non-passable or liquid block which is not known
+     *     to harm the player.</li>
+     *     <li>The block in question is not blacklisted in the config for the
+     *     floor or body (see {@link #CONFIG}).</li>
+     * </ul>
+     */
+    public final static TeleportHelperFilter DEFAULT = DummyObjectProvider.createFor(TeleportHelperFilter.class, "DEFAULT");
+
+    /**
+     * This filter attempts to find the following:
+     *
+     * <ul>
+     *     <li>A block that is air or a liquid which is not known by Sponge
+     *     to harm the player.</li>
+     *     <li>A similar block one block above the target.</li>
+     *     <li>That floor blocks are not cacti (and thus, hurt).</li>
+     * </ul>
+     */
+    public final static TeleportHelperFilter FLYING = DummyObjectProvider.createFor(TeleportHelperFilter.class, "FLYING");
+
+    /**
+     * This filter is the same as the {@link #DEFAULT} kernel, except that
+     * portals are not valid targets.
+     */
+    public final static TeleportHelperFilter NO_PORTAL = DummyObjectProvider.createFor(TeleportHelperFilter.class, "NO_PORTAL");
+
+    /**
+     * This filter is the same as the {@link #DEFAULT} kernel, except that
+     * only targets that can see the sky are considered.
+     */
+    public final static TeleportHelperFilter SURFACE_ONLY = DummyObjectProvider.createFor(TeleportHelperFilter.class, "SURFACE_ONLY");
+
+    // SORTFIELDS:OFF
+
+}


### PR DESCRIPTION
**Sponge API** | [Sponge Common](https://github.com/SpongePowered/SpongeCommon/pull/1362) | [Original Issue](https://github.com/SpongePowered/SpongeCommon/issues/848)

This PR opens up parts of the Sponge `TeleportHelper` to plugins and mods that support Sponge, allowing plugins reap the benefits of the TeleportHelper, whilst controlling what they consider to be a safe location for a player to warp to.

A <s>`TelportHelperKernel`</s> `TeleportHelperFilter` can be provided and registered with Sponge to control the following:

* Whether a `BlockState` is a suitable floor material.
* Whether a `BlockState` is a safe, passable material, that is, a player can travel through such a material and not get hurt.
* The above checks can be overriden for specific locations, for example, if you want to check to see if a location can see the sky (I use this in the surface only kernel, so an example of this can be seen in the SpongeCommon PR).
* Multiple filters can be specified, _all_ must return a positive result for a location to be accepted as a safe location.

I've also added two parameters to the `TeleportHelper#getSafeLocation` methods, one that takes an integer that specifies how far below a point the floor can be, and one that accepts the kernel.

One thing I haven't worked out yet, and is more one for SpongeCommon, configurable default blacklist for blocks, but as that is configuration and implementation, that does not come into play here.