### PR TITLE
Add defined flags to CommandContext

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/CommandContext.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandContext.java
@@ -282,7 +282,7 @@ public final class CommandContext {
      *      {@link CommandContext}
      */
     public Snapshot createSnapshot() {
-        return new Snapshot(this.parsedArgs);
+        return new Snapshot(this.parsedArgs, this.definedFlags);
     }
 
     /**
@@ -294,6 +294,8 @@ public final class CommandContext {
     public void applySnapshot(Snapshot snapshot) {
         this.parsedArgs.clear();
         this.parsedArgs.putAll(snapshot.args);
+        this.definedFlags.clear();
+        this.definedFlags.addAll(snapshot.flags);
     }
 
     /**
@@ -303,9 +305,11 @@ public final class CommandContext {
     public final class Snapshot {
 
         final Multimap<String, Object> args;
+        final Set<String> flags;
 
-        Snapshot(Multimap<String, Object> args) {
+        Snapshot(Multimap<String, Object> args, Set<String> flags) {
             this.args = ArrayListMultimap.create(args);
+            this.flags = Sets.newHashSet(flags);
         }
 
     }

--- a/src/main/java/org/spongepowered/api/command/args/CommandContext.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandContext.java
@@ -29,6 +29,7 @@ import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.text.Text;
@@ -38,6 +39,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Context that a command is executed in.
@@ -57,12 +59,14 @@ public final class CommandContext {
     public static final String TAB_COMPLETION = "tab-complete-50456"; // Random junk afterwards so we don't accidentally conflict with other args
 
     private final Multimap<String, Object> parsedArgs;
+    private final Set<String> definedFlags;
 
     /**
      * Create a new empty CommandContext.
      */
     public CommandContext() {
         this.parsedArgs = ArrayListMultimap.create();
+        this.definedFlags = Sets.newHashSet();
     }
 
     /**
@@ -194,6 +198,24 @@ public final class CommandContext {
     }
 
     /**
+     * Defines the flag as being present when parsing this context.
+     *
+     * @param key the key for the flag defined
+     */
+    public void addFlag(String key) {
+        definedFlags.add(key);
+    }
+
+    /**
+     * Defines the flag as being present when parsing this context.
+     *
+     * @param key the key for the flag defined
+     */
+    public void addFlag(Text key) {
+        addFlag(ArgUtils.textToArgKey(key));
+    }
+
+    /**
      * Perform a permissions check, throwing an exception if the required
      * permissions are not present.
      *
@@ -225,6 +247,26 @@ public final class CommandContext {
      */
     public boolean hasAny(Text key) {
         return hasAny(ArgUtils.textToArgKey(key));
+    }
+
+    /**
+     * Returns whether the given flag has been defined in this context.
+     *
+     * @param key The key to look up
+     * @return whether the flag is defined
+     */
+    public boolean hasFlag(String key) {
+        return definedFlags.contains(key);
+    }
+
+    /**
+     * Returns whether the given flag has been defined in this context.
+     *
+     * @param key The key to look up
+     * @return whether the flag is defined
+     */
+    public boolean hasFlag(Text key) {
+        return hasFlag(ArgUtils.textToArgKey(key));
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
@@ -340,8 +340,6 @@ public final class CommandFlags extends CommandElement {
 
         Builder() {}
 
-        private static final Function<String, CommandElement> MARK_TRUE_FUNC = input -> new FlagElement(Text.of(input), null);
-
         private Builder flag(Function<String, CommandElement> func, String... specs) {
             final List<String> availableFlags = new ArrayList<>(specs.length);
             CommandElement el = null;
@@ -388,7 +386,7 @@ public final class CommandFlags extends CommandElement {
          * @return this
          */
         public Builder flag(String... specs) {
-            return flag(MARK_TRUE_FUNC, specs);
+            return flag(input -> new FlagElement(Text.of(input), null), specs);
         }
 
         /**

--- a/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
@@ -504,14 +504,12 @@ public final class CommandFlags extends CommandElement {
         @Override
         public void parse(CommandSource source, CommandArgs args, CommandContext context) throws ArgumentParseException {
             String key = getUntranslatedKey();
-            if (key != null) {
-                context.addFlag(key);
-                if (valueElement != null) {
-                    valueElement.parse(source, args, context);
-                } else {
-                    context.putArg(key, true);
-                }
+            if (valueElement != null) {
+                valueElement.parse(source, args, context);
+            } else {
+                context.putArg(key, true);
             }
+            context.addFlag(key);
         }
 
         @Nullable
@@ -522,7 +520,7 @@ public final class CommandFlags extends CommandElement {
 
         @Override
         public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
-            return Collections.emptyList();
+            return valueElement != null ? valueElement.complete(src, args, context) : Collections.emptyList();
         }
 
     }

--- a/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandFlags.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.command.args;
 
-import static org.spongepowered.api.command.args.GenericArguments.markTrue;
 import static org.spongepowered.api.command.args.GenericArguments.requiringPermission;
 import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
 
@@ -34,6 +33,7 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.StartsWithPredicate;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -103,9 +103,11 @@ public final class CommandFlags extends CommandElement {
                 case ERROR:
                     throw args.createError(t("Unknown long flag %s specified", flagSplit[0]));
                 case ACCEPT_NONVALUE:
+                    context.addFlag(flag);
                     context.putArg(flag, flagSplit.length == 2 ? flagSplit[1] : true);
                     return true;
                 case ACCEPT_VALUE:
+                    context.addFlag(flag);
                     context.putArg(flag, flagSplit.length == 2 ? flagSplit[1] : args.next());
                     return true;
                 case IGNORE:
@@ -134,9 +136,11 @@ public final class CommandFlags extends CommandElement {
                     case ERROR:
                         throw args.createError(t("Unknown short flag %s specified", shortFlag));
                     case ACCEPT_NONVALUE:
+                        context.addFlag(shortFlag);
                         context.putArg(shortFlag, true);
                         break;
                     case ACCEPT_VALUE:
+                        context.addFlag(shortFlag);
                         context.putArg(shortFlag, args.next());
                         break;
                     default:
@@ -336,7 +340,7 @@ public final class CommandFlags extends CommandElement {
 
         Builder() {}
 
-        private static final Function<String, CommandElement> MARK_TRUE_FUNC = input -> markTrue(Text.of(input));
+        private static final Function<String, CommandElement> MARK_TRUE_FUNC = input -> new FlagElement(Text.of(input), null);
 
         private Builder flag(Function<String, CommandElement> func, String... specs) {
             final List<String> availableFlags = new ArrayList<>(specs.length);
@@ -398,7 +402,7 @@ public final class CommandFlags extends CommandElement {
          * @return this
          */
         public Builder permissionFlag(final String flagPermission, String... specs) {
-            return flag(input -> requiringPermission(markTrue(Text.of(input)), flagPermission), specs);
+            return flag(input -> requiringPermission(new FlagElement(Text.of(input), null), flagPermission), specs);
         }
 
         /**
@@ -413,7 +417,7 @@ public final class CommandFlags extends CommandElement {
          * @return this
          */
         public Builder valueFlag(CommandElement value, String... specs) {
-            return flag(ignore -> value, specs);
+            return flag(input -> new FlagElement(Text.of(input), value), specs);
         }
 
         /**
@@ -486,4 +490,41 @@ public final class CommandFlags extends CommandElement {
                     this.unknownLongFlagBehavior, this.anchorFlags);
         }
     }
+
+    private static class FlagElement extends CommandElement {
+
+        @Nullable
+        private final CommandElement valueElement;
+
+        private FlagElement(Text key, @Nullable CommandElement valueElement) {
+            super(key);
+            this.valueElement = valueElement;
+        }
+
+        @Override
+        public void parse(CommandSource source, CommandArgs args, CommandContext context) throws ArgumentParseException {
+            String key = getUntranslatedKey();
+            if (key != null) {
+                context.addFlag(key);
+                if (valueElement != null) {
+                    valueElement.parse(source, args, context);
+                } else {
+                    context.putArg(key, true);
+                }
+            }
+        }
+
+        @Nullable
+        @Override
+        protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+            return null; //unused
+        }
+
+        @Override
+        public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+            return Collections.emptyList();
+        }
+
+    }
+
 }


### PR DESCRIPTION
### Overview
Based on discussion in #1978, being able to differentiate between an absent flag and a flag with an absent optional value could be useful for handling default values. Additionally, this is extremely helpful when working with complex flag systems where the same value could be set through multiple flags (used in validation). The PR is intended to provide a base implementation and serve as discussion for whether this is worth adding to the API.

Additionally, given the new `hasFlag` method it would make sense to have this be the recommend way for checking non-value flags.

### Implementation

This adds methods to `CommandContext` for defining and checking flags, implemented with a set. Methods that accept a `Text` are also provided to match existing `putArg` methods, but this may not be necessary.

To handle parsing, a new `FlagElement` has been added that ensures flags are added to the context. The key used is the first flag found, same as for the element used previously. Notably, this replaces the use case for the `MarkTrue` element used previously, so this could potentially be deprecated as well.

Additionally, I made the decision to also define the flag for the `ACCEPT_VALUE` and `ACCEPT_NONVALUE` behaviors for unknown flags. This is probably worth discussing as well.