### PR TITLE
GenericArguments and CommandFlags Fixes

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
@@ -96,16 +96,17 @@ public final class CommandFlags extends CommandElement {
 
     private boolean parseLongFlag(CommandSource source, String longFlag, CommandArgs args, CommandContext context) throws ArgumentParseException {
         String[] flagSplit = longFlag.split("=", 2);
-        CommandElement element = this.longFlags.get(flagSplit[0].toLowerCase());
+        String flag = flagSplit[0].toLowerCase();
+        CommandElement element = this.longFlags.get(flag);
         if (element == null) {
             switch (this.unknownLongFlagBehavior) {
                 case ERROR:
                     throw args.createError(t("Unknown long flag %s specified", flagSplit[0]));
                 case ACCEPT_NONVALUE:
-                    context.putArg(flagSplit[0], flagSplit.length == 2 ? flagSplit[1] : true);
+                    context.putArg(flag, flagSplit.length == 2 ? flagSplit[1] : true);
                     return true;
                 case ACCEPT_VALUE:
-                    context.putArg(flagSplit[0], flagSplit.length == 2 ? flagSplit[1] : args.next());
+                    context.putArg(flag, flagSplit.length == 2 ? flagSplit[1] : args.next());
                     return true;
                 case IGNORE:
                     return false;
@@ -221,14 +222,14 @@ public final class CommandFlags extends CommandElement {
         Object state = args.getState();
         try {
             element.parse(src, args, context);
+            return null;
         } catch (ArgumentParseException ex) {
             args.setState(state);
-            String prefix = flagSplit.length == 2 ? flagSplit[0] + "=" : args.hasNext() ? "" : flagSplit[0] + " ";
+            String prefix = flagSplit.length == 2 ? flagSplit[0] + "=" : "";
             return element.complete(src, args, context).stream()
                     .map(s -> prefix + s)
                     .collect(Collectors.toList());
         }
-        return null;
     }
 
     @Nullable

--- a/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
@@ -35,7 +35,6 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.StartsWithPredicate;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -71,100 +70,75 @@ public final class CommandFlags extends CommandElement {
 
     @Override
     public void parse(CommandSource source, CommandArgs args, CommandContext context) throws ArgumentParseException {
-        Object startIdx = args.getState();
-        String arg;
+        Object state = args.getState();
         while (args.hasNext()) {
-            arg = args.next();
-            boolean ignore;
+            String arg = args.next();
+            boolean remove;
             if (arg.startsWith("-")) {
-                Object flagStartIdx = args.getState();
+                Object start = args.getState();
                 if (arg.startsWith("--")) { // Long flag
                     String longFlag = arg.substring(2);
-                    ignore = !parseLongFlag(source, longFlag, args, context);
+                    remove = parseLongFlag(source, longFlag, args, context);
                 } else {
                     arg = arg.substring(1);
-                    ignore = !parseShortFlags(source, arg, args, context);
+                    remove = parseShortFlags(source, arg, args, context);
                 }
-                if (!ignore) {
-                    args.removeArgs(flagStartIdx, args.getState());
+                if (remove) {
+                    args.removeArgs(start, args.getState());
                 }
             } else if (this.anchorFlags) {
                 break;
             }
         }
-
-        args.setState(startIdx);
+        args.setState(state);
         if (this.childElement != null) {
             this.childElement.parse(source, args, context);
         }
-
     }
 
     private boolean parseLongFlag(CommandSource source, String longFlag, CommandArgs args, CommandContext context) throws ArgumentParseException {
-        if (longFlag.contains("=")) {
-            final String[] flagSplit = longFlag.split("=", 2);
-            longFlag = flagSplit[0];
-            String value = flagSplit[1];
-            CommandElement element = this.longFlags.get(longFlag.toLowerCase());
-            if (element == null) {
-                switch (this.unknownLongFlagBehavior) {
-                    case ERROR:
-                        throw args.createError(t("Unknown long flag %s specified", args));
-                    case ACCEPT_NONVALUE:
-                    case ACCEPT_VALUE:
-                        context.putArg(longFlag, value);
-                        break;
-                    case IGNORE:
-                        return false;
-                    default:
-                        throw new Error("New UnknownFlagBehavior added without corresponding case clauses");
-                }
-            } else {
-                args.insertArg(value);
-                element.parse(source, args, context);
+        final String[] flagSplit = longFlag.split("=", 2);
+        CommandElement element = this.longFlags.get(flagSplit[0].toLowerCase());
+        if (element == null) {
+            switch (this.unknownLongFlagBehavior) {
+                case ERROR:
+                    throw args.createError(t("Unknown long flag %s specified", flagSplit[0]));
+                case ACCEPT_NONVALUE:
+                    context.putArg(longFlag, flagSplit.length == 2 ? flagSplit[1] : true);
+                    return true;
+                case ACCEPT_VALUE:
+                    context.putArg(longFlag, flagSplit.length == 2 ? flagSplit[1] : args.next());
+                    return true;
+                case IGNORE:
+                    return false;
+                default:
+                    throw new Error("New UnknownFlagBehavior added without corresponding case clauses");
             }
-        } else {
-            CommandElement element = this.longFlags.get(longFlag.toLowerCase());
-            if (element == null) {
-                switch (this.unknownLongFlagBehavior) {
-                    case ERROR:
-                        throw args.createError(t("Unknown long flag %s specified", args));
-                    case ACCEPT_NONVALUE:
-                        context.putArg(longFlag, true);
-                        break;
-                    case ACCEPT_VALUE:
-                        string(Text.of(longFlag)).parse(source, args, context);
-                        break;
-                    case IGNORE:
-                        return false;
-                    default:
-                        throw new Error("New UnknownFlagBehavior added without corresponding case clauses");
-                }
-            } else {
-                element.parse(source, args, context);
-            }
+        } else if (flagSplit.length == 2) {
+            args.insertArg(flagSplit[1]);
         }
+        element.parse(source, args, context);
         return true;
     }
 
     private boolean parseShortFlags(CommandSource source, String shortFlags, CommandArgs args, CommandContext context) throws ArgumentParseException {
-        for (int i = 0; i < shortFlags.length(); ++i) {
-            final String flagChar = shortFlags.substring(i, i + 1);
-            CommandElement element = this.shortFlags.get(flagChar);
+        for (int i = 0; i < shortFlags.length(); i++) {
+            String shortFlag = shortFlags.substring(i, i + 1);
+            CommandElement element = this.shortFlags.get(shortFlag);
             if (element == null) {
                 switch (this.unknownShortFlagBehavior) {
                     case IGNORE:
                         if (i == 0) {
                             return false;
                         }
-                        throw args.createError(t("Unknown short flag %s specified", flagChar));
+                        throw args.createError(t("Unknown short flag %s specified", shortFlag));
                     case ERROR:
-                        throw args.createError(t("Unknown short flag %s specified", flagChar));
+                        throw args.createError(t("Unknown short flag %s specified", shortFlag));
                     case ACCEPT_NONVALUE:
-                        context.putArg(flagChar, true);
+                        context.putArg(shortFlag, true);
                         break;
                     case ACCEPT_VALUE:
-                        string(Text.of(flagChar)).parse(source, args, context);
+                        string(Text.of(shortFlag)).parse(source, args, context);
                         break;
                     default:
                         throw new Error("New UnknownFlagBehavior added without corresponding case clauses");
@@ -211,120 +185,83 @@ public final class CommandFlags extends CommandElement {
 
     @Override
     public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
-        Object startIdx = args.getState();
-        Optional<String> arg;
+        Object state = args.getState();
         while (args.hasNext()) {
-            arg = args.nextIfPresent();
-            if (arg.get().startsWith("-")) {
-                Object flagStartIdx = args.getState();
-                if (arg.get().startsWith("--")) { // Long flag
-                    String longFlag = arg.get().substring(2);
-                    List<String> ret = tabCompleteLongFlag(longFlag, src, args, context);
-                    if (ret != null) {
-                        return ret;
-                    }
+            String next = args.nextIfPresent().get();
+            if (next.startsWith("-")) {
+                Object start = args.getState();
+                List<String> ret;
+                if (next.startsWith("--")) {
+                    ret = tabCompleteLongFlag(next.substring(2), src, args, context);
                 } else {
-                    final String argStr = arg.get().substring(1);
-                    List<String> ret = tabCompleteShortFlags(argStr, src, args, context);
-                    if (ret != null) {
-                        return ret;
-                    }
+                    ret = tabCompleteShortFlags(next.substring(1), src, args, context);
                 }
-                args.removeArgs(flagStartIdx, args.getState());
+                if (ret != null) {
+                    return ret;
+                }
+                args.removeArgs(start, args.getState());
             } else if (this.anchorFlags) {
                 break;
             }
         }
-
-        args.setState(startIdx);
-        if (this.childElement == null) {
-            return Collections.emptyList();
-        }
-        return this.childElement.complete(src, args, context);
+        args.setState(state);
+        return this.childElement != null ? childElement.complete(src, args, context) : ImmutableList.of();
     }
 
     @Nullable
     private List<String> tabCompleteLongFlag(String longFlag, CommandSource src, CommandArgs args, CommandContext context) {
-        if (longFlag.contains("=")) {
-            final String[] flagSplit = longFlag.split("=", 2);
-            longFlag = flagSplit[0];
-            String value = flagSplit[1];
-            CommandElement element = this.longFlags.get(longFlag.toLowerCase());
-            if (element == null) { // Whole flag is specified, we'll go to value
-                context.putArg(longFlag, value);
-            } else {
-                args.insertArg(value);
-                final String finalLongFlag = longFlag;
-                Object position = args.getState();
-                try {
-                    element.parse(src, args, context);
-                } catch (ArgumentParseException ex) {
-                    args.setState(position);
-                    return ImmutableList.copyOf(
-                        element.complete(src, args, context).stream().map(input -> "--" + finalLongFlag + "=" + input).collect(Collectors.toList()));
-                }
-            }
-        } else {
-            CommandElement element = this.longFlags.get(longFlag.toLowerCase());
-            if (element == null) {
-                List<String> retStrings = this.longFlags.keySet().stream()
-                    .filter(new StartsWithPredicate(longFlag))
-                    .map(arg -> "--" + arg)
-                    .collect(ImmutableList.toImmutableList());
-                if (retStrings.isEmpty() && this.unknownLongFlagBehavior == UnknownFlagBehavior.ACCEPT_VALUE) { // Then we probably have a
-                    // following arg specified, if there's anything
-                    args.nextIfPresent();
-                    return null;
-                }
-                return retStrings;
-            }
-            boolean complete = false;
-            Object state = args.getState();
-            try {
-                element.parse(src, args, context);
-            } catch (ArgumentParseException ex) {
-                complete = true;
-            }
-            if (!args.hasNext()) {
-                complete = true;
-            }
-            if (complete) {
-                args.setState(state);
-                return element.complete(src, args, context);
-            }
+        String[] flagSplit = longFlag.split("=", 2);
+        CommandElement element = this.longFlags.get(flagSplit[0].toLowerCase());
+        if (element == null) {
+            return this.longFlags.keySet().stream()
+                    .filter(new StartsWithPredicate(flagSplit[0]))
+                    .map(f -> "--" + f)
+                    .collect(Collectors.toList());
+        } else if (flagSplit.length == 2) {
+            args.insertArg(flagSplit[1]);
+        }
+        Object state = args.getState();
+        try {
+            element.parse(src, args, context);
+        } catch (ArgumentParseException ex) {
+            args.setState(state);
+            String start = flagSplit.length == 2 ? flagSplit[0] + "=" : args.hasNext() ? "" : flagSplit[0] + " ";
+            return element.complete(src, args, context).stream()
+                    .map(s -> start + s)
+                    .collect(Collectors.toList());
         }
         return null;
     }
 
     @Nullable
     private List<String> tabCompleteShortFlags(String shortFlags, CommandSource src, CommandArgs args, CommandContext context) {
-        for (int i = 0; i < shortFlags.length(); ++i) {
-            final String flagChar = shortFlags.substring(i, i + 1);
-            CommandElement element = this.shortFlags.get(flagChar);
+        for (int i = 0; i < shortFlags.length(); i++) {
+            CommandElement element = this.shortFlags.get(shortFlags.substring(i, i+ 1));
             if (element == null) {
                 if (i == 0 && this.unknownShortFlagBehavior == UnknownFlagBehavior.ACCEPT_VALUE) {
                     args.nextIfPresent();
                     return null;
                 }
-
-                continue;
-            }
-            Object start = args.getState();
-            try {
-                element.parse(src, args, context);
-            } catch (ArgumentParseException ex) {
-                args.setState(start);
-                return element.complete(src, args, context);
+            } else {
+                Object start = args.getState();
+                try {
+                    element.parse(src, args, context);
+                } catch (ArgumentParseException ex) {
+                    args.setState(start);
+                    return element.complete(src, args, context);
+                }
             }
         }
         return null;
     }
 
     public enum UnknownFlagBehavior {
+
         /**
          * Throw an {@link ArgumentParseException} when an unknown flag is encountered.
          */
         ERROR,
+
         /**
          * Mark the flag as a non-value flag.
          */
@@ -334,6 +271,7 @@ public final class CommandFlags extends CommandElement {
          * Mark the flag as a string-valued flag.
          */
         ACCEPT_VALUE,
+
         /**
          * Act as if the unknown flag is an ordinary argument.
          */
@@ -351,13 +289,7 @@ public final class CommandFlags extends CommandElement {
 
         Builder() {}
 
-        private static final Function<String, CommandElement> MARK_TRUE_FUNC = new Function<String, CommandElement>() {
-            @Nullable
-            @Override
-            public CommandElement apply(@Nullable String input) {
-                return markTrue(input);
-            }
-        };
+        private static final Function<String, CommandElement> MARK_TRUE_FUNC = input -> markTrue(Text.of(input));
 
         private Builder flag(Function<String, CommandElement> func, String... specs) {
             final List<String> availableFlags = new ArrayList<>(specs.length);
@@ -416,13 +348,7 @@ public final class CommandFlags extends CommandElement {
          * @return this
          */
         public Builder permissionFlag(final String flagPermission, String... specs) {
-            return flag(new Function<String, CommandElement>() {
-                @Nullable
-                @Override
-                public CommandElement apply(@Nullable String input) {
-                    return requiringPermission(markTrue(input), flagPermission);
-                }
-            }, specs);
+            return flag(input -> requiringPermission(markTrue(Text.of(input)), flagPermission), specs);
         }
 
         /**

--- a/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
@@ -97,17 +97,17 @@ public final class CommandFlags extends CommandElement {
     }
 
     private boolean parseLongFlag(CommandSource source, String longFlag, CommandArgs args, CommandContext context) throws ArgumentParseException {
-        final String[] flagSplit = longFlag.split("=", 2);
+        String[] flagSplit = longFlag.split("=", 2);
         CommandElement element = this.longFlags.get(flagSplit[0].toLowerCase());
         if (element == null) {
             switch (this.unknownLongFlagBehavior) {
                 case ERROR:
                     throw args.createError(t("Unknown long flag %s specified", flagSplit[0]));
                 case ACCEPT_NONVALUE:
-                    context.putArg(longFlag, flagSplit.length == 2 ? flagSplit[1] : true);
+                    context.putArg(flagSplit[0], flagSplit.length == 2 ? flagSplit[1] : true);
                     return true;
                 case ACCEPT_VALUE:
-                    context.putArg(longFlag, flagSplit.length == 2 ? flagSplit[1] : args.next());
+                    context.putArg(flagSplit[0], flagSplit.length == 2 ? flagSplit[1] : args.next());
                     return true;
                 case IGNORE:
                     return false;

--- a/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
@@ -26,7 +26,6 @@ package org.spongepowered.api.command.args;
 
 import static org.spongepowered.api.command.args.GenericArguments.markTrue;
 import static org.spongepowered.api.command.args.GenericArguments.requiringPermission;
-import static org.spongepowered.api.command.args.GenericArguments.string;
 import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
 
 import com.google.common.collect.ImmutableList;
@@ -39,7 +38,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 

--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -332,20 +332,18 @@ public final class GenericArguments {
                 Object start = args.getState();
                 try {
                     element.parse(src, args, context);
-                    if (start.equals(args.getState())) {
-                        completions.addAll(element.complete(src, args, context));
-                    } else if (!completions.isEmpty()) {
-                        completions.clear();
+                    if (args.hasNext()) {
+                        if (start.equals(args.getState())) {
+                            completions.addAll(element.complete(src, args, context));
+                        } else if (!completions.isEmpty()) {
+                            completions.clear();
+                        }
+                        continue;
                     }
-                    if (!args.hasNext()) {
-                        args.setState(start);
-                        completions.addAll(element.complete(src, args, context));
-                        break;
-                    }
-                } catch (ArgumentParseException ignored) {
-                    args.setState(start);
-                    return element.complete(src, args, context);
-                }
+                } catch (ArgumentParseException ignored) {}
+                args.setState(start);
+                completions.addAll(element.complete(src, args, context));
+                break;
             }
             return Lists.newArrayList(completions);
         }

--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -329,21 +329,20 @@ public final class GenericArguments {
         public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
             Set<String> completions = Sets.newHashSet();
             for (CommandElement element : elements) {
-                Object start = args.getState();
+                Object state = args.getState();
                 try {
                     element.parse(src, args, context);
-                    if (args.hasNext()) {
-                        if (start.equals(args.getState())) {
-                            completions.addAll(element.complete(src, args, context));
-                        } else if (!completions.isEmpty()) {
-                            completions.clear();
-                        }
-                        continue;
+                    if (args.getState().equals(state) || !args.hasNext()) {
+                        completions.addAll(element.complete(src, args, context));
+                        args.setState(state);
+                    } else {
+                        completions.clear();
                     }
-                } catch (ArgumentParseException ignored) {}
-                args.setState(start);
-                completions.addAll(element.complete(src, args, context));
-                break;
+                } catch (ArgumentParseException e) {
+                    args.setState(state);
+                    completions.addAll(element.complete(src, args, context));
+                    break;
+                }
             }
             return Lists.newArrayList(completions);
         }

--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -332,19 +332,24 @@ public final class GenericArguments {
                 Object state = args.getState();
                 try {
                     element.parse(src, args, context);
-                    if (args.hasNext()) {
-                        if (args.getState().equals(state)) {
-                            completions.addAll(element.complete(src, args, context));
-                            args.setState(state);
-                        } else {
-                            completions.clear();
+                    if (state.equals(args.getState())) {
+                        completions.addAll(element.complete(src, args, context));
+                        args.setState(state);
+                    } else if (args.hasNext()) {
+                        completions.clear();
+                    } else {
+                        args.setState(state);
+                        completions.addAll(element.complete(src, args, context));
+                        if (!(element instanceof OptionalCommandElement)) {
+                            break;
                         }
-                        continue;
+                        args.setState(state);
                     }
-                } catch (ArgumentParseException ignored) {}
-                args.setState(state);
-                completions.addAll(element.complete(src, args, context));
-                break;
+                } catch (ArgumentParseException ignored) {
+                    args.setState(state);
+                    completions.addAll(element.complete(src, args, context));
+                    break;
+                }
             }
             return Lists.newArrayList(completions);
         }
@@ -624,7 +629,7 @@ public final class GenericArguments {
         private final boolean considerInvalidFormatEmpty;
 
         OptionalCommandElement(CommandElement element, @Nullable Object value, boolean considerInvalidFormatEmpty) {
-            super(null);
+            super(element.getKey());
             this.element = element;
             this.value = value;
             this.considerInvalidFormatEmpty = considerInvalidFormatEmpty;

--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -332,17 +332,19 @@ public final class GenericArguments {
                 Object state = args.getState();
                 try {
                     element.parse(src, args, context);
-                    if (args.getState().equals(state) || !args.hasNext()) {
-                        completions.addAll(element.complete(src, args, context));
-                        args.setState(state);
-                    } else {
-                        completions.clear();
+                    if (args.hasNext()) {
+                        if (args.getState().equals(state)) {
+                            completions.addAll(element.complete(src, args, context));
+                            args.setState(state);
+                        } else {
+                            completions.clear();
+                        }
+                        continue;
                     }
-                } catch (ArgumentParseException e) {
-                    args.setState(state);
-                    completions.addAll(element.complete(src, args, context));
-                    break;
-                }
+                } catch (ArgumentParseException ignored) {}
+                args.setState(state);
+                completions.addAll(element.complete(src, args, context));
+                break;
             }
             return Lists.newArrayList(completions);
         }


### PR DESCRIPTION
This PR fixes a couple issues within `GenericArguments` and `CommandFlags`, particularly with tab completion.

### UserCommandElement

Previously, the `UserCommandElement` would delegate it's `returnSource` value to the `PlayerCommandElement` which checked for players. As a result, if the name of an offline user was entered it tried to return the `CommandSource` instead, which resulted in the `UserCommandElement` never attempting to parse a `User` from the given name.

### SequenceCommandElement

The `SequenceCommandElement` could not handle tab completion well for optional-like elements (`OptionalCommandElement`, `UserCommandElement` returning the source, `FlagsElement`, etc.) because any `ArgumentParseException` thrown was caught and handled by that element. Now, if the state of the args is the same before and after parsing an element, the completions for those will be cached in a `Set` to be returned later. If an element is parsed successfully, this cache is cleared.

### CommandFlags

Much of `CommandFlags` has been cleaned up and simplified, placing a large priority on fixing tab completion. I would also like to look into a `tabCompleteUnusedFlags` option that will tab complete for flags that haven't been used yet, although this will take a bit of work doing.

### Minor Changes

* `MarkTrueCommandElement` now uses a `Text` instead of a `String` key, and has been made `public`
* `OptionalCommandElement#parseValue` had a reversed `args.hasNext()` check
* The `PlayerCommandElement` key is now `@Nullable`
* Updated `CommandFlags.Builder` functions to remove `@Nullable` and use lambdas

### Review & Testing

I have not begun testing these with Sponge yet, but these changes come from those that I have tested within TeslaLibs. I will begin setting up Sponge tests tomorrow, and any help testing would be much appreciated!
