### PR TITLE
Adds a direct invulnerable to invulnerability data

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -1113,6 +1113,17 @@ public final class Keys {
     public static final Key<Value<Boolean>> INVISIBLE = KeyFactory.fake("INVISIBLE");
 
     /**
+     * Represents the {@link Key} for representing if an {@link Entity}
+     * is invulnerable or not.
+     *
+     * <p>This does not protect from the void, players in creative mode,
+     * and manual killing like the /kill command.</p>
+     *
+     * @see InvulnerabilityData#invulnerable()
+     */
+    public static final Key<Value<Boolean>> INVULNERABLE = KeyFactory.fake("INVULNERABLE");
+
+    /**
      * Represents the {@link Key} for the amount of ticks an {@link Entity}
      * will remain invulnerable for.
      *

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableInvulnerabilityData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableInvulnerabilityData.java
@@ -27,13 +27,13 @@ package org.spongepowered.api.data.manipulator.immutable.entity;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.entity.InvulnerabilityData;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.entity.Entity;
 
 /**
- * An {@link ImmutableDataManipulator} for the amount of "invulnerability"
- * ticks remaining on an {@link Entity} such that any "damage" occurring while
- * the {@link Entity} is "invulnerable" will not actually "damage" the
- * {@link Entity}.
+ * A {@link ImmutableDataManipulator} for the invulnerability an {@link Entity}
+ * can have such that any "damage" occurring while the {@link Entity} is
+ * "invulnerable" will not actually "damage" the {@link Entity}.
  */
 public interface ImmutableInvulnerabilityData extends ImmutableDataManipulator<ImmutableInvulnerabilityData, InvulnerabilityData> {
 
@@ -44,5 +44,17 @@ public interface ImmutableInvulnerabilityData extends ImmutableDataManipulator<I
      * @return The immutable value for the amount of ticks of invulnerability
      */
     ImmutableBoundedValue<Integer> invulnerableTicks();
+
+    /**
+     * Gets the boolean {@link ImmutableValue} which represents if an entity is
+     * invulnerable from most damage sources besides <b>besides</b> the void,
+     * players in creative mode, and manual killing like the /kill command.
+     *
+     * <p>This does not cover creative mode, where players can also
+     * be invulnerable.</p>
+     *
+     * @return The boolean value for whether or not the entity is invulnerable
+     */
+    ImmutableValue<Boolean> invulnerable();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/InvulnerabilityData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/InvulnerabilityData.java
@@ -32,19 +32,32 @@ import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.Entity;
 
 /**
- * A {@link DataManipulator} for the amount of "invulnerability" ticks
- * remaining on an {@link Entity} such that any "damage" occurring while the
- * {@link Entity} is "invulnerable" will not actually "damage" the
- * {@link Entity}.
+ * A {@link DataManipulator} for the invulnerability an {@link Entity} can have
+ * such that any "damage" occurring while the {@link Entity} is "invulnerable"
+ * will not actually "damage" the {@link Entity}.
  */
 public interface InvulnerabilityData extends DataManipulator<InvulnerabilityData, ImmutableInvulnerabilityData> {
 
     /**
-     * Gets the {@link Value} for the amount of "ticks" of "invulnerability".
+     * Gets the {@link MutableBoundedValue} for the amount of "ticks" of
+     * "invulnerability" an entity has because of being hurt recently.
      *
      * @return The value for the amount of ticks of invulnerability
      * @see Keys#INVULNERABILITY_TICKS
      */
     MutableBoundedValue<Integer> invulnerableTicks();
+
+    /**
+     * Gets the boolean {@link Value} which represents if an entity is
+     * invulnerable from most damage sources besides <b>besides</b> the void,
+     * players in creative mode, and manual killing like the /kill command.
+     *
+     * <p>This does not cover creative mode, where players can also
+     * be invulnerable.</p>
+     *
+     * @return The boolean value for whether or not the entity is invulnerable
+     * @see Keys#INVULNERABLE
+     */
+    Value<Boolean> invulnerable();
 
 }


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1595)

This adds control of direct invulnerability without timing to `InvulnerabilityData` alongside the ticks(being hurt). This allows entities to be impervious to damage **BESIDES damage from `DamageSources.VOID` and from a creative player.** 

**NEED INPUT:** Relating to the lack of protection of damage from creative players(due to this being used for armor stands I'm assuming?), I could change this check, removing the check if it is from a creative player from entity and moving that to armor stand instead. I'm open to feedback on this and please point out if it is used elsewhere in this manner. 