### PR TITLE
Fixes #1526 event factory method generations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         classpath 'gradle.plugin.net.minecrell:licenser:0.3'
         classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
         classpath 'gradle.plugin.org.spongepowered:spongegradle:0.8.1'
-        classpath 'gradle.plugin.org.spongepowered:event-impl-gen:5.0.2'
+        classpath 'gradle.plugin.org.spongepowered:event-impl-gen:5.4.0'
     }
 }
 
@@ -90,6 +90,9 @@ apply plugin: 'org.spongepowered.event-impl-gen'
 
 genEventImpl {
     outputFactory = 'org.spongepowered.api.event.SpongeEventFactory'
+
+    inclusiveAnnotation 'org.spongepowered.api.util.annotation.GenerateFactoryMethod'
+    exclusiveAnnotation 'org.spongepowered.api.util.annotation.AbstractEvent'
 
     include 'org/spongepowered/api/event/*/**/*'
     exclude 'org/spongepowered/api/event/cause/'

--- a/src/main/java/org/spongepowered/api/event/action/CollideEvent.java
+++ b/src/main/java/org/spongepowered/api/event/action/CollideEvent.java
@@ -28,6 +28,7 @@ import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
@@ -42,6 +43,7 @@ public interface CollideEvent extends Event, Cancellable {
      *
      * <p>Note: this should only fire once after the first impact.</p>
      */
+    @AbstractEvent
     interface Impact extends CollideEvent {
 
         /**

--- a/src/main/java/org/spongepowered/api/event/action/InteractEvent.java
+++ b/src/main/java/org/spongepowered/api/event/action/InteractEvent.java
@@ -27,12 +27,14 @@ package org.spongepowered.api.event.action;
 import com.flowpowered.math.vector.Vector3d;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
 import java.util.Optional;
 
 /**
  * Base event for all interactions.
  */
+@AbstractEvent
 public interface InteractEvent extends Event, Cancellable {
 
     /**

--- a/src/main/java/org/spongepowered/api/event/data/ChangeDataHolderEvent.java
+++ b/src/main/java/org/spongepowered/api/event/data/ChangeDataHolderEvent.java
@@ -31,6 +31,7 @@ import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.impl.AbstractValueChangeEvent;
+import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
 import org.spongepowered.api.util.annotation.eventgen.ImplementedBy;
 import org.spongepowered.api.util.annotation.eventgen.PropertySettings;
 
@@ -40,6 +41,7 @@ import org.spongepowered.api.util.annotation.eventgen.PropertySettings;
  * methods relating to modifying a {@link DataHolder} while this event
  * is being processed may produce awkward results.
  */
+@GenerateFactoryMethod
 public interface ChangeDataHolderEvent extends Event, Cancellable {
 
     /**

--- a/src/main/java/org/spongepowered/api/event/entity/AffectEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/AffectEntityEvent.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.Order;
 import org.spongepowered.api.event.impl.AbstractAffectEntityEvent;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 import org.spongepowered.api.util.annotation.eventgen.ImplementedBy;
 import org.spongepowered.api.util.annotation.eventgen.PropertySettings;
 import org.spongepowered.api.world.Location;
@@ -50,6 +51,7 @@ import java.util.function.Predicate;
  * {@link Explosion} "damaging" a varying amount of {@link Entity} instances.
  * Other cases will be included as necessary.
  */
+@AbstractEvent
 @ImplementedBy(AbstractAffectEntityEvent.class)
 public interface AffectEntityEvent extends Event, Cancellable {
 

--- a/src/main/java/org/spongepowered/api/event/entity/HarvestEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/HarvestEntityEvent.java
@@ -31,11 +31,13 @@ import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.entity.living.TargetLivingEvent;
 import org.spongepowered.api.event.entity.living.humanoid.TargetHumanoidEvent;
 import org.spongepowered.api.event.entity.living.humanoid.player.TargetPlayerEvent;
+import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
 
 /**
  * Called when an {@link Entity} has been killed and is being "harvested" (drops/etc). Happens
  * after {@link DestructEntityEvent}.
  */
+@GenerateFactoryMethod
 public interface HarvestEntityEvent extends ChangeEntityExperienceEvent {
 
     /**

--- a/src/main/java/org/spongepowered/api/event/entity/TargetEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/TargetEntityEvent.java
@@ -26,10 +26,12 @@ package org.spongepowered.api.event.entity;
 
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.Event;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
 /**
  * Base event for when a {@link Entity} is a target.
  */
+@AbstractEvent
 public interface TargetEntityEvent extends Event {
 
     /**

--- a/src/main/java/org/spongepowered/api/event/entity/explosive/TargetExplosiveEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/explosive/TargetExplosiveEvent.java
@@ -26,10 +26,12 @@ package org.spongepowered.api.event.entity.explosive;
 
 import org.spongepowered.api.entity.explosive.Explosive;
 import org.spongepowered.api.event.entity.TargetEntityEvent;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
 /**
  * Represents an event regarding an {@link Explosive}.
  */
+@AbstractEvent
 public interface TargetExplosiveEvent extends TargetEntityEvent {
 
     @Override

--- a/src/main/java/org/spongepowered/api/event/entity/explosive/TargetFusedExplosiveEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/explosive/TargetFusedExplosiveEvent.java
@@ -25,10 +25,12 @@
 package org.spongepowered.api.event.entity.explosive;
 
 import org.spongepowered.api.entity.explosive.FusedExplosive;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
 /**
  * Represents an event regarding a {@link FusedExplosive}.
  */
+@AbstractEvent
 public interface TargetFusedExplosiveEvent extends TargetExplosiveEvent {
 
     @Override

--- a/src/main/java/org/spongepowered/api/event/entity/item/TargetItemEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/item/TargetItemEvent.java
@@ -26,10 +26,12 @@ package org.spongepowered.api.event.entity.item;
 
 import org.spongepowered.api.entity.Item;
 import org.spongepowered.api.event.entity.TargetEntityEvent;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
 /**
  * Base event for all events with a {@link Item} as the source.
  */
+@AbstractEvent
 public interface TargetItemEvent extends TargetEntityEvent {
 
     @Override

--- a/src/main/java/org/spongepowered/api/event/entity/living/TargetAgentEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/TargetAgentEvent.java
@@ -25,7 +25,12 @@
 package org.spongepowered.api.event.entity.living;
 
 import org.spongepowered.api.entity.living.Agent;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
+/**
+ * Base event for all events with a {@link Agent} as the source.
+ */
+@AbstractEvent
 public interface TargetAgentEvent extends TargetLivingEvent {
 
     @Override

--- a/src/main/java/org/spongepowered/api/event/entity/living/TargetLivingEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/TargetLivingEvent.java
@@ -26,7 +26,12 @@ package org.spongepowered.api.event.entity.living;
 
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.event.entity.TargetEntityEvent;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
+/**
+ * Base event for all events with a {@link Living} as the source.
+ */
+@AbstractEvent
 public interface TargetLivingEvent extends TargetEntityEvent {
 
     @Override

--- a/src/main/java/org/spongepowered/api/event/entity/living/humanoid/HandInteractEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/humanoid/HandInteractEvent.java
@@ -26,7 +26,9 @@ package org.spongepowered.api.event.entity.living.humanoid;
 
 import org.spongepowered.api.data.type.HandType;
 import org.spongepowered.api.event.action.InteractEvent;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
+@AbstractEvent
 public interface HandInteractEvent extends InteractEvent {
 
     /**

--- a/src/main/java/org/spongepowered/api/event/entity/living/humanoid/TargetHumanoidEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/humanoid/TargetHumanoidEvent.java
@@ -27,7 +27,12 @@ package org.spongepowered.api.event.entity.living.humanoid;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.Humanoid;
 import org.spongepowered.api.event.entity.living.TargetLivingEvent;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
+/**
+ * Base event for all events with a {@link Humanoid} as the source.
+ */
+@AbstractEvent
 public interface TargetHumanoidEvent extends TargetLivingEvent {
 
     /**

--- a/src/main/java/org/spongepowered/api/event/entity/living/humanoid/player/TargetPlayerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/humanoid/player/TargetPlayerEvent.java
@@ -26,7 +26,12 @@ package org.spongepowered.api.event.entity.living.humanoid.player;
 
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.entity.living.humanoid.TargetHumanoidEvent;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
+/**
+ * Base event for all events with a {@link Player} as the source.
+ */
+@AbstractEvent
 public interface TargetPlayerEvent extends TargetHumanoidEvent {
 
     /**

--- a/src/main/java/org/spongepowered/api/event/entity/projectile/TargetProjectileEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/projectile/TargetProjectileEvent.java
@@ -26,10 +26,12 @@ package org.spongepowered.api.event.entity.projectile;
 
 import org.spongepowered.api.entity.projectile.Projectile;
 import org.spongepowered.api.event.entity.TargetEntityEvent;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
 /**
  * Base event for all events with an {@link Projectile} as the target.
  */
+@AbstractEvent
 public interface TargetProjectileEvent extends TargetEntityEvent {
 
     @Override

--- a/src/main/java/org/spongepowered/api/event/game/state/GameStateEvent.java
+++ b/src/main/java/org/spongepowered/api/event/game/state/GameStateEvent.java
@@ -26,10 +26,12 @@ package org.spongepowered.api.event.game.state;
 
 import org.spongepowered.api.GameState;
 import org.spongepowered.api.event.Event;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
 /**
  * Represents all {@link GameState} events.
  */
+@AbstractEvent
 public interface GameStateEvent extends Event {
 
     /**

--- a/src/main/java/org/spongepowered/api/event/item/inventory/AffectItemStackEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/AffectItemStackEvent.java
@@ -31,6 +31,7 @@ import org.spongepowered.api.event.Event;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -38,6 +39,7 @@ import java.util.function.Predicate;
 /**
  * Fired when {@link ItemStack}s are generated into a {@link Inventory}.
  */
+@AbstractEvent
 public interface AffectItemStackEvent extends Event, Cancellable {
 
     /**

--- a/src/main/java/org/spongepowered/api/event/item/inventory/AffectSlotEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/AffectSlotEvent.java
@@ -27,10 +27,12 @@ package org.spongepowered.api.event.item.inventory;
 import com.google.common.collect.Lists;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
 import java.util.List;
 import java.util.function.Predicate;
 
+@AbstractEvent
 public interface AffectSlotEvent extends AffectItemStackEvent {
     @Override
     List<SlotTransaction> getTransactions();

--- a/src/main/java/org/spongepowered/api/event/item/inventory/TargetContainerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/TargetContainerEvent.java
@@ -25,10 +25,12 @@
 package org.spongepowered.api.event.item.inventory;
 
 import org.spongepowered.api.item.inventory.Container;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
 /**
  * Base event for all events with an {@link Container} as the target.
  */
+@AbstractEvent
 public interface TargetContainerEvent extends TargetInventoryEvent {
     @Override
     Container getTargetInventory();

--- a/src/main/java/org/spongepowered/api/event/item/inventory/TargetInventoryEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/TargetInventoryEvent.java
@@ -26,10 +26,12 @@ package org.spongepowered.api.event.item.inventory;
 
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.item.inventory.Inventory;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
 /**
  * Base event for all events with an {@link Inventory} as the target.
  */
+@AbstractEvent
 public interface TargetInventoryEvent extends Event {
 
     /**

--- a/src/main/java/org/spongepowered/api/event/server/ClientPingServerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/server/ClientPingServerEvent.java
@@ -31,6 +31,7 @@ import org.spongepowered.api.network.status.StatusClient;
 import org.spongepowered.api.network.status.StatusResponse;
 import org.spongepowered.api.profile.GameProfile;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
 
 import java.util.List;
@@ -65,6 +66,7 @@ public interface ClientPingServerEvent extends Event, Cancellable {
     /**
      * Represents a mutable response to a status request.
      */
+    @AbstractEvent
     interface Response extends StatusResponse {
 
         /**
@@ -103,6 +105,7 @@ public interface ClientPingServerEvent extends Event, Cancellable {
          * Represents the information about the players on the server, sent
          * after the {@link ClientPingServerEvent}.
          */
+        @AbstractEvent
         interface Players extends StatusResponse.Players {
 
             /**

--- a/src/main/java/org/spongepowered/api/event/statistic/ChangeStatisticEvent.java
+++ b/src/main/java/org/spongepowered/api/event/statistic/ChangeStatisticEvent.java
@@ -28,11 +28,13 @@ import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.entity.living.humanoid.player.TargetPlayerEvent;
 import org.spongepowered.api.statistic.Statistic;
+import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
 
 /**
  * Represents an event that is triggered if a {@link Statistic}'s value is being
  * modified.
  */
+@GenerateFactoryMethod
 public interface ChangeStatisticEvent extends Event, Cancellable {
     /**
      * Gets the {@link Statistic}.

--- a/src/main/java/org/spongepowered/api/event/user/TargetUserEvent.java
+++ b/src/main/java/org/spongepowered/api/event/user/TargetUserEvent.java
@@ -26,11 +26,13 @@ package org.spongepowered.api.event.user;
 
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.event.Event;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 
 /**
  * An event where a {@link User} is the target. The action and source may not
  * be known.
  */
+@AbstractEvent
 public interface TargetUserEvent extends Event {
 
     /**

--- a/src/main/java/org/spongepowered/api/event/world/TargetWorldEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/TargetWorldEvent.java
@@ -25,8 +25,10 @@
 package org.spongepowered.api.event.world;
 
 import org.spongepowered.api.event.Event;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 import org.spongepowered.api.world.World;
 
+@AbstractEvent
 public interface TargetWorldEvent extends Event {
 
     /**

--- a/src/main/java/org/spongepowered/api/event/world/chunk/TargetChunkEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/chunk/TargetChunkEvent.java
@@ -25,11 +25,13 @@
 package org.spongepowered.api.event.world.chunk;
 
 import org.spongepowered.api.event.Event;
+import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
 import org.spongepowered.api.world.Chunk;
 
 /**
  * Base event for anything targeting a {@link Chunk}.
  */
+@AbstractEvent
 public interface TargetChunkEvent extends Event {
 
     /**

--- a/src/main/java/org/spongepowered/api/util/annotation/eventgen/AbstractEvent.java
+++ b/src/main/java/org/spongepowered/api/util/annotation/eventgen/AbstractEvent.java
@@ -22,22 +22,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.block;
+package org.spongepowered.api.util.annotation.eventgen;
 
-import org.spongepowered.api.block.BlockSnapshot;
-import org.spongepowered.api.event.Event;
-import org.spongepowered.api.util.annotation.eventgen.AbstractEvent;
+import org.spongepowered.api.event.entity.TargetEntityEvent;
 
 /**
- * Base event for when a {@link BlockSnapshot} is a target.
+ * Explicitly disables generation of an event factory method for an event class.
+ *
+ * <p>By default, an event which does not contain sub-interfaces will have
+ * an event factory method generated. This allows some events with abstract concepts,
+ * such as {@link TargetEntityEvent}, to avoid implementation generation.</p>
  */
-@AbstractEvent
-public interface TargetBlockEvent extends Event {
+public @interface AbstractEvent {
 
-    /**
-     * Gets the target {@link BlockSnapshot} of this {@link Event}.
-     *
-     * @return The BlockSnapshot
-     */
-    BlockSnapshot getTargetBlock();
 }


### PR DESCRIPTION
**SpongeAPI** | [**event-impl-gen**](https://github.com/SpongePowered/event-impl-gen/pull/5)

Fixes #1526
Added an annotation `org.spongepowered.api.util.annotation.eventgen.FactoryGenerationProof` to prevent abstract-mean event interfaces from getting a generation method.
You need to bump the dependency on event-impl-gen manually to see the effects, and I currently cannot test that unfortunately because I don't know how to update this dependency.