### PR TITLE
SmeltEvent Javadocs

### DIFF
--- a/src/main/java/org/spongepowered/api/event/block/tileentity/SmeltEvent.java
+++ b/src/main/java/org/spongepowered/api/event/block/tileentity/SmeltEvent.java
@@ -42,25 +42,44 @@ public interface SmeltEvent extends TargetTileEntityEvent {
      */
     ItemStackSnapshot getFuel();
 
+    /**
+     * The first tick of an item smelting.
+     * Note that actually no stacks are affected when starting to smelt.
+     */
     interface Start extends SmeltEvent, AffectItemStackEvent {}
 
+    /**
+     * Fires whenever fuel is consumed to refill the current burn time.
+     * Canceling this event prevents fuel from being consumed in a furnace In the current burn time to 0.
+     */
     interface ConsumeFuel extends SmeltEvent, AffectItemStackEvent {}
 
+    /**
+     * The smelting timer ticking up or down.
+     * Note that actually no stacks are affected when ticking.
+     */
     interface Tick extends SmeltEvent, AffectItemStackEvent {}
 
+    /**
+     * Fires when the smelting is interrupted causing the current smelting time to reset to 0.
+     */
     interface Interrupt extends SmeltEvent {
         /**
          * Gets an immutable {@link List} of {@link ItemStackSnapshot}s that are the result
          * of the smelt.
          * @return The smelt items
+         *
+         * @deprecated always empty
          */
+        @Deprecated
         List<ItemStackSnapshot> getSmeltedItems();
     }
 
     interface Finish extends SmeltEvent {
         /**
-         * Gets an immutable {@link List} of {@link ItemStackSnapshot}s that are the result
-         * of the smelt.
+         * Gets an immutable {@link List} of {@link ItemStackSnapshot}s that are the result of the smelt.
+         * Always exactly one item.
+         *
          * @return The smelt items
          */
         List<ItemStackSnapshot> getSmeltedItems();


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2265)

Have some Javadocs.


Notes for API8:

 - Start/Tick Up could be one event with the current smeltTime
 - Tick Down could be a separate event
 - Start/Tick do not actually affect itemstacks
 - Interrupt has no smelting result. It was cancelled...
 - Finish only has a single result. This could include an actual SlotTransaction.
 - ConsumeFuel could  include an actual SlotTransaction.