### PR TITLE
Update ChangeEntityExperienceEvent for implementation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 // Gradle plugins
 buildscript {
     repositories {
+        mavenLocal()
+        maven { url = 'https://repo.spongepowered.org/maven' }
         maven {
             name = 'gradle-plugins'
             url = 'https://plugins.gradle.org/m2'
@@ -11,7 +13,7 @@ buildscript {
         classpath 'gradle.plugin.net.minecrell:licenser:0.3'
         classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
         classpath 'gradle.plugin.org.spongepowered:spongegradle:0.8.1'
-        classpath 'gradle.plugin.org.spongepowered:event-impl-gen:5.0.2'
+        classpath 'org.spongepowered:event-impl-gen:5.4.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 // Gradle plugins
 buildscript {
     repositories {
-        mavenLocal()
         maven { url = 'https://repo.spongepowered.org/maven' }
         maven {
             name = 'gradle-plugins'

--- a/src/main/java/org/spongepowered/api/event/entity/ChangeEntityExperienceEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/ChangeEntityExperienceEvent.java
@@ -24,33 +24,70 @@
  */
 package org.spongepowered.api.event.entity;
 
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableExperienceHolderData;
+import org.spongepowered.api.data.manipulator.mutable.entity.ExperienceHolderData;
+import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.util.annotation.eventgen.AbsoluteSortPosition;
+import org.spongepowered.api.util.annotation.eventgen.PropertySettings;
 
 /**
  * An event that is related to experience.
  */
 public interface ChangeEntityExperienceEvent extends TargetEntityEvent, Cancellable {
 
+    @Override
+    Player getTargetEntity();
+
     /**
      * Gets the original experience unmodified by event changes.
      *
      * @return The experience
      */
-    int getOriginalExperience();
+    @PropertySettings(generateMethods = false, requiredParameter = false)
+    @Deprecated
+    default int getOriginalExperience() {
+        return getOriginalData().totalExperience().get();
+    }
 
     /**
-     * Gets the experience after an event has been processed.
+     * Gets the original values for the experience unmodified by event changes.
+     *
+     * @return The experience data
+     */
+    @AbsoluteSortPosition(1)
+    ImmutableExperienceHolderData getOriginalData();
+
+    /**
+     * Gets the original experience unmodified by event changes.
+     *
+     * @return The experience
+     */
+    @PropertySettings(generateMethods = false, requiredParameter = false)
+    @Deprecated
+    default int getExperience() {
+        return getFinalData().totalExperience().get();
+    }
+
+    /**
+     * Gets the original experience unmodified by event changes.
+     *
+     * @return The experience
+     */
+    @PropertySettings(generateMethods = false, requiredParameter = false)
+    @Deprecated
+    default void setExperience(int experience) {
+        getFinalData().set(Keys.TOTAL_EXPERIENCE, experience);
+    }
+
+    /**
+     * Gets the experience after an event has been processed. Modify this
+     * data manipulator to change the final experience.
      *
      * @return The experience to receive
      */
-    int getExperience();
-
-    /**
-     * Sets the amount of experience after an event has been processed.
-     * Negative values will remove experience.
-     *
-     * @param exp The experience to give or take
-     */
-    void setExperience(int exp);
+    @AbsoluteSortPosition(2)
+    ExperienceHolderData getFinalData();
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/ChangeEntityExperienceEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/ChangeEntityExperienceEvent.java
@@ -27,23 +27,22 @@ package org.spongepowered.api.event.entity;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableExperienceHolderData;
 import org.spongepowered.api.data.manipulator.mutable.entity.ExperienceHolderData;
-import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.entity.living.humanoid.player.TargetPlayerEvent;
 import org.spongepowered.api.util.annotation.eventgen.AbsoluteSortPosition;
 import org.spongepowered.api.util.annotation.eventgen.PropertySettings;
 
 /**
  * An event that is related to experience.
  */
-public interface ChangeEntityExperienceEvent extends TargetEntityEvent, Cancellable {
-
-    @Override
-    Player getTargetEntity();
+public interface ChangeEntityExperienceEvent extends TargetPlayerEvent, Cancellable {
 
     /**
-     * Gets the original experience unmodified by event changes.
+     * Gets the original total experience unmodified by event changes.
      *
      * @return The experience
+     * @deprecated Use {@link #getOriginalData()} instead, which provides more
+     * information about the experience.
      */
     @PropertySettings(generateMethods = false, requiredParameter = false)
     @Deprecated
@@ -60,9 +59,11 @@ public interface ChangeEntityExperienceEvent extends TargetEntityEvent, Cancella
     ImmutableExperienceHolderData getOriginalData();
 
     /**
-     * Gets the original experience unmodified by event changes.
+     * Gets the total experience after event changes.
      *
      * @return The experience
+     * @deprecated Use {@link #getFinalData()} instead, which provides more
+     * information about the experience.
      */
     @PropertySettings(generateMethods = false, requiredParameter = false)
     @Deprecated
@@ -71,9 +72,11 @@ public interface ChangeEntityExperienceEvent extends TargetEntityEvent, Cancella
     }
 
     /**
-     * Gets the original experience unmodified by event changes.
+     * Sets the final total experience after event changes.
      *
-     * @return The experience
+     * @param experience The experience
+     * @deprecated Modify the value returned by {@link #getFinalData()}
+     * instead, which provides more information about the experience.
      */
     @PropertySettings(generateMethods = false, requiredParameter = false)
     @Deprecated

--- a/src/main/java/org/spongepowered/api/event/entity/living/humanoid/ChangeLevelEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/humanoid/ChangeLevelEvent.java
@@ -25,13 +25,17 @@
 package org.spongepowered.api.event.entity.living.humanoid;
 
 import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.entity.ChangeEntityExperienceEvent;
 import org.spongepowered.api.event.entity.living.humanoid.player.TargetPlayerEvent;
 import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
 
 /**
  * Called when a human's level is changed.
+ *
+ * @deprecated Use {@link ChangeEntityExperienceEvent} instead
  */
 @GenerateFactoryMethod
+@Deprecated
 public interface ChangeLevelEvent extends TargetHumanoidEvent, Cancellable {
 
     /**

--- a/src/main/java/org/spongepowered/api/util/annotation/eventgen/FactoryMethod.java
+++ b/src/main/java/org/spongepowered/api/util/annotation/eventgen/FactoryMethod.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.util.annotation.eventgen;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks the annotated method as a factory method.
+ * A matching method will be generated in the factory class, which forwards
+ * to this method.
+ *
+ * <p>This annotation can be used to make backwards-compatible
+ * changes to an event class. By creating a method matching the old
+ * factory method signature, code expecting the old event signature
+ * will continue to function.</p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface FactoryMethod {
+}


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1893)

This rewrites `ChangeEntityExperienceEvent` to use data to convey both total experience and levels, and deprecates the old integer-based methods and the `ChangeLevelEvent` interface.