### PR TITLE
Add missing damage sources

### DIFF
--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSources.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSources.java
@@ -68,12 +68,6 @@ public final class DamageSources {
 
     public static final DamageSource VOID = DummyObjectProvider.createFor(DamageSource.class, "VOID");
 
-    /**
-     * Generally used to describe the damage taken when colliding into a wall
-     * while flying with an elytra.
-     */
-    public static final DamageSource WALL_COLLISION = DummyObjectProvider.createFor(DamageSource.class, "WALL_COLLISION");
-
     public static final DamageSource WITHER = DummyObjectProvider.createFor(DamageSource.class, "WITHER");
 
     // SORTFIELDS:OFF

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSources.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSources.java
@@ -45,6 +45,8 @@ public final class DamageSources {
 
     // SORTFIELDS:ON
 
+    public static final DamageSource DRAGON_BREATH = DummyObjectProvider.createFor(DamageSource.class, "DRAGON_BREATH");
+
     public static final DamageSource DROWNING = DummyObjectProvider.createFor(DamageSource.class, "DROWNING");
 
     public static final DamageSource FALLING = DummyObjectProvider.createFor(DamageSource.class, "FALLING");
@@ -62,6 +64,12 @@ public final class DamageSources {
     public static final DamageSource STARVATION = DummyObjectProvider.createFor(DamageSource.class, "STARVATION");
 
     public static final DamageSource VOID = DummyObjectProvider.createFor(DamageSource.class, "VOID");
+
+    /**
+     * Generally used to describe the damage taken when colliding into a wall
+     * while flying with an elytra.
+     */
+    public static final DamageSource WALL_COLLISION = DummyObjectProvider.createFor(DamageSource.class, "WALL_COLLISION");
 
     public static final DamageSource WITHER = DummyObjectProvider.createFor(DamageSource.class, "WITHER");
 

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSources.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSources.java
@@ -45,6 +45,9 @@ public final class DamageSources {
 
     // SORTFIELDS:ON
 
+    /**
+     * Generally used to describe the damage taken when by the dragon breath attack.
+     */
     public static final DamageSource DRAGON_BREATH = DummyObjectProvider.createFor(DamageSource.class, "DRAGON_BREATH");
 
     public static final DamageSource DROWNING = DummyObjectProvider.createFor(DamageSource.class, "DROWNING");


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1914)

This along with the implementation PR should fix https://github.com/SpongePowered/SpongeAPI/issues/1496 and https://github.com/SpongePowered/SpongeAPI/issues/1287

Fireworks is handled with an explosion type and as an `EntityDamageSource` while magma is handled as a `BlockDamageSource`.