### PR TITLE
Adds ability to get the connected chest from a chest, if it is there

### DIFF
--- a/src/main/java/org/spongepowered/api/block/tileentity/carrier/Chest.java
+++ b/src/main/java/org/spongepowered/api/block/tileentity/carrier/Chest.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.block.tileentity.carrier;
 import org.spongepowered.api.item.inventory.Inventory;
 
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Represents a Chest.
@@ -43,5 +44,12 @@ public interface Chest extends TileEntityCarrier {
      * @return The combined inventory, if available
      */
     Optional<Inventory> getDoubleChestInventory();
+
+    /**
+     * Returns the connected {@link Chest}s, if available.
+     *
+     * @return The connected Chests, if available
+     */
+    Set<Chest> getConnectedChests();
 
 }


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1697) | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1606)

Adds API to get the other double chest location.