### PR TITLE
Add possibility to remove a child at an index

### DIFF
--- a/src/main/java/org/spongepowered/api/text/Text.java
+++ b/src/main/java/org/spongepowered/api/text/Text.java
@@ -766,6 +766,30 @@ public abstract class Text implements TextRepresentable, DataSerializable, Compa
         }
 
         /**
+         * Removes the last child in this builder.
+         *
+         * @return This text builder
+         * @see #remove(int)
+         */
+        public Builder removeLastChild() {
+            int lastIndex = this.children.size() - 1;
+            this.remove(lastIndex);
+            return this;
+        }
+
+        /**
+         * Removes the child at the given index.
+         *
+         * @param index The index of the child
+         * @return This text builder
+         * @throws IndexOutOfBoundsException if the given index is out of bounds
+         */
+        public Builder remove(int index) {
+            this.children.remove(index);
+            return this;
+        }
+
+        /**
          * Removes the specified {@link Text} from this builder.
          *
          * @param children The texts to remove

--- a/src/main/java/org/spongepowered/api/text/Text.java
+++ b/src/main/java/org/spongepowered/api/text/Text.java
@@ -766,6 +766,18 @@ public abstract class Text implements TextRepresentable, DataSerializable, Compa
         }
 
         /**
+         * Removes the last child in this builder.
+         *
+         * @return This text builder
+         * @see #remove(int)
+         */
+        public Builder removeLastChild() {
+            int lastIndex = this.children.size() - 1;
+            this.remove(lastIndex);
+            return this;
+        }
+
+        /**
          * Removes the child at the given index.
          *
          * @param index The index of the child

--- a/src/main/java/org/spongepowered/api/text/Text.java
+++ b/src/main/java/org/spongepowered/api/text/Text.java
@@ -766,6 +766,18 @@ public abstract class Text implements TextRepresentable, DataSerializable, Compa
         }
 
         /**
+         * Removes the child at the given index.
+         *
+         * @param index The index of the child
+         * @return This text builder
+         * @throws IndexOutOfBoundsException if the given index is out of bounds
+         */
+        public Builder remove(int index) {
+            this.children.remove(index);
+            return this;
+        }
+
+        /**
          * Removes the specified {@link Text} from this builder.
          *
          * @param children The texts to remove

--- a/src/test/java/org/spongepowered/api/text/TextTest.java
+++ b/src/test/java/org/spongepowered/api/text/TextTest.java
@@ -109,11 +109,11 @@ public class TextTest {
                 .append(Text.of("."));
 
         assertThat(builder.getChildren().size(), is(4));
-        assertThat(builder.build().toPlainSingle(), is("Hello Sponge!."));
+        assertThat(builder.build().toPlain(), is("Hello Sponge!."));
         builder.remove(2);
         builder.removeLastChild();
         assertThat(builder.getChildren().size(), is(2));
-        assertThat(builder.build().toPlainSingle(), is("Hello Sponge"));
+        assertThat(builder.build().toPlain(), is("Hello Sponge"));
     }
 
     private static Text findText(Text root, String text) {

--- a/src/test/java/org/spongepowered/api/text/TextTest.java
+++ b/src/test/java/org/spongepowered/api/text/TextTest.java
@@ -100,6 +100,22 @@ public class TextTest {
         assertThat(server.getShiftClickAction().get(), is(insertText("Welcome Spongie!")));
     }
 
+    @Test
+    public void testRemoveAtIndex() {
+        Text.Builder builder = Text.builder()
+                .append(Text.of("Hello"))
+                .append(Text.of("Sponge"))
+                .append(Text.of("!"))
+                .append(Text.of("."));
+
+        assertThat(builder.getChildren().size(), is(4));
+        assertThat(builder.build().toPlain(), is("HelloSponge!."));
+        builder.remove(2);
+        builder.removeLastChild();
+        assertThat(builder.getChildren().size(), is(2));
+        assertThat(builder.build().toPlain(), is("HelloSponge"));
+    }
+
     private static Text findText(Text root, String text) {
         for (Text t : root.withChildren()) {
             if (t instanceof LiteralText && ((LiteralText) t).getContent().contains(text)) {

--- a/src/test/java/org/spongepowered/api/text/TextTest.java
+++ b/src/test/java/org/spongepowered/api/text/TextTest.java
@@ -109,11 +109,11 @@ public class TextTest {
                 .append(Text.of("."));
 
         assertThat(builder.getChildren().size(), is(4));
-        assertThat(builder.build().toPlain(), is("Hello Sponge!."));
+        assertThat(builder.build().toPlain(), is("HelloSponge!."));
         builder.remove(2);
         builder.removeLastChild();
         assertThat(builder.getChildren().size(), is(2));
-        assertThat(builder.build().toPlain(), is("Hello Sponge"));
+        assertThat(builder.build().toPlain(), is("HelloSponge"));
     }
 
     private static Text findText(Text root, String text) {

--- a/src/test/java/org/spongepowered/api/text/TextTest.java
+++ b/src/test/java/org/spongepowered/api/text/TextTest.java
@@ -102,7 +102,8 @@ public class TextTest {
 
     @Test
     public void testRemoveAtIndex() {
-        Text.Builder builder = Text.builder("Hello")
+        Text.Builder builder = Text.builder()
+                .append(Text.of("Hello"))
                 .append(Text.of("Sponge"))
                 .append(Text.of("!"))
                 .append(Text.of("."));

--- a/src/test/java/org/spongepowered/api/text/TextTest.java
+++ b/src/test/java/org/spongepowered/api/text/TextTest.java
@@ -100,6 +100,21 @@ public class TextTest {
         assertThat(server.getShiftClickAction().get(), is(insertText("Welcome Spongie!")));
     }
 
+    @Test
+    public void testRemoveAtIndex() {
+        Text.Builder builder = Text.builder("Hello")
+                .append(Text.of("Sponge"))
+                .append(Text.of("!"))
+                .append(Text.of("."));
+
+        assertThat(builder.getChildren().size(), is(4));
+        assertThat(builder.build().toPlainSingle(), is("Hello Sponge!."));
+        builder.remove(2);
+        builder.removeLastChild();
+        assertThat(builder.getChildren().size(), is(2));
+        assertThat(builder.build().toPlainSingle(), is("Hello Sponge"));
+    }
+
     private static Text findText(Text root, String text) {
         for (Text t : root.withChildren()) {
             if (t instanceof LiteralText && ((LiteralText) t).getContent().contains(text)) {


### PR DESCRIPTION
A user can now remove a child at a specific index.

This pull request fixes #1727 