### PR TITLE
Modify child command logic to allow for meaningful usage on subcommand failure

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/ArgumentParseException.java
+++ b/src/main/java/org/spongepowered/api/command/args/ArgumentParseException.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.command.args;
 import com.google.common.base.Strings;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
 
 /**
  * Exception thrown when an error occurs while parsing arguments.
@@ -76,6 +77,10 @@ public class ArgumentParseException extends CommandException {
         }
     }
 
+    private Text getSuperText() {
+        return super.getText();
+    }
+
     /**
      * Return a string pointing to the position of the arguments when this
      * exception occurs.
@@ -120,4 +125,29 @@ public class ArgumentParseException extends CommandException {
     public String getSourceString() {
         return this.source;
     }
+
+    /**
+     * An {@link ArgumentParseException} where the usage is already specified.
+     */
+    public static class WithUsage extends ArgumentParseException {
+        private static final long serialVersionUID = -786214501012293475L;
+
+        private final Text usage;
+
+        WithUsage(ArgumentParseException wrapped, Text usage) {
+            super(wrapped.getSuperText(), wrapped.getCause(), wrapped.getSourceString(), wrapped.getPosition());
+            this.usage = usage;
+        }
+
+        /**
+         * Gets the usage associated with this exception
+         *
+         * @return The usage
+         */
+        public Text getUsage() {
+            return this.usage;
+        }
+
+    }
+
 }


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1656)

One of the long standing issues with the Command API is that subcommands don't give useful feedback if a command fails. The current implementation of the command system is difficult to solve this effectively with - this is a best effort. It isn't breaking, but in order to activate behaviour where a subcommand failing gives meaningful usage requires `childArgumentParseExceptionFallback` on the CommandSpec builder to be set to `false`. It defaults to `true`, the current behaviour.

I felt it was better to propose this fix for API 7, even though #1587 will completely eclipse this in API 8. It gives devlopers the choice on how to handle their subcommands now. It honestly feels a little hacky, but it works. In theory, there is nothing stopping this going into API 5 and 6 either. Note that any plugin that doesn't use this method in the builder will get the old behaviour, so the change isn't breaking API wise or behaviour wise, plugins will have to update to use this new behaviour - there are some plugins out there, no doubt, that use the fallback as it is now.

Comments are welcome on naming (it's not my strong suit). Test plugin included in Common, some unit tests in API.

Fixes #1165, fixes #1272, fixes #1542, fixes #1647