### PR TITLE
CraftingInventory is not a Grid

### DIFF
--- a/src/main/java/org/spongepowered/api/item/inventory/Container.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Container.java
@@ -56,18 +56,16 @@ public interface Container extends Interactable {
      * Shows this Inventory to the given viewer.
      *
      * @param viewer The viewer to show this inventory to
-     * @param cause The {@link Cause} to use when opening the inventory
      * @throws IllegalArgumentException if a {@link PluginContainer} is not the root of the cause
      */
-    void open(Player viewer, Cause cause) throws IllegalArgumentException;
+    void open(Player viewer) throws IllegalArgumentException;
 
     /**
      * Stops showing this Inventory to the given viewer.
      *
      * @param viewer The viewer to stop showing this inventory to
-     * @param cause The {@link Cause} to provide when closing the inventory
      * @throws IllegalArgumentException if a {@link PluginContainer} is not the root of the cause
      */
-    void close(Player viewer, Cause cause) throws IllegalArgumentException;
+    void close(Player viewer) throws IllegalArgumentException;
 
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/crafting/CraftingInventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/crafting/CraftingInventory.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.item.inventory.crafting;
 
-import org.spongepowered.api.item.inventory.type.GridInventory;
+import org.spongepowered.api.item.inventory.type.OrderedInventory;
 import org.spongepowered.api.item.recipe.crafting.CraftingRecipe;
 import org.spongepowered.api.world.World;
 
@@ -34,7 +34,7 @@ import java.util.Optional;
  * A CraftingInventory represents the inventory of something that can craft
  * items.
  */
-public interface CraftingInventory extends GridInventory {
+public interface CraftingInventory extends OrderedInventory {
 
     /**
      * Gets the crafting matrix of this CraftingInventory.


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1710) | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1585) | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/1833)


A crafting inventory is not a grid but contains one.
