### PR TITLE
 SlotTransformation and Root Inventory

### DIFF
--- a/src/main/java/org/spongepowered/api/item/inventory/Inventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Inventory.java
@@ -61,6 +61,15 @@ public interface Inventory extends Iterable<Inventory>, Nameable {
     Inventory parent();
 
     /**
+     * Gets the root {@link Inventory} of this {@link Inventory}.
+     * This is equivalent to calling {@link #parent()} until it returns itself.
+     *
+     * @return the root inventory, returns this inventory if there is no
+     *       parent (this is a top-level inventory)
+     */
+    Inventory root();
+
+    /**
      * Returns an iterable view of all {@link Slot}s (leaf nodes) in this
      * Inventory.
      *

--- a/src/main/java/org/spongepowered/api/item/inventory/Slot.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Slot.java
@@ -30,12 +30,45 @@ package org.spongepowered.api.item.inventory;
 public interface Slot extends Inventory {
 
     /**
+     * A type of Slot
+     */
+    enum Type {
+
+        /**
+         * Slots in an Inventory as opposed to a {@link Container}
+         */
+        INVENTORY
+
+    }
+
+    /**
      * Gets the size of the stack in this slot. Essentially the same as calling
      * slot.peek().getQuantity(); but faster because it avoids the Optional
      * boxing.
-     * 
+     *
      * @return the stack size or -1 if this slot is empty
      */
     int getStackSize();
+
+    /**
+     * Transforms this Slot into given Type.
+     *
+     * <dl>
+     *   <dt>Example</dt>
+     *   <dd>In a InventoryEvent with a Container to get the actual inventory from Slot,
+     *     you may call this with {@link Type#INVENTORY}.</dd>
+     * </dl>
+     *
+     * @param type the type to transform into
+     * @return the transformed Slot or itself if already the correct type
+     */
+    Slot transform(Type type);
+
+    /**
+     * Transforms this Slot into the default Type.
+     *
+     * @return the transformed Slot or itself if already the default type
+     */
+    Slot transform();
 
 }


### PR DESCRIPTION
*SpongeAPI* | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1505)

For now the only tranformation is for transforming
ContainerSlots into InventorySlots

so that eventSlot.transform().root() is always the actual inventory clicked