### PR TITLE
[API 8 ?] Added/clarified documentation on arrows - Fix SpectralArrow

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/projectile/arrow/Arrow.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/arrow/Arrow.java
@@ -30,7 +30,10 @@ import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.api.entity.projectile.DamagingProjectile;
 
 /**
- * Represents an Arrow.
+ * Base interface representing an Arrow. You should not launch an Arrow, but instead on of its sub-interface (like {@link TippedArrow}).
+ *
+ * @see TippedArrow
+ * @see SpectralArrow
  */
 public interface Arrow extends DamagingProjectile {
 

--- a/src/main/java/org/spongepowered/api/entity/projectile/arrow/SpectralArrow.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/arrow/SpectralArrow.java
@@ -24,6 +24,11 @@
  */
 package org.spongepowered.api.entity.projectile.arrow;
 
-public interface SpectralArrow {
+import org.spongepowered.api.effect.potion.PotionEffectTypes;
+
+/**
+ * An {@link Arrow} applying the {@link PotionEffectTypes#GLOWING} effect on hit.
+ */
+public interface SpectralArrow extends Arrow {
 
 }

--- a/src/main/java/org/spongepowered/api/entity/projectile/arrow/TippedArrow.java
+++ b/src/main/java/org/spongepowered/api/entity/projectile/arrow/TippedArrow.java
@@ -24,6 +24,13 @@
  */
 package org.spongepowered.api.entity.projectile.arrow;
 
+import org.spongepowered.api.effect.potion.PotionEffectType;
+
+/**
+ * Represents an {@link Arrow} which can have a {@link PotionEffectType} applied.
+ *
+ * @see SpectralArrow
+ */
 public interface TippedArrow extends Arrow {
 
 }


### PR DESCRIPTION
SpongeAPI | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1776)

This PR adds/changes the javadocs of the Arrows projectiles. It also makes the SpectralArrow extend Arrow.
Due to this last point, this may be considered as a breaking change, @Zidane and I would like to know if this can be merged in stable-7 or should be in bleeding.