### PR TITLE
Add plugin adapters.

### DIFF
--- a/src/main/java/org/spongepowered/api/inject/InjectionPoint.java
+++ b/src/main/java/org/spongepowered/api/inject/InjectionPoint.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.inject;
+
+import com.google.common.reflect.TypeToken;
+import com.google.inject.Provider;
+import org.spongepowered.api.plugin.PluginAdapter;
+
+import java.lang.reflect.AnnotatedElement;
+
+/**
+ * Represents a point where a injection is happening. This injection
+ * point can be injected into a {@link Provider} to get the point at
+ * which a injection is occurring.
+ *
+ * <p>The default {@link InjectionPoint} injection can be overridden
+ * by a {@link PluginAdapter} to add support for different kind of
+ * injection points. For example a kotlin property.</p>
+ */
+public interface InjectionPoint extends AnnotatedElement {
+
+    /**
+     * Gets the source class in which this injection point is located.
+     *
+     * @return The source
+     */
+    TypeToken<?> getSource();
+
+    /**
+     * Gets value type at the injection point.
+     *
+     * @return The value type
+     */
+    TypeToken<?> getType();
+}

--- a/src/main/java/org/spongepowered/api/plugin/Plugin.java
+++ b/src/main/java/org/spongepowered/api/plugin/Plugin.java
@@ -104,18 +104,23 @@ public @interface Plugin {
     String[] authors() default {};
 
     /**
-     * The {@link PluginAdapter} that should be used.
+     * The {@link PluginAdapter} that should be used to construct the plugin.
      *
      * @return The class of the plugin adapter
      */
     Class<? extends PluginAdapter> adapter() default PluginAdapter.Default.class;
 
     /**
-     * The {@link Module}s which should be used. These modules are attached to the
-     * {@link Injector} before the injector is constructed by the {@link PluginAdapter}.
+     * The {@link Module}s which should be used additionally. These modules are
+     * attached to the {@link Injector} before the injector is constructed by the
+     * {@link PluginAdapter}.
      *
-     * <p>All the modules that are specified are required to have a public
-     * constructor with no parameters.</p>
+     * <p>These modules will be instantiated using the default {@link Injector} of
+     * the plugin. This allows all plugin related injections with the exception of
+     * the plugin instance which is at this point unavailable.</p>
+     *
+     * <p>How a new {@link Injector} is constructed from the modules will be determined
+     * by the {@link PluginAdapter}.</p>
      *
      * @return The injection modules
      */

--- a/src/main/java/org/spongepowered/api/plugin/Plugin.java
+++ b/src/main/java/org/spongepowered/api/plugin/Plugin.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.api.plugin;
 
+import com.google.inject.Injector;
+import com.google.inject.Module;
 import org.spongepowered.plugin.meta.PluginMetadata;
 
 import java.lang.annotation.ElementType;
@@ -107,5 +109,16 @@ public @interface Plugin {
      * @return The class of the plugin adapter
      */
     Class<? extends PluginAdapter> adapter() default PluginAdapter.Default.class;
+
+    /**
+     * The {@link Module}s which should be used. These modules are attached to the
+     * {@link Injector} before the injector is constructed by the {@link PluginAdapter}.
+     *
+     * <p>All the modules that are specified are required to have a public
+     * constructor with no parameters.</p>
+     *
+     * @return The injection modules
+     */
+    Class<? extends Module>[] injectionModules() default {};
 
 }

--- a/src/main/java/org/spongepowered/api/plugin/Plugin.java
+++ b/src/main/java/org/spongepowered/api/plugin/Plugin.java
@@ -101,4 +101,11 @@ public @interface Plugin {
      */
     String[] authors() default {};
 
+    /**
+     * The {@link PluginAdapter} that should be used.
+     *
+     * @return The class of the plugin adapter
+     */
+    Class<? extends PluginAdapter> adapter() default PluginAdapter.Default.class;
+
 }

--- a/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.plugin;
 
+import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
@@ -49,10 +50,11 @@ public interface PluginAdapter {
      * all plugin specific {@link Injector}s. The returned injector will be used
      * to construct the plugin defined {@link Module}s.
      *
+     * @param defaultModule De default module
      * @return The global injector
      */
-    default Injector createGlobalInjector(Injector defaultInjector) {
-        return defaultInjector;
+    default Injector createGlobalInjector(Module defaultModule) {
+        return Guice.createInjector(defaultModule);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
@@ -38,12 +38,25 @@ import java.util.Optional;
  *
  * <p>A plugin needs to specify this in the {@link Plugin} annotation.</p>
  *
- * <p>A plugin adapter requires a empty and public constructor.</p>
+ * <p>The plugin adapter will be constructed globally by a
+ * {@link Injector}. All injections that aren't plugin specific will
+ * be available for the {@link PluginAdapter}.</p>
  */
 public interface PluginAdapter {
 
     /**
-     * Gets the {@link Injector} that will be used to construct a plugin instance. Proper
+     * Creates the global {@link Injector} that will be used to construct
+     * all plugin specific {@link Injector}s. The returned injector will be used
+     * to construct the plugin defined {@link Module}s.
+     *
+     * @return The global modules
+     */
+    default Injector createGlobalInjector(Injector defaultInjector) {
+        return defaultInjector;
+    }
+
+    /**
+     * Creates the {@link Injector} that will be used to construct a plugin instance. Proper
      * bindings should be applied to the {@link Injector} that
      * {@code injector.getInstance(pluginClass)} would return the plugin instance.
      *
@@ -51,8 +64,8 @@ public interface PluginAdapter {
      * {@link IllegalStateException} will be thrown when constructing if this
      * isn't the case.</p>
      *
-     * <p>Calling {@link PluginContainer#getInstance()} during this
-     * method will always result in {@link Optional#empty()}.</p>
+     * <p>Calling {@link PluginContainer#getInstance()} during the injector construction
+     * will always result in {@link Optional#empty()}.</p>
      *
      * @param pluginContainer The plugin container the injector is being created for
      * @param pluginClass The plugin class

--- a/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
@@ -29,6 +29,9 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Represents a adapter for plugins. Adapters can be used to add support
  * to other programming languages for better support, to modify the
@@ -52,11 +55,12 @@ public interface PluginAdapter {
      * method will result in a {@link IllegalStateException}.</p>
      *
      * @param pluginContainer The plugin container the injector is being created for
-     * @param defaultInjector The default injector
      * @param pluginClass The plugin class
+     * @param defaultInjector The default injector
+     * @param pluginModules A immutable list of modules which are provided by the plugin
      * @return The injector
      */
-    <T> Injector getInjector(PluginContainer pluginContainer, Injector defaultInjector, Class<T> pluginClass);
+    <T> Injector getInjector(PluginContainer pluginContainer, Class<T> pluginClass, Injector defaultInjector, List<Module> pluginModules);
 
     /**
      * Represents the default {@link PluginAdapter}.
@@ -64,14 +68,16 @@ public interface PluginAdapter {
     final class Default implements PluginAdapter {
 
         @Override
-        public <T> Injector getInjector(PluginContainer pluginContainer, Injector defaultInjector, Class<T> pluginClass) {
+        public <T> Injector getInjector(PluginContainer pluginContainer, Class<T> pluginClass, Injector defaultInjector, List<Module> pluginModules) {
             final Module module = new AbstractModule() {
                 @Override
                 protected void configure() {
                     bind(pluginClass).in(Scopes.SINGLETON);
                 }
             };
-            return defaultInjector.createChildInjector(module);
+            final List<Module> modules = new ArrayList<>(pluginModules);
+            modules.add(0, module);
+            return defaultInjector.createChildInjector(modules);
         }
     }
 }

--- a/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
@@ -24,12 +24,10 @@
  */
 package org.spongepowered.api.plugin;
 
-import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -46,36 +44,43 @@ import java.util.Optional;
 public interface PluginAdapter {
 
     /**
-     * Creates the global {@link Injector} that will be used to construct
-     * all plugin specific {@link Injector}s. The returned injector will be used
-     * to construct the plugin defined {@link Module}s.
+     * Creates the global {@link Module} that will be used to construct
+     * all plugin specific {@link Injector}s. The returned module will be
+     * used to construct the plugin defined {@link Module}s.
+     *
+     * <p>All implicitly constructed objects for plugin defined modules
+     * by this global module won't be retained when it's passed into the
+     * plugin {@link Injector}. Everything that should be retained has
+     * to be manually bound in the module.</p>
      *
      * @param defaultModule De default module
      * @return The global injector
      */
-    default Injector createGlobalInjector(Module defaultModule) {
-        return Guice.createInjector(defaultModule);
+    default Module createGlobalModule(Module defaultModule) {
+        return defaultModule;
     }
 
     /**
-     * Creates the {@link Injector} that will be used to construct a plugin instance. Proper
-     * bindings should be applied to the {@link Injector} that
-     * {@code injector.getInstance(pluginClass)} would return the plugin instance.
+     * Creates the {@link Module} that will be used to construct a plugin instance. Proper
+     * bindings should be applied to the {@link Module} so that
+     * {@code injector.getInstance(pluginClass)} will return the plugin instance.
+     *
+     * <p>The provided default {@link Module} contains the default module and
+     * all the plugin provided {@link Module}s.</p>
      *
      * <p>A {@link Scopes#SINGLETON singleton} scope is expected for the plugin instance, a
      * {@link IllegalStateException} will be thrown when constructing if this
      * isn't the case.</p>
      *
-     * <p>Calling {@link PluginContainer#getInstance()} during the injector construction
+     * <p>Calling {@link PluginContainer#getInstance()} during the module construction
      * will always result in {@link Optional#empty()}.</p>
      *
      * @param pluginContainer The plugin container the injector is being created for
      * @param pluginClass The plugin class
-     * @param defaultInjector The default injector
-     * @param pluginModules A immutable list of modules which are provided by the plugin
-     * @return The injector
+     * @param defaultModule The default module
+     * @return The plugin module
      */
-    <T> Injector createInjector(PluginContainer pluginContainer, Class<T> pluginClass, Injector defaultInjector, List<Module> pluginModules);
+    <T> Module createPluginModule(PluginContainer pluginContainer, Class<T> pluginClass, Module defaultModule);
 
     /**
      * Represents the default {@link PluginAdapter}.

--- a/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
@@ -60,24 +60,11 @@ public interface PluginAdapter {
      * @param pluginModules A immutable list of modules which are provided by the plugin
      * @return The injector
      */
-    <T> Injector getInjector(PluginContainer pluginContainer, Class<T> pluginClass, Injector defaultInjector, List<Module> pluginModules);
+    <T> Injector createInjector(PluginContainer pluginContainer, Class<T> pluginClass, Injector defaultInjector, List<Module> pluginModules);
 
     /**
      * Represents the default {@link PluginAdapter}.
      */
-    final class Default implements PluginAdapter {
-
-        @Override
-        public <T> Injector getInjector(PluginContainer pluginContainer, Class<T> pluginClass, Injector defaultInjector, List<Module> pluginModules) {
-            final Module module = new AbstractModule() {
-                @Override
-                protected void configure() {
-                    bind(pluginClass).in(Scopes.SINGLETON);
-                }
-            };
-            final List<Module> modules = new ArrayList<>(pluginModules);
-            modules.add(0, module);
-            return defaultInjector.createChildInjector(modules);
-        }
+    interface Default extends PluginAdapter {
     }
 }

--- a/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.plugin;
+
+import com.google.inject.Injector;
+
+/**
+ * Represents a adapter for plugins. Adapters can be used to add support
+ * to other programming languages for better support, to modify the
+ * default instantiation behavior to add custom injections, etc.
+ *
+ * <p>A plugin needs to specify this in the {@link Plugin} annotation.</p>
+ *
+ * <p>A plugin adapter requires a empty and public constructor.</p>
+ */
+public interface PluginAdapter {
+
+    /**
+     * Gets the {@link Injector} that will be used to construct a plugin using
+     * this adapter.
+     *
+     * <p>Calling {@link PluginContainer#getInstance()} during this
+     * method will result in a {@link IllegalStateException}.</p>
+     *
+     * @param pluginContainer The plugin container the injector is being created for
+     * @param defaultInjector The default injector
+     * @return The injector
+     */
+    default Injector getInjector(PluginContainer pluginContainer, Injector defaultInjector) {
+        return defaultInjector;
+    }
+
+    /**
+     * Gets the plugin instance for the target plugin.
+     *
+     * <p>Calling {@link PluginContainer#getInstance()} during this
+     * method will result in a {@link IllegalStateException}.</p>
+     *
+     * @param pluginContainer The plugin container
+     * @param injector The injector that should be used to populate the plugin with injections
+     * @param pluginClass The plugin class
+     * @return The plugin instance
+     */
+    default <T> T getInstance(PluginContainer pluginContainer, Injector injector, Class<T> pluginClass) {
+        return injector.getInstance(pluginClass);
+    }
+
+    /**
+     * Represents the default {@link PluginAdapter}.
+     */
+    final class Default implements PluginAdapter {
+    }
+}

--- a/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
@@ -49,7 +49,7 @@ public interface PluginAdapter {
      * all plugin specific {@link Injector}s. The returned injector will be used
      * to construct the plugin defined {@link Module}s.
      *
-     * @return The global modules
+     * @return The global injector
      */
     default Injector createGlobalInjector(Injector defaultInjector) {
         return defaultInjector;

--- a/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
@@ -24,13 +24,12 @@
  */
 package org.spongepowered.api.plugin;
 
-import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents a adapter for plugins. Adapters can be used to add support
@@ -48,11 +47,12 @@ public interface PluginAdapter {
      * bindings should be applied to the {@link Injector} that
      * {@code injector.getInstance(pluginClass)} would return the plugin instance.
      *
-     * <p>A singleton is expected for the plugin instance, a {@link IllegalStateException}
-     * may be thrown when constructing if this isn't the case.</p>
+     * <p>A {@link Scopes#SINGLETON singleton} scope is expected for the plugin instance, a
+     * {@link IllegalStateException} will be thrown when constructing if this
+     * isn't the case.</p>
      *
      * <p>Calling {@link PluginContainer#getInstance()} during this
-     * method will result in a {@link IllegalStateException}.</p>
+     * method will always result in {@link Optional#empty()}.</p>
      *
      * @param pluginContainer The plugin container the injector is being created for
      * @param pluginClass The plugin class

--- a/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
+++ b/src/main/java/org/spongepowered/api/plugin/PluginAdapter.java
@@ -41,8 +41,12 @@ import com.google.inject.Scopes;
 public interface PluginAdapter {
 
     /**
-     * Gets the {@link Injector} that will be used to construct a plugin using
-     * this adapter.
+     * Gets the {@link Injector} that will be used to construct a plugin instance. Proper
+     * bindings should be applied to the {@link Injector} that
+     * {@code injector.getInstance(pluginClass)} would return the plugin instance.
+     *
+     * <p>A singleton is expected for the plugin instance, a {@link IllegalStateException}
+     * may be thrown when constructing if this isn't the case.</p>
      *
      * <p>Calling {@link PluginContainer#getInstance()} during this
      * method will result in a {@link IllegalStateException}.</p>
@@ -53,19 +57,6 @@ public interface PluginAdapter {
      * @return The injector
      */
     <T> Injector getInjector(PluginContainer pluginContainer, Injector defaultInjector, Class<T> pluginClass);
-
-    /**
-     * Gets the plugin instance for the target plugin.
-     *
-     * <p>Calling {@link PluginContainer#getInstance()} during this
-     * method will result in a {@link IllegalStateException}.</p>
-     *
-     * @param pluginContainer The plugin container
-     * @param injector The injector that should be used to populate the plugin with injections
-     * @param pluginClass The plugin class
-     * @return The plugin instance
-     */
-    <T> T getInstance(PluginContainer pluginContainer, Injector injector, Class<T> pluginClass);
 
     /**
      * Represents the default {@link PluginAdapter}.
@@ -81,11 +72,6 @@ public interface PluginAdapter {
                 }
             };
             return defaultInjector.createChildInjector(module);
-        }
-
-        @Override
-        public <T> T getInstance(PluginContainer pluginContainer, Injector injector, Class<T> pluginClass) {
-            return injector.getInstance(pluginClass);
         }
     }
 }


### PR DESCRIPTION
**API** | [Common](https://github.com/SpongePowered/SpongeCommon/pull/2238) | [Forge](https://github.com/SpongePowered/SpongeForge/pull/2694) | Vanilla | [KotlinAdapter](https://github.com/Cybermaxke/KotlinAdapter)

Supports alternate plugin instantiation and injections. Can be used e.g. for kotlin/scala object support, kotlin delegate property injections, custom plugin injections, etc.

I am going to write a test project to demonstrate how it can be used. SpongeVanilla support will follow once it's successfully tested on SpongeForge.

Kotlin Adapter:
https://github.com/Cybermaxke/KotlinAdapter/blob/master/src/main/kotlin/org/lanternpowered/kt/adapter/KotlinAdapter.kt

Kotlin Test Plugin:
https://github.com/Cybermaxke/KotlinAdapter/blob/master/src/main/kotlin/org/lanternpowered/kt/plugin/TestPlugin.kt