### PR TITLE
Add EntityUniverse.getNearbyEntities().

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.entity;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.flowpowered.math.vector.Vector3d;
@@ -493,13 +492,12 @@ public interface Entity extends Identifiable, Locatable, DataHolder, Translatabl
     /**
      * Gets the nearby entities within the desired distance.
      *
-     * @see World#getEntities(Predicate)
+     * @see World#getNearbyEntities(Vector3d, double)
      * @param distance The distance
      * @return The collection of nearby entities
      */
     default Collection<Entity> getNearbyEntities(double distance) {
-        checkArgument(distance > 0, "Distance must be above zero!");
-        return getNearbyEntities(entity -> entity.getTransform().getPosition().distance(this.getTransform().getPosition()) <= distance);
+        return this.getWorld().getNearbyEntities(this.getLocation().getPosition(), distance);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/world/extent/EntityUniverse.java
+++ b/src/main/java/org/spongepowered/api/world/extent/EntityUniverse.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.world.extent;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.flowpowered.math.imaginary.Quaterniond;
@@ -75,6 +76,26 @@ public interface EntityUniverse {
      * @return A collection of entities
      */
     Collection<Entity> getEntities();
+
+    /**
+     * Return a collection of entities contained within {@code distance} blocks
+     * of the specified location. This uses a sphere to test distances.
+     *
+     * <p>For world implementations, only some parts of the world is usually
+     * loaded, so this method will only return entities within those loaded
+     * parts.</p>
+     *
+     * @param location The location at the center of the search radius
+     * @param distance The search radius
+     * @return A collection of nearby entities
+     */
+    default Collection<Entity> getNearbyEntities(Vector3d location, double distance) {
+        checkNotNull(location, "location");
+        checkArgument(distance > 0, "distance must be > 0");
+        return this.getIntersectingEntities(new AABB(location.getX() - distance, location.getY() - distance, location.getZ() - distance,
+                location.getX() + distance, location.getY() + distance, location.getZ() + distance),
+                entity -> entity.getLocation().getPosition().distanceSquared(location) <= distance * distance);
+    }
 
     /**
      * Return a collection of entities contained within this universe, possibly


### PR DESCRIPTION
This is `default`-implemented, and uses an optimized implementation method that only checks entities in relevant chunks. `Entity.getNearbyEntities()` has been updated to use it.

Supersedes SpongePowered/SpongeCommon#1479.