### PR TITLE
Fix a few inconsistencies across the API.

### DIFF
--- a/src/main/java/org/spongepowered/api/item/ItemType.java
+++ b/src/main/java/org/spongepowered/api/item/ItemType.java
@@ -92,7 +92,7 @@ public interface ItemType extends CatalogType, Translatable, GameDictionary.Entr
     
     @Override
     default boolean matches(ItemStack stack) {
-        return checkNotNull(stack, "stack").getItem().equals(this);
+        return checkNotNull(stack, "stack").getType().equals(this);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
@@ -92,8 +92,19 @@ public interface ItemStack extends DataHolder, Translatable {
      * Gets the {@link ItemType} of this {@link ItemStack}.
      *
      * @return The item type
+     * @deprecated Use {@link #getType()}
      */
-    ItemType getItem();
+    @Deprecated
+    default ItemType getItem() {
+        return getType();
+    }
+
+    /**
+     * Gets the {@link ItemType} of this {@link ItemStack}.
+     *
+     * @return The item type
+     */
+    ItemType getType();
 
     /**
      * Gets the quantity of items in this stack. This may exceed the max stack

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackComparators.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackComparators.java
@@ -93,7 +93,7 @@ public final class ItemStackComparators {
             if (o2 == null) {
                 return -1;
             }
-            return o1.getItem().getName().compareTo(o2.getItem().getName());
+            return o1.getType().getName().compareTo(o2.getType().getName());
         }
 
     }

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackSnapshot.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackSnapshot.java
@@ -53,8 +53,20 @@ public interface ItemStackSnapshot extends ImmutableDataHolder<ItemStackSnapshot
      * {@link ItemStackSnapshot} is representing.
      *
      * @return The current stack size
+     * @deprecated Use {@link #getQuantity()}
      */
-    int getCount();
+    @Deprecated
+    default int getCount() {
+        return getQuantity();
+    }
+
+    /**
+     * Gets the quantity of items in this the {@link ItemStack} this
+     * {@link ItemStackSnapshot} is representing.
+     *
+     * @return The current stack size
+     */
+    int getQuantity();
 
     /**
      * Returns true if {@link #getCount()} is zero and therefore this

--- a/src/main/java/org/spongepowered/api/profile/GameProfileCache.java
+++ b/src/main/java/org/spongepowered/api/profile/GameProfileCache.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.profile;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.service.user.UserStorageService;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
@@ -48,7 +49,21 @@ public interface GameProfileCache {
      *     otherwise {@code false}
      */
     default boolean add(GameProfile profile) {
-        return this.add(profile, null);
+        return this.add(profile, (Instant) null);
+    }
+
+    /**
+     * Add an entry to this cache, with an optional expiration date.
+     *
+     * @param profile The profile to cache
+     * @param expiry The expiration date
+     * @return {@code true} if the profile was successfully cached,
+     *     otherwise {@code false}
+     * @deprecated Use {@link #add(GameProfile, Instant)}
+     */
+    @Deprecated
+    default boolean add(GameProfile profile, @Nullable Date expiry) {
+        return this.add(profile, expiry == null ? null : expiry.toInstant());
     }
 
     /**
@@ -59,7 +74,7 @@ public interface GameProfileCache {
      * @return {@code true} if the profile was successfully cached,
      *     otherwise {@code false}
      */
-    default boolean add(GameProfile profile, @Nullable Date expiry) {
+    default boolean add(GameProfile profile, @Nullable Instant expiry) {
         return this.add(profile, false, expiry);
     }
 
@@ -72,8 +87,24 @@ public interface GameProfileCache {
      * @param expiry The expiration date
      * @return {@code true} if the profile was successfully cached,
      *     otherwise {@code false}
+     * @deprecated Use {@link #add(GameProfile, boolean, Instant)}
      */
-    boolean add(GameProfile profile, boolean overwrite, @Nullable Date expiry);
+    @Deprecated
+    default boolean add(GameProfile profile, boolean overwrite, @Nullable Date expiry) {
+        return this.add(profile, overwrite, expiry == null ? null : expiry.toInstant());
+    }
+
+    /**
+     * Add an entry to this cache, with an optional expiration date.
+     *
+     * @param profile The profile to cache
+     * @param overwrite If we should overwrite the cache entry for
+     *      the provided profile
+     * @param expiry The expiration date
+     * @return {@code true} if the profile was successfully cached,
+     *     otherwise {@code false}
+     */
+    boolean add(GameProfile profile, boolean overwrite, @Nullable Instant expiry);
 
     /**
      * Remove an entry from this cache.


### PR DESCRIPTION
**API** | [Common](https://github.com/SpongePowered/SpongeCommon/pull/1441)

Changes:

- Make the `getCount`/`getQuantity` and `getItem`/`getType` method naming consistent between the `ItemStack` and `ItemStackSnapshot`.
- Use `Instant` instead of `Date` in the `GameProfileCache`. Fixes #1336? in case that `TemporalUnit` isn't desired in the Scheduler.`