### PR TITLE
Give permissions integer values to allow weighting

### DIFF
--- a/src/main/java/org/spongepowered/api/service/permission/SubjectCollection.java
+++ b/src/main/java/org/spongepowered/api/service/permission/SubjectCollection.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.service.permission;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 import org.spongepowered.api.service.context.Context;
 
 import java.util.Collection;
@@ -250,7 +251,9 @@ public interface SubjectCollection {
      * @param permission The permission to check
      * @return A reference to any subject known to have this permission
      *         set, and the value this permission is set to
+     * @deprecated See {@link #getAllWithPermissionValue(String)}
      */
+    @Deprecated
     CompletableFuture<Map<SubjectReference, Boolean>> getAllWithPermission(String permission);
 
     /**
@@ -265,7 +268,9 @@ public interface SubjectCollection {
      * @param permission The permission to check
      * @return A reference to any subject known to have this permission
      *         set, and the value this permission is set to
+     * @deprecated See {@link #getAllWithPermissionValue(Set, String)}
      */
+    @Deprecated
     CompletableFuture<Map<SubjectReference, Boolean>> getAllWithPermission(Set<Context> contexts, String permission);
 
     /**
@@ -284,7 +289,9 @@ public interface SubjectCollection {
      * @param permission The permission to check
      * @return A map containing any subject known to have this permission set,
      *         and the value this permission is set to
+     * @deprecated See {@link #getLoadedWithPermissionValue(String)}
      */
+    @Deprecated
     Map<Subject, Boolean> getLoadedWithPermission(String permission);
 
     /**
@@ -298,8 +305,86 @@ public interface SubjectCollection {
      * @param permission The permission to check
      * @return A map containing any subject known to have this permission set,
      *         and the value this permission is set to
+     * @deprecated See {@link #getLoadedWithPermissionValue(Set, String)}
      */
+    @Deprecated
     Map<Subject, Boolean> getLoadedWithPermission(Set<Context> contexts, String permission);
+
+    /**
+     * Return the identifiers of all known subjects with the given permission
+     * set.
+     *
+     * <p>This method <p>DOES NOT</p> consider inheritance, and will only query
+     * the data set to the subjects {@link Subject#getSubjectData()}. Transient
+     * data is not considered.</p>
+     *
+     * <p>As no context is passed, it is up to the implementation to decide
+     * which contexts to use. When available,
+     * {@link Subject#getActiveContexts()} is used for the lookup. Otherwise, it
+     * is likely that {@link SubjectData#GLOBAL_CONTEXT} will be
+     * used.</p>
+     *
+     * @param permission The permission to check
+     * @return A reference to any subject known to have this permission
+     *         set, and the value this permission is set to
+     */
+    default CompletableFuture<Map<SubjectReference, Integer>> getAllWithPermissionValue(String permission) {
+        return getAllWithPermission(permission).thenApply(map -> Maps.transformValues(map, val -> val ? 1 : -1));
+    }
+
+    /**
+     * Return the identifiers of all known subjects with the given permission
+     * set.
+     *
+     * <p>This method <p>DOES NOT</p> consider inheritance, and will only query
+     * the data set to the subjects {@link Subject#getSubjectData()}. Transient
+     * data is not considered.</p>
+     *
+     * @param contexts The context combination to check for permissions in
+     * @param permission The permission to check
+     * @return A reference to any subject known to have this permission
+     *         set, and the value this permission is set to
+     */
+    default CompletableFuture<Map<SubjectReference, Integer>> getAllWithPermissionValue(Set<Context> contexts, String permission) {
+        return getAllWithPermission(contexts, permission).thenApply(map -> Maps.transformValues(map, val -> val ? 1 : -1));
+    }
+
+    /**
+     * Return all loaded subjects with the given permission set.
+     *
+     * <p>This method <p>DOES NOT</p> consider inheritance, and will only query
+     * the data set to the subjects {@link Subject#getSubjectData()}. Transient
+     * data is not considered.</p>
+     *
+     * <p>As no context is passed, it is up to the implementation to decide
+     * which contexts to use. When available,
+     * {@link Subject#getActiveContexts()} is used for the lookup. Otherwise, it
+     * is likely that {@link SubjectData#GLOBAL_CONTEXT} will be
+     * used.</p>
+     *
+     * @param permission The permission to check
+     * @return A map containing any subject known to have this permission set,
+     *         and the value this permission is set to
+     */
+    default Map<Subject, Integer> getLoadedWithPermissionValue(String permission) {
+        return Maps.transformValues(getLoadedWithPermission(permission), val -> val ? 1 : -1);
+    }
+
+    /**
+     * Return all loaded subjects with the given permission set.
+     *
+     * <p>This method <p>DOES NOT</p> consider inheritance, and will only query
+     * the data set to the subjects {@link Subject#getSubjectData()}. Transient
+     * data is not considered.</p>
+     *
+     * @param contexts The context combination to check for permissions in
+     * @param permission The permission to check
+     * @return A map containing any subject known to have this permission set,
+     *         and the value this permission is set to
+     */
+    default Map<Subject, Integer> getLoadedWithPermissionValue(Set<Context> contexts, String permission) {
+        return Maps.transformValues(getLoadedWithPermission(contexts, permission), val -> val ? 1 : -1);
+    }
 
     /**
      * Gets the subject holding data that is applied by default to all
@@ -316,10 +401,6 @@ public interface SubjectCollection {
      * <p>It is also recommended to use
      * {@link Subject#getTransientSubjectData()} where possible to avoid
      * persisting unnecessary data.</p>
-     *
-     * <p>Assigning default permissions should be used sparingly, and by
-     * convention, only in situations where "default" game behaviour is restored
-     * by granting a certain permission.</p>
      *
      * @return The subject holding defaults for this collection
      */

--- a/src/main/java/org/spongepowered/api/text/channel/type/PermissionMessageChannel.java
+++ b/src/main/java/org/spongepowered/api/text/channel/type/PermissionMessageChannel.java
@@ -67,8 +67,8 @@ public class PermissionMessageChannel implements MessageChannel {
         PermissionService service = Sponge.getGame().getServiceManager().provideUnchecked(PermissionService.class);
 
         return service.getLoadedCollections().values().stream()
-                .flatMap(input -> input.getLoadedWithPermission(this.permission).entrySet().stream()
-                        .filter(Map.Entry::getValue)
+                .flatMap(input -> input.getLoadedWithPermissionValue(this.permission).entrySet().stream()
+                        .filter(ent -> ent.getValue() > 0)
                         .map(entry -> entry.getKey().getCommandSource().orElse(null))
                         .filter(source -> source != null))
                 .collect(ImmutableSet.toImmutableSet());

--- a/src/main/java/org/spongepowered/api/util/Tristate.java
+++ b/src/main/java/org/spongepowered/api/util/Tristate.java
@@ -28,7 +28,7 @@ package org.spongepowered.api.util;
  * Represents a simple tristate.
  */
 public enum Tristate {
-    TRUE(true) {
+    TRUE(true, 1) {
         @Override
         public Tristate and(Tristate other) {
             return other == TRUE || other == UNDEFINED ? TRUE : FALSE;
@@ -39,7 +39,7 @@ public enum Tristate {
             return TRUE;
         }
     },
-    FALSE(false) {
+    FALSE(false, -1) {
         @Override
         public Tristate and(Tristate other) {
             return FALSE;
@@ -50,7 +50,7 @@ public enum Tristate {
             return other == TRUE ? TRUE : FALSE;
         }
     },
-    UNDEFINED(false) {
+    UNDEFINED(false, 0) {
         @Override
         public Tristate and(Tristate other) {
             return other;
@@ -63,9 +63,11 @@ public enum Tristate {
     };
 
     private final boolean val;
+    private final int intVal;
 
-    Tristate(boolean val) {
+    Tristate(boolean val, int intVal) {
         this.val = val;
+        this.intVal = intVal;
     }
 
     /**
@@ -76,6 +78,22 @@ public enum Tristate {
      */
     public static Tristate fromBoolean(boolean val) {
         return val ? TRUE : FALSE;
+    }
+
+    /**
+     * Return the appropriate Tristate for a given integer value
+     *
+     * @param val The int value
+     * @return The appropriate tristate
+     */
+    public static Tristate fromInt(int val) {
+        if (val > 0) {
+            return TRUE;
+        } else if (val < 0) {
+            return FALSE;
+        } else {
+            return UNDEFINED;
+        }
     }
 
     /**
@@ -101,5 +119,14 @@ public enum Tristate {
      */
     public boolean asBoolean() {
         return this.val;
+    }
+
+    /**
+     * Returns the integer representation of this tristate.
+     *
+     * @return The integer tristate representation
+     */
+    public int asInt() {
+        return this.intVal;
     }
 }

--- a/src/test/java/org/spongepowered/api/service/permission/NodeTreeTest.java
+++ b/src/test/java/org/spongepowered/api/service/permission/NodeTreeTest.java
@@ -27,7 +27,6 @@ package org.spongepowered.api.service.permission;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-import org.spongepowered.api.util.Tristate;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,75 +35,75 @@ public class NodeTreeTest {
 
     @Test
     public void testAsMap() {
-        final Map<String, Boolean> testPermissions = new HashMap<>();
-        testPermissions.put("generate.rainbow", true);
-        testPermissions.put("generate.sunset", false);
-        testPermissions.put("generate", true);
-        testPermissions.put("generate.thunderstorm.explosive", false);
+        final Map<String, Integer> testPermissions = new HashMap<>();
+        testPermissions.put("generate.rainbow", 1);
+        testPermissions.put("generate.sunset", -1);
+        testPermissions.put("generate", 1);
+        testPermissions.put("generate.thunderstorm.explosive", -1);
 
-        NodeTree oldTree = NodeTree.of(testPermissions);
+        WeightedNodeTree oldTree = WeightedNodeTree.of(testPermissions);
 
         assertEquals(testPermissions, oldTree.asMap());
     }
 
     @Test
-    public void testWithValue() throws Exception {
-        final Map<String, Boolean> testPermissions = new HashMap<>();
-        testPermissions.put("generate.rainbow", true);
-        testPermissions.put("generate.sunset", false);
-        testPermissions.put("generate", true);
-        testPermissions.put("generate.thunderstorm.explosive", false);
+    public void testWithValue() {
+        final Map<String, Integer> testPermissions = new HashMap<>();
+        testPermissions.put("generate.rainbow", 1);
+        testPermissions.put("generate.sunset", -1);
+        testPermissions.put("generate", 1);
+        testPermissions.put("generate.thunderstorm.explosive", -1);
 
-        NodeTree oldTree = NodeTree.of(testPermissions);
-        assertEquals(Tristate.FALSE, oldTree.get("generate.thunderstorm.explosive"));
-        NodeTree newTree = oldTree.withValue("generate.thunderstorm.explosive", Tristate.TRUE);
-        assertEquals(Tristate.FALSE, oldTree.get("generate.thunderstorm.explosive"));
-        assertEquals(Tristate.TRUE, newTree.get("generate.thunderstorm.explosive"));
+        WeightedNodeTree oldTree = WeightedNodeTree.of(testPermissions);
+        assertEquals(-1, oldTree.get("generate.thunderstorm.explosive"));
+        WeightedNodeTree newTree = oldTree.withValue("generate.thunderstorm.explosive", 1);
+        assertEquals(-1, oldTree.get("generate.thunderstorm.explosive"));
+        assertEquals(1, newTree.get("generate.thunderstorm.explosive"));
     }
 
     @Test
-    public void testWithAll() throws Exception {
-        final Map<String, Boolean> testPermissions = new HashMap<>();
-        testPermissions.put("generate.rainbow", true);
-        testPermissions.put("generate.sunset", false);
-        testPermissions.put("generate", true);
-        testPermissions.put("generate.thunderstorm.explosive", false);
+    public void testWithAll() {
+        final Map<String, Integer> testPermissions = new HashMap<>();
+        testPermissions.put("generate.rainbow", 1);
+        testPermissions.put("generate.sunset", -1);
+        testPermissions.put("generate", 1);
+        testPermissions.put("generate.thunderstorm.explosive", -1);
 
-        NodeTree oldTree = NodeTree.of(testPermissions);
+        WeightedNodeTree oldTree = WeightedNodeTree.of(testPermissions);
 
-        final Map<String, Tristate> newPermissions = new HashMap<>();
-        newPermissions.put("generate.sunset.red", Tristate.TRUE);
-        newPermissions.put("generate.thunderstorm.explosive", Tristate.UNDEFINED);
-        newPermissions.put("something.new", Tristate.FALSE);
+        final Map<String, Integer> newPermissions = new HashMap<>();
+        newPermissions.put("generate.sunset.red", 1);
+        newPermissions.put("generate.thunderstorm.explosive", 0);
+        newPermissions.put("something.new", -1);
 
-        NodeTree newTree = oldTree.withAll(newPermissions);
+        WeightedNodeTree newTree = oldTree.withAll(newPermissions);
 
-        assertEquals(Tristate.FALSE, oldTree.get("generate.sunset.red"));
-        assertEquals(Tristate.TRUE, newTree.get("generate.sunset.red"));
+        assertEquals(-1, oldTree.get("generate.sunset.red"));
+        assertEquals(1, newTree.get("generate.sunset.red"));
 
-        assertEquals(Tristate.FALSE, oldTree.get("generate.thunderstorm.explosive"));
-        assertEquals(Tristate.UNDEFINED, newTree.get("generate.thunderstorm.explosive"));
+        assertEquals(-1, oldTree.get("generate.thunderstorm.explosive"));
+        assertEquals(0, newTree.get("generate.thunderstorm.explosive"));
 
-        assertEquals(Tristate.UNDEFINED, oldTree.get("something.new"));
-        assertEquals(Tristate.FALSE, newTree.get("something.new"));
+        assertEquals(0, oldTree.get("something.new"));
+        assertEquals(-1, newTree.get("something.new"));
     }
 
     @Test
-    public void testCreateFromValues() throws Exception {
-        final Map<String, Boolean> testPermissions = new HashMap<>();
-        testPermissions.put("generate.rainbow", true);
-        testPermissions.put("generate.sunset", false);
-        testPermissions.put("generate", true);
-        testPermissions.put("generate.thunderstorm.explosive", false);
+    public void testCreateFromValues() {
+        final Map<String, Integer> testPermissions = new HashMap<>();
+        testPermissions.put("generate.rainbow", 1);
+        testPermissions.put("generate.sunset", -1);
+        testPermissions.put("generate", 1);
+        testPermissions.put("generate.thunderstorm.explosive", -1);
 
-        NodeTree nodes = NodeTree.of(testPermissions, Tristate.UNDEFINED);
+        WeightedNodeTree nodes = WeightedNodeTree.of(testPermissions, 0);
 
-        assertEquals(Tristate.TRUE, nodes.get("generate.rainbow"));
-        assertEquals(Tristate.TRUE, nodes.get("generate.rainbow.double"));
-        assertEquals(Tristate.FALSE, nodes.get("generate.sunset"));
-        assertEquals(Tristate.FALSE, nodes.get("generate.sunset.east"));
-        assertEquals(Tristate.TRUE, nodes.get("generate.thunderstorm"));
-        assertEquals(Tristate.FALSE, nodes.get("generate.thunderstorm.explosive"));
-        assertEquals(Tristate.UNDEFINED, nodes.get("random.perm"));
+        assertEquals(1, nodes.get("generate.rainbow"));
+        assertEquals(1, nodes.get("generate.rainbow.double"));
+        assertEquals(-1, nodes.get("generate.sunset"));
+        assertEquals(-1, nodes.get("generate.sunset.east"));
+        assertEquals(1, nodes.get("generate.thunderstorm"));
+        assertEquals(-1, nodes.get("generate.thunderstorm.explosive"));
+        assertEquals(0, nodes.get("random.perm"));
     }
 }


### PR DESCRIPTION
**API** | [Common](https://github.com/SpongePowered/SpongeCommon/pull/2340) | no forge changes

Based on discussions with @lucko and @bloodmc, this gives more flexibility with how different levels of permission take priority over each other.

PEX has had weighted permissions for quite a while now, so hopefully it makes sense to bring them into Sponge as well.

I've kept the old methods around to avoid breaking changes -- the deprecated methods and classes can go away for API 8.