### PR TITLE
Fix ContextValue Annotation for Event Listeners

### DIFF
--- a/src/main/java/org/spongepowered/api/event/cause/EventContext.java
+++ b/src/main/java/org/spongepowered/api/event/cause/EventContext.java
@@ -97,6 +97,19 @@ public final class EventContext {
         return Optional.ofNullable((T) this.entries.get(key));
     }
 
+    @SuppressWarnings("unchecked")
+    public <T> Optional<T> findByName(String possibleName, Class<T> klass) {
+        checkNotNull(possibleName, "String names cannot be null");
+        checkNotNull(klass, "Type class cannot be null");
+        checkArgument(!possibleName.isEmpty(), "String names cannot be empty");
+        final String simplified = possibleName.toLowerCase().replace('_', ' ');
+        return (Optional<T>) this.entries.entrySet().stream()
+            .filter(entry -> entry.getKey().getName().toLowerCase().contains(simplified))
+            .map(Map.Entry::getValue)
+            .filter(klass::isInstance)
+            .findFirst();
+    }
+
     /**
      * Gets the value corresponding to the given key from the context.
      *

--- a/src/main/java/org/spongepowered/api/event/cause/EventContextKeys.java
+++ b/src/main/java/org/spongepowered/api/event/cause/EventContextKeys.java
@@ -106,6 +106,65 @@ public final class EventContextKeys {
 
     // SORTFIELDS:OFF
 
+    public static final class Named {
+        // SORTFIELDS:ON
+
+        public static final String BLOCK_HIT = "BLOCK_HIT";
+
+        public static final String CREATOR = "CREATOR";
+
+        public static final String DAMAGE_TYPE = "DAMAGE_TYPE";
+
+        public static final String DISMOUNT_TYPE = "DISMOUNT_TYPE";
+
+        public static final String ENTITY_HIT = "ENTITY_HIT";
+
+        public static final String FAKE_PLAYER = "FAKE_PLAYER";
+
+        public static final String FIRE_SPREAD = "FIRE_SPREAD";
+
+        public static final String IGNITER = "IGNITER";
+
+        public static final String LAST_DAMAGE_SOURCE = "LAST_DAMAGE_SOURCE";
+
+        public static final String LEAVES_DECAY = "LEAVES_DECAY";
+
+        public static final String LIQUID_MIX = "LIQUID_MIX";
+
+        public static final String NOTIFIER = "NOTIFIER";
+
+        public static final String OWNER = "OWNER";
+
+        public static final String PISTON_EXTEND = "PISTON_EXTEND";
+
+        public static final String PISTON_RETRACT = "PISTON_RETRACT";
+
+        public static final String PLAYER = "PLAYER";
+
+        public static final String PLAYER_BREAK = "PLAYER_BREAK";
+
+        public static final String PLAYER_PLACE = "PLAYER_PLACE";
+
+        public static final String PLAYER_SIMULATED = "PLAYER_SIMULATED";
+
+        public static final String PLUGIN = "PLUGIN";
+
+        public static final String PROJECTILE_SOURCE = "PROJECTILE_SOURCE";
+
+        public static final String SERVICE_MANAGER = "SERVICE_MANAGER";
+
+        public static final String SPAWN_TYPE = "SPAWN_TYPE";
+
+        public static final String TELEPORT_TYPE = "TELEPORT_TYPE";
+
+        public static final String THROWER = "THROWER";
+
+        public static final String USED_ITEM = "USED_ITEM";
+
+        public static final String WEAPON = "WEAPON";
+        // SORTFIELDS:OFF
+
+    }
     @SuppressWarnings("unchecked")
     private static <T> EventContextKey<T> createFor(String id) {
         return DummyObjectProvider.createFor(EventContextKey.class, id);

--- a/src/main/java/org/spongepowered/api/event/filter/cause/ContextValue.java
+++ b/src/main/java/org/spongepowered/api/event/filter/cause/ContextValue.java
@@ -44,7 +44,11 @@ import java.lang.annotation.Target;
 public @interface ContextValue {
 
     /**
-     * Gets the name to use with the {@link EventContextKey}.
+     * Gets the name to use with the {@link EventContextKey}. For reference,
+     * utilize
+     * {@link org.spongepowered.api.event.cause.EventContextKeys.Named#BLOCK_HIT_NAME}
+     * as an example for what constants to use. The name is not irrelevent as it
+     * will be matched by the existing name at registration case insensitive.
      *
      * @return The name to use
      */
@@ -54,7 +58,7 @@ public @interface ContextValue {
      * If specified the possible type for the returned object (normally
      * specified by the type of the annotated parameter) is restricted to only
      * the specified types.
-     *
+     * <p>
      * <p>For exampled annotating a parameter of type Monster would normally
      * accept all entities extending Monster, however with the includes
      * specified as Enderman and Zombie the possible Monsters returned would be


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1528)

Long story short: Since the Cause and Context PR merge, this annotation which *replaced* `@Named`, we've been unable to reproduce the feature set due to the language requirements that annotations are utilizing constants at *compile* time and not *runtime*. As such, it's not feasible to use for example:
```java
@Listener
public void onChange(ChangeBlockEvent.Place event, @ContextValue(EventContextKeys.OWNER.getName()) Player player) {
 // foo
}
```
This will result in a compile time error due to the lack of constants in this case.

This adds the constants to be used and some fuzzy string matching on the context to perform the job as expected.