### PR TITLE
Deprecate EventContextKeys#THROWER for removal in API 8

### DIFF
--- a/src/main/java/org/spongepowered/api/event/cause/EventContextKeys.java
+++ b/src/main/java/org/spongepowered/api/event/cause/EventContextKeys.java
@@ -99,6 +99,11 @@ public final class EventContextKeys {
 
     public static final EventContextKey<TeleportType> TELEPORT_TYPE = createFor("TELEPORT_TYPE");
 
+    /**
+     * @deprecated this key is a duplicate of {@link #PROJECTILE_SOURCE} and will be removed in API 8.
+     * See <a href="https://github.com/SpongePowered/SpongeAPI/issues/1774">this issue on SpongeAPI</a>, Use {@link #PROJECTILE_SOURCE} instead.
+     */
+    @Deprecated
     public static final EventContextKey<ProjectileSource> THROWER = createFor("THROWER");
 
     public static final EventContextKey<ItemStackSnapshot> USED_ITEM = createFor("USED_ITEM");


### PR DESCRIPTION
As the title says, `EventContextKeys#THROWER` will disappear in API 8.
See #1774 
An update will be made in #1766 to remove it for API 8.