### PR TITLE
Fix criteria spelling from critieria to criteria - Fixes #1669

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,7 +188,7 @@ sortClassFields {
     add 'main', 'org.spongepowered.api.item.inventory.equipment.EquipmentTypes'
     add 'main', 'org.spongepowered.api.scoreboard.CollisionRules'
     add 'main', 'org.spongepowered.api.scoreboard.Visibilities'
-    add 'main', 'org.spongepowered.api.scoreboard.critieria.Criteria'
+    add 'main', 'org.spongepowered.api.scoreboard.criteria.Criteria'
     add 'main', 'org.spongepowered.api.scoreboard.displayslot.DisplaySlots'
     add 'main', 'org.spongepowered.api.scoreboard.objective.displaymode.ObjectiveDisplayModes'
     add 'main', 'org.spongepowered.api.service.economy.transaction.TransactionTypes'

--- a/src/main/java/org/spongepowered/api/CatalogTypes.java
+++ b/src/main/java/org/spongepowered/api/CatalogTypes.java
@@ -57,7 +57,7 @@ import org.spongepowered.api.item.inventory.equipment.EquipmentType;
 import org.spongepowered.api.item.recipe.crafting.CraftingRecipe;
 import org.spongepowered.api.scoreboard.CollisionRule;
 import org.spongepowered.api.scoreboard.Visibility;
-import org.spongepowered.api.scoreboard.critieria.Criterion;
+import org.spongepowered.api.scoreboard.criteria.Criterion;
 import org.spongepowered.api.scoreboard.displayslot.DisplaySlot;
 import org.spongepowered.api.scoreboard.objective.displaymode.ObjectiveDisplayMode;
 import org.spongepowered.api.service.economy.transaction.TransactionType;

--- a/src/main/java/org/spongepowered/api/scoreboard/Scoreboard.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Scoreboard.java
@@ -26,7 +26,7 @@ package org.spongepowered.api.scoreboard;
 
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.scoreboard.critieria.Criterion;
+import org.spongepowered.api.scoreboard.criteria.Criterion;
 import org.spongepowered.api.scoreboard.displayslot.DisplaySlot;
 import org.spongepowered.api.scoreboard.objective.Objective;
 import org.spongepowered.api.text.Text;

--- a/src/main/java/org/spongepowered/api/scoreboard/criteria/Criteria.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/criteria/Criteria.java
@@ -22,7 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.scoreboard.critieria;
+package org.spongepowered.api.scoreboard.criteria;
 
 import org.spongepowered.api.effect.potion.PotionEffectTypes;
 import org.spongepowered.api.scoreboard.objective.Objective;

--- a/src/main/java/org/spongepowered/api/scoreboard/criteria/Criterion.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/criteria/Criterion.java
@@ -22,5 +22,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-@org.spongepowered.api.util.annotation.NonnullByDefault
-package org.spongepowered.api.scoreboard.critieria;
+package org.spongepowered.api.scoreboard.criteria;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
+/**
+ * Represents a set of behaviours for an objective, which may cause it to be
+ * automatically updated.
+ */
+@CatalogedBy(Criteria.class)
+public interface Criterion extends CatalogType {
+
+    /**
+     * Gets the name of this criterion.
+     *
+     * @return The name of this criterion
+     */
+    @Override
+    String getName();
+
+}

--- a/src/main/java/org/spongepowered/api/scoreboard/criteria/package-info.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/criteria/package-info.java
@@ -22,24 +22,5 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.scoreboard.critieria;
-
-import org.spongepowered.api.CatalogType;
-import org.spongepowered.api.util.annotation.CatalogedBy;
-
-/**
- * Represents a set of behaviours for an objective, which may cause it to be
- * automatically updated.
- */
-@CatalogedBy(Criteria.class)
-public interface Criterion extends CatalogType {
-
-    /**
-     * Gets the name of this criterion.
-     *
-     * @return The name of this criterion
-     */
-    @Override
-    String getName();
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.api.scoreboard.criteria;

--- a/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
@@ -27,7 +27,7 @@ package org.spongepowered.api.scoreboard.objective;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.scoreboard.Score;
 import org.spongepowered.api.scoreboard.Scoreboard;
-import org.spongepowered.api.scoreboard.critieria.Criterion;
+import org.spongepowered.api.scoreboard.criteria.Criterion;
 import org.spongepowered.api.scoreboard.objective.displaymode.ObjectiveDisplayMode;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.ResettableBuilder;

--- a/src/main/java/org/spongepowered/api/statistic/Statistic.java
+++ b/src/main/java/org/spongepowered/api/statistic/Statistic.java
@@ -25,7 +25,7 @@
 package org.spongepowered.api.statistic;
 
 import org.spongepowered.api.CatalogType;
-import org.spongepowered.api.scoreboard.critieria.Criterion;
+import org.spongepowered.api.scoreboard.criteria.Criterion;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1630)

Fixes "criteria" spelling - #1669 

This is a minor spelling cleanup of a package name so it is breaking. So we have to decide if we want to make this change and whether we should make it now or in API 8. Since API 7 is not stable yet, may be best to make the change now to get it over with. 