### PR TITLE
add fillContainer for plugins to implement

### DIFF
--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractBooleanData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractBooleanData.java
@@ -56,8 +56,7 @@ public abstract class AbstractBooleanData<M extends DataManipulator<M, I>, I ext
     }
 
     @Override
-    public DataContainer toContainer() {
-        return super.toContainer()
-                .set(this.usedKey.getQuery(), getValue());
+    protected DataContainer fillContainer(DataContainer dataContainer) {
+        return dataContainer.set(this.usedKey.getQuery(), getValue());
     }
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractBoundedComparableData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractBoundedComparableData.java
@@ -85,8 +85,7 @@ public abstract class AbstractBoundedComparableData<T extends Comparable<T>, M e
     }
 
     @Override
-    public DataContainer toContainer() {
-        return super.toContainer()
-                .set(this.usedKey.getQuery(), this.getValue());
+    protected DataContainer fillContainer(DataContainer dataContainer) {
+        return dataContainer.set(this.usedKey.getQuery(), this.getValue());
     }
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractData.java
@@ -207,9 +207,17 @@ public abstract class AbstractData<M extends DataManipulator<M, I>, I extends Im
     }
 
     @Override
-    public DataContainer toContainer() {
-        return DataContainer.createNew()
-                .set(Queries.CONTENT_VERSION, getContentVersion());
+    public final DataContainer toContainer() {
+        return this.fillContainer(DataContainer.createNew().set(Queries.CONTENT_VERSION, getContentVersion()));
     }
+
+    /**
+     * Implement this method to add the data to be persisted.
+     *
+     * @param dataContainer The DataContainer
+     *
+     * @return The filled DataContainer
+     */
+    protected abstract DataContainer fillContainer(DataContainer dataContainer);
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractSingleCatalogData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractSingleCatalogData.java
@@ -59,8 +59,7 @@ public abstract class AbstractSingleCatalogData<T extends CatalogType, M extends
     }
 
     @Override
-    public DataContainer toContainer() {
-        return super.toContainer()
-                .set(this.usedKey.getQuery(), this.getValue().getId());
+    protected DataContainer fillContainer(DataContainer dataContainer) {
+        return dataContainer.set(this.usedKey.getQuery(), this.getValue().getId());
     }
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractSingleEnumData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/common/AbstractSingleEnumData.java
@@ -53,9 +53,8 @@ public abstract class AbstractSingleEnumData<E extends Enum<E>, M extends DataMa
     }
 
     @Override
-    public DataContainer toContainer() {
-        return super.toContainer()
-                .set(this.usedKey.getQuery(), this.getValue().name());
+    protected DataContainer fillContainer(DataContainer dataContainer) {
+        return dataContainer.set(this.usedKey.getQuery(), this.getValue().name());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1761)

Plugindevs often forget to override `toContainer` this change forces them to implement `fillContainer`.
This has also the added benefit of always adding the content-version which could have been missed when not calling `super.toContainer()` in the override

https://github.com/SpongePowered/SpongeAPI/issues/1586
