### PR TITLE
Added navigator interface for basic path operations

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -44,6 +44,7 @@ import org.spongepowered.api.effect.particle.ParticleType;
 import org.spongepowered.api.effect.potion.PotionEffect;
 import org.spongepowered.api.effect.potion.PotionEffectType;
 import org.spongepowered.api.entity.*;
+import org.spongepowered.api.entity.ai.navigation.Navigator;
 import org.spongepowered.api.entity.explosive.Explosive;
 import org.spongepowered.api.entity.explosive.FusedExplosive;
 import org.spongepowered.api.entity.hanging.ItemFrame;
@@ -914,6 +915,14 @@ public final class Keys {
      * @see MovementSpeedData#flySpeed()
      */
     public static final Key<Value<Double>> FLYING_SPEED = DummyObjectProvider.createExtendedFor(Key.class,"FLYING_SPEED");
+
+    /**
+     * Represents the {@link Key} for the following range of an {@link Agent}.
+     *
+     * @see AgentData#followRange()
+     * @see Navigator#getFollowRange()
+     */
+    public static final Key<MutableBoundedValue<Double>> FOLLOW_RANGE = DummyObjectProvider.createExtendedFor(Key.class, "FOLLOW_RANGE");
 
     /**
      * Represents the {@link Key} for the food level of a {@link Humanoid}.

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/AgentData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/AgentData.java
@@ -27,10 +27,13 @@ package org.spongepowered.api.data.manipulator.mutable.entity;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableAgentData;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.entity.ai.navigation.Navigator;
+import org.spongepowered.api.entity.living.Agent;
 
 /**
- * Data regarding the toggle of AI tasks on an entity.
+ * Data regarding AI tasks on an entity.
  */
 public interface AgentData extends DataManipulator<AgentData, ImmutableAgentData> {
 
@@ -41,5 +44,15 @@ public interface AgentData extends DataManipulator<AgentData, ImmutableAgentData
      * @see Keys#AI_ENABLED
      */
     Value<Boolean> aiEnabled();
+
+    /**
+     * Gets the {@link MutableBoundedValue} for the current follow range of this agent's
+     * {@link Agent#getNavigator() navigator}.
+     *
+     * @return The value for the current follow range
+     * @see Keys#FOLLOW_RANGE
+     * @see Navigator#getFollowRange()
+     */
+    MutableBoundedValue<Double> followRange();
 
 }

--- a/src/main/java/org/spongepowered/api/entity/ai/navigation/Navigator.java
+++ b/src/main/java/org/spongepowered/api/entity/ai/navigation/Navigator.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.entity.ai.navigation;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.mutable.entity.AgentData;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.ai.task.AITask;
+import org.spongepowered.api.entity.living.Agent;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
+
+/**
+ * A navigator allows an {@link Agent} finding a route when executing
+ * {@link AITask AI tasks}.
+ */
+public interface Navigator {
+
+    /**
+     * Gets the agent which this navigator belongs to.
+     *
+     * @return The owner of the navigator
+     */
+    Agent getOwner();
+
+    /**
+     * Gets the speed for following along the current route.
+     *
+     * <p>It will be multiplied by entity attribute modifiers.</p>
+     *
+     * @return The speed value
+     */
+    double getSpeed();
+
+    /**
+     * Sets the speed for following along the current route.
+     *
+     * <p>It will be multiplied by entity attribute modifiers.</p>
+     *
+     * @param speed The new speed value
+     */
+    void setSpeed(double speed);
+
+    /**
+     * Navigates to a block position.
+     *
+     * <p>Once set, the navigator will continuously try to
+     * guide the agent to this location.</p>
+     *
+     * @param target The target location
+     */
+    void navigate(Location<World> target);
+
+    /**
+     * Navigates to an entity.
+     *
+     * <p>The actual target location is the bottom center of
+     * the entity's bounding box.</p>
+     *
+     * <p>Once set, the navigator will continuously try to
+     * guide the agent to the location of the target when this
+     * method is called: the location does not automatically update.</p>
+     *
+     * @param target The target entity
+     * @see #navigate(Location)
+     */
+    void navigate(Entity target);
+
+    /**
+     * Gets the current search range of the navigator.
+     *
+     * <p>This value is calculated after attributed modifiers are applied.</p>
+     *
+     * <p>The original value can be set with {@link AgentData#followRange()}.</p>
+     *
+     * @return The current search range
+     * @see Keys#FOLLOW_RANGE
+     * @see AgentData#followRange()
+     */
+    double getFollowRange();
+
+}

--- a/src/main/java/org/spongepowered/api/entity/ai/navigation/package-info.java
+++ b/src/main/java/org/spongepowered/api/entity/ai/navigation/package-info.java
@@ -22,32 +22,4 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.manipulator.immutable.entity;
-
-import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
-import org.spongepowered.api.data.manipulator.mutable.entity.AgentData;
-import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
-import org.spongepowered.api.data.value.immutable.ImmutableValue;
-import org.spongepowered.api.entity.living.Agent;
-
-/**
- * An {@link ImmutableDataManipulator} for AI tasks on {@link Agent}s.
- */
-public interface ImmutableAgentData extends ImmutableDataManipulator<ImmutableAgentData, AgentData> {
-
-    /**
-     * Gets the {@link ImmutableValue} for whether AI tasks are enabled or not.
-     *
-     * @return The immutable value for the current "enabled" state of ai tasks
-     */
-    ImmutableValue<Boolean> aiEnabled();
-
-    /**
-     * Gets the {@link ImmutableBoundedValue} for the current follow range of this agent's
-     * {@link Agent#getNavigator() navigator}.
-     *
-     * @return The immutable value for the current follow range
-     */
-    ImmutableBoundedValue<Double> followRange();
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.api.entity.ai.navigation;

--- a/src/main/java/org/spongepowered/api/entity/living/Agent.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Agent.java
@@ -26,10 +26,12 @@ package org.spongepowered.api.entity.living;
 
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.mutable.entity.AgentData;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.ai.Goal;
 import org.spongepowered.api.entity.ai.GoalType;
+import org.spongepowered.api.entity.ai.navigation.Navigator;
 import org.spongepowered.api.entity.ai.task.AITask;
 
 import java.util.Optional;
@@ -84,4 +86,21 @@ public interface Agent extends Living {
      * @return The goal or {@link Optional#empty()} if not found.
      */
     <T extends Agent> Optional<Goal<T>> getGoal(GoalType type);
+
+    /**
+     * Gets the navigator for the agent.
+     *
+     * @return The navigator
+     */
+    Navigator getNavigator();
+
+    /**
+     * Gets the {@link MutableBoundedValue} for this agent's following range in blocks.
+     *
+     * @return The following range
+     */
+    default MutableBoundedValue<Double> followRange() {
+        return getValue(Keys.FOLLOW_RANGE).get();
+    }
+
 }


### PR DESCRIPTION
**SpongeAPI** | [**SpongeCommon**](https://github.com/SpongePowered/SpongeCommon/pull/1752)

This also adds a following range attribute modifier to the API to help plugins using the navigator.

To make things simple, the pull just exposed the most basic operation that is the most likely frequently used. I hope @Cybermaxke may comment on this so that different path finding systems may find an agreement.

Edit: added link to spongecommon