### PR TITLE
Adds basic elytra data

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -1154,6 +1154,14 @@ public final class Keys {
     public static final Key<Value<Boolean>> IS_AFLAME = DummyObjectProvider.createExtendedFor(Key.class,"IS_AFLAME");
 
     /**
+     * Represents the {@link Key} for whether a {@link Player} is flying with an
+     * {@link ItemTypes#ELYTRA}.
+     *
+     * @see ElytraFlyingData#elytraFlying()
+     */
+    public static final Key<Value<Boolean>> IS_ELYTRA_FLYING = DummyObjectProvider.createExtendedFor(Key.class, "IS_ELYTRA_FLYING");
+
+    /**
      * Represents the {@link Key} for whether an {@link Entity} is flying.
      *
      * <p>This key only tells whether an entity is flying at the moment. On a

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableElytraFlyingData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableElytraFlyingData.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.entity.ElytraFlyingData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.item.ItemTypes;
+
+/**
+ * An {@link ImmutableDataManipulator} which represents whether or not a {@link Player}
+ * is flying in elytra style, which in vanilla usually means they also have a
+ * {@link ItemTypes#ELYTRA} equipped in their chest slot.
+ */
+public interface ImmutableElytraFlyingData extends ImmutableDataManipulator<ImmutableElytraFlyingData, ElytraFlyingData> {
+
+    /**
+     * Gets the {@link ImmutableValue} elytra flying state.
+     *
+     * @return The elytra flying state immutable value
+     * @see Keys#IS_ELYTRA_FLYING
+     */
+    ImmutableValue<Boolean> elytraFlying();
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/ElytraFlyingData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/ElytraFlyingData.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableElytraFlyingData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.item.ItemTypes;
+
+/**
+ * A {@link DataManipulator} which represents whether or not a {@link Player}
+ * is flying in elytra style, which in vanilla usually means they also have a
+ * {@link ItemTypes#ELYTRA} equipped in their chest slot.
+ */
+public interface ElytraFlyingData extends DataManipulator<ElytraFlyingData, ImmutableElytraFlyingData> {
+
+    /**
+     * Gets the {@link Value} elytra flying state.
+     *
+     * @return The elytra flying state value
+     * @see Keys#IS_ELYTRA_FLYING
+     */
+    Value<Boolean> elytraFlying();
+
+}


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1702)

Adds a basic elytra data which can be expanded later on as this part of it is a common request.

With this API, you can get whether a player is flying elytra style or not. You can also stop them from flying elytra style with `player.offer(Keys.IS_ELYTRA_FLYING, false)` and have them start elytra flying if they are currently falling and have an elytra on with `player.offer(Keys.IS_ELYTRA_FLYING, true)`.

More capability will be introduced later down the road, but this is the most common request and was more easily done.

Fixes https://github.com/SpongePowered/SpongeAPI/issues/1618 and various Discord requests

Works towards https://github.com/SpongePowered/SpongeAPI/issues/1663