### PR TITLE
Added a Record API

### DIFF
--- a/src/main/java/org/spongepowered/api/data/property/item/RecordProperty.java
+++ b/src/main/java/org/spongepowered/api/data/property/item/RecordProperty.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.property.item;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.data.Property;
+import org.spongepowered.api.data.property.AbstractProperty;
+import org.spongepowered.api.effect.sound.record.RecordType;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.inventory.ItemStack;
+
+/**
+ * A {@link RecordProperty} used to retrieve a {@link RecordType}
+ * from a {@link ItemType} or {@link ItemStack}.
+ */
+public final class RecordProperty extends AbstractProperty<String, RecordType> {
+
+    public RecordProperty(RecordType instrument) {
+        super(checkNotNull(instrument, "instrument"));
+    }
+
+    @Override
+    public int compareTo(Property<?, ?> o) {
+        if (!(o instanceof RecordProperty)) {
+            return -1;
+        }
+        return getValue().getId().compareTo(((RecordProperty) o).getValue().getId());
+    }
+}

--- a/src/main/java/org/spongepowered/api/effect/Viewer.java
+++ b/src/main/java/org/spongepowered/api/effect/Viewer.java
@@ -29,6 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.flowpowered.math.vector.Vector3d;
 import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.effect.sound.record.RecordType;
 import org.spongepowered.api.effect.particle.ParticleEffect;
 import org.spongepowered.api.effect.sound.SoundCategories;
 import org.spongepowered.api.effect.sound.SoundCategory;
@@ -150,6 +151,24 @@ public interface Viewer {
      *        0 and 2
      */
     void playSound(SoundType sound, SoundCategory category, Vector3d position, double volume, double pitch, double minVolume);
+
+    /**
+     * Plays the given {@link RecordType} at the given position. The benefit of playing
+     * {@link RecordType} instead of a {@link SoundType} allows you to stop them through
+     * the {@link #stopRecord(Vector3i)}. Playing a new {@link RecordType} at the same
+     * position will cancel the currently playing one.
+     *
+     * @param position The position
+     * @param recordType The record type
+     */
+    void playRecord(Vector3i position, RecordType recordType);
+
+    /**
+     * Stops the record that is playing at the given position.
+     *
+     * @param position The position
+     */
+    void stopRecord(Vector3i position);
 
     /**
      * Sends a {@link Title} to this player.

--- a/src/main/java/org/spongepowered/api/effect/sound/record/RecordType.java
+++ b/src/main/java/org/spongepowered/api/effect/sound/record/RecordType.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.effect.sound.record;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.block.tileentity.Jukebox;
+import org.spongepowered.api.text.translation.Translatable;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
+/**
+ * Represents the type of record that can be
+ * played by a {@link Jukebox}.
+ */
+@CatalogedBy(RecordTypes.class)
+public interface RecordType extends CatalogType, Translatable {
+
+}

--- a/src/main/java/org/spongepowered/api/effect/sound/record/RecordType.java
+++ b/src/main/java/org/spongepowered/api/effect/sound/record/RecordType.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.effect.sound.record;
 
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.block.tileentity.Jukebox;
+import org.spongepowered.api.effect.sound.SoundType;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
@@ -36,4 +37,11 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
 @CatalogedBy(RecordTypes.class)
 public interface RecordType extends CatalogType, Translatable {
 
+    /**
+     * Gets the {@link SoundType} that is used
+     * by this {@link RecordType}.
+     *
+     * @return The sound type
+     */
+    SoundType getSound();
 }

--- a/src/main/java/org/spongepowered/api/effect/sound/record/RecordTypes.java
+++ b/src/main/java/org/spongepowered/api/effect/sound/record/RecordTypes.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.effect.sound.record;
+
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+
+public final class RecordTypes {
+
+    // SORTFIELDS:ON
+
+    public static final RecordType BLOCKS = DummyObjectProvider.createFor(RecordType.class, "BLOCKS");
+
+    public static final RecordType CAT = DummyObjectProvider.createFor(RecordType.class, "CAT");
+
+    public static final RecordType CHIRP = DummyObjectProvider.createFor(RecordType.class, "CHIRP");
+
+    public static final RecordType ELEVEN = DummyObjectProvider.createFor(RecordType.class, "ELEVEN");
+
+    public static final RecordType FAR = DummyObjectProvider.createFor(RecordType.class, "FAR");
+
+    public static final RecordType MALL = DummyObjectProvider.createFor(RecordType.class, "MALL");
+
+    public static final RecordType MELLOHI = DummyObjectProvider.createFor(RecordType.class, "MELLOHI");
+
+    public static final RecordType STAL = DummyObjectProvider.createFor(RecordType.class, "STAL");
+
+    public static final RecordType STRAD = DummyObjectProvider.createFor(RecordType.class, "STRAD");
+
+    public static final RecordType THIRTEEN = DummyObjectProvider.createFor(RecordType.class, "THIRTEEN");
+
+    public static final RecordType WAIT = DummyObjectProvider.createFor(RecordType.class, "WAIT");
+
+    public static final RecordType WARD = DummyObjectProvider.createFor(RecordType.class, "WARD");
+
+    // SORTFIELDS:OFF
+
+    private RecordTypes() {
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/effect/sound/record/package-info.java
+++ b/src/main/java/org/spongepowered/api/effect/sound/record/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.effect.sound.record;


### PR DESCRIPTION
**API** | [Common](https://github.com/SpongePowered/SpongeCommon/pull/1438)

Fixes #1365

Additions:

- Play/stop a `RecordType` at a block position.
- Retrieve the `RecordType` from a `ItemStack` or `ItemType`.