### PR TITLE
Allow the Registration of EventListeners for Keys

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Key.java
+++ b/src/main/java/org/spongepowered/api/data/key/Key.java
@@ -28,10 +28,13 @@ import com.google.common.reflect.TypeToken;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataQuery;
 import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.event.EventListener;
+import org.spongepowered.api.event.data.ChangeDataHolderEvent;
 import org.spongepowered.api.util.ResettableBuilder;
 import org.spongepowered.api.util.TypeTokens;
 
@@ -81,6 +84,8 @@ public interface Key<V extends BaseValue<?>> extends CatalogType {
      * @return The recommended {@link DataQuery} for use
      */
     DataQuery getQuery();
+
+    <E extends DataHolder> void registerEvent(Class<E> holderFilter, EventListener<ChangeDataHolderEvent.ValueChange> listener);
 
     interface Builder<E, V extends BaseValue<E>> extends ResettableBuilder<Key<V>, Builder<E, V>> {
 

--- a/src/main/java/org/spongepowered/api/data/key/KeyFactory.java
+++ b/src/main/java/org/spongepowered/api/data/key/KeyFactory.java
@@ -197,35 +197,4 @@ public final class KeyFactory {
         checkArgument(id.contains(":"), "A key must have a plugin id prefix with \":\" separating the plugin id and key id!");
     }
 
-    static <E, V extends BaseValue<E>> Key<V> fake(final String keyName) {
-        return new Key<V>() {
-            final TypeToken<V> token = new TypeToken<V>() {};
-
-            @Override
-            public String getId() {
-                throw new UnsupportedOperationException("Key " + keyName + " is not implemented");
-            }
-
-            @Override
-            public String getName() {
-                throw new UnsupportedOperationException("Key " + keyName + " is not implemented");
-            }
-
-            @Override
-            public TypeToken<V> getValueToken() {
-                throw new UnsupportedOperationException("Key " + keyName + " is not implemented");
-            }
-
-            @Override
-            public TypeToken<?> getElementToken() {
-                throw new UnsupportedOperationException("Key " + keyName + " is not implemented");
-            }
-
-            @Override
-            public DataQuery getQuery() {
-                throw new UnsupportedOperationException("Key " + keyName + " is not implemented");
-            }
-        };
-    }
-
 }

--- a/src/main/java/org/spongepowered/api/util/TypeTokens.java
+++ b/src/main/java/org/spongepowered/api/util/TypeTokens.java
@@ -29,6 +29,7 @@ import com.flowpowered.math.vector.Vector3i;
 import com.google.common.reflect.TypeToken;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.data.value.mutable.PatternListValue;
 import org.spongepowered.api.item.enchantment.Enchantment;
 import org.spongepowered.api.data.meta.PatternLayer;
 import org.spongepowered.api.data.type.*;
@@ -420,6 +421,7 @@ public class TypeTokens {
     public static final TypeToken<WireAttachmentType> WIRE_ATTACHMENT_TYPE_TOKEN = new TypeToken<WireAttachmentType>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<Value<WireAttachmentType>> WIRE_ATTACHMENT_TYPE_VALUE_TOKEN = new TypeToken<Value<WireAttachmentType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<PatternListValue> PATTERN_LIST_VALUE_TOKEN = new TypeToken<PatternListValue>() {private static final long serialVerionUID = -1;};
 
     // SORTFIELDS:OFF
 


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1670)
This is to supersede #1695 in some aspects to make it more functional to allow plugins to isolate specific key event listeners. The implementation of the event is also directing the flow of this being used.