### PR TITLE
Deprecate unused DisplacementProperty for removal in API 8

### DIFF
--- a/src/main/java/org/spongepowered/api/data/property/DisplacementProperty.java
+++ b/src/main/java/org/spongepowered/api/data/property/DisplacementProperty.java
@@ -33,6 +33,11 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+/**
+ * @deprecated As of API 7, intended for removal in API 8, with no alternative
+ *     due to accidental existence in the API
+ */
+@Deprecated
 public class DisplacementProperty extends AbstractProperty<String, Set<BlockType>> {
 
     /**


### PR DESCRIPTION
_TL;DR: This property is unused and unimplemented, and no one I asked knew what it was supposed to represent, so I am creating this PR to either remove it for now or figure out what it is supposed to be for so I can fix it and actually implement it._

So I noticed the `DisplacementProperty` is currently unused and unimplemented. I tried tracking down what it was meant to do, but I could not figure it out and it seems to have either been replaced or it was decided it was not needed. After asking around it seems no one else knew exactly it was supposed to be used for either. 

Currently the Javadocs aren't useful in distinguishing what it exactly is and it is in the base property package which doesn't really make sense either. For the moment with it not implemented, lacking good Javadocs, and little knowledge of what it is for, it is best to remove it.

If someone knows what it is supposed to represent, feel free tell me, and I will look into implementing it, moving it to the proper package,adding more useful Javadocs, and then update this PR for that :)

If this helps, it seems to have history as [`HarvestingProperty`](https://jd.spongepowered.org/6.0.0/org/spongepowered/api/data/property/item/HarvestingProperty.html) and that is what its Javadocs were copied from that until someone updated them.

**Edit:** Changed to deprecate instead of remove, in-case anyone is currently using the property.