### PR TITLE
add original and final slot info to ChangeInventoryEvent.Held

### DIFF
--- a/src/main/java/org/spongepowered/api/event/item/inventory/ChangeInventoryEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/ChangeInventoryEvent.java
@@ -33,6 +33,7 @@ import org.spongepowered.api.event.entity.item.TargetItemEvent;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.item.inventory.Slot;
 import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
 
 import java.util.List;
@@ -49,10 +50,25 @@ public interface ChangeInventoryEvent extends TargetInventoryEvent, AffectSlotEv
     }
 
     /**
-     * Fired when a {@link Living} changes it's held {@link ItemStack}.
+     * Fired when a {@link Living} changes it's held {@link Slot}.
+     *
+     * <p>This can happen by either scrolling or pressing the number key for the slot.</p>
      */
     interface Held extends ChangeInventoryEvent {
 
+        /**
+         * The previously selected slot.
+         *
+         * @return The previously selected slot.
+         */
+        Slot getOriginalSlot();
+
+        /**
+         * The new selected slot.
+         *
+         * @return The new selected slot.
+         */
+        Slot getFinalSlot();
     }
 
     /**


### PR DESCRIPTION
[**SpongeAPI**](https://github.com/SpongePowered/SpongeAPI/pull/1805) | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1870)

Although the event already contains SlotTransactions with the affected slots it is not clear which one was the previous Slot / new Slot.

https://github.com/SpongePowered/SpongeAPI/issues/1334
https://github.com/SpongePowered/SpongeCommon/issues/926