### PR TITLE
Defines acceptsArbitraryLongFlags false behavior, SpongeAPI#2024

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
@@ -418,13 +418,17 @@ public final class CommandFlags extends CommandElement {
 
         /**
          * If this is true, any long flag (--) will be accepted and added as a
-         * flag.
+         * flag. If false, unknown long flags are considered errors.
          *
          * @param acceptsArbitraryLongFlags Whether any long flag is accepted
          * @return this
+         *
+         * @deprecated in favor of
+         *         {@link #setUnknownLongFlagBehavior(UnknownFlagBehavior)}.
          */
+        @Deprecated
         public Builder setAcceptsArbitraryLongFlags(boolean acceptsArbitraryLongFlags) {
-            setUnknownLongFlagBehavior(UnknownFlagBehavior.ACCEPT_NONVALUE);
+            setUnknownLongFlagBehavior(acceptsArbitraryLongFlags ? UnknownFlagBehavior.ACCEPT_NONVALUE : UnknownFlagBehavior.ERROR);
             return this;
         }
 


### PR DESCRIPTION
This PR defines the false behavior of `acceptsArbitraryLongFlags` to be `Error`. The method is also deprecated in favor of `setUnknownLongFlagBehavior`, which appears to be the intention.

This addresses SpongeAPI#2024, as the parameter was previously unused and always result in unknown flags being accepted. Unsure if this would be accepted but figured it was worth discussing and easy enough to set up.