### PR TITLE
Allow plugins to use a separate implementation class for custom data.

### DIFF
--- a/src/main/java/org/spongepowered/api/data/DataRegistration.java
+++ b/src/main/java/org/spongepowered/api/data/DataRegistration.java
@@ -54,11 +54,27 @@ public interface DataRegistration<T extends DataManipulator<T, I>, I extends Imm
     Class<T> getManipulatorClass();
 
     /**
+     * Gets the implementing class of the {@link DataManipulator} for this
+     * registration.
+     *
+     * @return The manipulator class registered
+     */
+    Class<? extends T> getImplementationClass();
+
+    /**
      * Gets the {@link ImmutableDataManipulator} class for this registration.
      *
      * @return The immutable class registered
      */
     Class<I> getImmutableManipulatorClass();
+
+    /**
+     * Gets the implementing class of the {@link ImmutableDataManipulator} for
+     * this registration.
+     *
+     * @return The immutable manipulator class registered
+     */
+    Class<? extends I> getImmutableImplementationClass();
 
     /**
      * Gets the {@link DataManipulatorBuilder} registered for this registration.
@@ -106,6 +122,31 @@ public interface DataRegistration<T extends DataManipulator<T, I>, I extends Imm
          *     been set already
          */
         Builder<T, I> immutableClass(Class<I> immutableDataClass) throws IllegalStateException;
+
+        /**
+         * Optionally sets a separate implementation class for the
+         * {@link DataManipulator}. <strong>THIS MUST BE CALLED AFTER
+         * {@link #dataClass(Class)}!</strong>
+         *
+         * @param dataImplementationClass The data manipulator implementation
+         * @return This builder, for chaining
+         * @throws IllegalStateException If the data manipulator class has not
+         *     been set already
+         */
+        Builder<T, I> dataImplementation(Class<? extends T> dataImplementationClass) throws IllegalStateException;
+
+        /**
+         * Optionally sets a separate implementation class for the
+         * {@link ImmutableDataManipulator}. <strong>THIS MUST BE CALLED AFTER
+         * {@link #dataClass(Class)}!</strong>
+         *
+         * @param immutableImplementationClass The immutable data manipulator
+         *     implementation
+         * @return This builder, for chaining
+         * @throws IllegalStateException If the immutable data manipulator
+         *     class has not been set already
+         */
+        Builder<T, I> immutableImplementation(Class<? extends I> immutableImplementationClass) throws IllegalStateException;
 
         /**
          * Sets the id for the manipulator. The id should be formatted


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1666)

Sponge uses an interface and a separate implementing class for its `DataManipulator`s, and a few plugin developers have been [trying to use that model](https://forums.spongepowered.org/t/custom-data-not-working/21832?u=jbyoshi). However, `DataRegistration` doesn't allow multiple classes to be registered to it. This PR adds that option. (However, it remains optional for any plugins that don't currently use it, or don't want to use it.)