### PR TITLE
Inventory Transfer Events

### DIFF
--- a/src/main/java/org/spongepowered/api/event/item/inventory/ChangeInventoryEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/ChangeInventoryEvent.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.api.event.item.inventory;
 
+import org.spongepowered.api.data.Transaction;
+import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.entity.Item;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.living.player.Player;
@@ -32,6 +34,8 @@ import org.spongepowered.api.event.Event;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.Slot;
+import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
+import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
 import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
 
 import java.util.List;
@@ -96,30 +100,41 @@ public interface ChangeInventoryEvent extends Event, AffectSlotEvent {
         Inventory getSourceInventory();
 
         /**
-         * Fired before an {@link Inventory} attempts to transfer items.
+         * Gets the target {@link Inventory} of this {@link Event}.
+         *
+         * @return The target {@link Inventory}
          */
-        interface Pre extends Event, Cancellable {
+        Inventory getTargetInventory();
 
-            /**
-             * Gets the source {@link Inventory} of this {@link Event}.
-             *
-             * @return The source {@link Inventory}
-             */
-            Inventory getSourceInventory();
+        /**
+         * Fired before an {@link Inventory} attempts to transfer any items.
+         */
+        interface Pre extends Transfer, Cancellable {
 
-            /**
-             * Gets the target {@link Inventory} of this {@link Event}.
-             *
-             * @return The target {@link Inventory}
-             */
-            Inventory getTargetInventory();
         }
 
         /**
-         * Fires after an {@link Inventory} transferred an item.
+         * Fires before an {@link Inventory} attempts to transfer an item.
+         *
+         * <p>The event will be automatically cancelled when the modified {@link #transferredItem()} cannot fit the target inventory.</p>
+         *
+         * <p>When this event is cancelled a transfer is attempted for the remaining source slots.</p>
          */
-        interface Post extends Transfer {
+        interface PreItem extends Transfer, Cancellable {
 
+            /**
+             * The item getting transferred.
+             *
+             * @return The item getting transferred
+             */
+            Transaction<ItemStackSnapshot> transferredItem();
+
+            /**
+             * Returns the source slot transaction for this item transfer.
+             *
+             * @return The source slot transaction for this item transfer
+             */
+            SlotTransaction sourceSlot();
         }
 
     }

--- a/src/main/java/org/spongepowered/api/event/item/inventory/ChangeInventoryEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/ChangeInventoryEvent.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.event.item.inventory;
 
-import org.spongepowered.api.data.Transaction;
-import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.entity.Item;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.living.player.Player;
@@ -34,8 +32,6 @@ import org.spongepowered.api.event.Event;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.Slot;
-import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
-import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
 import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
 
 import java.util.List;
@@ -84,58 +80,6 @@ public interface ChangeInventoryEvent extends Event, AffectSlotEvent {
      * Fired when a {@link Player} swaps it's hands.
      */
     interface SwapHand extends ChangeInventoryEvent {
-
-    }
-
-    /**
-     * Fired when an {@link Inventory} transfers items into another.
-     */
-    interface Transfer extends ChangeInventoryEvent {
-
-        /**
-         * Gets the source {@link Inventory} of this {@link Event}.
-         *
-         * @return The source {@link Inventory}
-         */
-        Inventory getSourceInventory();
-
-        /**
-         * Gets the target {@link Inventory} of this {@link Event}.
-         *
-         * @return The target {@link Inventory}
-         */
-        Inventory getTargetInventory();
-
-        /**
-         * Fired before an {@link Inventory} attempts to transfer any items.
-         */
-        interface Pre extends Transfer, Cancellable {
-
-        }
-
-        /**
-         * Fires before an {@link Inventory} attempts to transfer an item.
-         *
-         * <p>The event will be automatically cancelled when the modified {@link #transferredItem()} cannot fit the target inventory.</p>
-         *
-         * <p>When this event is cancelled a transfer is attempted for the remaining source slots.</p>
-         */
-        interface PreItem extends Transfer, Cancellable {
-
-            /**
-             * The item getting transferred.
-             *
-             * @return The item getting transferred
-             */
-            Transaction<ItemStackSnapshot> transferredItem();
-
-            /**
-             * Returns the source slot transaction for this item transfer.
-             *
-             * @return The source slot transaction for this item transfer
-             */
-            SlotTransaction sourceSlot();
-        }
 
     }
 

--- a/src/main/java/org/spongepowered/api/event/item/inventory/TransferInventoryEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/TransferInventoryEvent.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.item.inventory;
+
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.Event;
+import org.spongepowered.api.item.inventory.Inventory;
+import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.item.inventory.Slot;
+
+/**
+ * Fired when an {@link Inventory} transfers items into another.
+ */
+public interface TransferInventoryEvent extends Event {
+
+    /**
+     * Gets the source {@link Inventory} of this {@link Event}.
+     *
+     * @return The source {@link Inventory}
+     */
+    Inventory getSourceInventory();
+
+    /**
+     * Gets the target {@link Inventory} of this {@link Event}.
+     *
+     * @return The target {@link Inventory}
+     */
+    Inventory getTargetInventory();
+
+    /**
+     * Fired before an {@link Inventory} attempts to transfer any items.
+     */
+    interface Pre extends TransferInventoryEvent, Cancellable {
+
+    }
+
+    /**
+     * Fires after an {@link Inventory} transferred an item into an other inventory.
+     */
+    interface Post extends TransferInventoryEvent {
+
+        /**
+         * The item getting transferred.
+         *
+         * @return The item getting transferred
+         */
+        ItemStackSnapshot getTransferredItem();
+
+        /**
+         * Returns the source slot of this item transfer.
+         *
+         * @return The source slot of this item transfer
+         */
+        Slot getSourceSlot();
+
+        /**
+         * Returns the target slot of this item transfer.
+         *
+         * @return The target slot of this item transfer
+         */
+        Slot getTargetSlot();
+    }
+
+}


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2107) | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/2452)

`.Post` was impossible to implement for mods.
https://github.com/SpongePowered/SpongeForge/issues/2411

Moves `ChangeInventoryEvent.Transfer` to `TransferInventoryEvent`
`TransferInventoryEvent.Post` cannot be cancelled anymore. It now includes the Source/Target Slot and the ItemStack transferred.