### PR TITLE
Small changes for implementing parrot data

### DIFF
--- a/src/main/java/org/spongepowered/api/data/type/ParrotVariants.java
+++ b/src/main/java/org/spongepowered/api/data/type/ParrotVariants.java
@@ -27,7 +27,7 @@ package org.spongepowered.api.data.type;
 import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
 
 /**
- * An enumeration of known vanilla {@link OcelotType}s.
+ * An enumeration of known vanilla {@link ParrotVariant}s.
  */
 public final class ParrotVariants {
 

--- a/src/main/java/org/spongepowered/api/util/TypeTokens.java
+++ b/src/main/java/org/spongepowered/api/util/TypeTokens.java
@@ -287,6 +287,10 @@ public class TypeTokens {
 
     public static final TypeToken<OptionalValue<UUID>> OPTIONAL_UUID_VALUE_TOKEN = new TypeToken<OptionalValue<UUID>>() {private static final long serialVersionUID = -1;};
 
+    public static final TypeToken<ParrotVariant> PARROT_VARIANT_TOKEN = new TypeToken<ParrotVariant>() {private static final long serialVersionUID = -1;};
+
+    public static final TypeToken<Value<ParrotVariant>> PARROT_VARIANT_VALUE_TOKEN = new TypeToken<Value<ParrotVariant>>() {private static final long serialVersionUID = -1;};
+
     public static final TypeToken<ParticleType> PARTICLE_TYPE_TOKEN = new TypeToken<ParticleType>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<Value<ParticleType>> PARTICLE_TYPE_VALUE_TOKEN = new TypeToken<Value<ParticleType>>() {private static final long serialVersionUID = -1;};


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1495) 

This makes a small Javadocs change and adds the type tokens needed for the parrot variants.

For more information see the SpongeCommon PR.