### PR TITLE
Change SkinData to use a custom ProfileProperty

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -72,6 +72,7 @@ import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.merchant.TradeOffer;
 import org.spongepowered.api.profile.GameProfile;
+import org.spongepowered.api.profile.property.ProfileProperty;
 import org.spongepowered.api.statistic.Statistic;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.Axis;
@@ -1823,9 +1824,9 @@ public final class Keys {
      * having that skin. The binary skin data is signed by Mojang so fully
      * customized skins are not possible.</p>
      *
-     * @see SkinData#skinUniqueId()
+     * @see SkinData#skin()
      */
-    public static final Key<Value<UUID>> SKIN_UNIQUE_ID = DummyObjectProvider.createExtendedFor(Key.class,"SKIN_UNIQUE_ID");
+    public static final Key<Value<ProfileProperty>> SKIN = DummyObjectProvider.createExtendedFor(Key.class,"SKIN_UNIQUE_ID");
 
     /**
      * Represents the {@link Key} for the type of skull a block or item stack

--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -1826,7 +1826,7 @@ public final class Keys {
      *
      * @see SkinData#skin()
      */
-    public static final Key<Value<ProfileProperty>> SKIN = DummyObjectProvider.createExtendedFor(Key.class,"SKIN_UNIQUE_ID");
+    public static final Key<Value<ProfileProperty>> SKIN = DummyObjectProvider.createExtendedFor(Key.class,"SKIN");
 
     /**
      * Represents the {@link Key} for the type of skull a block or item stack

--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -1828,6 +1828,13 @@ public final class Keys {
      */
     public static final Key<Value<ProfileProperty>> SKIN = DummyObjectProvider.createExtendedFor(Key.class,"SKIN");
 
+    /**
+     * Represents the {@link Key} for whether or not changes to {@link Keys#SKIN} should
+     * be reflected in an entitie's {@link GameProfile}.
+     *
+     * @see SkinData#updateGameProfile()
+     *
+     * */
     public static final Key<Value<Boolean>> UPDATE_GAME_PROFILE = DummyObjectProvider.createExtendedFor(Key.class, "UPDATE_GAME_PROFILE");
 
     /**

--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -1828,6 +1828,8 @@ public final class Keys {
      */
     public static final Key<Value<ProfileProperty>> SKIN = DummyObjectProvider.createExtendedFor(Key.class,"SKIN");
 
+    public static final Key<Value<Boolean>> UPDATE_GAME_PROFILE = DummyObjectProvider.createExtendedFor(Key.class, "UPDATE_GAME_PROFILE");
+
     /**
      * Represents the {@link Key} for the type of skull a block or item stack
      * has.

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableSkinData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableSkinData.java
@@ -33,7 +33,7 @@ import org.spongepowered.api.profile.GameProfile;
 import org.spongepowered.api.profile.property.ProfileProperty;
 
 /**
- * Represents the UUID of the skin for a {@link Humanoid}.
+ * Represents the skin data for a {@link Humanoid}.
  *
  * <p>In order to be accepted by the client, all skins must be
  * signed by Mojang.</p>

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableSkinData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableSkinData.java
@@ -24,28 +24,36 @@
  */
 package org.spongepowered.api.data.manipulator.immutable.entity;
 
+import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.entity.SkinData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.entity.living.Humanoid;
-import org.spongepowered.api.entity.living.player.Player;
-
-import java.util.UUID;
+import org.spongepowered.api.profile.GameProfile;
+import org.spongepowered.api.profile.property.ProfileProperty;
 
 /**
- * An {@link ImmutableDataManipulator} handling the {@link UUID} for  the
- * {@link Humanoid} skin used. Usually this is meant where the {@link UUID}
- * belongs to a {@link Player} but without relying on a {@link Player},
- * the {@link Humanoid} will use the same skin url on the server.
+ * Represents the UUID of the skin for a {@link Humanoid}.
+ *
+ * <p>In order to be accepted by the client, all skins must be
+ * signed by Mojang.</p>
+ *
+ * <p>SkinData should be used instead of manipulating a {@link Humanoid}'s
+ * {@link GameProfile}. This ensures that the {@link Humanoid}'s skin is
+ * properly updated on all viewing clients.</p>
  */
 public interface ImmutableSkinData extends ImmutableDataManipulator<ImmutableSkinData, SkinData> {
 
     /**
-     * Gets the {@link ImmutableValue} for the {@link UUID} of the skin to
-     * display on a {@link Humanoid} entity for customization.
+     * Gets the {@link ImmutableValue} for the {@link ProfileProperty} of the skin to display on a
+     * {@link Humanoid} entity for customization.
      *
-     * @return The immutable value for the skin uuid
+     * <p>The name of the {@link ProfileProperty} MUST be {@link ProfileProperty#TEXTURES},
+     * and have a valid signature, in order to be accepted by the client.</p>
+     *
+     * @return The value for the skin uuid
+     * @see Keys#SKIN
      */
-    ImmutableValue<UUID> skinUniqueId();
+    ImmutableValue<ProfileProperty> skin();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableSkinData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableSkinData.java
@@ -28,6 +28,7 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.entity.SkinData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.entity.living.Human;
 import org.spongepowered.api.entity.living.Humanoid;
 import org.spongepowered.api.profile.GameProfile;
 import org.spongepowered.api.profile.property.ProfileProperty;
@@ -55,5 +56,22 @@ public interface ImmutableSkinData extends ImmutableDataManipulator<ImmutableSki
      * @see Keys#SKIN
      */
     ImmutableValue<ProfileProperty> skin();
+
+    /**
+     * Gets the {@link ImmutableValue} for whether or not to update the tab list
+     * with the player's new skin
+     *
+     * <p>If this value is <code>true</code>, then the player's new skin
+     * will display in the tab list.
+     *
+     * If it is <code>false</code>, then the tab list will not be modified.
+     * Assuming that tab list hasn't been changed by a plugin, the
+     * player's original skin will be displayed.</p>
+     *
+     * <p>For {@link Human}s, setting this to <code>false</code> will cause the human
+     * to be completely absent from the tab list.</p>
+     * @return
+     */
+    ImmutableValue<Boolean> updateGameProfile();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableSkinData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableSkinData.java
@@ -51,7 +51,7 @@ public interface ImmutableSkinData extends ImmutableDataManipulator<ImmutableSki
      * <p>The name of the {@link ProfileProperty} MUST be {@link ProfileProperty#TEXTURES},
      * and have a valid signature, in order to be accepted by the client.</p>
      *
-     * @return The value for the skin uuid
+     * @return The value for the skin property
      * @see Keys#SKIN
      */
     ImmutableValue<ProfileProperty> skin();

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableSkinData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableSkinData.java
@@ -62,15 +62,16 @@ public interface ImmutableSkinData extends ImmutableDataManipulator<ImmutableSki
      * with the player's new skin
      *
      * <p>If this value is <code>true</code>, then the player's new skin
-     * will display in the tab list.
+     * will display in the tab list.</p>
      *
-     * If it is <code>false</code>, then the tab list will not be modified.
+     * <p>If it is <code>false</code>, then the tab list will not be modified.
      * Assuming that tab list hasn't been changed by a plugin, the
      * player's original skin will be displayed.</p>
      *
      * <p>For {@link Human}s, setting this to <code>false</code> will cause the human
      * to be completely absent from the tab list.</p>
-     * @return
+     * @return Whether to update the gameprofile
+     * @see Keys#UPDATE_GAME_PROFILE
      */
     ImmutableValue<Boolean> updateGameProfile();
 

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/SkinData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/SkinData.java
@@ -29,24 +29,33 @@ import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSkinData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.living.Humanoid;
+import org.spongepowered.api.profile.GameProfile;
+import org.spongepowered.api.profile.property.ProfileProperty;
 
 import java.util.UUID;
 
 /**
  * Represents the UUID of the skin for a {@link Humanoid}.
  *
- * <p>Unfortunately the actual binary data for the skin is not able to be
- * manipulated because it must be signed on mojang's server.</p>
+ * <p>In order to be accepted by the client, all skins must be
+ * signed by Mojang.</p>
+ *
+ * <p>SkinData should be used instead of manipulating a {@link Humanoid}'s
+ * {@link GameProfile}. This ensures that the {@link Humanoid}'s skin is
+ * properly updated on all viewing clients.</p>
  */
 public interface SkinData extends DataManipulator<SkinData, ImmutableSkinData> {
 
     /**
-     * Gets the {@link Value} for the {@link UUID} of the skin to display on a
+     * Gets the {@link Value} for the {@link ProfileProperty} of the skin to display on a
      * {@link Humanoid} entity for customization.
      *
+     * <p>The name of the {@link ProfileProperty} MUST be {@link ProfileProperty#TEXTURES},
+     * and have a valid signature, in order to be accepted by the client.</p>
+     *
      * @return The value for the skin uuid
-     * @see Keys#SKIN_UNIQUE_ID
+     * @see Keys#SKIN
      */
-    Value<UUID> skinUniqueId();
+    Value<ProfileProperty> skin();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/SkinData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/SkinData.java
@@ -32,8 +32,6 @@ import org.spongepowered.api.entity.living.Humanoid;
 import org.spongepowered.api.profile.GameProfile;
 import org.spongepowered.api.profile.property.ProfileProperty;
 
-import java.util.UUID;
-
 /**
  * Represents the skin data for a {@link Humanoid}.
  *
@@ -53,7 +51,7 @@ public interface SkinData extends DataManipulator<SkinData, ImmutableSkinData> {
      * <p>The name of the {@link ProfileProperty} MUST be {@link ProfileProperty#TEXTURES},
      * and have a valid signature, in order to be accepted by the client.</p>
      *
-     * @return The value for the skin uuid
+     * @return The value for the skin property
      * @see Keys#SKIN
      */
     Value<ProfileProperty> skin();

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/SkinData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/SkinData.java
@@ -35,7 +35,7 @@ import org.spongepowered.api.profile.property.ProfileProperty;
 import java.util.UUID;
 
 /**
- * Represents the UUID of the skin for a {@link Humanoid}.
+ * Represents the skin data for a {@link Humanoid}.
  *
  * <p>In order to be accepted by the client, all skins must be
  * signed by Mojang.</p>

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/SkinData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/SkinData.java
@@ -66,18 +66,19 @@ public interface SkinData extends DataManipulator<SkinData, ImmutableSkinData> {
      * will be automatically displayed in the tab list. Calls to
      * {@link User#getProfile()} will return a {@link GameProfile}
      * with its {@link ProfileProperty#TEXTURES} property
-     * set to the new skin.
+     * set to the new skin.</p>
      *
-     * If it is <code>false</code>, then the tab list will not be modified,
+     * <p>If it is <code>false</code>, then the tab list will not be modified,
      * and {@link User#getProfile()} will return the user's original profile.
-     * However, all players will still see the new skin in-game.
+     * However, all players will still see the new skin in-game.</p>
      *
-     * Assuming that tab list hasn't been changed by a plugin, the
+     * <p>Assuming that tab list hasn't been changed by a plugin, the
      * player's original skin will be displayed.</p>
      *
      * <p>For {@link Human}s, setting this to <code>false</code> will cause the human
      * to be completely absent from the tab list.</p>
-     * @return
+     * @return Whether to update the gameprofile
+     * @see Keys#UPDATE_GAME_PROFILE
      */
     Value<Boolean> updateGameProfile();
 

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/SkinData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/SkinData.java
@@ -28,7 +28,9 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSkinData;
 import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.entity.living.Human;
 import org.spongepowered.api.entity.living.Humanoid;
+import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.profile.GameProfile;
 import org.spongepowered.api.profile.property.ProfileProperty;
 
@@ -55,5 +57,28 @@ public interface SkinData extends DataManipulator<SkinData, ImmutableSkinData> {
      * @see Keys#SKIN
      */
     Value<ProfileProperty> skin();
+
+    /**
+     * Gets the {@Value} for whether or not to update the player's
+     * {@link GameProfile}
+     *
+     * <p>If this value is <code>true</code>, then the player's new skin
+     * will be automatically displayed in the tab list. Calls to
+     * {@link User#getProfile()} will return a {@link GameProfile}
+     * with its {@link ProfileProperty#TEXTURES} property
+     * set to the new skin.
+     *
+     * If it is <code>false</code>, then the tab list will not be modified,
+     * and {@link User#getProfile()} will return the user's original profile.
+     * However, all players will still see the new skin in-game.
+     *
+     * Assuming that tab list hasn't been changed by a plugin, the
+     * player's original skin will be displayed.</p>
+     *
+     * <p>For {@link Human}s, setting this to <code>false</code> will cause the human
+     * to be completely absent from the tab list.</p>
+     * @return
+     */
+    Value<Boolean> updateGameProfile();
 
 }

--- a/src/main/java/org/spongepowered/api/entity/living/player/tab/TabListEntry.java
+++ b/src/main/java/org/spongepowered/api/entity/living/player/tab/TabListEntry.java
@@ -168,6 +168,9 @@ public interface TabListEntry {
         /**
          * Sets the profile for entries created by this builder.
          *
+         * <p>A copy of the passed {@link GameProfile} is used,
+         * so further changes to the original object will have no effect.</p>
+         *
          * @param profile The profile
          * @return The builder
          */

--- a/src/main/java/org/spongepowered/api/profile/property/ProfileProperty.java
+++ b/src/main/java/org/spongepowered/api/profile/property/ProfileProperty.java
@@ -47,7 +47,7 @@ public interface ProfileProperty extends DataSerializable {
     /**
      * The name of the {@code textures} property.
      *
-     * This is used with {@link SkinData} to set the skin of a {@link Humanoid}
+     * <p>This is used with {@link SkinData} to set the skin of a {@link Humanoid}.</p>
      */
     static String TEXTURES = "textures";
 

--- a/src/main/java/org/spongepowered/api/profile/property/ProfileProperty.java
+++ b/src/main/java/org/spongepowered/api/profile/property/ProfileProperty.java
@@ -44,8 +44,9 @@ import javax.annotation.Nullable;
 public interface ProfileProperty {
 
     /**
-     * The name of the special 'textures' property. This is
-     * used with {@link SkinData} to set the skin of a {@link Humanoid}
+     * The name of the {@code textures} property.
+     *
+     * This is used with {@link SkinData} to set the skin of a {@link Humanoid}
      */
     static String TEXTURES = "textures";
 

--- a/src/main/java/org/spongepowered/api/profile/property/ProfileProperty.java
+++ b/src/main/java/org/spongepowered/api/profile/property/ProfileProperty.java
@@ -25,6 +25,8 @@
 package org.spongepowered.api.profile.property;
 
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.manipulator.mutable.entity.SkinData;
+import org.spongepowered.api.entity.living.Humanoid;
 import org.spongepowered.api.profile.GameProfile;
 
 import java.util.Optional;
@@ -40,6 +42,12 @@ import javax.annotation.Nullable;
  * @see #of(String, String, String)
  */
 public interface ProfileProperty {
+
+    /**
+     * The name of the special 'textures' property. This is
+     * used with {@link SkinData} to set the skin of a {@link Humanoid}
+     */
+    static String TEXTURES = "textures";
 
     /**
      * Creates a new property.

--- a/src/main/java/org/spongepowered/api/profile/property/ProfileProperty.java
+++ b/src/main/java/org/spongepowered/api/profile/property/ProfileProperty.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.profile.property;
 
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.manipulator.mutable.entity.SkinData;
 import org.spongepowered.api.entity.living.Humanoid;
 import org.spongepowered.api.profile.GameProfile;
@@ -41,7 +42,7 @@ import javax.annotation.Nullable;
  * @see #of(String, String)
  * @see #of(String, String, String)
  */
-public interface ProfileProperty {
+public interface ProfileProperty extends DataSerializable {
 
     /**
      * The name of the {@code textures} property.

--- a/src/main/java/org/spongepowered/api/util/TypeTokens.java
+++ b/src/main/java/org/spongepowered/api/util/TypeTokens.java
@@ -94,6 +94,7 @@ import org.spongepowered.api.item.enchantment.Enchantment;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.merchant.TradeOffer;
 import org.spongepowered.api.profile.GameProfile;
+import org.spongepowered.api.profile.property.ProfileProperty;
 import org.spongepowered.api.statistic.Statistic;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.rotation.Rotation;
@@ -469,6 +470,10 @@ public final class TypeTokens {
     public static final TypeToken<WireAttachmentType> WIRE_ATTACHMENT_TYPE_TOKEN = new TypeToken<WireAttachmentType>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<Value<WireAttachmentType>> WIRE_ATTACHMENT_TYPE_VALUE_TOKEN = new TypeToken<Value<WireAttachmentType>>() {private static final long serialVersionUID = -1;};
+
+    public static final TypeToken<ProfileProperty> PROFILE_PROPERTY_TOKEN = new TypeToken<ProfileProperty>() {private static final long serialVersionUID = -1;};
+
+    public static final TypeToken<Value<ProfileProperty>> PROFILE_PROPERTY_VALUE_TOKEN = new TypeToken<Value<ProfileProperty>>() {private static final long serialVersionUID = -1;};
 
     // SORTFIELDS:OFF
 


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1926)

It's often useful to be able to set an arbitrary signed
skin payload for a Humanoid:

* Plugins may want to use a skin that is not currently set on any
player
* The Mojang skin API has notoriously strict IP-based rate-limiting.
Servers, especially those that are part of a larger network, may
wish to implement their own caching system.

This commit allows plugins to set use valid skin ProfileProperty
with SkinData, rather than being constrained to use a skin currently
in use by a specific player.