### PR TITLE
Rewrite inventory queries.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,6 +186,7 @@ sortClassFields {
     add 'main', 'org.spongepowered.api.item.FireworkShapes'
     add 'main', 'org.spongepowered.api.item.ItemTypes'
     add 'main', 'org.spongepowered.api.item.inventory.equipment.EquipmentTypes'
+    add 'main', 'org.spongepowered.api.item.inventory.query.QueryOperationTypes'
     add 'main', 'org.spongepowered.api.scoreboard.CollisionRules'
     add 'main', 'org.spongepowered.api.scoreboard.Visibilities'
     add 'main', 'org.spongepowered.api.scoreboard.critieria.Criteria'

--- a/src/main/java/org/spongepowered/api/item/inventory/query/QueryOperation.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/query/QueryOperation.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.item.inventory.query;
+
+/**
+ * Represents an operation that is part of a query. The details of the
+ * filtering are implementation-specific and are not exposed in this
+ * interface.
+ */
+public interface QueryOperation<T> {
+
+    /**
+     * Returns the {@link QueryOperationType} used to
+     * {@linkplain QueryOperationType#of(Object) create} this query operation.
+     *
+     * @return The type of this query operation
+     */
+    QueryOperationType<T> getType();
+
+}

--- a/src/main/java/org/spongepowered/api/item/inventory/query/QueryOperationType.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/query/QueryOperationType.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.item.inventory.query;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.item.inventory.Inventory;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
+/**
+ * Represents a possible type of operation for an {@linkplain
+ * Inventory#query(QueryOperation...) inventory query}.
+ *
+ * @param <T> The argument type for the query
+ */
+@CatalogedBy(QueryOperationTypes.class)
+public interface QueryOperationType<T> extends CatalogType {
+
+    /**
+     * Returns a query operation that tests for the specified argument.
+     *
+     * @param arg The object to test the inventory against
+     * @return A query that may be passed to {@link
+     * Inventory#query(QueryOperation...)}
+     */
+    QueryOperation<T> of(T arg);
+
+}

--- a/src/main/java/org/spongepowered/api/item/inventory/query/QueryOperationTypes.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/query/QueryOperationTypes.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.item.inventory.query;
+
+import org.spongepowered.api.Nameable;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.inventory.Inventory;
+import org.spongepowered.api.item.inventory.InventoryProperty;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.property.InventoryTitle;
+import org.spongepowered.api.text.translation.Translation;
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+
+import java.util.function.Predicate;
+
+public final class QueryOperationTypes {
+
+    // SORTFIELDS:ON
+
+    /**
+     * Tests based on an inventory property present on the target inventory.
+     *
+     * @see Inventory#getProperties(Inventory, Class)
+     */
+    public static final QueryOperationType<InventoryProperty<?, ?>> INVENTORY_PROPERTY = DummyObjectProvider.createFor(QueryOperationType.class,
+            "INVENTORY_PROPERTY");
+
+    /**
+     * Tests based on the title of the inventory.
+     *
+     * @see InventoryTitle
+     * @see Nameable#getName()
+     */
+    public static final QueryOperationType<Translation> INVENTORY_TRANSLATION = DummyObjectProvider.createFor(QueryOperationType.class,
+            "INVENTORY_TRANSLATION");
+
+    /**
+     * Tests based on the class of the inventory.
+     */
+    public static final QueryOperationType<Class<? extends Inventory>> INVENTORY_TYPE = DummyObjectProvider.createFor(QueryOperationType.class,
+            "INVENTORY_TYPE");
+
+    /**
+     * Allows a custom condition for the items contained within an item stack.
+     */
+    public static final QueryOperationType<Predicate<ItemStack>> ITEM_STACK_CUSTOM = DummyObjectProvider.createFor(QueryOperationType.class,
+            "ITEM_STACK_CUSTOM");
+
+    /**
+     * Tests for an exact match of the item stack contained in each slot.
+     *
+     * @see ItemStack#equals(Object)
+     */
+    public static final QueryOperationType<ItemStack> ITEM_STACK_EXACT = DummyObjectProvider.createFor(QueryOperationType.class, "ITEM_STACK_EXACT");
+
+    /**
+     * Tests for an exact match of the item stack contained in each slot, with
+     * the exception of the quantity. This allows testing for custom data on
+     * item stacks that may be moved and stacked by players.
+     *
+     * @see ItemStack#equalTo(ItemStack)
+     */
+    public static final QueryOperationType<ItemStack> ITEM_STACK_IGNORE_QUANTITY = DummyObjectProvider.createFor(QueryOperationType.class,
+            "ITEM_STACK_IGNORE_QUANTITY");
+
+    /**
+     * Tests for a match of the type of item contained in each slot.
+     *
+     * @see ItemStack#getType()
+     */
+    public static final QueryOperationType<ItemType> ITEM_TYPE = DummyObjectProvider.createFor(QueryOperationType.class, "ITEM_TYPE");
+
+    // SORTFIELDS:OFF
+
+    private QueryOperationTypes() {}
+
+}


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1440)

When inventories were first added, they had support for querying for sub-inventories based on various attributes about them. One of those attributes was the type of `ItemStack` they contained. However, sometimes, developers want to use the quantity of the `ItemStack`, and sometimes they want to ignore it but keep the data on it. Originally, the way to specify this was through a quantity of `-1`. Then Minecraft dropped support for negative quantities. Sponge left in its wake a `queryAny()` method that ignored the quantity. In a discussion earlier today, Mumfrey decided this system needed to change, and I decided to be the one to write it. This version exposes a `QueryOperation` that tells the query how to treat each argument. It should also be more flexible than the current system in case Minecraft breaks some other behavior in the future.

Closes https://github.com/SpongePowered/SpongeCommon/issues/1431.