### PR TITLE
Fix flowpowered links - site is down

### DIFF
--- a/gradle/sponge.gradle
+++ b/gradle/sponge.gradle
@@ -88,8 +88,8 @@ javadoc {
             'https://google.github.io/guice/api-docs/4.1/javadoc/',
             'https://zml2008.github.io/configurate/configurate-core/apidocs/',
             'https://zml2008.github.io/configurate/configurate-hocon/apidocs/',
-            'https://flowpowered.com/math/',
-            'https://flowpowered.com/noise/',
+            'https://flow.github.io/math/',
+            'https://flow.github.io/noise/',
             'http://asm.ow2.org/asm50/javadoc/user/',
             'https://docs.oracle.com/javase/8/docs/api/'
     )


### PR DESCRIPTION
Noticed the flowpowered site was down and switched the links to their (probably more reliable) GitHub page. Sorry if I'm merging to the wrong branch.