### PR TITLE
Add PlainPagedData

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -378,6 +378,9 @@ public final class Keys {
      * Represents the {@link Key} for the content of a
      * {@link ItemTypes#WRITTEN_BOOK}.
      *
+     * <p>Use {@link Keys#PLAIN_BOOK_PAGES} if you wish to inspect the contents
+     * of a {@link ItemTypes#WRITABLE_BOOK}.</p>
+     *
      * @see PagedData#pages()
      */
     public static final Key<ListValue<Text>> BOOK_PAGES = DummyObjectProvider.createExtendedFor(Key.class,"BOOK_PAGES");
@@ -1612,6 +1615,17 @@ public final class Keys {
      * @see PlayerCreatedData#playerCreated()
      */
     public static final Key<Value<Boolean>> PLAYER_CREATED = DummyObjectProvider.createExtendedFor(Key.class,"PLAYER_CREATED");
+
+    /**
+     * Represents the {@link Key} for the content of a
+     * {@link ItemTypes#WRITABLE_BOOK}.
+     *
+     * <p>Use {@link Keys#BOOK_PAGES} if you wish to get the contents of a
+     * {@link ItemTypes#WRITTEN_BOOK}</p>
+     *
+     * @see PlainPagedData#pages()
+     */
+    public static final Key<ListValue<String>> PLAIN_BOOK_PAGES = DummyObjectProvider.createExtendedFor(Key.class,"PLAIN_BOOK_PAGES");
 
     /**
      * Represents the {@link Key} for representing the {@link PortionType}

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/item/ImmutablePlainPagedData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/item/ImmutablePlainPagedData.java
@@ -22,13 +22,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.manipulator.mutable.item;
+package org.spongepowered.api.data.manipulator.immutable.item;
 
-import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.data.manipulator.DataManipulator;
-import org.spongepowered.api.data.manipulator.immutable.item.ImmutablePagedData;
-import org.spongepowered.api.data.manipulator.mutable.ListData;
-import org.spongepowered.api.data.value.mutable.ListValue;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.ImmutableListData;
+import org.spongepowered.api.data.manipulator.mutable.item.PagedData;
+import org.spongepowered.api.data.manipulator.mutable.item.PlainPagedData;
+import org.spongepowered.api.data.value.immutable.ImmutableListValue;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.text.Text;
@@ -36,19 +36,18 @@ import org.spongepowered.api.text.Text;
 import java.util.List;
 
 /**
- * An {@link DataManipulator} handling the {@link List} of pages of
- * {@link Text} for an {@link ItemStack} of type {@link ItemTypes#WRITTEN_BOOK}
+ * An {@link ImmutableDataManipulator} handling the {@link List} of pages of
+ * {@link Text} for an {@link ItemStack} of type {@link ItemTypes#WRITABLE_BOOK}
  * such that the text elements are single pages.
  */
-public interface PagedData extends ListData<Text, PagedData, ImmutablePagedData> {
+public interface ImmutablePlainPagedData extends ImmutableListData<String, ImmutablePlainPagedData, PlainPagedData> {
 
     /**
-     * Gets the {@link ListValue} for the {@link Text} pages.
+     * Gets the {@link ImmutableListValue} for the {@link Text} pages.
      *
-     * @return The list value of text pages
-     * @see Keys#BOOK_PAGES
+     * @return The immutable list value of text pages
      */
-    default ListValue<Text> pages() {
+    default ImmutableListValue<String> pages() {
         return getListValue();
     }
 

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/item/PlainPagedData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/item/PlainPagedData.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.data.manipulator.mutable.item;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.item.ImmutablePagedData;
+import org.spongepowered.api.data.manipulator.immutable.item.ImmutablePlainPagedData;
 import org.spongepowered.api.data.manipulator.mutable.ListData;
 import org.spongepowered.api.data.value.mutable.ListValue;
 import org.spongepowered.api.item.ItemTypes;
@@ -37,18 +38,18 @@ import java.util.List;
 
 /**
  * An {@link DataManipulator} handling the {@link List} of pages of
- * {@link Text} for an {@link ItemStack} of type {@link ItemTypes#WRITTEN_BOOK}
+ * {@link Text} for an {@link ItemStack} of type {@link ItemTypes#WRITABLE_BOOK}
  * such that the text elements are single pages.
  */
-public interface PagedData extends ListData<Text, PagedData, ImmutablePagedData> {
+public interface PlainPagedData extends ListData<String, PlainPagedData, ImmutablePlainPagedData> {
 
     /**
      * Gets the {@link ListValue} for the {@link Text} pages.
      *
      * @return The list value of text pages
-     * @see Keys#BOOK_PAGES
+     * @see Keys#PLAIN_BOOK_PAGES
      */
-    default ListValue<Text> pages() {
+    default ListValue<String> pages() {
         return getListValue();
     }
 

--- a/src/main/java/org/spongepowered/api/util/TypeTokens.java
+++ b/src/main/java/org/spongepowered/api/util/TypeTokens.java
@@ -272,6 +272,8 @@ public final class TypeTokens {
 
     public static final TypeToken<ListValue<PotionEffect>> LIST_POTION_VALUE_TOKEN = new TypeToken<ListValue<PotionEffect>>() {private static final long serialVersionUID = -1;};
 
+    public static final TypeToken<ListValue<String>> LIST_STRING_VALUE_TOKEN = new TypeToken<ListValue<String>>() {private static final long serialVersionUID = -1;};
+
     public static final TypeToken<List<Text>> LIST_TEXT_TOKEN = new TypeToken<List<Text>>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<ListValue<Text>> LIST_TEXT_VALUE_TOKEN = new TypeToken<ListValue<Text>>() {private static final long serialVersionUID = -1;};


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2065) | [Original Issue](https://github.com/SpongePowered/SpongeCommon/issues/509)

Adds `PlainPagedData` for writable books, along with associated key and required `TypeToken`. See the SpongeCommon issue for more details.