### PR TITLE
Fix failable futures swallowing errors

### DIFF
--- a/src/main/java/org/spongepowered/api/util/Functional.java
+++ b/src/main/java/org/spongepowered/api/util/Functional.java
@@ -156,7 +156,7 @@ public class Functional {
         CompletableFuture<T> ret = new CompletableFuture<>();
         try {
             ret.complete(call.call());
-        } catch (Exception e) {
+        } catch (Throwable e) {
             ret.completeExceptionally(e);
         }
         return ret;
@@ -176,7 +176,7 @@ public class Functional {
         exec.execute(() -> {
             try {
                 ret.complete(call.call());
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 ret.completeExceptionally(e);
             }
         });


### PR DESCRIPTION
This PR changes the catch type in `Functional#failableFuture` from `Exception` to `Throwable`. In only catching `Exceptions`, these methods were simply swallowing `Errors` and hanging the server when calls inevitably never completed.

The code affected hasn't been modified since 2015, so it should be trivial to merge this into virtually any other branch.