### PR TITLE
Allow Entity deaths to be Cancellable

### DIFF
--- a/src/main/java/org/spongepowered/api/event/entity/DestructEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/DestructEntityEvent.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.event.entity;
 
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.Living;
+import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.entity.living.TargetLivingEvent;
 import org.spongepowered.api.event.message.MessageChannelEvent;
 import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
@@ -42,7 +43,7 @@ public interface DestructEntityEvent extends TargetEntityEvent, MessageChannelEv
      * A derivative of {@link DestructEntityEvent} where the removal of the {@link Living}, the {@link TargetLivingEvent#getTargetEntity()},
      * is due to it losing its health.
      */
-    interface Death extends DestructEntityEvent, TargetLivingEvent {
+    interface Death extends DestructEntityEvent, TargetLivingEvent, Cancellable {
 
         /**
          * Applies the {@link DefaultGameRules#KEEP_INVENTORY} gamerule to this entity alone.

--- a/src/main/java/org/spongepowered/api/event/entity/DestructEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/DestructEntityEvent.java
@@ -34,19 +34,29 @@ import org.spongepowered.api.world.gamerule.DefaultGameRules;
 
 /**
  * An event where the {@link Entity} is being either removed usually due to
- * the {@link Entity} being marked as "dead". Happens before {@link HarvestEntityEvent}.
+ * the {@link Entity} being marked as "dead". Happens before
+ * {@link HarvestEntityEvent}.
  */
 @GenerateFactoryMethod
 public interface DestructEntityEvent extends TargetEntityEvent, MessageChannelEvent {
 
     /**
-     * A derivative of {@link DestructEntityEvent} where the removal of the {@link Living}, the {@link TargetLivingEvent#getTargetEntity()},
+     * A derivative of {@link DestructEntityEvent} where the removal of the
+     * {@link Living}, the {@link TargetLivingEvent#getTargetEntity()},
      * is due to it losing its health.
+     *
+     * <p>Note that cancelling this event will have the implication that the
+     * entity will have restored health and not enter a "death" state to
+     * play a dying animation, drop items, and drop experience. It is highly
+     * encouraged to keep the cancellation of this event at a mimium as in modded
+     * environments, cancelling this event may have other implications that mods
+     * may not consider and cause bugs.</p>
      */
     interface Death extends DestructEntityEvent, TargetLivingEvent, Cancellable {
 
         /**
-         * Applies the {@link DefaultGameRules#KEEP_INVENTORY} gamerule to this entity alone.
+         * Applies the {@link DefaultGameRules#KEEP_INVENTORY} gamerule to this
+         * entity alone.
          *
          * <p>This only works for players</p>
          *
@@ -57,7 +67,8 @@ public interface DestructEntityEvent extends TargetEntityEvent, MessageChannelEv
         /**
          * Returns whether the inventory is kept after death.
          *
-         * <p>By default this is the same as the {@link DefaultGameRules#KEEP_INVENTORY} gamerule</p>
+         * <p>By default this is the same as the
+         * {@link DefaultGameRules#KEEP_INVENTORY} gamerule.</p>
          *
          * @return Whether the inventory is kept after death.
          */

--- a/src/main/java/org/spongepowered/api/event/entity/SpawnEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/SpawnEntityEvent.java
@@ -28,8 +28,10 @@ import org.spongepowered.api.block.tileentity.MobSpawner;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.entity.spawn.SpawnTypes;
+import org.spongepowered.api.event.impl.AbstractSpawnEntityEvent;
 import org.spongepowered.api.event.network.ClientConnectionEvent;
 import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
+import org.spongepowered.api.util.annotation.eventgen.ImplementedBy;
 
 /**
  * Raised when an {@link Entity} is spawned. This usually follows the chain of
@@ -44,6 +46,7 @@ import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
  * recommended event to interact with connecting players.</p>
  */
 @GenerateFactoryMethod
+@ImplementedBy(AbstractSpawnEntityEvent.class)
 public interface SpawnEntityEvent extends AffectEntityEvent {
 
     interface ChunkLoad extends SpawnEntityEvent {}

--- a/src/main/java/org/spongepowered/api/event/impl/AbstractSpawnEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/AbstractSpawnEntityEvent.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.impl;
+
+import com.google.common.base.Preconditions;
+import org.spongepowered.api.event.cause.EventContextKeys;
+import org.spongepowered.api.event.entity.SpawnEntityEvent;
+
+public abstract class AbstractSpawnEntityEvent extends AbstractEvent implements SpawnEntityEvent {
+
+    @Override
+    protected void init() {
+        Preconditions.checkState(getContext().containsKey(EventContextKeys.SPAWN_TYPE), "SpawnType not set for SpawnEvent as required per contract!");
+    }
+}


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1882) | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/2110)
This is mostly to bring in compatibility of entity deaths to match Forge's requirements, while this is somewhat of an implementation leak that it's "possible", it's just not recommended as the health status of the entity could have adverse effects.