### PR TITLE
Update SpongeAPI for ChangeEntityEquipmentEvents

### DIFF
--- a/src/main/java/org/spongepowered/api/event/entity/ChangeEntityEquipmentEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/ChangeEntityEquipmentEvent.java
@@ -33,12 +33,14 @@ import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.entity.living.TargetLivingEvent;
 import org.spongepowered.api.event.entity.living.humanoid.TargetHumanoidEvent;
 import org.spongepowered.api.event.entity.living.humanoid.player.TargetPlayerEvent;
+import org.spongepowered.api.event.impl.AbstractChangeEntityEquipmentEvent;
 import org.spongepowered.api.event.item.inventory.TargetInventoryEvent;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.Slot;
-import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
+import org.spongepowered.api.util.annotation.eventgen.ImplementedBy;
+import org.spongepowered.api.util.annotation.eventgen.PropertySettings;
 
 import java.util.Optional;
 
@@ -46,13 +48,10 @@ import java.util.Optional;
  * Called when an entity changes an equipped item. This can occur whenever
  * a {@link Slot} belonging to an {@link Inventory} of an {@link Entity}
  * is filled with an {@link ItemStack}, emptied of an {@link ItemStack},
- * or swapped with an {@link ItemStack}. The requirement of course is
- * that if the {@link #getOriginalItemStack()} is {@link Optional#empty()}, then
- * the {@link #getItemStack()} must be present, and vice versa. In the event
- * that a change to the suggested {@link ItemStack}, the use of the
- * {@link Transaction} is recommended.
+ * or swapped with an {@link ItemStack}. In the event that a change to the
+ * {@link ItemStack}, the use of the {@link Transaction} is recommended.
  */
-@GenerateFactoryMethod
+@ImplementedBy(AbstractChangeEntityEquipmentEvent.class)
 public interface ChangeEntityEquipmentEvent extends TargetEntityEvent, TargetInventoryEvent, Cancellable {
 
     /**
@@ -62,7 +61,10 @@ public interface ChangeEntityEquipmentEvent extends TargetEntityEvent, TargetInv
      * <p>The previously equipped item may have been empty.</p>
      *
      * @return The original itemstack, if available
+     * @deprecated Use {@link #getTransaction()} instead
      */
+    @Deprecated
+    @PropertySettings(requiredParameter = false, generateMethods = false)
     Optional<ItemStackSnapshot> getOriginalItemStack();
 
     /**
@@ -72,8 +74,22 @@ public interface ChangeEntityEquipmentEvent extends TargetEntityEvent, TargetInv
      * <p>The itemstack may not exist or the slot is being emptied.</p>
      *
      * @return The new item stack, if available
+     * @deprecated Use {@link #getTransaction()} instead
      */
+    @Deprecated
+    @PropertySettings(requiredParameter = false, generateMethods = false)
     Optional<Transaction<ItemStackSnapshot>> getItemStack();
+
+    /**
+     * Gets the {@link Transaction} of {@link ItemStackSnapshot}s for this event.
+     *
+     * @return The transaction of the item
+     */
+    default Transaction<ItemStackSnapshot> getTransaction() {
+        @SuppressWarnings("deprecation")
+        Optional<Transaction<ItemStackSnapshot>> optional = this.getItemStack();
+        return optional.orElseThrow(() -> new IllegalStateException("No transaction available!"));
+    }
 
     @Override
     Slot getTargetInventory();

--- a/src/main/java/org/spongepowered/api/event/entity/ChangeEntityEquipmentEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/ChangeEntityEquipmentEvent.java
@@ -85,6 +85,7 @@ public interface ChangeEntityEquipmentEvent extends TargetEntityEvent, TargetInv
      *
      * @return The transaction of the item
      */
+    @PropertySettings(generateMethods = false)
     default Transaction<ItemStackSnapshot> getTransaction() {
         @SuppressWarnings("deprecation")
         Optional<Transaction<ItemStackSnapshot>> optional = this.getItemStack();

--- a/src/main/java/org/spongepowered/api/event/impl/AbstractChangeEntityEquipmentEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/AbstractChangeEntityEquipmentEvent.java
@@ -48,4 +48,9 @@ public abstract class AbstractChangeEntityEquipmentEvent extends AbstractEvent i
     public Optional<Transaction<ItemStackSnapshot>> getItemStack() {
         return Optional.of(this.getTransaction());
     }
+
+    @Override
+    public Transaction<ItemStackSnapshot> getTransaction() {
+        return this.transaction;
+    }
 }

--- a/src/main/java/org/spongepowered/api/event/impl/AbstractChangeEntityEquipmentEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/AbstractChangeEntityEquipmentEvent.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.impl;
+
+import org.spongepowered.api.data.Transaction;
+import org.spongepowered.api.event.entity.ChangeEntityEquipmentEvent;
+import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.util.annotation.eventgen.UseField;
+
+import java.util.Optional;
+
+/**
+ * @author ustc_zzzz
+ */
+public abstract class AbstractChangeEntityEquipmentEvent extends AbstractEvent implements ChangeEntityEquipmentEvent {
+    @UseField protected Transaction<ItemStackSnapshot> transaction;
+
+    @Override
+    @Deprecated
+    public Optional<ItemStackSnapshot> getOriginalItemStack() {
+        return Optional.ofNullable(this.getTransaction().getOriginal());
+    }
+
+    @Override
+    @Deprecated
+    public Optional<Transaction<ItemStackSnapshot>> getItemStack() {
+        return Optional.of(this.getTransaction());
+    }
+}

--- a/src/main/java/org/spongepowered/api/event/impl/AbstractChangeEntityEquipmentEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/AbstractChangeEntityEquipmentEvent.java
@@ -31,9 +31,6 @@ import org.spongepowered.api.util.annotation.eventgen.UseField;
 
 import java.util.Optional;
 
-/**
- * @author ustc_zzzz
- */
 public abstract class AbstractChangeEntityEquipmentEvent extends AbstractEvent implements ChangeEntityEquipmentEvent {
     @UseField protected Transaction<ItemStackSnapshot> transaction;
 


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](//github.com/SpongePowered/SpongeCommon/pull/1895)

* `getOriginalItemStack` and `getItemStack` are marked as deprecated.
* a new method named `getTransaction` is added.