### PR TITLE
Add exhaustion to damage source and add some javadocs

### DIFF
--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSource.java
@@ -61,8 +61,8 @@ public interface DamageSource {
     DamageType getType();
 
     /**
-     * Gets whether this {@link DamageSource} can not be modified and the
-     * damage is absolute.
+     * Gets whether this {@link DamageSource}'s damage is absolute and
+     * will ignore potion effects and enchantments.
      *
      * @return If this damage source deals absolute damage
      */
@@ -112,8 +112,9 @@ public interface DamageSource {
      * Gets the amount of exhaustion this {@link DamageSource} will
      * add to the entity, generally only to players.
      *
-     * <p>In vanilla this is generally set to 0.1 by default and
-     * overridden and set to 0 if the damage is set to be absolute.</p>
+     * <p>In vanilla gameplay this is set to 0.1 by default and
+     * overridden to 0 if the source is set to be absolute or
+     * as overriding armor.</p>
      *
      * @return The increase in exhaustion
      */
@@ -133,14 +134,18 @@ public interface DamageSource {
 
         /**
          * Sets this {@link DamageSource} as dealing damage that
-         * bypasses armor.
+         * bypasses armor modifiers.
+         *
+         * <p>This sets the exhaustion increase caused
+         * by this source to 0. You can override this
+         * with {@link #exhaustion(double)}.</p>
          *
          * @return This builder
          */
         B bypassesArmor();
 
         /**
-         * Sets whether this {@link DamageSource} as an explosion.
+         * Sets this {@link DamageSource} as an explosion.
          *
          * @return This builder
          */
@@ -148,8 +153,12 @@ public interface DamageSource {
 
 
         /**
-         * Sets this {@link DamageSource} as not being able to be modified
-         * with damage that is absolute.
+         * Sets whether this {@link DamageSource}'s damage is absolute and
+         * will ignore potion effects and enchantments.
+         *
+         * <p>This sets the exhaustion increase caused
+         * by this source to 0. You can override this
+         * with {@link #exhaustion(double)}.</p>
          *
          * @return This builder
          */
@@ -175,9 +184,14 @@ public interface DamageSource {
          * Sets the amount of exhaustion this {@link DamageSource} will
          * add to the entity, generally only to players.
          *
-         * <p>In vanilla this defaults .1 in vanilla, and turns to 0 if the
-         * damage is absolute. This builder generally defaults to it to 0.1
-         * and is not overridden if you set the damage as absolute.</p>
+         * <p>In vanilla gameplay, the default is 0.1, unless if the damage
+         * is absolute or bypasses armor, where the exhaustion gets set to 0.
+         * This builder follows this mechanic, but if you set the exhaustion
+         * through this method that will be overridden.</p>
+         *
+         * <p>If you don't set this exhaustion manually, calling
+         * {@link #absolute()} or {@link #bypassesArmor()} will
+         * set this 0 and if you don't this will default to 0.1.</p>
          *
          * @param exhaustion The amount of exhaustion to add to the entity
          * @return This builder
@@ -187,7 +201,7 @@ public interface DamageSource {
         /**
          * Sets the {@link DamageType} of this source.
          *
-         * <p>This is often required to be set.</p>
+         * <p>This is required to be set.</p>
          *
          * @param damageType The desired damage type
          * @return This builder

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSource.java
@@ -108,24 +108,99 @@ public interface DamageSource {
      */
     boolean doesAffectCreative();
 
+    /**
+     * Gets the amount of exhaustion this {@link DamageSource} will
+     * add to the entity, generally only to players.
+     *
+     * <p>In vanilla this is generally set to 0.1 by default and
+     * overridden and set to 0 if the damage is set to be absolute.</p>
+     *
+     * @return The increase in exhaustion
+     */
+    double getExhaustion();
+
     interface Builder extends DamageSourceBuilder<DamageSource, Builder> { }
 
     interface DamageSourceBuilder<T extends DamageSource, B extends DamageSourceBuilder<T, B>> extends ResettableBuilder<T, B> {
 
+        /**
+         * Sets this {@link DamageSource}'s damage to be scaled
+         * by {@link Difficulty}.
+         *
+         * @return This builder
+         */
         B scalesWithDifficulty();
 
+        /**
+         * Sets this {@link DamageSource} as dealing damage that
+         * bypasses armor.
+         *
+         * @return This builder
+         */
         B bypassesArmor();
 
+        /**
+         * Sets whether this {@link DamageSource} as an explosion.
+         *
+         * @return This builder
+         */
         B explosion();
 
+
+        /**
+         * Sets this {@link DamageSource} as not being able to be modified
+         * with damage that is absolute.
+         *
+         * @return This builder
+         */
         B absolute();
 
+        /**
+         * Sets this {@link DamageSource} as considered to be magical
+         * damage. An example is potions.
+         *
+         * @return This builder
+         */
         B magical();
 
+        /**
+         * Sets this {@link DamageSource} as considered to damage creative, or
+         * otherwise "normally unharmable" players.
+         *
+         * @return This builder
+         */
         B creative();
 
+        /**
+         * Sets the amount of exhaustion this {@link DamageSource} will
+         * add to the entity, generally only to players.
+         *
+         * <p>In vanilla this defaults .1 in vanilla, and turns to 0 if the
+         * damage is absolute. This builder generally defaults to it to 0.1
+         * and is not overridden if you set the damage as absolute.</p>
+         *
+         * @param exhaustion The amount of exhaustion to add to the entity
+         * @return This builder
+         */
+        B exhaustion(double exhaustion);
+
+        /**
+         * Sets the {@link DamageType} of this source.
+         *
+         * <p>This is often required to be set.</p>
+         *
+         * @param damageType The desired damage type
+         * @return This builder
+         */
         B type(DamageType damageType);
 
+        /**
+         * Builds an instance of this damage source, based on
+         * the values you inputted into the builder.
+         *
+         * @return The resulting damage source
+         * @throws IllegalStateException If a value required to be set is not set
+         */
         T build() throws IllegalStateException;
 
     }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSource.java
@@ -56,7 +56,13 @@ public abstract class AbstractDamageSource implements DamageSource {
         this.explosive = builder.explosion;
         this.magic = builder.magical;
         this.creative = builder.creative;
-        this.exhaustion = builder.exhaustion;
+        if (builder.exhaustion != null) {
+            this.exhaustion = builder.exhaustion;
+        } else if (this.absolute || this.bypassesArmor) {
+            this.exhaustion = 0.0;
+        } else {
+            this.exhaustion = 0.1;
+        }
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSource.java
@@ -46,6 +46,7 @@ public abstract class AbstractDamageSource implements DamageSource {
     private final boolean explosive;
     private final boolean magic;
     private final boolean creative;
+    private final double exhaustion;
 
     protected AbstractDamageSource(AbstractDamageSourceBuilder<?, ?> builder) {
         this.apiDamageType = checkNotNull(builder.damageType, "DamageType cannot be null!");
@@ -55,6 +56,7 @@ public abstract class AbstractDamageSource implements DamageSource {
         this.explosive = builder.explosion;
         this.magic = builder.magical;
         this.creative = builder.creative;
+        this.exhaustion = builder.exhaustion;
     }
 
     @Override
@@ -90,6 +92,11 @@ public abstract class AbstractDamageSource implements DamageSource {
     @Override
     public boolean doesAffectCreative() {
         return this.creative;
+    }
+
+    @Override
+    public double getExhaustion() {
+        return this.exhaustion;
     }
 
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSourceBuilder.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSourceBuilder.java
@@ -39,8 +39,8 @@ public abstract class AbstractDamageSourceBuilder<T extends DamageSource, B exte
     protected boolean absolute = false;
     protected boolean magical = false;
     protected boolean creative = false;
+    protected double exhaustion = 0.1;
     protected DamageType damageType = null;
-
 
     @Override
     public B scalesWithDifficulty() {
@@ -79,6 +79,12 @@ public abstract class AbstractDamageSourceBuilder<T extends DamageSource, B exte
     }
 
     @Override
+    public B exhaustion(double exhaustion) {
+        this.exhaustion = exhaustion;
+        return (B) this;
+    }
+
+    @Override
     public B type(DamageType damageType) {
         this.damageType = checkNotNull(damageType, "DamageType cannot be null!");
         return (B) this;
@@ -93,12 +99,13 @@ public abstract class AbstractDamageSourceBuilder<T extends DamageSource, B exte
         this.explosion = value.isExplosive();
         this.creative = value.doesAffectCreative();
         this.magical = value.isMagic();
+        this.exhaustion = value.getExhaustion();
+        this.damageType = value.getType();
         return (B) this;
     }
 
     @Override
     public B reset() {
-
         return (B) this;
     }
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSourceBuilder.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSourceBuilder.java
@@ -29,6 +29,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import org.spongepowered.api.event.cause.entity.damage.DamageType;
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
 
+import javax.annotation.Nullable;
+
 @SuppressWarnings("unchecked")
 public abstract class AbstractDamageSourceBuilder<T extends DamageSource, B extends DamageSource.DamageSourceBuilder<T, B>>
     implements DamageSource.DamageSourceBuilder<T, B> {
@@ -39,7 +41,7 @@ public abstract class AbstractDamageSourceBuilder<T extends DamageSource, B exte
     protected boolean absolute = false;
     protected boolean magical = false;
     protected boolean creative = false;
-    protected double exhaustion = 0.1;
+    @Nullable protected Double exhaustion = null;
     protected DamageType damageType = null;
 
     @Override
@@ -106,6 +108,14 @@ public abstract class AbstractDamageSourceBuilder<T extends DamageSource, B exte
 
     @Override
     public B reset() {
+        this.scales = false;
+        this.bypasses = false;
+        this.explosion = false;
+        this.absolute = false;
+        this.magical = false;
+        this.creative = false;
+        this.exhaustion = null;
+        this.damageType = null;
         return (B) this;
     }
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractEntityDamageSource.java
@@ -39,6 +39,7 @@ public abstract class AbstractEntityDamageSource implements EntityDamageSource {
     private final boolean explosive;
     private final boolean magic;
     private final boolean creative;
+    private final double exhaustion;
     private final Entity source;
 
     protected AbstractEntityDamageSource(AbstractEntityDamageSourceBuilder<?, ?> builder) {
@@ -49,6 +50,7 @@ public abstract class AbstractEntityDamageSource implements EntityDamageSource {
         this.explosive = builder.explosion;
         this.magic = builder.magical;
         this.creative = builder.creative;
+        this.exhaustion = builder.exhaustion;
         this.source = checkNotNull(builder.source, "Entity source cannot be null!");
     }
 
@@ -90,6 +92,11 @@ public abstract class AbstractEntityDamageSource implements EntityDamageSource {
     @Override
     public boolean doesAffectCreative() {
         return this.creative;
+    }
+
+    @Override
+    public double getExhaustion() {
+        return this.exhaustion;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractEntityDamageSource.java
@@ -50,7 +50,13 @@ public abstract class AbstractEntityDamageSource implements EntityDamageSource {
         this.explosive = builder.explosion;
         this.magic = builder.magical;
         this.creative = builder.creative;
-        this.exhaustion = builder.exhaustion;
+        if (builder.exhaustion != null) {
+            this.exhaustion = builder.exhaustion;
+        } else if (this.absolute || this.bypassesArmor) {
+            this.exhaustion = 0.0;
+        } else {
+            this.exhaustion = 0.1;
+        }
         this.source = checkNotNull(builder.source, "Entity source cannot be null!");
     }
 

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSource.java
@@ -51,7 +51,13 @@ public abstract class AbstractIndirectEntityDamageSource implements IndirectEnti
         this.explosive = builder.explosion;
         this.magic = builder.magical;
         this.creative = builder.creative;
-        this.exhaustion = builder.exhaustion;
+        if (builder.exhaustion != null) {
+            this.exhaustion = builder.exhaustion;
+        } else if (this.absolute || this.bypassesArmor) {
+            this.exhaustion = 0.0;
+        } else {
+            this.exhaustion = 0.1;
+        }
         this.source = checkNotNull(builder.sourceEntity, "Entity source cannot be null!");
         this.indirect = checkNotNull(builder.indirect, "Indirect source cannot be null!");
     }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSource.java
@@ -39,6 +39,7 @@ public abstract class AbstractIndirectEntityDamageSource implements IndirectEnti
     private final boolean explosive;
     private final boolean magic;
     private final boolean creative;
+    private final double exhaustion;
     private final Entity source;
     private final Entity indirect;
 
@@ -50,6 +51,7 @@ public abstract class AbstractIndirectEntityDamageSource implements IndirectEnti
         this.explosive = builder.explosion;
         this.magic = builder.magical;
         this.creative = builder.creative;
+        this.exhaustion = builder.exhaustion;
         this.source = checkNotNull(builder.sourceEntity, "Entity source cannot be null!");
         this.indirect = checkNotNull(builder.indirect, "Indirect source cannot be null!");
     }
@@ -97,6 +99,11 @@ public abstract class AbstractIndirectEntityDamageSource implements IndirectEnti
     @Override
     public Entity getIndirectSource() {
         return this.indirect;
+    }
+
+    @Override
+    public double getExhaustion() {
+        return this.exhaustion;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1573)

Adds the ability to set and retrieve the exhaustion of a damage source. Also adds some Javadocs while I'm at it. I'm open to changes of the defaults for exhaustion and where I set the exhaustion when building the damage sources(refer to common PR).