### PR TITLE
Fix NegativeArraySizeException in BlockState.MatcherBuilder.build()

### DIFF
--- a/src/main/java/org/spongepowered/api/block/BlockState.java
+++ b/src/main/java/org/spongepowered/api/block/BlockState.java
@@ -286,7 +286,7 @@ public interface BlockState extends ImmutableDataHolder<BlockState>, DirectionRe
          */
         public StateMatcher build() throws IllegalStateException {
             checkState(this.type != null, "BlockType cannot be null!");
-            return new StateMatcher(this.type, this.traits.toArray(new BlockTrait<?>[this.traits.size() - 1]), this.values.toArray());
+            return new StateMatcher(this.type, this.traits.toArray(new BlockTrait<?>[0]), this.values.toArray());
 
         }
 


### PR DESCRIPTION
When no traits were specified, MatcherBuilder.build() would throw a
NegativeArraySizeException because of flawed logic (size always one too
small).

A size of 0 is specified here, because it's faster than getting the size
and passing it.

Fixes #1835 .

PS: Created this PR because asking to fix it in IRC didn't seem to help.