### PR TITLE
Ensure that an argument that is an exact match always takes precedence

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/CommandContext.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandContext.java
@@ -50,6 +50,11 @@ public final class CommandContext {
      */
     public static final String TARGET_BLOCK_ARG = "targetblock-pos048658"; // Random junk afterwards so we don't accidentally conflict with other args
 
+    /**
+     * The argument key to indicate that a tab completion is taking place.
+     */
+    public static final String TAB_COMPLETION = "tab-complete-50456"; // Random junk afterwards so we don't accidentally conflict with other args
+
     private final Multimap<String, Object> parsedArgs;
 
     /**

--- a/src/main/java/org/spongepowered/api/command/spec/CommandSpec.java
+++ b/src/main/java/org/spongepowered/api/command/spec/CommandSpec.java
@@ -395,6 +395,7 @@ public final class CommandSpec implements CommandCallable {
         if (targetPos != null) {
             ctx.putArg(CommandContext.TARGET_BLOCK_ARG, targetPos);
         }
+        ctx.putArg(CommandContext.TAB_COMPLETION, true);
         return complete(source, args, ctx);
     }
 


### PR DESCRIPTION
For reference, some of the discussion in https://github.com/SpongePowered/SpongeAPI/pull/1514 is relevant, but this will fix a more immediate problem.

There are two things that this fixes - and I'm PRing because I haven't tested this yet and don't currently have the setup to do so:

### Some arguments require escaping for an exact match

Take the fake player `[Mekanism]`. If this is entered into the `UserCommandElement`, this will not match the fake player `[Mekanism]` because the argument is transformed into the regex `^[Mekanism]`, meaning it'll match any player that starts with any of the letters in `Mekanism`. The `PatternMatchingCommandElement` _does_ try to match a choice with an element, but only _after_ filtering choices with the regex.

This PR will fix that by ensuring the exact match test happens _before_ the regex is used to filter the elements. This should fix exactness checks for `BlockState` `CatalogTypes` too, which often use `[]` characters.

### The UserCommandElement tries to use a PlayerCommandElement first - sometimes erroneously matching a Player before a User

Assume that there are two players that have joined the server: `dualspiral` and `dualspiral_`. Say `dualspiral_` is online and `dualspiral` is offline. Due to the current setup of the `UserCommandElement`, it wraps a `PlayerCommandElement`, which picks out the online "dualspiral_" even if only `dualspiral` (or `dualspira` etc.) is typed - which is clearly not intended.

This moves the user exactness check to the beginning of the element parser.