### PR TITLE
Add SubjectDataUpdateEvent for permission changes

### DIFF
--- a/src/main/java/org/spongepowered/api/event/permission/SubjectDataUpdateEvent.java
+++ b/src/main/java/org/spongepowered/api/event/permission/SubjectDataUpdateEvent.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.permission;
+
+import org.spongepowered.api.event.Event;
+import org.spongepowered.api.service.permission.Subject;
+import org.spongepowered.api.service.permission.SubjectData;
+
+/**
+ * Fired after a given {@link Subject}'s {@link SubjectData} is updated.
+ *
+ * <p>The event will be fired after the change has been fully applied, meaning
+ * calls querying the {@link Subject} will reflect the change.</p>
+ *
+ * <p>This event is always called asynchronously.</p>
+ */
+public interface SubjectDataUpdateEvent extends Event {
+
+    /**
+     * Gets the updated {@link SubjectData}.
+     *
+     * @return the updated data
+     */
+    SubjectData getUpdatedData();
+
+}

--- a/src/main/java/org/spongepowered/api/event/permission/package-info.java
+++ b/src/main/java/org/spongepowered/api/event/permission/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.permission;

--- a/src/main/java/org/spongepowered/api/service/permission/SubjectData.java
+++ b/src/main/java/org/spongepowered/api/service/permission/SubjectData.java
@@ -64,9 +64,24 @@ public interface SubjectData {
     Set<Context> GLOBAL_CONTEXT = Collections.emptySet();
 
     /**
+     * Gets the {@link Subject} which holds this data.
+     *
+     * @return The subject which holds this data
+     */
+    Subject getSubject();
+
+    /**
+     * Return if this SubjectData is transient.
+     *
+     * @return If this SubjectData is transient
+     * @see Subject#getTransientSubjectData()
+     */
+    boolean isTransient();
+
+    /**
      * Return all permissions associated with this data object.
      *
-     * @return an immutable copy of the mappings between contexts and lists of
+     * @return An immutable copy of the mappings between contexts and lists of
      *         permissions containing every permission registered
      */
     Map<Set<Context>, Map<String, Boolean>> getAllPermissions();


### PR DESCRIPTION
Continues on from #1524 (and #1411)

### Why only an update event?
More specific update events are hard to (accurately) implement, and I personally don't think they'll get used. The PermissionService API is already pretty confusing to understand (especially to implement) and I think adding events into the mix will make things significantly more difficult.

Adding more specific stuff like `PermissionSetEvent` raises questions about what to do for bulk changes, changes which are made offline, etc.

In my opinion, a simple update event is all that is needed. It allows plugins which use permissions for data storage to update any caches they may have when data is updated.

#### Should the event be called async?
The API was recently updated to use CompletableFutures for SubjectData changes, so imo, it makes sense for the event to **always** be called async.

Consistency is obviously important, it can't be sometimes async and sometimes not. I'm not sure if async events would be a new addition for Sponge, but I assume they're supported? (in other words, is the EventManager thread safe?)

I think that's about it.