### PR TITLE
Add fastutil as an API dependency - Closes #1590

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     compile 'com.google.errorprone:error_prone_annotations:2.0.15'
     compile 'com.google.code.gson:gson:2.8.0'
     compile 'org.apache.commons:commons-lang3:3.5'
+    compile 'it.unimi.dsi:fastutil:7.1.0'
     // Only included in server
     compile 'com.google.code.findbugs:jsr305:3.0.1'
 


### PR DESCRIPTION
Adds fastutil as a dependency, since it is a library that Minecraft itself includes the full version of, we use it in the implementation, and many plugin developers will probably find use in it as well. Sure they could use it expecting Minecraft to have it, but that causes issues as there is then no guarantee a Sponge implementation includes a complete, compatible version of the library, or even one at all.

Closes https://github.com/SpongePowered/SpongeAPI/issues/1590