### PR TITLE
Add method to get the precipitation level of a column

### DIFF
--- a/src/main/java/org/spongepowered/api/world/extent/Extent.java
+++ b/src/main/java/org/spongepowered/api/world/extent/Extent.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.world.extent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.flowpowered.math.vector.Vector2i;
 import com.flowpowered.math.vector.Vector3d;
 import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.block.BlockSnapshot;
@@ -117,15 +118,6 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
     int getHighestYAt(int x, int z);
 
     /**
-     * Returns the y level that precipitation ends falling in the given column.
-     *
-     * <p>A value is still returned for columns in biomes which do not receive precipitation.</p>
-     *
-     * @return the y level that precipitation ends
-     */
-    int getPrecipitationLevel(int x, int z);
-
-    /**
      * Get the {@link Location} of the highest block that sunlight can reach in
      * the given column.
      *
@@ -137,6 +129,26 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
      */
     default Vector3i getHighestPositionAt(Vector3i position) {
         return new Vector3i(position.getX(), getHighestYAt(position.getX(), position.getZ()), position.getZ());
+    }
+
+    /**
+     * Returns the y level that precipitation ends falling in the given column.
+     *
+     * <p>A value is still returned for columns in biomes which do not receive precipitation.</p>
+     *
+     * @return the y level that precipitation ends
+     */
+    int getPrecipitationLevel(int x, int z);
+
+    /**
+     * Returns the y level that precipitation ends falling in the given column.
+     *
+     * <p>A value is still returned for columns in biomes which do not receive precipitation.</p>
+     *
+     * @return the y level that precipitation ends
+     */
+    default int getPrecipitationLevel(Vector2i column) {
+        return this.getPrecipitationLevel(column.getX(), column.getY());
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/world/extent/Extent.java
+++ b/src/main/java/org/spongepowered/api/world/extent/Extent.java
@@ -134,7 +134,8 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
     /**
      * Returns the y level that precipitation ends falling in the given column.
      *
-     * <p>A value is still returned for columns in biomes which do not receive precipitation.</p>
+     * <p>A value is still returned for columns in biomes which do not
+     * receive precipitation.</p>
      *
      * @return the y level that precipitation ends
      */
@@ -143,7 +144,8 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
     /**
      * Returns the y level that precipitation ends falling in the given column.
      *
-     * <p>A value is still returned for columns in biomes which do not receive precipitation.</p>
+     * <p>A value is still returned for columns in biomes which do not
+     * receive precipitation.</p>
      *
      * @return the y level that precipitation ends
      */

--- a/src/main/java/org/spongepowered/api/world/extent/Extent.java
+++ b/src/main/java/org/spongepowered/api/world/extent/Extent.java
@@ -118,6 +118,19 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
     int getHighestYAt(int x, int z);
 
     /**
+     * Get the y value of the highest block that sunlight can reach in the given
+     * column.
+     *
+     * <p>This method ignores all transparent blocks, providing the highest
+     * opaque block.</p>
+     *
+     * @return The y value of the highest opaque block
+     */
+    default int getHighestYAt(Vector2i column) {
+        return this.getHighestYAt(column.getX(), column.getY());
+    }
+
+    /**
      * Get the {@link Location} of the highest block that sunlight can reach in
      * the given column.
      *
@@ -139,7 +152,7 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
      *
      * @return The y level that precipitation ends
      */
-    int getPrecipitationLevel(int x, int z);
+    int getPrecipitationLevelAt(int x, int z);
 
     /**
      * Returns the y level that precipitation ends falling in the given column.
@@ -149,8 +162,21 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
      *
      * @return The y level that precipitation ends
      */
-    default int getPrecipitationLevel(Vector2i column) {
-        return this.getPrecipitationLevel(column.getX(), column.getY());
+    default int getPrecipitationLevelAt(Vector2i column) {
+        return this.getPrecipitationLevelAt(column.getX(), column.getY());
+    }
+
+    /**
+     * Returns the position that precipitation ends falling in the column
+     * of the given position.
+     *
+     * <p>A position is still returned for positions in biomes which do not
+     * receive precipitation.</p>
+     *
+     * @return The position that precipitation ends
+     */
+    default Vector3i getPrecipitationLevelAt(Vector3i position) {
+        return new Vector3i(position.getX(), this.getPrecipitationLevelAt(position.getX(), position.getZ()), position.getZ());
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/world/extent/Extent.java
+++ b/src/main/java/org/spongepowered/api/world/extent/Extent.java
@@ -137,7 +137,7 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
      * <p>A value is still returned for columns in biomes which do not
      * receive precipitation.</p>
      *
-     * @return the y level that precipitation ends
+     * @return The y level that precipitation ends
      */
     int getPrecipitationLevel(int x, int z);
 
@@ -147,7 +147,7 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
      * <p>A value is still returned for columns in biomes which do not
      * receive precipitation.</p>
      *
-     * @return the y level that precipitation ends
+     * @return The y level that precipitation ends
      */
     default int getPrecipitationLevel(Vector2i column) {
         return this.getPrecipitationLevel(column.getX(), column.getY());

--- a/src/main/java/org/spongepowered/api/world/extent/Extent.java
+++ b/src/main/java/org/spongepowered/api/world/extent/Extent.java
@@ -117,6 +117,15 @@ public interface Extent extends EntityUniverse, TileEntityVolume, InteractableVo
     int getHighestYAt(int x, int z);
 
     /**
+     * Returns the y level that precipitation ends falling in the given column.
+     *
+     * <p>A value is still returned for columns in biomes which do not receive precipitation.</p>
+     *
+     * @return the y level that precipitation ends
+     */
+    int getPrecipitationLevel(int x, int z);
+
+    /**
      * Get the {@link Location} of the highest block that sunlight can reach in
      * the given column.
      *


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1388)

This is a response to the feature request #1560, adding a method to Extent to get the y level that precipitation ends.