### PR TITLE
Move recipe registration and all recipes will be catalog types.

### DIFF
--- a/src/main/java/org/spongepowered/api/item/recipe/Recipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/Recipe.java
@@ -24,12 +24,20 @@
  */
 package org.spongepowered.api.item.recipe;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.item.recipe.crafting.CraftingRecipe;
+import org.spongepowered.api.item.recipe.smelting.SmeltingRecipe;
 
 /**
- * A general interface for recipes.
+ * A general interface for recipes. Every direct sub interface
+ * of this class will require it's own registry module. Depending
+ * for what purpose a {@link Recipe} is implemented, different
+ * sub classes will be used.
+ * <p>The currently supported recipe types are
+ * {@link CraftingRecipe} and {@link SmeltingRecipe}.
  */
-public interface Recipe {
+public interface Recipe extends CatalogType {
 
     /**
      * A general result of this recipe. This result may be customized depending

--- a/src/main/java/org/spongepowered/api/item/recipe/RecipeRegistry.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/RecipeRegistry.java
@@ -24,25 +24,35 @@
  */
 package org.spongepowered.api.item.recipe;
 
+import org.spongepowered.api.event.game.GameRegistryEvent.Register;
+import org.spongepowered.api.registry.CatalogRegistryModule;
+
 import java.util.Collection;
 
 /**
  * A RecipeRegistry holds all registered recipes for a given game.
  */
-public interface RecipeRegistry<T extends Recipe> {
+public interface RecipeRegistry<T extends Recipe> extends CatalogRegistryModule<T> {
 
     /**
      * Registers the given {@link Recipe} to make it available to craft.
      *
      * @param recipe The {@link Recipe} to register
+     * @deprecated All recipes should be registered in
+     *     their proper {@link Register} event
      */
+    @Deprecated
     void register(T recipe);
 
     /**
      * Retrieves all recipes registered in this registry.
      *
      * @return An unmodifiable collection of registered recipes
+     * @deprecated Use {@link #getAll()} instead
      */
-    Collection<T> getRecipes();
+    @Deprecated
+    default Collection<T> getRecipes() {
+        return getAll();
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/CraftingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/CraftingRecipe.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.item.recipe.crafting;
 
-import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
@@ -51,7 +50,7 @@ import java.util.Optional;
  * eventually return a boolean given an crafting grid.</p>
  */
 @CatalogedBy(CraftingRecipes.class)
-public interface CraftingRecipe extends Recipe, CatalogType {
+public interface CraftingRecipe extends Recipe {
 
     /**
      * Checks if the given {@link CraftingGridInventory} fits the required

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapedCraftingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapedCraftingRecipe.java
@@ -240,10 +240,35 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
             /**
              * Sets the group of the recipe.
              *
-             * @param name the group
+             * @param name The group
              * @return This builder, for chaining
              */
             EndStep group(@Nullable String name);
+
+            /**
+             * Sets the id of the recipe (without the namespace).
+             *
+             * @param id The id
+             * @return This builder, for chaining
+             */
+            EndStep id(String id);
+
+            /**
+             * Sets the name of the recipe.
+             *
+             * @param name The name
+             * @return This builder, for chaining
+             */
+            EndStep name(String name);
+
+            /**
+             * Builds a {@link ShapedCraftingRecipe} from this builder.
+             *
+             * @return A new {@link ShapedCraftingRecipe}
+             * @throws IllegalStateException If not all required options
+             *     were specified
+             */
+            ShapedCraftingRecipe build();
 
             /**
              * Builds a {@link ShapedCraftingRecipe} from this builder.
@@ -253,7 +278,10 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
              * @return A new {@link ShapedCraftingRecipe}
              * @throws IllegalStateException If not all required options
              *     were specified
+             * @deprecated Use the method {@link #build()}
+             *     in combination with {@link #id(String)}.
              */
+            @Deprecated
             ShapedCraftingRecipe build(String id, Object plugin);
         }
     }

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapelessCraftingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapelessCraftingRecipe.java
@@ -107,10 +107,35 @@ public interface ShapelessCraftingRecipe extends CraftingRecipe {
             /**
              * Sets the group of the recipe.
              *
-             * @param name the group
+             * @param name The group
              * @return This builder, for chaining
              */
             EndStep group(@Nullable String name);
+
+            /**
+             * Sets the id of the recipe (without the namespace).
+             *
+             * @param id The id
+             * @return This builder, for chaining
+             */
+            EndStep id(String id);
+
+            /**
+             * Sets the name of the recipe.
+             *
+             * @param name The name
+             * @return This builder, for chaining
+             */
+            EndStep name(String name);
+
+            /**
+             * Builds a {@link ShapelessCraftingRecipe} from this builder.
+             *
+             * @return A new {@link ShapelessCraftingRecipe}
+             * @throws IllegalStateException If not all required options
+             *     were specified
+             */
+            ShapelessCraftingRecipe build();
 
             /**
              * Builds a new {@link ShapelessCraftingRecipe} from this builder.
@@ -120,7 +145,10 @@ public interface ShapelessCraftingRecipe extends CraftingRecipe {
              * @return A new {@link ShapelessCraftingRecipe}
              * @throws IllegalStateException If not all required options
              *     were specified
+             * @deprecated Use the method {@link #build()}
+             *     in combination with {@link #id(String)}.
              */
+            @Deprecated
             ShapelessCraftingRecipe build(String id, Object plugin);
         }
 

--- a/src/main/java/org/spongepowered/api/item/recipe/smelting/SmeltingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/smelting/SmeltingRecipe.java
@@ -29,6 +29,7 @@ import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.Recipe;
+import org.spongepowered.api.item.recipe.crafting.ShapedCraftingRecipe;
 import org.spongepowered.api.util.ResettableBuilder;
 
 import java.util.Optional;
@@ -174,6 +175,22 @@ public interface SmeltingRecipe extends Recipe {
              * @return This builder, for chaining
              */
             EndStep experience(double experience);
+
+            /**
+             * Sets the id of the recipe (without the namespace).
+             *
+             * @param id The id
+             * @return This builder, for chaining
+             */
+            EndStep id(String id);
+
+            /**
+             * Sets the name of the recipe.
+             *
+             * @param name The name
+             * @return This builder, for chaining
+             */
+            EndStep name(String name);
 
             /**
              * Builds the recipe and returns it.


### PR DESCRIPTION
* Moves the `SmeltingRecipe` and `CraftingRecipe` registration to the `GameRegistryEvent.Register` event.
* `CraftingRecipe`s must be reloadable, because they are loaded from json files in resource (data) packs.
* Turn `SmeltingRecipe` (`Recipe`) into a `CatalogType`, it's only a matter of time before smelting recipes are also loaded from json files, better prepare for this. This also makes it consistent with the crafting recipes which are already `CatalogType`s.
