### PR TITLE
Selector updates and improvements

### DIFF
--- a/src/main/java/org/spongepowered/api/text/selector/ArgumentTypes.java
+++ b/src/main/java/org/spongepowered/api/text/selector/ArgumentTypes.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.scoreboard.Team;
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -45,7 +46,8 @@ public final class ArgumentTypes {
      * <p>In Vanilla, this is represented by the {@code x}, {@code y} and
      * {@code z} selector keys.</p>
      */
-    public static final ArgumentHolder.Vector3<Vector3i, Integer> POSITION = null;
+    public static final ArgumentHolder.Vector3<Vector3i, Integer> POSITION =
+            DummyObjectProvider.createExtendedFor(ArgumentHolder.Vector3.class, "POSITION");
 
     /**
      * The argument types representing the radius of the selector.
@@ -53,14 +55,18 @@ public final class ArgumentTypes {
      * <p>In Vanilla, this is represented by the {@code r} (for minimum) and
      * {@code rm} (for maximum) selector keys.</p>
      */
-    public static final ArgumentHolder.Limit<ArgumentType<Integer>> RADIUS = null;
+    public static final ArgumentHolder.Limit<ArgumentType<Integer>> RADIUS =
+            DummyObjectProvider.createExtendedFor(ArgumentHolder.Limit.class, "RADIUS");
 
     /**
      * The argument type filtering based on the {@link GameMode} of a player.
      *
      * <p>In Vanilla, this is represented by the {@code m} selector key.</p>
+     *
+     * <p>Note that this element is of type {@link ArgumentType.Invertible}.</p>
      */
-    public static final ArgumentType<GameMode> GAME_MODE = null;
+    public static final ArgumentType<GameMode> GAME_MODE =
+            DummyObjectProvider.createExtendedFor(ArgumentType.class, "GAME_MODE");
 
     /**
      * The argument type limiting the number of results of a {@link Selector}.
@@ -73,7 +79,8 @@ public final class ArgumentTypes {
      *
      * <p>In Vanilla, this is represented by the {@code c} selector key.</p>
      */
-    public static final ArgumentType<Integer> COUNT = null;
+    public static final ArgumentType<Integer> COUNT =
+            DummyObjectProvider.createExtendedFor(ArgumentType.class, "COUNT");
 
     /**
      * The argument types filtering based on the number of experience levels of
@@ -82,7 +89,8 @@ public final class ArgumentTypes {
      * <p>In Vanilla, this is represented by the {@code l} (for maximum) and
      * {@code lm} (for minimum) selector keys.</p>
      */
-    public static final ArgumentHolder.Limit<ArgumentType<Integer>> LEVEL = null;
+    public static final ArgumentHolder.Limit<ArgumentType<Integer>> LEVEL =
+            DummyObjectProvider.createExtendedFor(ArgumentHolder.Limit.class, "LEVEL");
 
     /**
      * The argument type filtering based on the {@link Team} of the target.
@@ -92,7 +100,8 @@ public final class ArgumentTypes {
      * <p>In Vanilla, this is represented by the {@code team} selector key with
      * the {@code !} prefix for inverted values.</p>
      */
-    public static final ArgumentType.Invertible<String> TEAM = null;
+    public static final ArgumentType.Invertible<String> TEAM =
+            DummyObjectProvider.createExtendedFor(ArgumentType.Invertible.class, "TEAM");
 
     /**
      * The argument type filtering based on the name of the target. Inverting
@@ -102,7 +111,8 @@ public final class ArgumentTypes {
      * <p>In Vanilla, this is represented by the {@code name} selector key with
      * the {@code !} prefix for inverted values.</p>
      */
-    public static final ArgumentType.Invertible<String> NAME = null;
+    public static final ArgumentType.Invertible<String> NAME =
+            DummyObjectProvider.createExtendedFor(ArgumentType.Invertible.class, "NAME");
 
     /**
      * The argument type filtering targets which aren't in the specified volume.
@@ -110,7 +120,8 @@ public final class ArgumentTypes {
      * <p>In Vanilla, this is represented by the {@code dx}, {@code dy} and
      * {@code dz} selector keys.</p>
      */
-    public static final ArgumentHolder.Vector3<Vector3i, Integer> DIMENSION = null;
+    public static final ArgumentHolder.Vector3<Vector3i, Integer> DIMENSION =
+            DummyObjectProvider.createExtendedFor(ArgumentHolder.Vector3.class, "DIMENSION");
 
     /**
      * The argument type filtering targets within a specific rotation range.
@@ -120,14 +131,16 @@ public final class ArgumentTypes {
      * {@code rx}/{@code ry} (for minimum) and {@code rxm}/{@code rym} selector
      * keys.</p>
      */
-    public static final ArgumentHolder.Limit<ArgumentHolder.Vector3<Vector3d, Double>> ROTATION = null;
+    public static final ArgumentHolder.Limit<ArgumentHolder.Vector3<Vector3d, Double>> ROTATION =
+            DummyObjectProvider.createExtendedFor(ArgumentHolder.Limit.class, "ROTATION");
 
     /**
      * The argument type filtering targets based on the {@link EntityType}.
      *
      * <p>In Vanilla, this is represented by the {@code type} selector key.</p>
      */
-    public static final ArgumentType.Invertible<EntityType> ENTITY_TYPE = null;
+    public static final ArgumentType.Invertible<EntityType> ENTITY_TYPE =
+            DummyObjectProvider.createExtendedFor(ArgumentType.Invertible.class, "ENTITY_TYPE");
 
     @SuppressWarnings("deprecation")
     static SelectorFactory getFactory() {

--- a/src/main/java/org/spongepowered/api/text/selector/Selector.java
+++ b/src/main/java/org/spongepowered/api/text/selector/Selector.java
@@ -52,18 +52,6 @@ import java.util.Set;
  * </p>
  * </p>
  *
- * <p>
- * Additionally, Vanilla will ignore position data unless one of the following
- * arguments is present:
- * <ul>
- *   <li>{@link ArgumentTypes#POSITION}</li>
- *   <li>{@link ArgumentTypes#DIMENSION}</li>
- *   <li>{@link ArgumentTypes#RADIUS}</li>
- * </ul>
- * All {@code resolve} methods have a look-alike named {@code resolveForce}
- * which always uses the given position data.
- * </p>
- *
  * @see <a href="http://minecraft.gamepedia.com/Selector#Target_selectors">
  *      Target selectors on the Minecraft Wiki</a>
  */
@@ -166,6 +154,9 @@ public interface Selector {
     /**
      * Resolves this {@link Selector} to a list of entities around the origin.
      *
+     * <p>The returned set may be ordered based on distance from the origin
+     * (with the nearest first).</p>
+     *
      * @param origin The source that should be considered the origin of this
      *        selector
      * @return The matched entities
@@ -176,6 +167,9 @@ public interface Selector {
      * Resolves this {@link Selector} to a list of entities around (0|0|0) in
      * the given {@link Extent Extent(s)}.
      *
+     * <p>The returned set may be ordered based on distance from the origin
+     * (with the nearest first).</p>
+     *
      * @param extent The extents to search for targets
      * @return The matched entities
      */
@@ -185,6 +179,9 @@ public interface Selector {
      * Resolves this {@link Selector} to a list of entities around (0|0|0) in
      * the given {@link Extent Extent(s)}.
      *
+     * <p>The returned set may be ordered based on distance from the origin
+     * (with the nearest first).</p>
+     *
      * @param extent The extents to search for targets
      * @return The matched entities
      */
@@ -193,6 +190,9 @@ public interface Selector {
     /**
      * Resolves this {@link Selector} to a list of entities around the given
      * {@link Location}.
+     *
+     * <p>The returned set may be ordered based on distance from the origin
+     * (with the nearest first).</p>
      *
      * @param location The location to resolve the selector around
      * @return The matched entities
@@ -205,8 +205,12 @@ public interface Selector {
      * @param origin The source that should be considered the origin of this
      *        selector
      * @return The matched entities
+     * @deprecated Use {@link #resolve(CommandSource)}
      */
-    Set<Entity> resolveForce(CommandSource origin);
+    @Deprecated
+    default Set<Entity> resolveForce(CommandSource origin) {
+        return resolve(origin);
+    }
 
     /**
      * Resolves this {@link Selector} to a list of entities around (0|0|0) in
@@ -214,8 +218,12 @@ public interface Selector {
      *
      * @param extent The extents to search for targets
      * @return The matched entities
+     * @deprecated Use {@link #resolve(Extent[])}
      */
-    Set<Entity> resolveForce(Extent... extent);
+    @Deprecated
+    default Set<Entity> resolveForce(Extent... extent) {
+        return resolve(extent);
+    }
 
     /**
      * Resolves this {@link Selector} to a list of entities around (0|0|0) in
@@ -223,8 +231,12 @@ public interface Selector {
      *
      * @param extent The extents to search for targets
      * @return The matched entities
+     * @deprecated Use {@link #resolve(Collection)}
      */
-    Set<Entity> resolveForce(Collection<? extends Extent> extent);
+    @Deprecated
+    default Set<Entity> resolveForce(Collection<? extends Extent> extent) {
+        return resolve(extent);
+    }
 
     /**
      * Resolves this {@link Selector} to a list of entities around the given
@@ -232,8 +244,12 @@ public interface Selector {
      *
      * @param location The location to resolve the selector around
      * @return The matched entities
+     * @deprecated Use {@link #resolve(Location)}
      */
-    Set<Entity> resolveForce(Location<World> location);
+    @Deprecated
+    default Set<Entity> resolveForce(Location<World> location) {
+        return resolve(location);
+    }
 
     /**
      * Converts this {@link Selector} to a valid selector string.

--- a/src/main/java/org/spongepowered/api/text/selector/SelectorTypes.java
+++ b/src/main/java/org/spongepowered/api/text/selector/SelectorTypes.java
@@ -48,6 +48,12 @@ public final class SelectorTypes {
      * The nearest player selector type.
      */
     public static final SelectorType NEAREST_PLAYER = DummyObjectProvider.createFor(SelectorType.class, "NEAREST_PLAYER");
+    
+    /**
+     * The self selector type. This only targets players, if the command sender
+     * is a command block or the console, this selector will return nothing.
+     */
+    public static final SelectorType SOURCE = DummyObjectProvider.createFor(SelectorType.class, "SOURCE");
 
     /**
      * The random selector type. This targets only players by default, but may


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2033)

Previous PRs: [Original API PR](https://github.com/SpongePowered/SpongeAPI/pull/1270) | [Original Common PR](https://github.com/SpongePowered/SpongeCommon/pull/793) | [Revised API PR](https://github.com/SpongePowered/SpongeAPI/pull/1645) | [Revised Common PR](https://github.com/SpongePowered/SpongeCommon/pull/1519)

With thanks to @kenzierocks and @rexbut for their contributions, however, as both of these PRs went stale (sorry!) and I've had no response on https://github.com/SpongePowered/SpongeCommon/pull/1519, I figured it best to open the new PR, get it reviewed and in as there are issues with selectors selecting the wrong things as it stands.

This PR is mostly to add the `@s` selector and deprecate the `resolveForce` methods. It also removes nulls from the API level and replaces them with dummy objects. 

This is a non-breaking change and as such is targeting API 7.x. Once this is sorted, a breaking change PR to bleeding can then follow based on the changes in the previous PRs - please see those for what they are.

See the Common PR for more details.