### PR TITLE
Add method to get the temperature at a specific position

### DIFF
--- a/src/main/java/org/spongepowered/api/world/Location.java
+++ b/src/main/java/org/spongepowered/api/world/Location.java
@@ -512,6 +512,15 @@ public final class Location<E extends Extent> implements DataHolder {
     }
 
     /**
+     * Gets the temperature at this location based on the biome.
+     *
+     * @return The temperature at this location
+     */
+    public double getTemperature() {
+        return getExtent().getTemperature(getBiomePosition());
+    }
+
+    /**
      * Gets the base type of block.
      *
      * <p>The type does not include block data such as the contents of
@@ -918,5 +927,4 @@ public final class Location<E extends Extent> implements DataHolder {
         return otherLoc.getExtent().equals(getExtent())
             && otherLoc.getPosition().equals(getPosition());
     }
-
 }

--- a/src/main/java/org/spongepowered/api/world/extent/BiomeVolume.java
+++ b/src/main/java/org/spongepowered/api/world/extent/BiomeVolume.java
@@ -186,8 +186,22 @@ public interface BiomeVolume {
      */
     BiomeVolumeWorker<? extends BiomeVolume> getBiomeWorker();
 
+    /**
+     * Gets the temperature at the specified location based on the biome.
+     *
+     * @param x The X position
+     * @param y The Y position
+     * @param z The Z position
+     * @return The temperature at this location
+     */
     double getTemperature(int x, int y, int z);
 
+    /**
+     * Gets the temperature at the specified location based on the biome.
+     *
+     * @param pos The position
+     * @return The temperature at this location
+     */
     default double getTemperature(Vector3i pos) {
         return this.getTemperature(pos.getX(), pos.getY(), pos.getZ());
     }

--- a/src/main/java/org/spongepowered/api/world/extent/BiomeVolume.java
+++ b/src/main/java/org/spongepowered/api/world/extent/BiomeVolume.java
@@ -186,4 +186,10 @@ public interface BiomeVolume {
      */
     BiomeVolumeWorker<? extends BiomeVolume> getBiomeWorker();
 
+    double getTemperature(int x, int y, int z);
+
+    default double getTemperature(Vector3i pos) {
+        return this.getTemperature(pos.getX(), pos.getY(), pos.getZ());
+    }
+
 }


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2170)

Biomes can have different temperatures at different positions - for example, snow only occurs when the ground is higher up. This PR adds a method to get the temperature.