### PR TITLE
Deprecate BedData in favor of DyeableData.

### DIFF
--- a/src/main/java/org/spongepowered/api/block/tileentity/Bed.java
+++ b/src/main/java/org/spongepowered/api/block/tileentity/Bed.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.block.tileentity;
 
 import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.mutable.DyeableData;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.BedData;
 import org.spongepowered.api.data.type.DyeColor;
 import org.spongepowered.api.data.value.mutable.Value;
@@ -38,9 +39,20 @@ public interface Bed extends TileEntity {
      * Gets the {@link BedData data} of this {@link Bed bed}.
      *
      * @return The current bed data for this bed
+     * @deprecated Use {@link #getDyeableData()} instead
      */
+    @Deprecated
     default BedData getBedData() {
         return this.get(BedData.class).get();
+    }
+
+    /**
+     * Gets the {@link DyeableData data} of this {@link Bed bed}.
+     *
+     * @return The current bed data for this bed
+     */
+    default DyeableData getDyeableData() {
+        return this.get(DyeableData.class).get();
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/tileentity/ImmutableBedData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/tileentity/ImmutableBedData.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.data.manipulator.immutable.tileentity;
 
 import org.spongepowered.api.block.tileentity.Bed;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.ImmutableDyeableData;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.BedData;
 import org.spongepowered.api.data.type.DyeColor;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
@@ -33,7 +34,10 @@ import org.spongepowered.api.data.value.immutable.ImmutableValue;
 /**
  * An {@link ImmutableDataManipulator} handling the various data of a
  * {@link Bed}.
+ *
+ * @deprecated Use {@link ImmutableDyeableData} instead
  */
+@Deprecated
 public interface ImmutableBedData extends ImmutableDataManipulator<ImmutableBedData, BedData> {
 
     /**

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/tileentity/BedData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/tileentity/BedData.java
@@ -27,13 +27,17 @@ package org.spongepowered.api.data.manipulator.mutable.tileentity;
 import org.spongepowered.api.block.tileentity.Bed;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableBedData;
+import org.spongepowered.api.data.manipulator.mutable.DyeableData;
 import org.spongepowered.api.data.type.DyeColor;
 import org.spongepowered.api.data.value.mutable.Value;
 
 /**
  * A {@link DataManipulator} handling the various data of a
  * {@link Bed}.
+ *
+ * @deprecated Use {@link DyeableData} instead
  */
+@Deprecated
 public interface BedData extends DataManipulator<BedData, ImmutableBedData> {
 
     /**


### PR DESCRIPTION
`BedData` only contains a key for dye colors. We already have that in `DyeableData`.

Related: SpongePowered/SpongeCommon#1611