### PR TITLE
Make StateMatcher serializable

### DIFF
--- a/src/main/java/org/spongepowered/api/block/BlockStateMatcher.java
+++ b/src/main/java/org/spongepowered/api/block/BlockStateMatcher.java
@@ -26,6 +26,8 @@ package org.spongepowered.api.block;
 
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.trait.BlockTrait;
+import org.spongepowered.api.data.DataSerializable;
+import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.util.ResettableBuilder;
 
 import java.util.List;
@@ -39,7 +41,7 @@ import java.util.function.Predicate;
  * that contains 4 traits, and only 2 are wanting to be matched,
  * then the other two traits may be variable).
  */
-public interface BlockStateMatcher extends Predicate<BlockState> {
+public interface BlockStateMatcher extends Predicate<BlockState>, DataSerializable {
 
     /**
      * Constructs a new {@link Builder} to construct a {@link BlockStateMatcher}.
@@ -78,7 +80,7 @@ public interface BlockStateMatcher extends Predicate<BlockState> {
     /**
      * A builder for building {@link BlockStateMatcher}s.
      */
-    interface Builder extends ResettableBuilder<BlockStateMatcher, Builder> {
+    interface Builder extends DataBuilder<BlockStateMatcher> {
 
         /**
          * Sets the root {@link BlockType} for the {@link BlockStateMatcher}.


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1795)

Makes StateMatcher serializable.

I'm a bit unsure about where to register the builder. Anyone mind pointing that out to me? Closes #1528.