### PR TITLE
Makes necessary changes for damageabledata implementation

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -1306,6 +1306,9 @@ public final class Keys {
      *
      * <p>This will usually be an entity snapshot of a {@link Living}.</p>
      *
+     * <p>This data will usually only be present within 100 ticks of the attack
+     * occurring.</p>
+     *
      * @see DamageableData#lastAttacker()
      */
     public static final Key<OptionalValue<EntitySnapshot>> LAST_ATTACKER = KeyFactory.fake("LAST_ATTACKER");
@@ -1321,6 +1324,9 @@ public final class Keys {
     /**
      * Represents the {@link Key} for the last amount of damage received by an
      * {@link Entity}.
+     *
+     * <p>This data will usually only be present within 100 ticks of the attack
+     * occurring.</p>
      *
      * @see DamageableData#lastDamage()
      */

--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -1304,9 +1304,11 @@ public final class Keys {
     /**
      * Represents the {@link Key} for who last attacked an {@link Entity}.
      *
+     * <p>This will usually be an entity snapshot of a {@link Living}.</p>
+     *
      * @see DamageableData#lastAttacker()
      */
-    public static final Key<OptionalValue<Living>> LAST_ATTACKER = KeyFactory.fake("LAST_ATTACKER");
+    public static final Key<OptionalValue<EntitySnapshot>> LAST_ATTACKER = KeyFactory.fake("LAST_ATTACKER");
 
     /**
      * Represents the {@link Key} for the output yielded by the last command of

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableDamageableData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableDamageableData.java
@@ -37,6 +37,9 @@ import java.util.Optional;
  * An {@link ImmutableDataManipulator} for retaining the last known "attacker"
  * for an {@link Entity}. If there is no known last attacker, the
  * {@link #lastAttacker()} may have an {@link Optional#EMPTY} value.
+ *
+ * <p>This data will usually only stay around for 100 ticks, which is generally
+ * around 5 or so seconds.</p>
  */
 public interface ImmutableDamageableData extends ImmutableDataManipulator<ImmutableDamageableData, DamageableData> {
 
@@ -45,12 +48,18 @@ public interface ImmutableDamageableData extends ImmutableDataManipulator<Immuta
      *
      * <p>This will usually be an entity snapshot of a {@link Living}.</p>
      *
+     * <p>This data will usually only be present within 100 ticks of the attack
+     * occurring.</p>
+     *
      * @return The last attacker as an optional value
      */
     ImmutableOptionalValue<EntitySnapshot> lastAttacker();
 
     /**
      * Gets the last amount of damage taken by this entity as an optional value.
+     *
+     * <p>This data will usually only be present within 100 ticks of the attack
+     * occurring.</p>
      *
      * @return The last damage dealt as an optional value
      */

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableDamageableData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableDamageableData.java
@@ -28,28 +28,29 @@ import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.entity.DamageableData;
 import org.spongepowered.api.data.value.immutable.ImmutableOptionalValue;
 import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.EntitySnapshot;
 import org.spongepowered.api.entity.living.Living;
 
 import java.util.Optional;
 
 /**
  * An {@link ImmutableDataManipulator} for retaining the last known "attacker"
- * for an {@link Entity}. Usually, the last attacker is known, however, due to
- * the lifetime of the game, the last attacker may "expire" or die, in which
- * case, the {@link #lastAttacker()} may have an {@link Optional#empty()}
- * value.
+ * for an {@link Entity}. If there is no known last attacker, the
+ * {@link #lastAttacker()} may have an {@link Optional#EMPTY} value.
  */
 public interface ImmutableDamageableData extends ImmutableDataManipulator<ImmutableDamageableData, DamageableData> {
 
     /**
      * Gets the {@link ImmutableOptionalValue} for the last attacker.
      *
+     * <p>This will usually be an entity snapshot of a {@link Living}.</p>
+     *
      * @return The last attacker as an optional value
      */
-    ImmutableOptionalValue<Living> lastAttacker();
+    ImmutableOptionalValue<EntitySnapshot> lastAttacker();
 
     /**
-     * Gets the last amount of damage dealt as an optional value.
+     * Gets the last amount of damage taken by this entity as an optional value.
      *
      * @return The last damage dealt as an optional value
      */

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/DamageableData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/DamageableData.java
@@ -29,29 +29,30 @@ import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableDamageableData;
 import org.spongepowered.api.data.value.mutable.OptionalValue;
 import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.EntitySnapshot;
 import org.spongepowered.api.entity.living.Living;
 
 import java.util.Optional;
 
 /**
  * A {@link DataManipulator} for retaining the last known "attacker" for an
- * {@link Entity}. Usually, the last attacker is known, however, due to
- * the lifetime of the game, the last attacker may "expire" or die, in which
- * case, the {@link #lastAttacker()} may have an {@link Optional#empty()}
- * value.
+ * {@link Entity}. If there is no known last attacker, the {@link #lastAttacker()}
+ * may have an {@link Optional#EMPTY} value.
  */
 public interface DamageableData extends DataManipulator<DamageableData, ImmutableDamageableData> {
 
     /**
      * Gets the {@link OptionalValue} for the last attacker.
      *
+     * <p>This will usually be an entity snapshot of a {@link Living}.</p>
+     *
      * @return The last attacker as an optional value
      * @see Keys#LAST_ATTACKER
      */
-    OptionalValue<Living> lastAttacker();
+    OptionalValue<EntitySnapshot> lastAttacker();
 
     /**
-     * Gets the last amount of damage dealt as an optional value.
+     * Gets the last amount of damage taken by this entity as an optional value.
      *
      * @return The last damage dealt as an optional value
      * @see Keys#LAST_DAMAGE

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/DamageableData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/DamageableData.java
@@ -38,6 +38,9 @@ import java.util.Optional;
  * A {@link DataManipulator} for retaining the last known "attacker" for an
  * {@link Entity}. If there is no known last attacker, the {@link #lastAttacker()}
  * may have an {@link Optional#EMPTY} value.
+ *
+ * <p>This data will usually only stay around for 100 ticks, which is generally
+ * around 5 or so seconds.</p>
  */
 public interface DamageableData extends DataManipulator<DamageableData, ImmutableDamageableData> {
 
@@ -46,6 +49,9 @@ public interface DamageableData extends DataManipulator<DamageableData, Immutabl
      *
      * <p>This will usually be an entity snapshot of a {@link Living}.</p>
      *
+     * <p>This data will usually only be present within 100 ticks of the attack
+     * occurring.</p>
+     *
      * @return The last attacker as an optional value
      * @see Keys#LAST_ATTACKER
      */
@@ -53,6 +59,9 @@ public interface DamageableData extends DataManipulator<DamageableData, Immutabl
 
     /**
      * Gets the last amount of damage taken by this entity as an optional value.
+     *
+     * <p>This data will usually only be present within 100 ticks of the attack
+     * occurring.</p>
      *
      * @return The last damage dealt as an optional value
      * @see Keys#LAST_DAMAGE

--- a/src/main/java/org/spongepowered/api/entity/living/Living.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Living.java
@@ -34,6 +34,7 @@ import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.api.data.value.mutable.OptionalValue;
 import org.spongepowered.api.effect.potion.PotionEffect;
 import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.EntitySnapshot;
 import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 import org.spongepowered.api.scoreboard.TeamMember;
 
@@ -89,16 +90,18 @@ public interface Living extends Entity, ProjectileSource, TeamMember {
      *
      * @return A copy of the current damageable data
      */
-    default DamageableData getMortalData() {
+    default DamageableData getDamageableData() {
         return get(DamageableData.class).get();
     }
 
     /**
      * Gets the {@link OptionalValue} for the last attacker.
      *
+     * <p>This is generally an entity snapshot of a {@link Living}.</p>
+     *
      * @return The last attacker as an optional value
      */
-    default OptionalValue<Living> lastAttacker() {
+    default OptionalValue<EntitySnapshot> lastAttacker() {
         return getValue(Keys.LAST_ATTACKER).get();
     }
 

--- a/src/main/java/org/spongepowered/api/util/TypeTokens.java
+++ b/src/main/java/org/spongepowered/api/util/TypeTokens.java
@@ -203,8 +203,10 @@ public class TypeTokens {
 
     public static final TypeToken<Value<ItemStackSnapshot>> ITEM_SNAPSHOT_VALUE_TOKEN = new TypeToken<Value<ItemStackSnapshot>>() {private static final long serialVersionUID = -1;};
 
+    @Deprecated
     public static final TypeToken<Optional<Living>> LAST_ATTACKER_TOKEN = new TypeToken<Optional<Living>>() {private static final long serialVersionUID = -1;};
 
+    @Deprecated
     public static final TypeToken<OptionalValue<Living>> LAST_ATTACKER_VALUE_TOKEN = new TypeToken<OptionalValue<Living>>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<List<DyeColor>> LIST_DYE_COLOR_TOKEN = new TypeToken<List<DyeColor>>() {private static final long serialVersionUID = -1;};
@@ -270,6 +272,14 @@ public class TypeTokens {
     public static final TypeToken<OcelotType> OCELOT_TOKEN = new TypeToken<OcelotType>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<Value<OcelotType>> OCELOT_VALUE_TOKEN = new TypeToken<Value<OcelotType>>() {private static final long serialVersionUID = -1;};
+
+    public static final TypeToken<Optional<Double>> OPTIONAL_DOUBLE_TOKEN = new TypeToken<Optional<Double>>() {private static final long serialVersionUID = -1;};
+
+    public static final TypeToken<OptionalValue<Double>> OPTIONAL_DOUBLE_VALUE_TOKEN = new TypeToken<OptionalValue<Double>>() {private static final long serialVersionUID = -1;};
+
+    public static final TypeToken<Optional<EntitySnapshot>> OPTIONAL_ENTITY_SNAPSHOT_TOKEN = new TypeToken<Optional<EntitySnapshot>>() {private static final long serialVersionUID = -1;};
+
+    public static final TypeToken<OptionalValue<EntitySnapshot>> OPTIONAL_ENTITY_SNAPSHOT_VALUE_TOKEN = new TypeToken<OptionalValue<EntitySnapshot>>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<Optional<PotionEffectType>> OPTIONAL_POTION_TOKEN = new TypeToken<Optional<PotionEffectType>>() {private static final long serialVersionUID = -1;};
 


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1643)

This makes changes to the API for implementing `DamageableData`. 

I need a lot of feedback on this, especially on turning `Living` to `EntitySnapshot`. I believe it does have to be changed but this may not be the best choice, possibly simply `UUID` is better.

More review is needed in the implementation though, as I wasn't exactly sure the best way to do everything. For example, I followed the old implemented fashion of `Living#lastDamage` where it would be empty if the `lastAttacker` was empty as well. Also I was not 100% on the various `toContainer` and `fill` methods.

To-do:

- [x] Clean up changes

- [x] Create a test plugin

- [x] Test changes thoroughly 