### PR TITLE
Make catalog type builders consistent.

### DIFF
--- a/src/main/java/org/spongepowered/api/advancement/Advancement.java
+++ b/src/main/java/org/spongepowered/api/advancement/Advancement.java
@@ -29,11 +29,12 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.advancement.criteria.AdvancementCriterion;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.TextRepresentable;
-import org.spongepowered.api.util.ResettableBuilder;
+import org.spongepowered.api.util.CatalogBuilder;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+
 import javax.annotation.Nullable;
 
 /**
@@ -103,7 +104,7 @@ public interface Advancement extends CatalogType, TextRepresentable {
     /**
      * A builder to create {@link Advancement}s.
      */
-    interface Builder extends ResettableBuilder<Advancement, Builder> {
+    interface Builder extends CatalogBuilder<Advancement, Builder> {
 
         /**
          * Sets the parent {@link Advancement}. Defaults to {code null}.
@@ -130,13 +131,7 @@ public interface Advancement extends CatalogType, TextRepresentable {
          */
         Builder displayInfo(@Nullable DisplayInfo displayInfo);
 
-        /**
-         * Sets the identifier of the {@link Advancement}
-         * (without the namespace).
-         *
-         * @param id The identifier
-         * @return This builder, for chaining
-         */
+        @Override
         Builder id(String id);
 
         /**
@@ -148,13 +143,10 @@ public interface Advancement extends CatalogType, TextRepresentable {
          * @param name The name
          * @return This builder, for chaining
          */
+        @Override
         Builder name(String name);
 
-        /**
-         * Builds the {@link Advancement}.
-         *
-         * @return The advancement
-         */
+        @Override
         Advancement build();
 
         @Override

--- a/src/main/java/org/spongepowered/api/advancement/AdvancementTree.java
+++ b/src/main/java/org/spongepowered/api/advancement/AdvancementTree.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.advancement;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.util.CatalogBuilder;
 import org.spongepowered.api.util.ResettableBuilder;
 
 /**
@@ -64,7 +65,7 @@ public interface AdvancementTree extends CatalogType {
     /**
      * A builder to create {@link AdvancementTree}s.
      */
-    interface Builder extends ResettableBuilder<AdvancementTree, Builder> {
+    interface Builder extends CatalogBuilder<AdvancementTree, Builder> {
 
         /**
          * Sets the root {@link Advancement}. The root advancement MUST have
@@ -90,31 +91,22 @@ public interface AdvancementTree extends CatalogType {
 
         // Builder background(ResourcePath background);
 
-        /**
-         * Sets the identifier of the {@link AdvancementTree}
-         * (without the namespace).
-         *
-         * @param id The identifier
-         * @return This builder, for chaining
-         */
+        @Override
         Builder id(String id);
 
         /**
          * Sets the name of the {@link AdvancementTree}. Defaults to
          * the plain {@link DisplayInfo#getTitle()} of the root
-         * {@link Advancement} if  {@link DisplayInfo} is present.
+         * {@link Advancement} if {@link DisplayInfo} is present.
          * Otherwise will it default to the identifier ({@link #id(String)}).
          *
          * @param name The name
          * @return This builder, for chaining
          */
+        @Override
         Builder name(String name);
 
-        /**
-         * Builds the {@link AdvancementTree}.
-         *
-         * @return The advancement tree
-         */
+        @Override
         AdvancementTree build();
 
         @Override

--- a/src/main/java/org/spongepowered/api/data/key/Key.java
+++ b/src/main/java/org/spongepowered/api/data/key/Key.java
@@ -35,7 +35,7 @@ import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.event.EventListener;
 import org.spongepowered.api.event.data.ChangeDataHolderEvent;
-import org.spongepowered.api.util.ResettableBuilder;
+import org.spongepowered.api.util.CatalogBuilder;
 import org.spongepowered.api.util.TypeTokens;
 
 import java.lang.reflect.Type;
@@ -102,7 +102,7 @@ public interface Key<V extends BaseValue<?>> extends CatalogType {
      */
     <E extends DataHolder> void registerEvent(Class<E> holderFilter, EventListener<ChangeDataHolderEvent.ValueChange> listener);
 
-    interface Builder<E, V extends BaseValue<E>> extends ResettableBuilder<Key<V>, Builder<E, V>> {
+    interface Builder<E, V extends BaseValue<E>> extends CatalogBuilder<Key<V>, Builder<E, V>> {
 
         /**
          * Starter method for the builder, to be used immediately after
@@ -123,23 +123,10 @@ public interface Key<V extends BaseValue<?>> extends CatalogType {
          */
         <T, B extends BaseValue<T>> Builder<T, B> type(TypeToken<B> token);
 
-        /**
-         * Sets the string id to be used for {@link CatalogType#getId()}.
-         *
-         * <p>This should be formatted appropriately, review {@link CatalogType}
-         * documentation for formatted ids.</p>
-         *
-         * @param id The string id
-         * @return This builder, for chaining
-         */
+        @Override
         Builder<E, V> id(String id);
 
-        /**
-         * Sets the human readable name for the generated {@link Key}.
-         *
-         * @param name The human readable name
-         * @return This builder, for chaining
-         */
+        @Override
         Builder<E, V> name(String name);
 
         /**
@@ -159,6 +146,7 @@ public interface Key<V extends BaseValue<?>> extends CatalogType {
          *
          * @return The generated Key
          */
+        @Override
         Key<V> build();
 
         @Override

--- a/src/main/java/org/spongepowered/api/item/recipe/smelting/SmeltingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/smelting/SmeltingRecipe.java
@@ -24,11 +24,14 @@
  */
 package org.spongepowered.api.item.recipe.smelting;
 
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.Recipe;
+import org.spongepowered.api.text.translation.Translation;
+import org.spongepowered.api.util.CatalogBuilder;
 import org.spongepowered.api.util.ResettableBuilder;
 
 import java.util.Optional;
@@ -39,7 +42,7 @@ import java.util.function.Predicate;
  * suit your creative needs, or you can simply use the
  * {@link SmeltingRecipe.Builder}.
  */
-public interface SmeltingRecipe extends Recipe {
+public interface SmeltingRecipe extends Recipe, CatalogType {
 
     /**
      * Builds a simple furnace recipe. Note, that you can implement the
@@ -162,7 +165,7 @@ public interface SmeltingRecipe extends Recipe {
 
         }
 
-        interface EndStep extends Builder {
+        interface EndStep extends Builder, CatalogBuilder<SmeltingRecipe, Builder> {
 
             /**
              * Changes the experience and returns this builder. It is the
@@ -175,13 +178,16 @@ public interface SmeltingRecipe extends Recipe {
              */
             EndStep experience(double experience);
 
-            /**
-             * Builds the recipe and returns it.
-             *
-             * @return The built recipe
-             * @throws IllegalStateException If not all required options
-             *     were specified
-             */
+            @Override
+            EndStep id(String id);
+
+            @Override
+            EndStep name(String name);
+
+            @Override
+            EndStep name(Translation name);
+
+            @Override
             SmeltingRecipe build();
         }
     }

--- a/src/main/java/org/spongepowered/api/util/CatalogBuilder.java
+++ b/src/main/java/org/spongepowered/api/util/CatalogBuilder.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.util;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.text.translation.Translation;
+
+/**
+ * A base builder to construct {@link CatalogType}s.
+ */
+public interface CatalogBuilder<C extends CatalogType, B extends ResettableBuilder<C, B>> extends ResettableBuilder<C, B> {
+
+    /**
+     * Sets the id of the {@link CatalogType} (without the namespace/plugin id).
+     *
+     * @param id The id
+     * @return This builder for chaining
+     */
+    B id(String id);
+
+    /**
+     * Sets the name of the {@link CatalogType}. Defaults to {@link #id(String)}.
+     *
+     * @param name The name
+     * @return This builder for chaining
+     */
+    B name(String name);
+
+    /**
+     * Sets the name of the {@link CatalogType} as a {@link Translation}. Defaults to {@link #id}.
+     *
+     * @param translation The name translation
+     * @return This builder for chaining
+     */
+    B name(Translation translation);
+
+    /**
+     * Builds the {@link CatalogType} of type {@link C}.
+     *
+     * <p>The last {@link PluginContainer} in the cause stack will be used to
+     * determine which plugin was used to construct the {@link CatalogType}.</p>
+     *
+     * @return The built catalog type
+     * @throws IllegalStateException If not all required options were specified
+     */
+    C build() throws IllegalStateException;
+
+    /**
+     * @deprecated It's not allowed to duplicate catalog types.
+     */
+    @Deprecated
+    @Override
+    default B from(C value) {
+        throw new UnsupportedOperationException("Duplicating catalog types isn't allowed.");
+    }
+}


### PR DESCRIPTION
**API** | [Common](https://github.com/SpongePowered/SpongeCommon/pull/2075)

Adds a common builder interface for catalog types to ensure consistency.All original build methods are deprecated and will be removed in bleeding.

Already makes `FurnaceRecipe` a catalog type. For stable, if no id is set, an auto generated one will be used instead.

Please let me know if I missed any catalog type builders. And is it worth to also target stable?

Impl will follow later.