### PR TITLE
Added Data manipulator/Keys for Disabled Slots in an ArmorStand.

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -71,6 +71,7 @@ import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.enchantment.Enchantment;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.item.inventory.equipment.EquipmentType;
 import org.spongepowered.api.item.merchant.TradeOffer;
 import org.spongepowered.api.profile.GameProfile;
 import org.spongepowered.api.statistic.Statistic;
@@ -87,6 +88,7 @@ import org.spongepowered.api.world.weather.Weather;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -276,6 +278,20 @@ public final class Keys {
      * @see ArmorStandData#marker()
      */
     public static final Key<Value<Boolean>> ARMOR_STAND_MARKER = DummyObjectProvider.createExtendedFor(Key.class,"ARMOR_STAND_MARKER");
+
+    /**
+     * Represents the {@link Key} for whether players are prevented from taking
+     * items from an equipment slot on an {@link ArmorStand}
+     */
+    public static final Key<SetValue<EquipmentType>> ARMOR_STAND_TAKING_DISABLED = DummyObjectProvider
+	    .createExtendedFor(Key.class, "ARMOR_STAND_TAKING_DISABLED");
+
+    /**
+     * Represents the {@link Key} for whether players are prevented from taking
+     * items from an equipment slot on an {@link ArmorStand}
+     */
+    public static final Key<SetValue<EquipmentType>> ARMOR_STAND_PLACING_DISABLED = DummyObjectProvider
+	    .createExtendedFor(Key.class, "ARMOR_STAND_PLACING_DISABLED");
 
     /**
      * Represents the {@link Key} for the type of {@link Art} shown by

--- a/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/catalog/CatalogEntityData.java
@@ -104,6 +104,13 @@ public final class CatalogEntityData {
      * will calm down after a certain amount of time has passed.
      */
     public static final Class<AngerableData> ANGERABLE_DATA = AngerableData.class;
+    
+    /**
+     * The {@link DisabledSlotsData} signifies which slots are unable to be taken
+     * from / placed into in an armour stand
+     */
+    public static final Class<DisabledSlotsData> DISABLED_SLOTS_DATA = DisabledSlotsData.class;
+    
     /**
      * The {@link ArtData} that signifies what piece of {@link Art} is being
      * displayed. It is applicable for {@link Painting} entities.

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableDisabledSlotsData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableDisabledSlotsData.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.entity.DisabledSlotsData;
+import org.spongepowered.api.data.value.immutable.ImmutableSetValue;
+import org.spongepowered.api.entity.living.ArmorStand;
+import org.spongepowered.api.item.inventory.equipment.EquipmentType;
+
+/**
+ * A {@link ImmutableDataManipulator} for the disabled slots in an
+ * {@link ArmorStand}.
+ * 
+ * A slot can have taking disabled, placing disabled or both.
+ */
+public interface ImmutableDisabledSlotsData
+	extends ImmutableDataManipulator<ImmutableDisabledSlotsData, DisabledSlotsData> {
+
+    /**
+     * Controls slots that players can't take items from.
+     * 
+     * @return A set of slots that players cannot take from.
+     * @see Key#ARMOR_STAND_TAKING_DISABLED
+     */
+    ImmutableSetValue<EquipmentType> takingDisabled();
+
+    /**
+     * Controls slots that players can't place items into.
+     * 
+     * @return A set of slots that players cannot place into.
+     * @see Key#ARMOR_STAND_PLACING_DISABLED
+     */
+    ImmutableSetValue<EquipmentType> placingDisabled();
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/DisabledSlotsData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/DisabledSlotsData.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableDisabledSlotsData;
+import org.spongepowered.api.data.value.mutable.SetValue;
+import org.spongepowered.api.entity.living.ArmorStand;
+import org.spongepowered.api.item.inventory.equipment.EquipmentType;
+
+/**
+ * A {@link DataManipulator} for the disabled slots in an {@link ArmorStand}.
+ * 
+ * A slot can have taking disabled, placing disabled or both.
+ */
+public interface DisabledSlotsData extends DataManipulator<DisabledSlotsData, ImmutableDisabledSlotsData> {
+
+    /**
+     * Controls slots that players can't take items from.
+     * 
+     * @return A set of slots that players cannot take from.
+     * @see Key#ARMOR_STAND_TAKING_DISABLED
+     */
+    SetValue<EquipmentType> takingDisabled();
+
+    /**
+     * Controls slots that players can't place items into.
+     * 
+     * @return A set of slots that players cannot place into.
+     * @see Key#ARMOR_STAND_PLACING_DISABLED
+     */
+    SetValue<EquipmentType> placingDisabled();
+
+}

--- a/src/main/java/org/spongepowered/api/entity/living/ArmorStand.java
+++ b/src/main/java/org/spongepowered/api/entity/living/ArmorStand.java
@@ -27,8 +27,11 @@ package org.spongepowered.api.entity.living;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.mutable.entity.ArmorStandData;
 import org.spongepowered.api.data.manipulator.mutable.entity.BodyPartRotationalData;
+import org.spongepowered.api.data.manipulator.mutable.entity.DisabledSlotsData;
+import org.spongepowered.api.data.value.mutable.SetValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.ArmorEquipable;
+import org.spongepowered.api.item.inventory.equipment.EquipmentType;
 
 /**
  * Represents an armor stand.
@@ -98,4 +101,15 @@ public interface ArmorStand extends Living, ArmorEquipable {
         return get(ArmorStandData.class).get();
     }
 
+    default SetValue<EquipmentType> placingDisabled() {
+        return getValue(Keys.ARMOR_STAND_PLACING_DISABLED).get();
+    }
+
+    default SetValue<EquipmentType> takingDisabled() {
+        return getValue(Keys.ARMOR_STAND_TAKING_DISABLED).get();
+    }
+
+    default DisabledSlotsData getDisabledSlotsData() {
+        return get(DisabledSlotsData.class).get();
+    }
 }

--- a/src/main/java/org/spongepowered/api/util/TypeTokens.java
+++ b/src/main/java/org/spongepowered/api/util/TypeTokens.java
@@ -95,6 +95,7 @@ import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.enchantment.Enchantment;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.item.inventory.equipment.EquipmentType;
 import org.spongepowered.api.item.merchant.TradeOffer;
 import org.spongepowered.api.item.potion.PotionType;
 import org.spongepowered.api.profile.GameProfile;
@@ -415,6 +416,8 @@ public final class TypeTokens {
     public static final TypeToken<Set<Direction>> SET_DIRECTION_TOKEN = new TypeToken<Set<Direction>>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<SetValue<Direction>> SET_DIRECTION_VALUE_TOKEN = new TypeToken<SetValue<Direction>>() {private static final long serialVersionUID = -1;};
+
+    public static final TypeToken<SetValue<EquipmentType>> SET_EQUIPMENT_TYPE_TOKEN = new TypeToken<SetValue<EquipmentType>>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<Short> SHORT_TOKEN = new TypeToken<Short>() {private static final long serialVersionUID = -1;};
 


### PR DESCRIPTION
Heyo,

I'm not sure if I've done everything needed to register a new DataManipulator so I've done what seemed relevant.

DisabledSlotsData (DISABLED_SLOTS_DATA in CatalogEntityData) has methods:

  - `takingDisabled()` (`ARMOR_STAND_TAKING_DISABLED`)
  - `placingDisabled()` (`ARMOR_STAND_PLACING_DISABLED`)

which each return `Map<EquipmentType, Boolean>`. The boolean for each slot is if that action is disabled (ie false allows access).

Fixes #1837 