### PR TITLE
Replace integer ticks durations with Duration across the API.

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -85,6 +85,7 @@ import org.spongepowered.api.util.weighted.WeightedSerializableObject;
 import org.spongepowered.api.world.explosion.Explosion;
 import org.spongepowered.api.world.weather.Weather;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -748,14 +749,14 @@ public final class Keys {
     public static final Key<MutableBoundedValue<Integer>> EXPERIENCE_SINCE_LEVEL = DummyObjectProvider.createExtendedFor(Key.class,"EXPERIENCE_SINCE_LEVEL");
 
     /**
-     * Represents the {@link Key} for after how many ticks an entity or
+     * Represents the {@link Key} for how long an entity or
      * {@link Weather} will last before expiring.
      *
-     * <p>Usually applies to {@link Endermite}s or {@link Item}s.</p>
+     * <p>Usually applies to {@link Weather}, {@link Endermite}s or {@link Item}s.</p>
      *
-     * @see ExpirableData#expireTicks()
+     * @see ExpirableData#expireDuration()
      */
-    public static final Key<MutableBoundedValue<Integer>> EXPIRATION_TICKS = DummyObjectProvider.createExtendedFor(Key.class,"EXPIRATION_TICKS");
+    public static final Key<Value<Duration>> EXPIRATION_DURATION = DummyObjectProvider.createExtendedFor(Key.class,"EXPIRATION_DURATION");
 
     /**
      * Represents the {@link Key} for the radius of the {@link Explosion} to

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableExpirableData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableExpirableData.java
@@ -26,24 +26,26 @@ package org.spongepowered.api.data.manipulator.immutable.entity;
 
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.entity.ExpirableData;
-import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.explosive.PrimedTNT;
 import org.spongepowered.api.entity.living.monster.Endermite;
 
+import java.time.Duration;
+
 /**
- * An {@link ImmutableDataManipulator} handling the "expiring" ticks remaining
+ * An {@link ImmutableDataManipulator} handling the "expiring" duration
  * for an {@link Entity} to "remain" existing in a world. Usually applicable to
  * {@link Endermite}s, {@link PrimedTNT}, etc.
  */
 public interface ImmutableExpirableData extends ImmutableDataManipulator<ImmutableExpirableData, ExpirableData> {
 
     /**
-     * Gets the {@link ImmutableBoundedValue} for the amount of "ticks"
-     * remaining before the "expiration" occurs.
+     * Gets the {@link ImmutableValue} for the duration
+     * before the "expiration" occurs.
      *
-     * @return The immutable bounded value for the amount of ticks remaining
+     * @return The immutable bounded value for the remaining duration
      */
-    ImmutableBoundedValue<Integer> expireTicks();
+    ImmutableValue<Duration> expireDuration();
 
 }

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/ExpirableData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/ExpirableData.java
@@ -27,25 +27,27 @@ package org.spongepowered.api.data.manipulator.mutable.entity;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableExpirableData;
-import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.Item;
 import org.spongepowered.api.entity.living.monster.Endermite;
 import org.spongepowered.api.world.weather.Weather;
 
+import java.time.Duration;
+
 /**
- * Signifies that an entity will expire after the value has
- * decayed to the minimum. Usually applicable to {@link Weather},
+ * Signifies that an entity will expire after the duration has
+ * elapsed. Usually applicable to {@link Weather},
  * {@link Endermite}s and {@link Item}s.
  */
 public interface ExpirableData extends DataManipulator<ExpirableData, ImmutableExpirableData> {
 
     /**
-     * Gets the {@link MutableBoundedValue} for the amount of "ticks"
-     * remaining before the "expiration" occurs.
+     * Gets the {@link Value} for the duration
+     * before the "expiration" occurs.
      *
-     * @return The immutable bounded value for the amount of ticks remaining
-     * @see Keys#EXPIRATION_TICKS
+     * @return The bounded value for the remaining duration
+     * @see Keys#EXPIRATION_DURATION
      */
-    MutableBoundedValue<Integer> expireTicks();
+    Value<Duration> expireDuration();
 
 }

--- a/src/main/java/org/spongepowered/api/entity/living/monster/Endermite.java
+++ b/src/main/java/org/spongepowered/api/entity/living/monster/Endermite.java
@@ -26,7 +26,9 @@ package org.spongepowered.api.entity.living.monster;
 
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.mutable.entity.ExpirableData;
-import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.data.value.mutable.Value;
+
+import java.time.Duration;
 
 /**
  * Represents an endermite.
@@ -43,12 +45,12 @@ public interface Endermite extends Monster {
     }
 
     /**
-     * Gets the {@link MutableBoundedValue} for the amount of "ticks"
-     * remaining before the "expiration" occurs.
+     * Gets the {@link Value} for the duration
+     * before the "expiration" occurs.
      *
-     * @return The immutable bounded value for the amount of ticks remaining
+     * @return The bounded value for the remaining duration
      */
-    default MutableBoundedValue<Integer> expireTicks() {
-        return getValue(Keys.EXPIRATION_TICKS).get();
+    default Value<Duration> expireDuration() {
+        return getValue(Keys.EXPIRATION_DURATION).get();
     }
 }

--- a/src/main/java/org/spongepowered/api/entity/vehicle/minecart/FurnaceMinecart.java
+++ b/src/main/java/org/spongepowered/api/entity/vehicle/minecart/FurnaceMinecart.java
@@ -24,29 +24,27 @@
  */
 package org.spongepowered.api.entity.vehicle.minecart;
 
+import java.time.Duration;
+
 /**
  * Represents a minecart with a furnace inside it.
  */
 public interface FurnaceMinecart extends Minecart {
 
     /**
-     * Gets the current fuel time in ticks.
+     * Gets the duration of fuel the furnace has left before
+     * the minecraft starts to decelerate to a stop.
      *
-     * <p>Usually, the fuel time will decay until reaching 0. At zero, the fuel
-     * minecart will decelerate to a stop.</p>
-     *
-     * @return The current fuel time in ticks
+     * @return The fuel duration
      */
-    int getFuel();
+    Duration getFuelDuration();
 
     /**
-     * Sets the fuel time in ticks.
+     * Sets the duration of fuel the furnace has left before
+     * the minecraft starts to decelerate to a stop.
      *
-     * <p>Usually, the fuel time will decay until reaching 0. At zero, the fuel
-     * minecart will decelerate to a stop.</p>
-     *
-     * @param fuel The fuel time in ticks
+     * @param duration The fuel duration
      */
-    void setFuel(int fuel);
+    void setFuelDuration(Duration duration);
 
 }

--- a/src/main/java/org/spongepowered/api/entity/weather/WeatherEffect.java
+++ b/src/main/java/org/spongepowered/api/entity/weather/WeatherEffect.java
@@ -26,8 +26,10 @@ package org.spongepowered.api.entity.weather;
 
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.mutable.entity.ExpirableData;
-import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.Entity;
+
+import java.time.Duration;
 
 /**
  * Represents weather, such as {@link Lightning}.
@@ -58,13 +60,13 @@ public interface WeatherEffect extends Entity {
     }
 
     /**
-     * Gets the {@link MutableBoundedValue} for the amount of "ticks" remaining
+     * Gets the {@link Value} for the duration
      * before the "expiration" occurs.
      *
-     * @return The immutable bounded value for the amount of ticks remaining
+     * @return The bounded value for the remaining duration
      */
-    default MutableBoundedValue<Integer> expireTicks() {
-        return getValue(Keys.EXPIRATION_TICKS).get();
+    default Value<Duration> expireDuration() {
+        return getValue(Keys.EXPIRATION_DURATION).get();
     }
 
 }

--- a/src/main/java/org/spongepowered/api/util/MinecraftTemporalUnit.java
+++ b/src/main/java/org/spongepowered/api/util/MinecraftTemporalUnit.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalUnit;
+
+public class MinecraftTemporalUnit implements TemporalUnit {
+
+    private final String name;
+    private final Duration duration;
+
+    public MinecraftTemporalUnit(String name, Duration duration) {
+        this.name = requireNonNull(name, "name");
+        this.duration = requireNonNull(duration, "duration");
+    }
+
+    @Override
+    public Duration getDuration() {
+        return this.duration;
+    }
+
+    // Lets consider minecraft related time units to be always
+    // time related, and never date based.
+
+    @Override
+    public boolean isDurationEstimated() {
+        return false;
+    }
+
+    @Override
+    public boolean isDateBased() {
+        return false;
+    }
+
+    @Override
+    public boolean isTimeBased() {
+        return true;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <R extends Temporal> R addTo(R temporal, long amount) {
+        return (R) temporal.plus(amount, this);
+    }
+
+    @Override
+    public long between(Temporal temporal1Inclusive, Temporal temporal2Exclusive) {
+        return temporal1Inclusive.until(temporal2Exclusive, this);
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
+}

--- a/src/main/java/org/spongepowered/api/util/TemporalUnits.java
+++ b/src/main/java/org/spongepowered/api/util/TemporalUnits.java
@@ -1,0 +1,146 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.util;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+
+/**
+ * An enumeration of all the default and minecraft related {@link TemporalUnit}s.
+ */
+public final class TemporalUnits {
+
+    // The default temporal units, from ChronoUnit
+
+    /**
+     * @see ChronoUnit#NANOS
+     */
+    public static final ChronoUnit NANOS = ChronoUnit.NANOS;
+
+    /**
+     * @see ChronoUnit#MILLIS
+     */
+    public static final ChronoUnit MILLIS = ChronoUnit.MILLIS;
+
+    /**
+     * @see ChronoUnit#SECONDS
+     */
+    public static final ChronoUnit SECONDS = ChronoUnit.SECONDS;
+
+    /**
+     * @see ChronoUnit#MINUTES
+     */
+    public static final ChronoUnit MINUTES = ChronoUnit.MINUTES;
+
+    /**
+     * @see ChronoUnit#HOURS
+     */
+    public static final ChronoUnit HOURS = ChronoUnit.HOURS;
+
+    /**
+     * @see ChronoUnit#HALF_DAYS
+     */
+    public static final ChronoUnit HALF_DAYS = ChronoUnit.HALF_DAYS;
+
+    /**
+     * @see ChronoUnit#DAYS
+     */
+    public static final ChronoUnit DAYS = ChronoUnit.DAYS;
+
+    /**
+     * @see ChronoUnit#WEEKS
+     */
+    public static final ChronoUnit WEEKS = ChronoUnit.WEEKS;
+
+    /**
+     * @see ChronoUnit#MONTHS
+     */
+    public static final ChronoUnit MONTHS = ChronoUnit.MONTHS;
+
+    /**
+     * @see ChronoUnit#YEARS
+     */
+    public static final ChronoUnit YEARS = ChronoUnit.YEARS;
+
+    /**
+     * @see ChronoUnit#DECADES
+     */
+    public static final ChronoUnit DECADES = ChronoUnit.DECADES;
+
+    /**
+     * @see ChronoUnit#CENTURIES
+     */
+    public static final ChronoUnit CENTURIES = ChronoUnit.CENTURIES;
+
+    /**
+     * @see ChronoUnit#MILLENNIA
+     */
+    public static final ChronoUnit MILLENNIA = ChronoUnit.MILLENNIA;
+
+    /**
+     * @see ChronoUnit#ERAS
+     */
+    public static final ChronoUnit ERAS = ChronoUnit.ERAS;
+
+    /**
+     * @see ChronoUnit#FOREVER
+     */
+    public static final ChronoUnit FOREVER = ChronoUnit.FOREVER;
+
+    // Minecraft related temporal units
+
+    // TODO: Move impl to sponge common?
+
+    /**
+     * A {@link MinecraftTemporalUnit} which represents one minecraft tick.
+     */
+    public static final MinecraftTemporalUnit MINECRAFT_TICKS =
+            new MinecraftTemporalUnit("MinecraftTicks", Duration.ofMillis(50));
+
+    /**
+     * A {@link MinecraftTemporalUnit} which represents a minecraft day.
+     */
+    public static final MinecraftTemporalUnit MINECRAFT_DAYS =
+            new MinecraftTemporalUnit("MinecraftDays", MINECRAFT_TICKS.getDuration().multipliedBy(24000));
+
+    /**
+     * A {@link MinecraftTemporalUnit} which represents a half minecraft day.
+     */
+    public static final MinecraftTemporalUnit HALF_MINECRAFT_DAYS =
+            new MinecraftTemporalUnit("HalfMinecraftDays", MINECRAFT_TICKS.getDuration().multipliedBy(12000));
+
+    /**
+     * A {@link MinecraftTemporalUnit} which represents a minecraft day.
+     */
+    public static final MinecraftTemporalUnit MINECRAFT_WEEKS =
+            new MinecraftTemporalUnit("MinecraftWeeks", MINECRAFT_DAYS.getDuration().multipliedBy(7));
+
+    // Suppress default constructor to ensure non-instantiability.
+    private TemporalUnits() {
+        throw new AssertionError("You should not be attempting to instantiate this class.");
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/util/TemporalUnits.java
+++ b/src/main/java/org/spongepowered/api/util/TemporalUnits.java
@@ -132,12 +132,6 @@ public final class TemporalUnits {
     public static final MinecraftTemporalUnit HALF_MINECRAFT_DAYS =
             new MinecraftTemporalUnit("HalfMinecraftDays", MINECRAFT_TICKS.getDuration().multipliedBy(12000));
 
-    /**
-     * A {@link MinecraftTemporalUnit} which represents a minecraft day.
-     */
-    public static final MinecraftTemporalUnit MINECRAFT_WEEKS =
-            new MinecraftTemporalUnit("MinecraftWeeks", MINECRAFT_DAYS.getDuration().multipliedBy(7));
-
     // Suppress default constructor to ensure non-instantiability.
     private TemporalUnits() {
         throw new AssertionError("You should not be attempting to instantiate this class.");


### PR DESCRIPTION
See https://github.com/SpongePowered/SpongeAPI/issues/1814

Right now I only added a catalog of `TemporalUnit`s, including minecraft related ones. But we have to keep the conversation going about this. 

Will very likely be held off after the 1.13 update to avoid conflics with changes. The catalog could be merged early, maybe even for API 7.x