### PR TITLE
add primary interaction Slot to ClickInventoryEvent

### DIFF
--- a/src/main/java/org/spongepowered/api/event/item/inventory/ClickInventoryEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/ClickInventoryEvent.java
@@ -24,7 +24,12 @@
  */
 package org.spongepowered.api.event.item.inventory;
 
+import org.spongepowered.api.item.inventory.Slot;
+
+import java.util.Optional;
+
 public interface ClickInventoryEvent extends ChangeInventoryEvent, InteractInventoryEvent {
+
     interface Primary extends ClickInventoryEvent {}
 
     interface Middle extends ClickInventoryEvent {}
@@ -87,4 +92,13 @@ public interface ClickInventoryEvent extends ChangeInventoryEvent, InteractInven
     interface NumberPress extends ClickInventoryEvent {
         int getNumber();
     }
+
+    /**
+     * Returns the primary interaction Slot.
+     *
+     * <p>May return {@link Optional#empty()} for events that do not directly interact with a Slot</p>
+     *
+     * @return The primary interaction Slot
+     */
+    Optional<Slot> getSlot();
 }

--- a/src/main/java/org/spongepowered/api/event/item/inventory/ClickInventoryEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/ClickInventoryEvent.java
@@ -25,44 +25,111 @@
 package org.spongepowered.api.event.item.inventory;
 
 import org.spongepowered.api.item.inventory.Slot;
+import org.spongepowered.api.item.inventory.entity.Hotbar;
 
 import java.util.Optional;
 
+/**
+ * A click interaction in an open container.
+ */
 public interface ClickInventoryEvent extends ChangeInventoryEvent, InteractInventoryEvent {
 
+    /**
+     * A click with the primary mouse button.
+     */
     interface Primary extends ClickInventoryEvent {}
 
+    /**
+     * A click with the middle mouse button.
+     */
     interface Middle extends ClickInventoryEvent {}
 
+    /**
+     * A click with the secondary mouse button.
+     */
     interface Secondary extends ClickInventoryEvent {}
 
+    /**
+     * A click in a creative inventory.
+     * <p>The client can dictate what stack is in a Slot</p>
+     */
     interface Creative extends ClickInventoryEvent {}
-    
+
+    /**
+     * A click with the <code>shift</code> modifier active.
+     * <p>Usually contains multiple transactions.</p>
+     * <p>{@link #getSlot()} returns the primary interaction Slot.</p>
+     * <p>The Shift-Double-Click action fires this event multiple times.
+     * In that case the primary interaction Slot is the Slot of the item moved away.</p>
+     */
     interface Shift extends ClickInventoryEvent {
+        /**
+         * A click with the primary mouse button and the <code>shift</code> modifier active
+         */
         interface Primary extends Shift, ClickInventoryEvent.Primary {}
 
+        /**
+         * A click with the secondary mouse button and the <code>shift</code> modifier active
+         */
         interface Secondary extends Shift, ClickInventoryEvent.Secondary {}
     }
 
+    /**
+     * A double-click with the primary mouse button collecting items onto the cursor.
+     * <p>Note that a Shift-Double-Click instead fires multiple {@link ClickInventoryEvent.Shift} events.</p>
+     */
     interface Double extends ClickInventoryEvent.Primary {}
 
+    /**
+     * An interaction resulting in dropping an item.
+     */
     interface Drop extends ClickInventoryEvent, DropItemEvent.Dispense {
+        /**
+         * An interaction dropping a single item. (Q)
+         */
         interface Single extends Drop {}
 
+        /**
+         * An interaction dropping an entire stack. (shift-Q)
+         */
         interface Full extends Drop {}
 
+        /**
+         * A click outside of the inventory resulting in dropping the item on cursor.
+         * {@link #getSlot()} will return empty as no slot was clicked.
+         */
         interface Outside extends Drop {
+            /**
+             * A click with the primary mouse button dropping the entire stack on the cursor.
+             */
             interface Primary extends Outside, ClickInventoryEvent.Primary {}
 
+            /**
+             * A click with the secondary mouse button dropping a single item from the cursor.
+             */
             interface Secondary extends Outside, ClickInventoryEvent.Secondary {}
         }
     }
 
+    /**
+     * A completed drag Interaction.
+     * <p>Usually contains multiple transactions. {@link #getSlot()} returns empty as there is no primary interaction Slot.</p>
+     */
     interface Drag extends ClickInventoryEvent {
+        /**
+         * A completed drag Interaction distributing the cursor stack evenly among the slots.
+         */
         interface Primary extends Drag, ClickInventoryEvent.Primary {}
 
+        /**
+         * A completed drag Interaction distributing a single item from the cursor stack on each slot.
+         */
         interface Secondary extends Drag, ClickInventoryEvent.Secondary {}
 
+        /**
+         * A completed drag Interaction cloning the cursor stack on each slot.
+         * <p>Only changes slots in creative mode</p>
+         */
         interface Middle extends Drag, ClickInventoryEvent.Middle {}
     }
 
@@ -89,6 +156,9 @@ public interface ClickInventoryEvent extends ChangeInventoryEvent, InteractInven
         interface All extends Recipe {}
     }
 
+    /**
+     * A number press swapping the {@link Hotbar} slot with the slot the mouse hovers over.
+     */
     interface NumberPress extends ClickInventoryEvent {
         int getNumber();
     }

--- a/src/main/java/org/spongepowered/api/event/item/inventory/CraftItemEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/CraftItemEvent.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.event.item.inventory;
 
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.item.inventory.Slot;
 import org.spongepowered.api.item.inventory.crafting.CraftingInventory;
 import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
 import org.spongepowered.api.item.recipe.Recipe;
@@ -75,5 +76,12 @@ public interface CraftItemEvent extends ChangeInventoryEvent {
          * @return The crafting transaction
          */
         ItemStackSnapshot getCrafted();
+
+        /**
+         * Returns the crafting output Slot.
+         *
+         * @return The crafting output Slot
+         */
+        @Override Optional<Slot> getSlot();
     }
 }


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2176)

Events with a primary interaction Slot:
- [x] ClickInventoryEvent.Primary
- [x] ClickInventoryEvent.Middle
- [x] ClickInventoryEvent.Secondary
- [x] ClickInventoryEvent.Creative
- [x] ClickInventoryEvent.Shift(.Primary/.Secondary)
- [x] ClickInventoryEvent.Double
- [x] ClickInventoryEvent.Drop.Single
- [x] ClickInventoryEvent.Drop.Full
- [x] ClickInventoryEvent.NumberPress
- [x] CraftItemEvent.Craft

Events without a primary interaction Slot:
- [x] ClickInventoryEvent.Drop.Outside no slot
- [x] ClickInventoryEvent.Recipe no slot
- [x] ClickInventoryEvent.Drag (would require some kind of packet tracking)