### PR TITLE
Fix PlayerCommandElement autocompletion and enhance CommandArgs

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/CommandArgs.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandArgs.java
@@ -165,6 +165,15 @@ public final class CommandArgs {
     }
 
     /**
+     * Get an arg at the specified position.
+     *
+     * @param index index of the element to return
+     */
+    public String get(int index) {
+        return this.args.get(index).getValue();
+    }
+
+    /**
      * Insert an arg as the next arg to be returned by {@link #next()}.
      *
      * @param value The argument to insert
@@ -212,6 +221,15 @@ public final class CommandArgs {
         for (int i = startIdx; i <= endIdx; ++i) {
             this.args.remove(startIdx);
         }
+    }
+
+    /**
+     * Returns the number of arguments
+     *
+     * @return the number of arguments
+     */
+    public int size() {
+        return this.args.size();
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -1433,6 +1433,19 @@ public final class GenericArguments {
         }
 
         @Override
+        public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+            if (args.size() == 0) {
+                return Collections.emptyList();
+            }
+            final String last = args.get(args.size() - 1);
+
+            return Sponge.getServer().getOnlinePlayers().stream()
+                    .filter(p -> p.getName().startsWith(last))
+                    .map(User::getName)
+                    .collect(Collectors.toList());
+        }
+
+        @Override
         protected Iterable<String> getChoices(CommandSource source) {
             return Sponge.getGame().getServer().getOnlinePlayers().stream()
                 .map(input -> input == null ? null : input.getName())

--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -1433,16 +1433,6 @@ public final class GenericArguments {
         }
 
         @Override
-        public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
-            final String last = (args.size() == 0) ? "" : args.get(args.size() - 1);
-
-            return Sponge.getServer().getOnlinePlayers().stream()
-                    .filter(p -> p.getName().startsWith(last))
-                    .map(User::getName)
-                    .collect(Collectors.toList());
-        }
-
-        @Override
         protected Iterable<String> getChoices(CommandSource source) {
             return Sponge.getGame().getServer().getOnlinePlayers().stream()
                 .map(input -> input == null ? null : input.getName())

--- a/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
+++ b/src/main/java/org/spongepowered/api/command/args/GenericArguments.java
@@ -1434,10 +1434,7 @@ public final class GenericArguments {
 
         @Override
         public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
-            if (args.size() == 0) {
-                return Collections.emptyList();
-            }
-            final String last = args.get(args.size() - 1);
+            final String last = (args.size() == 0) ? "" : args.get(args.size() - 1);
 
             return Sponge.getServer().getOnlinePlayers().stream()
                     .filter(p -> p.getName().startsWith(last))


### PR DESCRIPTION
The issue can be replicated using the skull testplugin.

user "sponge" join the game

before: `/skullme sponge bukk<tab>` -> `/skullme sponge sponge`
with this PR: `/skullme sponge bukk<tab>` -> `/skullme sponge bukk`

Also, add `size` and `get` to `CommandArgs` to help plugin provided command elements

Note: the two added methods can be replicated using `getAll().size()` and `getAll().get(index)`, however `getAll()` has quite a bit of overhead.