### PR TITLE
Do not append spaces after CommandElements whose usages are empty.

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -476,9 +476,12 @@ public final class GenericArguments {
         public Text getUsage(CommandSource commander) {
             final Text.Builder build = Text.builder();
             for (Iterator<CommandElement> it = this.elements.iterator(); it.hasNext();) {
-                build.append(it.next().getUsage(commander));
-                if (it.hasNext()) {
-                    build.append(CommandMessageFormatting.SPACE_TEXT);
+                Text usage = it.next().getUsage(commander);
+                if (!usage.isEmpty()) {
+                    build.append(usage);
+                    if (it.hasNext()) {
+                        build.append(CommandMessageFormatting.SPACE_TEXT);
+                    }
                 }
             }
             return build.build();


### PR DESCRIPTION
This PR fixes `GenericArguments.SequenceCommandElement` so that when any of its elements' usages are empty, it will not append extra spaces to the resulting usage.

#### Use Case:

I have a Kotlin annotation-based command system that represents functions' containing classes (needed to be able to call the function with `kotlin-reflect`) as hidden `CommandElement`s (i.e. they aren't part of the command's displayed usage). Currently, whenever the command functions are built with multiple containing classes, there are a bunch of extra spaces appended after the command's name. It would look better if those additional spaces were not there.