### PR TITLE
[WIP] Added a variety system for item and block types.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,6 +202,8 @@ sortClassFields {
     add 'main', 'org.spongepowered.api.util.TypeTokens'
     add 'main', 'org.spongepowered.api.util.ban.BanTypes'
     add 'main', 'org.spongepowered.api.util.rotation.Rotations'
+    add 'main', 'org.spongepowered.api.variant.VariantCollections'
+    add 'main', 'org.spongepowered.api.variant.Varieties'
     add 'main', 'org.spongepowered.api.world.biome.BiomeTypes'
     add 'main', 'org.spongepowered.api.world.DimensionTypes'
     add 'main', 'org.spongepowered.api.world.GeneratorTypes'

--- a/src/main/java/org/spongepowered/api/GameRegistry.java
+++ b/src/main/java/org/spongepowered/api/GameRegistry.java
@@ -57,6 +57,8 @@ import org.spongepowered.api.text.serializer.TextSerializers;
 import org.spongepowered.api.text.translation.Translation;
 import org.spongepowered.api.util.ResettableBuilder;
 import org.spongepowered.api.util.rotation.Rotation;
+import org.spongepowered.api.variant.VarietyQuery;
+import org.spongepowered.api.variant.VarietyQueryable;
 import org.spongepowered.api.world.extent.ExtentBufferFactory;
 
 import java.awt.image.BufferedImage;
@@ -113,6 +115,36 @@ public interface GameRegistry {
      * @return A collection of all known types of the requested catalog type
      */
     <T extends CatalogType> Collection<T> getAllOf(Class<T> typeClass);
+
+    /**
+     * Attempts to retrieve the first specific type of {@link CatalogType} based on
+     * the given type and {@link VarietyQuery}.
+     *
+     * <p>Some types may not be available for various reasons including but not
+     * restricted to: mods adding custom types, plugins providing custom types,
+     * game version changes.</p>
+     *
+     * @param typeClass The class of the type of {@link CatalogType}
+     * @param <T> The type of catalog type
+     * @return The found catalog type, if available
+     * @see CatalogType
+     */
+    <T extends CatalogType & VarietyQueryable> Optional<T> getFirst(Class<T> typeClass, VarietyQuery query);
+
+    /**
+     * Gets a collection of all available found specific types of
+     * {@link CatalogType} requested that match the {@link VarietyQuery}.
+     *
+     * <p>The presented {@link CatalogType}s may not exist in default catalogs
+     * due to various reasons including but not restricted to: mods, plugins,
+     * game changes.</p>
+     *
+     * @param typeClass The class of {@link CatalogType}
+     * @param query The variety query
+     * @param <T> The type of {@link CatalogType}
+     * @return A collection of all known types of the requested catalog type
+     */
+    <T extends CatalogType & VarietyQueryable> Collection<T> getAllOf(Class<T> typeClass, VarietyQuery query);
 
     /**
      * Gets a collection of all available found specific types of

--- a/src/main/java/org/spongepowered/api/block/BlockState.java
+++ b/src/main/java/org/spongepowered/api/block/BlockState.java
@@ -45,6 +45,7 @@ import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.util.Cycleable;
 import org.spongepowered.api.util.ResettableBuilder;
+import org.spongepowered.api.variant.VarietyQueryable;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
@@ -64,7 +65,7 @@ import javax.annotation.Nullable;
  * a single instance of a particular {@link BlockState} as they are immutable,
  * a particular instance may be cached for various uses.
  */
-public interface BlockState extends ImmutableDataHolder<BlockState>, DirectionRelativePropertyHolder, CatalogType {
+public interface BlockState extends ImmutableDataHolder<BlockState>, DirectionRelativePropertyHolder, CatalogType, VarietyQueryable {
 
     /**
      * Creates a new {@link Builder} for building {@link BlockState}s.

--- a/src/main/java/org/spongepowered/api/block/BlockType.java
+++ b/src/main/java/org/spongepowered/api/block/BlockType.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.block;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.block.trait.BlockTrait;
 import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.property.TransformablePropertyHolder;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
@@ -43,7 +44,8 @@ import java.util.Optional;
  * via {@link DataHolder}.</p>
  */
 @CatalogedBy(BlockTypes.class)
-public interface BlockType extends CatalogType, Translatable, VarietyQueryable {
+public interface BlockType extends CatalogType, Translatable, VarietyQueryable,
+        TransformablePropertyHolder<BlockType> {
 
     /**
      * Return the internal ID for the block.

--- a/src/main/java/org/spongepowered/api/block/BlockType.java
+++ b/src/main/java/org/spongepowered/api/block/BlockType.java
@@ -27,10 +27,10 @@ package org.spongepowered.api.block;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.block.trait.BlockTrait;
 import org.spongepowered.api.data.DataHolder;
-import org.spongepowered.api.data.property.PropertyHolder;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
+import org.spongepowered.api.variant.VarietyQueryable;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -43,7 +43,7 @@ import java.util.Optional;
  * via {@link DataHolder}.</p>
  */
 @CatalogedBy(BlockTypes.class)
-public interface BlockType extends CatalogType, Translatable, PropertyHolder {
+public interface BlockType extends CatalogType, Translatable, VarietyQueryable {
 
     /**
      * Return the internal ID for the block.

--- a/src/main/java/org/spongepowered/api/data/property/BooleanProperty.java
+++ b/src/main/java/org/spongepowered/api/data/property/BooleanProperty.java
@@ -33,7 +33,7 @@ import org.spongepowered.api.util.Coerce;
  * Represents an item property that has an integer value. Examples may include
  * {@link FoodRestorationProperty}, {@link SaturationProperty} etc.
  */
-public class BooleanProperty extends AbstractProperty<String, Boolean> {
+public class BooleanProperty extends NonnullAbstractProperty<String, Boolean> {
 
     /**
      * Create a new integer property with the specified value.

--- a/src/main/java/org/spongepowered/api/data/property/DoubleProperty.java
+++ b/src/main/java/org/spongepowered/api/data/property/DoubleProperty.java
@@ -33,7 +33,7 @@ import org.spongepowered.api.util.Coerce;
  * Represents an item property that has an integer value. Examples may include
  * {@link FoodRestorationProperty}, {@link SaturationProperty} etc.
  */
-public class DoubleProperty extends AbstractProperty<String, Double> {
+public class DoubleProperty extends NonnullAbstractProperty<String, Double> {
 
     /**
      * Create a new integer property with the specified value.

--- a/src/main/java/org/spongepowered/api/data/property/NonnullAbstractProperty.java
+++ b/src/main/java/org/spongepowered/api/data/property/NonnullAbstractProperty.java
@@ -26,9 +26,18 @@ package org.spongepowered.api.data.property;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import org.spongepowered.api.data.Property;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/**
+ * A base class for {@link Property}s where the value
+ * will never be {@code null}.
+ *
+ * @param <K> The key type
+ * @param <V> The value type
+ */
 public abstract class NonnullAbstractProperty<K, V> extends AbstractProperty<K, V> {
 
     /**

--- a/src/main/java/org/spongepowered/api/data/property/NonnullAbstractProperty.java
+++ b/src/main/java/org/spongepowered/api/data/property/NonnullAbstractProperty.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.property;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public abstract class NonnullAbstractProperty<K, V> extends AbstractProperty<K, V> {
+
+    /**
+     * Initialise key to default, and value to the supplied value.
+     *
+     * @param value The value of the property
+     */
+    protected NonnullAbstractProperty(V value) {
+        super(checkNotNull(value, "value"));
+    }
+
+    /**
+     * Initialise the value to the specified value and use the specified
+     * operator, use the default key.
+     *
+     * @param value The property value
+     * @param op The operator for the property
+     */
+    protected NonnullAbstractProperty(V value, @Nullable Operator op) {
+        super(checkNotNull(value, "value"), op);
+    }
+
+    /**
+     * Use the specified key and value and set operator to the default.
+     *
+     * @param key The key identifying the property
+     * @param value The property value
+     */
+    protected NonnullAbstractProperty(@Nullable K key, V value) {
+        super(key, checkNotNull(value, "value"));
+    }
+
+    protected NonnullAbstractProperty(@Nullable K key, V value, @Nullable Operator op) {
+        super(key, checkNotNull(value, "value"), op);
+    }
+
+    @Nonnull
+    @Override
+    public V getValue() {
+        return super.getValue();
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/property/TransformablePropertyHolder.java
+++ b/src/main/java/org/spongepowered/api/data/property/TransformablePropertyHolder.java
@@ -49,5 +49,5 @@ public interface TransformablePropertyHolder<T extends TransformablePropertyHold
      * @param property The property
      * @return The transformed property holder, if successful
      */
-    Optional<T> transform(Property<?, ?> property);
+    Optional<T> transformWith(Property<?, ?> property);
 }

--- a/src/main/java/org/spongepowered/api/data/property/TransformablePropertyHolder.java
+++ b/src/main/java/org/spongepowered/api/data/property/TransformablePropertyHolder.java
@@ -25,50 +25,29 @@
 package org.spongepowered.api.data.property;
 
 import org.spongepowered.api.data.Property;
-import org.spongepowered.api.util.Coerce;
+import org.spongepowered.api.data.property.item.CookedProperty;
+import org.spongepowered.api.item.ItemTypes;
+
+import java.util.Optional;
 
 /**
- * Represents an block property that has an integer value. Examples may include
+ * Represents a {@link PropertyHolder} that can be transformed into another
+ * {@link PropertyHolder} by modifying supported {@link Property}s.
+ *
+ * @param <T> The property holder type
  */
-public class IntProperty extends NonnullAbstractProperty<String, Integer> {
+public interface TransformablePropertyHolder<T extends TransformablePropertyHolder<T>> extends PropertyHolder {
 
     /**
-     * Create a new integer property with the specified value.
+     * Transforms this property holder with the given {@link Property}. The
+     * transformed property holder will be returned if the {@link Property}
+     * and property value are supported.
+     * <p>For example, this can be used to transform a {@link ItemTypes#BEEF}
+     * into a {@link ItemTypes#COOKED_BEEF} when applying the
+     * {@link CookedProperty} with a {@code true} value.
      *
-     * @param value value to match
+     * @param property The property
+     * @return The transformed property holder, if successful
      */
-    public IntProperty(int value) {
-        super(Coerce.toInteger(value));
-    }
-
-    /**
-     * Create a new integer property with the specified value and logical
-     * operator.
-     *
-     * @param value value to match
-     * @param operator logical operator to use when comparing to other
-     *      properties
-     */
-    public IntProperty(int value, Operator operator) {
-        super(value, operator);
-    }
-
-    /**
-     * Create a new integer property with the specified value and logical
-     * operator.
-     *
-     * @param value value to match
-     * @param operator logical operator to use when comparing to other
-     *      properties
-     */
-    public IntProperty(Object value, Operator operator) {
-        super(Coerce.toInteger(value), operator);
-    }
-
-    @Override
-    public int compareTo(Property<?, ?> other) {
-        return this.getValue().compareTo(other == null ? 1 : Coerce.toInteger(other.getValue()));
-    }
-
-
+    Optional<T> transform(Property<?, ?> property);
 }

--- a/src/main/java/org/spongepowered/api/data/property/common/DyeColorProperty.java
+++ b/src/main/java/org/spongepowered/api/data/property/common/DyeColorProperty.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.property.common;
+
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.data.Property;
+import org.spongepowered.api.data.property.NonnullAbstractProperty;
+import org.spongepowered.api.data.type.DyeColor;
+import org.spongepowered.api.data.type.DyeColors;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.util.Coerce;
+
+import javax.annotation.Nullable;
+
+/**
+ * A property that can used to retrieve the {@link DyeColor} from dyeable
+ * {@link BlockType}s or {@link ItemType}s.
+ */
+public final class DyeColorProperty extends NonnullAbstractProperty<String, DyeColor> {
+
+    /**
+     * Constructs a new {@link DyeColorProperty} with
+     * the specified {@link DyeColor}.
+     *
+     * @param value The dye color
+     */
+    public DyeColorProperty(DyeColor value) {
+        super(value);
+    }
+
+    /**
+     * Constructs a new {@link DyeColorProperty} with
+     * the specified {@link DyeColor} and {@link Operator}.
+     *
+     * @param value The dye color
+     * @param operator The operator
+     */
+    public DyeColorProperty(DyeColor value, Operator operator) {
+        super(value, operator);
+    }
+
+    @Override
+    public int compareTo(@Nullable Property<?, ?> o) {
+        final DyeColor other = Coerce.toPseudoEnum(o == null ? null : o.getValue(), DyeColor.class, DyeColors.class, DyeColors.WHITE);
+        return getValue().getId().compareTo(o == null ? "" : other.getId());
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/property/common/TreeTypeProperty.java
+++ b/src/main/java/org/spongepowered/api/data/property/common/TreeTypeProperty.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.property.common;
+
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.data.Property;
+import org.spongepowered.api.data.property.NonnullAbstractProperty;
+import org.spongepowered.api.data.type.TreeType;
+import org.spongepowered.api.data.type.TreeTypes;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.util.Coerce;
+
+import javax.annotation.Nullable;
+
+/**
+ * A property that can used to retrieve the {@link TreeType} from wood
+ * based {@link BlockType}s or {@link ItemType}s.
+ */
+public final class TreeTypeProperty extends NonnullAbstractProperty<String, TreeType> {
+
+    /**
+     * Constructs a new {@link TreeTypeProperty} with
+     * the specified {@link TreeType}.
+     *
+     * @param value The tree type
+     */
+    public TreeTypeProperty(TreeType value) {
+        super(value);
+    }
+
+    /**
+     * Constructs a new {@link TreeTypeProperty} with
+     * the specified {@link TreeType} and {@link Operator}.
+     *
+     * @param value The tree type
+     * @param operator The operator
+     */
+    public TreeTypeProperty(TreeType value, Operator operator) {
+        super(value, operator);
+    }
+
+    @Override
+    public int compareTo(@Nullable Property<?, ?> o) {
+        final TreeType other = Coerce.toPseudoEnum(o == null ? null : o.getValue(), TreeType.class, TreeTypes.class, TreeTypes.OAK);
+        return getValue().getId().compareTo(o == null ? "" : other.getId());
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/property/common/package-info.java
+++ b/src/main/java/org/spongepowered/api/data/property/common/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.api.data.property.common;

--- a/src/main/java/org/spongepowered/api/data/property/item/CookedProperty.java
+++ b/src/main/java/org/spongepowered/api/data/property/item/CookedProperty.java
@@ -22,53 +22,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.property;
+package org.spongepowered.api.data.property.item;
 
-import org.spongepowered.api.data.Property;
-import org.spongepowered.api.util.Coerce;
+import org.spongepowered.api.data.property.BooleanProperty;
+import org.spongepowered.api.data.property.common.TreeTypeProperty;
+import org.spongepowered.api.item.ItemTypes;
 
 /**
- * Represents an block property that has an integer value. Examples may include
+ * Represents the state that something is cooked, this is usually
+ * food. For example, {@link ItemTypes#BEEF} is uncooked and
+ * {@link ItemTypes#COOKED_BEEF} is cooked. This property will
+ * only be supported by objects that support both states.
  */
-public class IntProperty extends NonnullAbstractProperty<String, Integer> {
+public final class CookedProperty extends BooleanProperty {
 
     /**
-     * Create a new integer property with the specified value.
+     * Constructs a new {@link CookedProperty} with
+     * the specified cooked state.
      *
-     * @param value value to match
+     * @param value The cooked state
      */
-    public IntProperty(int value) {
-        super(Coerce.toInteger(value));
+    public CookedProperty(boolean value) {
+        super(value);
     }
 
     /**
-     * Create a new integer property with the specified value and logical
-     * operator.
+     * Constructs a new {@link TreeTypeProperty} with
+     * the specified cooked state and {@link Operator}.
      *
-     * @param value value to match
-     * @param operator logical operator to use when comparing to other
-     *      properties
+     * @param value The cooked state
+     * @param operator The operator
      */
-    public IntProperty(int value, Operator operator) {
+    public CookedProperty(boolean value, Operator operator) {
         super(value, operator);
     }
-
-    /**
-     * Create a new integer property with the specified value and logical
-     * operator.
-     *
-     * @param value value to match
-     * @param operator logical operator to use when comparing to other
-     *      properties
-     */
-    public IntProperty(Object value, Operator operator) {
-        super(Coerce.toInteger(value), operator);
-    }
-
-    @Override
-    public int compareTo(Property<?, ?> other) {
-        return this.getValue().compareTo(other == null ? 1 : Coerce.toInteger(other.getValue()));
-    }
-
-
 }

--- a/src/main/java/org/spongepowered/api/data/property/item/RecordProperty.java
+++ b/src/main/java/org/spongepowered/api/data/property/item/RecordProperty.java
@@ -24,10 +24,8 @@
  */
 package org.spongepowered.api.data.property.item;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.spongepowered.api.data.Property;
-import org.spongepowered.api.data.property.AbstractProperty;
+import org.spongepowered.api.data.property.NonnullAbstractProperty;
 import org.spongepowered.api.effect.sound.record.RecordType;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
@@ -36,10 +34,10 @@ import org.spongepowered.api.item.inventory.ItemStack;
  * A {@link RecordProperty} used to retrieve a {@link RecordType}
  * from a {@link ItemType} or {@link ItemStack}.
  */
-public final class RecordProperty extends AbstractProperty<String, RecordType> {
+public final class RecordProperty extends NonnullAbstractProperty<String, RecordType> {
 
     public RecordProperty(RecordType instrument) {
-        super(checkNotNull(instrument, "instrument"));
+        super(instrument);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/item/ItemType.java
+++ b/src/main/java/org/spongepowered/api/item/ItemType.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.GameDictionary;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.data.Property;
+import org.spongepowered.api.data.property.TransformablePropertyHolder;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.text.translation.Translatable;
@@ -42,7 +43,8 @@ import java.util.Optional;
  * A type of item.
  */
 @CatalogedBy(ItemTypes.class)
-public interface ItemType extends CatalogType, Translatable, GameDictionary.Entry, VarietyQueryable {
+public interface ItemType extends CatalogType, Translatable, GameDictionary.Entry, VarietyQueryable,
+        TransformablePropertyHolder<ItemType> {
 
     /**
      * Gets the corresponding {@link BlockType} of this item if one exists.

--- a/src/main/java/org/spongepowered/api/item/ItemType.java
+++ b/src/main/java/org/spongepowered/api/item/ItemType.java
@@ -34,6 +34,7 @@ import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.text.translation.Translatable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
+import org.spongepowered.api.variant.VarietyQueryable;
 
 import java.util.Optional;
 
@@ -41,7 +42,7 @@ import java.util.Optional;
  * A type of item.
  */
 @CatalogedBy(ItemTypes.class)
-public interface ItemType extends CatalogType, Translatable, GameDictionary.Entry {
+public interface ItemType extends CatalogType, Translatable, GameDictionary.Entry, VarietyQueryable {
 
     /**
      * Gets the corresponding {@link BlockType} of this item if one exists.
@@ -82,8 +83,23 @@ public interface ItemType extends CatalogType, Translatable, GameDictionary.Entr
      * @param propertyClass The item property class
      * @param <T> The type of item property
      * @return The item property, if available
+     * @deprecated Use {@link #getProperty(Class)} instead
      */
+    @Deprecated
     <T extends Property<?, ?>> Optional<T> getDefaultProperty(Class<T> propertyClass);
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>While item stacks do have properties, generally, there is an
+     * intrinsic default property for many item types. However, it should be
+     * considered that when mods are introducing their own custom items, they
+     * too could introduce different item properties based on various data on
+     * the item stack. The default properties retrieved from here should merely
+     * be considered as a default, not as a definitive property.</p>
+     */
+    @Override
+    <T extends Property<?, ?>> Optional<T> getProperty(Class<T> propertyClass);
     
     @Override
     default ItemType getType() {

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
@@ -42,6 +42,7 @@ import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.text.translation.Translatable;
+import org.spongepowered.api.variant.VarietyQueryable;
 
 import java.util.Map;
 import java.util.Set;
@@ -56,7 +57,7 @@ import java.util.function.Predicate;
  * use {@link DataHolder#get(Class)} in order to retrieve information regarding
  * this item stack.</p>
  */
-public interface ItemStack extends DataHolder, Translatable {
+public interface ItemStack extends DataHolder, Translatable, VarietyQueryable {
 
     /**
      * Creates a new {@link Builder} to build an {@link ItemStack}.

--- a/src/main/java/org/spongepowered/api/variant/MatchOperator.java
+++ b/src/main/java/org/spongepowered/api/variant/MatchOperator.java
@@ -24,32 +24,18 @@
  */
 package org.spongepowered.api.variant;
 
-import org.spongepowered.api.CatalogType;
-import org.spongepowered.api.block.BlockType;
-import org.spongepowered.api.data.Property;
-import org.spongepowered.api.data.property.PropertyHolder;
-import org.spongepowered.api.data.property.common.TreeTypeProperty;
-import org.spongepowered.api.data.type.TreeTypes;
-
-import java.util.Collection;
-
 /**
- * A variety is a kind of marker that can be used to group
- * {@link VarietyQueryable}s. For example grouping all the
- * stair {@link BlockType}s that are available.
- * <p>Some varieties may also contain {@link Property}s which
- * can also be used to match the queryables. For example,
- * the {@link Varieties#BIRCH} will contain a {@link TreeTypeProperty}
- * with the tree type {@link TreeTypes#BIRCH}. This property
- * can also be used to query for a block with a specific tree type.
+ * A operator to define how a {@link Variety} should be matched.
  */
-public interface Variety extends CatalogType, PropertyHolder {
+// TODO: Better name?
+public enum MatchOperator {
+    /**
+     * Matches the {@link Variety} to be equal.
+     */
+    EQUAL,
 
     /**
-     * Gets a {@link Collection} with all the {@link VarietyQueryable}
-     * types this variety supports.
-     *
-     * @return The collection
+     * Matches the {@link Variety} to be not equal.
      */
-    Collection<Class<? extends VarietyQueryable>> getSupportedTypes();
+    NOT_EQUAL,
 }

--- a/src/main/java/org/spongepowered/api/variant/VariantCollection.java
+++ b/src/main/java/org/spongepowered/api/variant/VariantCollection.java
@@ -24,9 +24,12 @@
  */
 package org.spongepowered.api.variant;
 
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.Property;
+import org.spongepowered.api.util.ResettableBuilder;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Optional;
 
 /**
@@ -35,7 +38,40 @@ import java.util.Optional;
  *
  * @param <T> The variety queryable object type
  */
+@SuppressWarnings("unchecked")
 public interface VariantCollection<T extends VarietyQueryable> {
+
+    /**
+     * Creates a {@link Builder}.
+     *
+     * @param <T> The variety queryable type
+     * @return The builder
+     */
+    static <T extends VarietyQueryable> Builder<T> builder() {
+        return Sponge.getRegistry().createBuilder(Builder.class);
+    }
+
+    /**
+     * Creates a {@link VariantCollection} for the given {@link Iterable}.
+     *
+     * @param iterable The iterable
+     * @param <T> The variety queryable type
+     * @return The variant collection
+     */
+    static <T extends VarietyQueryable> VariantCollection<T> of(Iterable<T> iterable) {
+        return VariantCollection.<T>builder().addAll(iterable).build();
+    }
+
+    /**
+     * Creates a {@link VariantCollection} for the given {@link Iterable}.
+     *
+     * @param queryables The queryables
+     * @param <T> The variety queryable type
+     * @return The variant collection
+     */
+    static <T extends VarietyQueryable> VariantCollection<T> of(T... queryables) {
+        return VariantCollection.<T>builder().add(queryables).build();
+    }
 
     /**
      * Gets a {@link VariantCollection} with all
@@ -53,7 +89,22 @@ public interface VariantCollection<T extends VarietyQueryable> {
      * @param variety The variety
      * @return A new variant collection with the matches
      */
-    VariantCollection<T> query(Variety variety);
+    default VariantCollection<T> query(Variety variety) {
+        return query(VarietyQuery.of(variety));
+    }
+
+    /**
+     * Gets a {@link VariantCollection} with all
+     * the {@link T}s that match the {@link Variety} with
+     * the specific {@link MatchOperator}.
+     *
+     * @param variety The variety
+     * @param operator The operator
+     * @return A new variant collection with the matches
+     */
+    default VariantCollection<T> query(Variety variety, MatchOperator operator) {
+        return query(VarietyQuery.of(variety, operator));
+    }
 
     /**
      * Gets a {@link VariantCollection} with all
@@ -62,14 +113,16 @@ public interface VariantCollection<T extends VarietyQueryable> {
      * @param property The property
      * @return A new variant collection with the matches
      */
-    VariantCollection<T> query(Property<?, ?> property);
+    default VariantCollection<T> query(Property<?, ?> property) {
+        return query(VarietyQuery.of(property));
+    }
 
     /**
      * Gets the first {@link T} that matches
      * the {@link VarietyQuery}.
      *
      * @param query The variety query
-     * @return The catalog type, if present
+     * @return The matched type, if present
      */
     Optional<T> queryFirst(VarietyQuery query);
 
@@ -78,30 +131,93 @@ public interface VariantCollection<T extends VarietyQueryable> {
      * the {@link Variety}.
      *
      * @param variety The variety
-     * @return The catalog type, if present
+     * @return The matched type, if present
      */
-    Optional<T> queryFirst(Variety variety);
+    default Optional<T> queryFirst(Variety variety) {
+        return queryFirst(VarietyQuery.of(variety));
+    }
+
+    /**
+     * Gets the first {@link T} that matches the {@link Variety}
+     * with the specific {@link MatchOperator}.
+     *
+     * @param variety The variety
+     * @param operator The operator
+     * @return The matched type, if present
+     */
+    default Optional<T> queryFirst(Variety variety, MatchOperator operator) {
+        return queryFirst(VarietyQuery.of(variety, operator));
+    }
 
     /**
      * Gets the first {@link T} that matches
      * the {@link Property}.
      *
      * @param property The property
-     * @return The catalog type, if present
+     * @return The matched type, if present
      */
-    Optional<T> queryFirst(Property<?, ?> property);
+    default Optional<T> queryFirst(Property<?, ?> property) {
+        return queryFirst(VarietyQuery.of(property));
+    }
 
     /**
      * Gets the first {@link T} within this collection.
      *
-     * @return The first catalog type, if present
+     * @return The first matched type, if present
      */
     Optional<T> first();
 
     /**
      * Gets all the {@link T} within this collection.
      *
-     * @return The collection with all the catalog types
+     * @return The collection with all the matched types
      */
     Collection<T> all();
+
+    /**
+     * A builder to create {@link VariantCollection}s.
+     *
+     * @param <T> The type of the variety queryable
+     */
+    interface Builder<T extends VarietyQueryable> extends ResettableBuilder<VariantCollection<T>, Builder<T>> {
+
+        /**
+         * Adds the {@link VarietyQueryable} object.
+         *
+         * @param queryable The queryable
+         * @return This builder, for chaining
+         */
+        Builder<T> add(T queryable);
+
+        /**
+         * Adds the {@link VarietyQueryable} objects.
+         *
+         * @param queryables The queryables
+         * @return This builder, for chaining
+         */
+        Builder<T> add(T... queryables);
+
+        /**
+         * Adds the {@link VarietyQueryable} objects.
+         *
+         * @param iterable The queryables iterable
+         * @return This builder, for chaining
+         */
+        Builder<T> addAll(Iterable<T> iterable);
+
+        /**
+         * Adds the {@link VarietyQueryable} objects.
+         *
+         * @param iterator The queryables iterator
+         * @return This builder, for chaining
+         */
+        Builder<T> addAll(Iterator<T> iterator);
+
+        /**
+         * Builds the {@link VariantCollection}.
+         *
+         * @return The variant collection
+         */
+        VariantCollection<T> build();
+    }
 }

--- a/src/main/java/org/spongepowered/api/variant/VariantCollection.java
+++ b/src/main/java/org/spongepowered/api/variant/VariantCollection.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.variant;
+
+import org.spongepowered.api.data.Property;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Represents a collection of {@link VarietyQueryable}s that can be filtered
+ * using a {@link VarietyQuery}.
+ *
+ * @param <T> The variety queryable object type
+ */
+public interface VariantCollection<T extends VarietyQueryable> {
+
+    /**
+     * Gets a {@link VariantCollection} with all
+     * the {@link T}s that match the {@link VarietyQuery}.
+     *
+     * @param query The variety query
+     * @return A new variant collection with the matches
+     */
+    VariantCollection<T> query(VarietyQuery query);
+
+    /**
+     * Gets a {@link VariantCollection} with all
+     * the {@link T}s that match the {@link Variety}.
+     *
+     * @param variety The variety
+     * @return A new variant collection with the matches
+     */
+    VariantCollection<T> query(Variety variety);
+
+    /**
+     * Gets a {@link VariantCollection} with all
+     * the {@link T}s that match the {@link Property property}.
+     *
+     * @param property The property
+     * @return A new variant collection with the matches
+     */
+    VariantCollection<T> query(Property<?, ?> property);
+
+    /**
+     * Gets the first {@link T} that matches
+     * the {@link VarietyQuery}.
+     *
+     * @param query The variety query
+     * @return The catalog type, if present
+     */
+    Optional<T> queryFirst(VarietyQuery query);
+
+    /**
+     * Gets the first {@link T} that matches
+     * the {@link Variety}.
+     *
+     * @param variety The variety
+     * @return The catalog type, if present
+     */
+    Optional<T> queryFirst(Variety variety);
+
+    /**
+     * Gets the first {@link T} that matches
+     * the {@link Property}.
+     *
+     * @param property The property
+     * @return The catalog type, if present
+     */
+    Optional<T> queryFirst(Property<?, ?> property);
+
+    /**
+     * Gets the first {@link T} within this collection.
+     *
+     * @return The first catalog type, if present
+     */
+    Optional<T> first();
+
+    /**
+     * Gets all the {@link T} within this collection.
+     *
+     * @return The collection with all the catalog types
+     */
+    Collection<T> all();
+}

--- a/src/main/java/org/spongepowered/api/variant/VariantCollections.java
+++ b/src/main/java/org/spongepowered/api/variant/VariantCollections.java
@@ -24,24 +24,33 @@
  */
 package org.spongepowered.api.variant;
 
+import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
 
+/**
+ * An enumeration of default {@link VariantCollection}s.
+ */
 @SuppressWarnings("unchecked")
 public final class VariantCollections {
 
     // SORTFIELDS:ON
 
     /**
-     * A collection with all the available {@link ItemType}s.
-     */
-    public static final VariantCollection<ItemType> ITEMS = DummyObjectProvider.createFor(VariantCollection.class, "ITEMS");
-
-    /**
      * A collection with all the available {@link BlockType}s.
      */
     public static final VariantCollection<BlockType> BLOCKS = DummyObjectProvider.createFor(VariantCollection.class, "BLOCKS");
+
+    /**
+     * A collection with all the available {@link BlockState}s.
+     */
+    public static final VariantCollection<BlockType> BLOCK_STATES = DummyObjectProvider.createFor(VariantCollection.class, "BLOCK_STATES");
+
+    /**
+     * A collection with all the available {@link ItemType}s.
+     */
+    public static final VariantCollection<ItemType> ITEMS = DummyObjectProvider.createFor(VariantCollection.class, "ITEMS");
 
     // SORTFIELDS:OFF
 

--- a/src/main/java/org/spongepowered/api/variant/VariantCollections.java
+++ b/src/main/java/org/spongepowered/api/variant/VariantCollections.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.variant;
+
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+
+@SuppressWarnings("unchecked")
+public final class VariantCollections {
+
+    // SORTFIELDS:ON
+
+    /**
+     * A collection with all the available {@link ItemType}s.
+     */
+    public static final VariantCollection<ItemType> ITEMS = DummyObjectProvider.createFor(VariantCollection.class, "ITEMS");
+
+    /**
+     * A collection with all the available {@link BlockType}s.
+     */
+    public static final VariantCollection<BlockType> BLOCKS = DummyObjectProvider.createFor(VariantCollection.class, "BLOCKS");
+
+    // SORTFIELDS:OFF
+
+    private VariantCollections() {
+    }
+}

--- a/src/main/java/org/spongepowered/api/variant/Varieties.java
+++ b/src/main/java/org/spongepowered/api/variant/Varieties.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.variant;
+
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+
+public final class Varieties {
+
+    // SORTFIELDS:ON
+
+    /**
+     * Represent something that has a {@link BlockType}, this has only
+     * effect against matching {@link ItemType}s. Matching against {@link BlockType}s
+     * will return {@code true} for everything.
+     */
+    public static final Variety BLOCK = DummyObjectProvider.createFor(Variety.class, "BLOCK");
+
+    public static final Variety STAIRS = DummyObjectProvider.createFor(Variety.class, "STAIRS");
+
+    public static final Variety SLABS = DummyObjectProvider.createFor(Variety.class, "SLABS");
+
+    public static final Variety BUTTON = DummyObjectProvider.createFor(Variety.class, "BUTTON");
+
+    public static final Variety DOOR = DummyObjectProvider.createFor(Variety.class, "DOOR");
+
+    public static final Variety FENCE = DummyObjectProvider.createFor(Variety.class, "FENCE");
+
+    public static final Variety FENCE_GATE = DummyObjectProvider.createFor(Variety.class, "FENCE_GATE");
+
+    public static final Variety PRESSURE_PLATE = DummyObjectProvider.createFor(Variety.class, "PRESSURE_PLATE");
+
+    public static final Variety TRAPDOOR = DummyObjectProvider.createFor(Variety.class, "TRAPDOOR");
+
+    public static final Variety LOG = DummyObjectProvider.createFor(Variety.class, "LOG");
+
+    public static final Variety LEAVES = DummyObjectProvider.createFor(Variety.class, "LEAVES");
+
+    public static final Variety PLANKS = DummyObjectProvider.createFor(Variety.class, "PLANKS");
+
+    public static final Variety BARK = DummyObjectProvider.createFor(Variety.class, "BARK");
+
+    public static final Variety WOOL = DummyObjectProvider.createFor(Variety.class, "WOOL");
+
+    public static final Variety WOOD = DummyObjectProvider.createFor(Variety.class, "WOOD");
+
+    public static final Variety OAK = DummyObjectProvider.createFor(Variety.class, "OAK");
+
+    public static final Variety BIRCH = DummyObjectProvider.createFor(Variety.class, "BIRCH");
+
+    public static final Variety SPRUCE = DummyObjectProvider.createFor(Variety.class, "SPRUCE");
+
+    public static final Variety JUNGLE = DummyObjectProvider.createFor(Variety.class, "JUNGLE");
+
+    public static final Variety DARK_OAK = DummyObjectProvider.createFor(Variety.class, "DARK_OAK");
+
+    public static final Variety ACACIA = DummyObjectProvider.createFor(Variety.class, "ACACIA");
+
+    public static final Variety COAL = DummyObjectProvider.createFor(Variety.class, "COAL");
+
+    public static final Variety GOLDEN_APPLE = DummyObjectProvider.createFor(Variety.class, "GOLDEN_APPLE");
+
+    public static final Variety PUMPKIN = DummyObjectProvider.createFor(Variety.class, "PUMPKIN");
+
+    // TODO: A lot more
+
+    // SORTFIELDS:OFF
+
+    private Varieties() {
+    }
+}

--- a/src/main/java/org/spongepowered/api/variant/Varieties.java
+++ b/src/main/java/org/spongepowered/api/variant/Varieties.java
@@ -28,6 +28,9 @@ import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
 
+/**
+ * An enumeration of default {@link Variety}s.
+ */
 public final class Varieties {
 
     // SORTFIELDS:ON

--- a/src/main/java/org/spongepowered/api/variant/Variety.java
+++ b/src/main/java/org/spongepowered/api/variant/Variety.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.variant;
+
+import org.spongepowered.api.CatalogType;
+
+public interface Variety extends CatalogType {
+
+}

--- a/src/main/java/org/spongepowered/api/variant/VarietyQuery.java
+++ b/src/main/java/org/spongepowered/api/variant/VarietyQuery.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.variant;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.Property;
+import org.spongepowered.api.util.ResettableBuilder;
+
+import java.util.Collection;
+
+// TODO: Better name?
+public interface VarietyQuery {
+
+    static Builder builder() {
+        return Sponge.getRegistry().createBuilder(Builder.class);
+    }
+
+    /**
+     * Gets the {@link Variety varieties} that
+     * will be matched.
+     *
+     * @return The varieties
+     */
+    Collection<Variety> getVarieties();
+
+    /**
+     * Gets the {@link Property properties} that
+     * will be matched.
+     *
+     * @return The properties
+     */
+    Collection<Property<?,?>> getProperties();
+
+    interface Builder extends ResettableBuilder<VarietyQuery, Builder> {
+
+        Builder variety(Variety variety);
+
+        Builder varieties(Variety... varieties);
+
+        Builder varieties(Iterable<Variety> varieties);
+
+        Builder property(Property<?,?> property);
+
+        Builder properties(Property<?,?>... properties);
+
+        Builder properties(Property<?,?> properties);
+
+        VarietyQuery build();
+    }
+}

--- a/src/main/java/org/spongepowered/api/variant/VarietyQuery.java
+++ b/src/main/java/org/spongepowered/api/variant/VarietyQuery.java
@@ -30,20 +30,60 @@ import org.spongepowered.api.util.ResettableBuilder;
 
 import java.util.Collection;
 
-// TODO: Better name?
+/**
+ * A variety query will be used to match a set of specific
+ * {@link Variety varieties} and {@link Property properties} on
+ * a {@link VarietyQueryable}.
+ */
 public interface VarietyQuery {
 
+    /**
+     * Creates a {@link Builder} to create {@link VarietyQuery variety queries}.
+     *
+     * @return The builder
+     */
     static Builder builder() {
         return Sponge.getRegistry().createBuilder(Builder.class);
     }
 
     /**
-     * Gets the {@link Variety varieties} that
-     * will be matched.
+     * Creates a {@link VarietyQuery} from the provided {@link Variety}.
      *
-     * @return The varieties
+     * @param variety The variety
+     * @return The variety query
      */
-    Collection<Variety> getVarieties();
+    static VarietyQuery of(Variety variety) {
+        return builder().variety(variety).build();
+    }
+
+    /**
+     * Creates a {@link VarietyQuery} from the provided {@link Variety}
+     * and the specific {@link MatchOperator}.
+     *
+     * @param variety The variety
+     * @return The variety query
+     */
+    static VarietyQuery of(Variety variety, MatchOperator operator) {
+        return builder().variety(variety, operator).build();
+    }
+
+    /**
+     * Creates a {@link VarietyQuery} from the provided
+     * {@link Property properties}.
+     *
+     * @param properties The properties
+     * @return The variety query
+     */
+    static VarietyQuery of(Property<?,?>... properties) {
+        return builder().properties(properties).build();
+    }
+
+    /**
+     * Gets the {@link VarietyQueryEntry} that will be matched.
+     *
+     * @return The variety entries
+     */
+    Collection<VarietyQueryEntry> getVarietyEntries();
 
     /**
      * Gets the {@link Property properties} that
@@ -53,20 +93,89 @@ public interface VarietyQuery {
      */
     Collection<Property<?,?>> getProperties();
 
+    /**
+     * A builder to create {@link VarietyQuery variety queries}.
+     */
     interface Builder extends ResettableBuilder<VarietyQuery, Builder> {
 
-        Builder variety(Variety variety);
+        /**
+         * Adds the {@link Variety varieties}.
+         *
+         * @param varieties The varieties
+         * @return This builder, for chaining
+         */
+        default Builder varieties(Variety... varieties) {
+            for (Variety variety : varieties) {
+                variety(variety);
+            }
+            return this;
+        }
 
-        Builder varieties(Variety... varieties);
+        /**
+         * Adds the {@link Variety varieties}.
+         *
+         * @param varieties The varieties
+         * @return This builder, for chaining
+         */
+        default Builder varieties(Iterable<Variety> varieties) {
+            for (Variety variety : varieties) {
+                variety(variety);
+            }
+            return this;
+        }
 
-        Builder varieties(Iterable<Variety> varieties);
+        /**
+         * Adds the {@link Variety}.
+         *
+         * @param variety The variety
+         * @return This builder, for chaining
+         */
+        default Builder variety(Variety variety) {
+            return variety(variety, MatchOperator.EQUAL);
+        }
 
+        /**
+         * Adds the {@link Variety} with a specific
+         * {@link MatchOperator}.
+         *
+         * @param variety The variety
+         * @param operator The operator
+         * @return This builder, for chaining
+         */
+        Builder variety(Variety variety, MatchOperator operator);
+
+        /**
+         * Adds the {@link Property} that should
+         * be matched.
+         *
+         * @param property The property
+         * @return This builder, for chaining
+         */
         Builder property(Property<?,?> property);
 
+        /**
+         * Adds the {@link Property properties} that should
+         * be matched.
+         *
+         * @param properties The properties
+         * @return This builder, for chaining
+         */
         Builder properties(Property<?,?>... properties);
 
-        Builder properties(Property<?,?> properties);
+        /**
+         * Adds the {@link Property properties} that should
+         * be matched.
+         *
+         * @param properties The properties
+         * @return This builder, for chaining
+         */
+        Builder properties(Iterable<Property<?,?>> properties);
 
+        /**
+         * Builds the {@link VarietyQuery}.
+         *
+         * @return The variety query
+         */
         VarietyQuery build();
     }
 }

--- a/src/main/java/org/spongepowered/api/variant/VarietyQueryEntry.java
+++ b/src/main/java/org/spongepowered/api/variant/VarietyQueryEntry.java
@@ -24,32 +24,24 @@
  */
 package org.spongepowered.api.variant;
 
-import org.spongepowered.api.CatalogType;
-import org.spongepowered.api.block.BlockType;
-import org.spongepowered.api.data.Property;
-import org.spongepowered.api.data.property.PropertyHolder;
-import org.spongepowered.api.data.property.common.TreeTypeProperty;
-import org.spongepowered.api.data.type.TreeTypes;
-
-import java.util.Collection;
-
 /**
- * A variety is a kind of marker that can be used to group
- * {@link VarietyQueryable}s. For example grouping all the
- * stair {@link BlockType}s that are available.
- * <p>Some varieties may also contain {@link Property}s which
- * can also be used to match the queryables. For example,
- * the {@link Varieties#BIRCH} will contain a {@link TreeTypeProperty}
- * with the tree type {@link TreeTypes#BIRCH}. This property
- * can also be used to query for a block with a specific tree type.
+ * A {@link Variety} that will be matched
+ * with a specific {@link MatchOperator}.
  */
-public interface Variety extends CatalogType, PropertyHolder {
+// TODO: Better name?, or use tuple instead?
+public interface VarietyQueryEntry {
 
     /**
-     * Gets a {@link Collection} with all the {@link VarietyQueryable}
-     * types this variety supports.
+     * Gets the {@link Variety} that will be matched.
      *
-     * @return The collection
+     * @return The variety
      */
-    Collection<Class<? extends VarietyQueryable>> getSupportedTypes();
+    Variety getVariety();
+
+    /**
+     * Gets the {@link MatchOperator} of this entry.
+     *
+     * @return The operator
+     */
+    MatchOperator getOperator();
 }

--- a/src/main/java/org/spongepowered/api/variant/VarietyQueryable.java
+++ b/src/main/java/org/spongepowered/api/variant/VarietyQueryable.java
@@ -24,11 +24,10 @@
  */
 package org.spongepowered.api.variant;
 
-import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.data.property.PropertyHolder;
 
 /**
- * Represents a {@link CatalogType} that can be filtered in a {@link VariantCollection}.
+ * Represents something that can be filtered in a {@link VariantCollection}.
  */
 // TODO: Better name?
 public interface VarietyQueryable extends PropertyHolder {

--- a/src/main/java/org/spongepowered/api/variant/VarietyQueryable.java
+++ b/src/main/java/org/spongepowered/api/variant/VarietyQueryable.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.variant;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.data.property.PropertyHolder;
+
+/**
+ * Represents a {@link CatalogType} that can be filtered in a {@link VariantCollection}.
+ */
+// TODO: Better name?
+public interface VarietyQueryable extends PropertyHolder {
+
+    /**
+     * Gets whether this object matches the requirements
+     * of the {@link VarietyQuery}.
+     *
+     * @param query The query
+     * @return Matches
+     */
+    boolean matches(VarietyQuery query);
+}

--- a/src/main/java/org/spongepowered/api/variant/package-info.java
+++ b/src/main/java/org/spongepowered/api/variant/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.variant;


### PR DESCRIPTION
This is a PR as preparation for 1.13, this system allows you to query for specific properties/collections of blocks and items. For example, you can query for all the blocks that are dyed blue. More info will follow.

Related to:
https://github.com/SpongePowered/SpongeAPI/issues/1667
Blocked by: https://github.com/SpongePowered/SpongeAPI/pull/1871

### Features?
- Query ItemTypes, BlockTypes, ItemStacks based on specific varieties/variants.
```java
// Get all the wool item types
VariantCollection<ItemType> woolItems = VariantCollections.ITEMS.query(VarietyQuery.builder()
        .variety(Varieties.WOOL)
        .build());
// OR
woolItems = VariantCollections.ITEMS.query(Varieties.WOOL);

// Get all the wool items that aren't blue or light blue dyed
VariantCollection<ItemType> nonBlueWoolItems = VariantCollections.ITEMS.query(VarietyQuery.builder()
        .variety(Varieties.WOOL)
        .property(new DyeColorProperty(DyeColors.BLUE, Property.Operator.NOTEQUAL))
        .property(new DyeColorProperty(DyeColors.LIGHT_BLUE, Property.Operator.NOTEQUAL))
        .build());
```
- Transform ItemTypes, BlockTypes based on applicable properties.
```java
ItemType someShulkerBox = ItemTypes.WHITE_SHULKER_BOX;
// Want a other color of shulker box, without the need to query?
someShulkerBox = someShulkerBox.transformWith(new DyeColorProperty(DyeColors.BLUE)).get();
```

### Names?
Please give some input on them, we currently have the following possible options:

Varieties:
- VarietyCollection
- VarietyCollections
- Variety
- Varieties
- VarietyQueryable
- VarietyQuery
- VarietyQueryEntry 

OR

Variants:
- VariantCollection
- VariantCollections
- Variant
- Variants
- VariantQueryable
- VariantQuery
- VariantQueryEntry 

OTHER:

Independent:
- MatchOperator

TODO:
- [ ] Add variant matcher

@gabizou 