### PR TITLE
Expand the Instrument/Noteblock API.

### DIFF
--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/tileentity/ImmutableNoteData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/tileentity/ImmutableNoteData.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.data.manipulator.immutable.tileentity;
 
 import org.spongepowered.api.block.tileentity.Note;
+import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.NoteData;
 import org.spongepowered.api.data.type.NotePitch;
@@ -40,6 +41,7 @@ public interface ImmutableNoteData extends ImmutableDataManipulator<ImmutableNot
      * Gets the {@link ImmutableValue} for the {@link NotePitch}.
      *
      * @return The immutable value for the note pitch
+     * @see Keys#NOTE_PITCH
      */
     ImmutableValue<NotePitch> note();
 

--- a/src/main/java/org/spongepowered/api/data/property/block/InstrumentProperty.java
+++ b/src/main/java/org/spongepowered/api/data/property/block/InstrumentProperty.java
@@ -22,43 +22,36 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.block.tileentity;
+package org.spongepowered.api.data.property.block;
 
-import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.data.manipulator.mutable.tileentity.NoteData;
-import org.spongepowered.api.data.type.NotePitch;
-import org.spongepowered.api.data.value.mutable.Value;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.data.Property;
+import org.spongepowered.api.data.property.AbstractProperty;
+import org.spongepowered.api.data.type.InstrumentType;
 
 /**
- * Represents a note block.
- *
- * <p>A {@link Note} will always have a valid {@link NoteData} to play.</p>
+ * A {@link InstrumentProperty} provides the {@link InstrumentType} that will be
+ * used for the target block if a {@link BlockTypes#NOTEBLOCK} is placed on top of it.
  */
-public interface Note extends TileEntity {
+public final class InstrumentProperty extends AbstractProperty<String, InstrumentType> {
 
     /**
-     * Attempts to play the currently stored {@link NotePitch} from this
-     * {@link Note} tile entity.
-     */
-    void playNote();
-
-    /**
-     * Retrieves the {@link NoteData} for this note block.
+     * Constructs a new {@link InstrumentProperty} with the
+     * specified {@link InstrumentType}.
      *
-     * @return the note data
+     * @param instrument The instrument type
      */
-    default NoteData getNoteData() {
-        return get(NoteData.class).get();
+    public InstrumentProperty(InstrumentType instrument) {
+        super(checkNotNull(instrument, "instrument"));
     }
 
-    /**
-     * Gets the {@link Value} for the {@link NotePitch}.
-     *
-     * @return The value for the note pitch
-     * @see Keys#NOTE_PITCH
-     */
-    default Value<NotePitch> note() {
-        return getValue(Keys.NOTE_PITCH).get();
+    @Override
+    public int compareTo(Property<?, ?> o) {
+        if (!(o instanceof InstrumentProperty)) {
+            return -1;
+        }
+        return getValue().getId().compareTo(((InstrumentProperty) o).getValue().getId());
     }
-
 }

--- a/src/main/java/org/spongepowered/api/data/type/InstrumentType.java
+++ b/src/main/java/org/spongepowered/api/data/type/InstrumentType.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.effect.sound.SoundType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
@@ -33,4 +34,11 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
 @CatalogedBy(InstrumentTypes.class)
 public interface InstrumentType extends CatalogType {
 
+    /**
+     * Gets the {@link SoundType} that is used by
+     * this {@link InstrumentType}.
+     *
+     * @return The sound
+     */
+    SoundType getSound();
 }

--- a/src/main/java/org/spongepowered/api/data/type/InstrumentTypes.java
+++ b/src/main/java/org/spongepowered/api/data/type/InstrumentTypes.java
@@ -34,11 +34,21 @@ public final class InstrumentTypes {
 
     public static final InstrumentType BASS_DRUM = DummyObjectProvider.createFor(InstrumentType.class, "BASS_DRUM");
 
+    public static final InstrumentType BELL = DummyObjectProvider.createFor(InstrumentType.class, "BELL");
+
+    public static final InstrumentType CHIME = DummyObjectProvider.createFor(InstrumentType.class, "CHIME");
+
+    public static final InstrumentType FLUTE = DummyObjectProvider.createFor(InstrumentType.class, "FLUTE");
+
+    public static final InstrumentType GUITAR = DummyObjectProvider.createFor(InstrumentType.class, "GUITAR");
+
     public static final InstrumentType HARP = DummyObjectProvider.createFor(InstrumentType.class, "HARP");
 
     public static final InstrumentType HIGH_HAT = DummyObjectProvider.createFor(InstrumentType.class, "HIGH_HAT");
 
     public static final InstrumentType SNARE = DummyObjectProvider.createFor(InstrumentType.class, "SNARE");
+
+    public static final InstrumentType XYLOPHONE = DummyObjectProvider.createFor(InstrumentType.class, "XYLOPHONE");
 
     // SORTFIELDS:OFF
 

--- a/src/main/java/org/spongepowered/api/effect/sound/SoundCategories.java
+++ b/src/main/java/org/spongepowered/api/effect/sound/SoundCategories.java
@@ -24,18 +24,33 @@
  */
 package org.spongepowered.api.effect.sound;
 
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+
 public final class SoundCategories {
 
-    public static final SoundCategory MASTER = null;
-    public static final SoundCategory MUSIC = null;
-    public static final SoundCategory RECORD = null;
-    public static final SoundCategory WEATHER = null;
-    public static final SoundCategory BLOCK = null;
-    public static final SoundCategory HOSTILE = null;
-    public static final SoundCategory NEUTRAL = null;
-    public static final SoundCategory PLAYER = null;
-    public static final SoundCategory AMBIENT = null;
-    public static final SoundCategory VOICE = null;
+    // SORTFIELDS:ON
+
+    public static final SoundCategory AMBIENT = DummyObjectProvider.createFor(SoundCategory.class, "AMBIENT");
+
+    public static final SoundCategory BLOCK = DummyObjectProvider.createFor(SoundCategory.class, "BLOCK");
+
+    public static final SoundCategory HOSTILE = DummyObjectProvider.createFor(SoundCategory.class, "HOSTILE");
+
+    public static final SoundCategory MASTER = DummyObjectProvider.createFor(SoundCategory.class, "MASTER");
+
+    public static final SoundCategory MUSIC = DummyObjectProvider.createFor(SoundCategory.class, "MUSIC");
+
+    public static final SoundCategory NEUTRAL = DummyObjectProvider.createFor(SoundCategory.class, "NEUTRAL");
+
+    public static final SoundCategory PLAYER = DummyObjectProvider.createFor(SoundCategory.class, "PLAYER");
+
+    public static final SoundCategory RECORD = DummyObjectProvider.createFor(SoundCategory.class, "RECORD");
+
+    public static final SoundCategory VOICE = DummyObjectProvider.createFor(SoundCategory.class, "VOICE");
+
+    public static final SoundCategory WEATHER = DummyObjectProvider.createFor(SoundCategory.class, "WEATHER");
+
+    // SORTFIELDS:OFF
 
     private SoundCategories() {
     }


### PR DESCRIPTION
**API** | [Common](https://github.com/SpongePowered/SpongeCommon/pull/1437)

Fixes #1595 

Changes:

- Added the missing `InstrumentType`s.
- Added `InstrumentProperty`, which can be used to retrieve a `InstrumentType` from a `BlockType`. For example `BlockTypes.BONE_BLOCK` would return `InstrumentTypes.XYLOPHONE`.
- Added DummyObjectProviders for SoundCategories.