### PR TITLE
Add chorus fruit teleport type - Fixes #1556

### DIFF
--- a/src/main/java/org/spongepowered/api/event/cause/entity/teleport/TeleportTypes.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/teleport/TeleportTypes.java
@@ -32,6 +32,8 @@ public final class TeleportTypes {
 
     public static final TeleportType COMMAND = DummyObjectProvider.createFor(TeleportType.class, "COMMAND");
 
+    public static final TeleportType CHORUS_FRUIT = DummyObjectProvider.createFor(TeleportType.class, "CHORUS_FRUIT");
+
     public static final TeleportType ENTITY_TELEPORT = DummyObjectProvider.createFor(TeleportType.class, "ENTITY_TELEPORT");
 
     public static final TeleportType PLUGIN = DummyObjectProvider.createFor(TeleportType.class, "PLUGIN");


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1629) 

Essentially adds a chorus fruit teleport type, to see if a teleport was caused by a player eating a chorus fruit.

Tested with: 

```Java
@Listener
public void onTeleport(MoveEntityEvent.Teleport event, @Root Player player) {
    event.getContext().get(EventContextKeys.TELEPORT_TYPE).ifPresent(t -> player.sendMessage(Text.of(TextColors.GOLD, "TeleportType: ", TextColors.GRAY, t.getId())));
}
```