### PR TITLE
Create RegainHealthEvent for Entities

### DIFF
--- a/src/main/java/org/spongepowered/api/CatalogTypes.java
+++ b/src/main/java/org/spongepowered/api/CatalogTypes.java
@@ -49,8 +49,6 @@ import org.spongepowered.api.event.cause.EventContextKey;
 import org.spongepowered.api.event.cause.entity.damage.DamageModifierType;
 import org.spongepowered.api.event.cause.entity.damage.DamageType;
 import org.spongepowered.api.event.cause.entity.dismount.DismountType;
-import org.spongepowered.api.event.cause.entity.health.HealingType;
-import org.spongepowered.api.event.cause.entity.health.HealthModifierType;
 import org.spongepowered.api.event.cause.entity.spawn.SpawnType;
 import org.spongepowered.api.event.cause.entity.teleport.TeleportType;
 import org.spongepowered.api.extra.fluid.FluidType;
@@ -227,9 +225,11 @@ public final class CatalogTypes {
 
     public static final Class<HandType> HAND_TYPE = HandType.class;
 
-    public static final Class<HealingType> HEALING_TYPE = HealingType.class;
+    @Deprecated
+    public static final Class<org.spongepowered.api.event.cause.entity.health.HealingType> HEALING_TYPE = org.spongepowered.api.event.cause.entity.health.HealingType.class;
 
-    public static final Class<HealthModifierType> HEALTH_MODIFIER_TYPE = HealthModifierType.class;
+    @Deprecated
+    public static final Class<org.spongepowered.api.event.cause.entity.health.HealthModifierType> HEALTH_MODIFIER_TYPE = org.spongepowered.api.event.cause.entity.health.HealthModifierType.class;
 
     public static final Class<HeldEquipmentType> HELD_EQUIPMENT_TYPE = HeldEquipmentType.class;
 

--- a/src/main/java/org/spongepowered/api/event/cause/EventContextKeys.java
+++ b/src/main/java/org/spongepowered/api/event/cause/EventContextKeys.java
@@ -29,6 +29,7 @@ import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.data.type.HandType;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.Living;
+import org.spongepowered.api.entity.living.monster.Wither;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.entity.projectile.source.ProjectileSource;
@@ -36,6 +37,7 @@ import org.spongepowered.api.event.block.ChangeBlockEvent;
 import org.spongepowered.api.event.cause.entity.damage.DamageType;
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
 import org.spongepowered.api.event.cause.entity.dismount.DismountType;
+import org.spongepowered.api.event.cause.entity.health.HealingType;
 import org.spongepowered.api.event.cause.entity.spawn.SpawnType;
 import org.spongepowered.api.event.cause.entity.teleport.TeleportType;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
@@ -53,6 +55,14 @@ import org.spongepowered.api.world.explosion.Explosion;
 public final class EventContextKeys {
 
     // SORTFIELDS:ON
+
+    /**
+     * Used when a {@link Living} entity is being "healed" by a source of a
+     * certain kind.
+     *
+     * For example, a {@link Wither} generating health on it's first spawn.
+     */
+    public static final EventContextKey<HealingType> HEALING_TYPE = createFor("HEALING_TYPE");
 
     /**
      * Used to queue a block event to be processed in a {@link World}.

--- a/src/main/java/org/spongepowered/api/event/cause/entity/health/HealingType.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/health/HealingType.java
@@ -26,10 +26,11 @@ package org.spongepowered.api.event.cause.entity.health;
 
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.event.entity.HealEntityEvent;
+import org.spongepowered.api.event.entity.RegainHealthEvent;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
- * Represents a type of "healing", used for {@link HealEntityEvent}s.
+ * Represents a type of "healing", used for {@link RegainHealthEvent}s.
  */
 @CatalogedBy(HealingTypes.class)
 public interface HealingType extends CatalogType {

--- a/src/main/java/org/spongepowered/api/event/cause/entity/health/HealingTypes.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/health/HealingTypes.java
@@ -30,6 +30,8 @@ public final class HealingTypes {
 
     // SORTFIELDS:ON
 
+    public static final HealingType GENERIC = DummyObjectProvider.createFor(HealingType.class, "GENERIC");
+
     public static final HealingType BOSS = DummyObjectProvider.createFor(HealingType.class, "BOSS");
 
     public static final HealingType FOOD = DummyObjectProvider.createFor(HealingType.class, "FOOD");
@@ -39,6 +41,8 @@ public final class HealingTypes {
     public static final HealingType POTION = DummyObjectProvider.createFor(HealingType.class, "POTION");
 
     public static final HealingType UNDEAD = DummyObjectProvider.createFor(HealingType.class, "UNDEAD");
+
+    public static final HealingType DIFFICULTY = DummyObjectProvider.createFor(HealingType.class, "DIFFICULTY");
 
     // SORTFIELDS:OFF
 

--- a/src/main/java/org/spongepowered/api/event/cause/entity/health/HealthFunction.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/health/HealthFunction.java
@@ -32,6 +32,11 @@ import org.spongepowered.api.event.cause.entity.ModifierFunction;
 
 import java.util.function.DoubleUnaryOperator;
 
+/**
+ *
+ * @deprecated Not actually implemented, an oversight. Will be removed in API 8
+ */
+@Deprecated
 public class HealthFunction implements ModifierFunction<HealthModifier> {
 
     public static final DoubleUnaryOperator NO_HEALTH = value -> 0.0d;
@@ -42,7 +47,9 @@ public class HealthFunction implements ModifierFunction<HealthModifier> {
      * @param first The health modifier to use
      * @param second The unary operator to use
      * @return The resulting health function
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     public static HealthFunction of(HealthModifier first, DoubleUnaryOperator second) {
         return new HealthFunction(first, second);
     }
@@ -57,7 +64,9 @@ public class HealthFunction implements ModifierFunction<HealthModifier> {
      * healing modifications.
      *
      * @param modifier The damage modifier
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     public HealthFunction(HealthModifier modifier) {
         this(modifier, NO_HEALTH);
     }
@@ -68,7 +77,9 @@ public class HealthFunction implements ModifierFunction<HealthModifier> {
      *
      * @param modifier The health modifier to use
      * @param function The double unary operator to use
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     public HealthFunction(HealthModifier modifier, DoubleUnaryOperator function) {
         this.modifier = checkNotNull(modifier, "modifier");
         this.function = checkNotNull(function, "function");
@@ -78,7 +89,9 @@ public class HealthFunction implements ModifierFunction<HealthModifier> {
      * Gets the {@link HealthModifier} for this function.
      *
      * @return The health modifier
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     @Override
     public HealthModifier getModifier() {
         return this.modifier;
@@ -88,7 +101,9 @@ public class HealthFunction implements ModifierFunction<HealthModifier> {
      * Gets the {@link DoubleUnaryOperator} for this function.
      *
      * @return The healing function
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     @Override
     public DoubleUnaryOperator getFunction() {
         return this.function;

--- a/src/main/java/org/spongepowered/api/event/cause/entity/health/HealthModifier.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/health/HealthModifier.java
@@ -41,14 +41,19 @@ import java.util.function.DoubleUnaryOperator;
  * towards an entity such that the raw damage is the input of a
  * {@link DoubleUnaryOperator} such that the output will be the final damage
  * applied to the {@link Entity}.
+ * @deprecated Not actually implemented, an oversight. Will be removed in API 8
  */
+@SuppressWarnings({"DeprecatedIsStillUsed", "deprecation"})
+@Deprecated
 public interface HealthModifier {
 
     /**
      * Creates a new {@link Builder} for constructing new {@link HealthModifier}s.
      *
      * @return A new builder
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     static Builder builder() {
         return Sponge.getRegistry().createBuilder(Builder.class);
     }
@@ -57,20 +62,26 @@ public interface HealthModifier {
      * Gets the {@link HealthModifierType} for this {@link HealthModifier}.
      *
      * @return The damage modifier type
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     HealthModifierType getType();
 
     /**
      * Gets the cause of this {@link HealthModifier}.
      *
      * @return The cause of this damage modifier
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     Cause getCause();
 
     /**
      * A builder that creates {@link HealthModifier}s, for use in both plugin
      * and implementation requirements.
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     final class Builder implements ResettableBuilder<HealthModifier, Builder> {
 
         HealthModifierType type;
@@ -83,7 +94,9 @@ public interface HealthModifier {
          * Creates a new {@link Builder}.
          *
          * @return The new builder instance
+         * @deprecated Not actually implemented, an oversight. Will be removed in API 8
          */
+        @Deprecated
         public static Builder builder() {
             return new Builder();
         }
@@ -94,7 +107,9 @@ public interface HealthModifier {
          *
          * @param healthModifierType The health modifier type
          * @return This builder, for chaining
+         * @deprecated Not actually implemented, an oversight. Will be removed in API 8
          */
+        @Deprecated
         public Builder type(HealthModifierType healthModifierType) {
             this.type = checkNotNull(healthModifierType);
             return this;
@@ -105,7 +120,9 @@ public interface HealthModifier {
          *
          * @param cause The cause for the health modifier
          * @return This builder, for chaining
+         * @deprecated Not actually implemented, an oversight. Will be removed in API 8
          */
+        @Deprecated
         public Builder cause(Cause cause) {
             this.cause = checkNotNull(cause);
             return this;
@@ -116,7 +133,9 @@ public interface HealthModifier {
          * {@link Cause} and {@link HealthModifierType}.
          *
          * @return The newly created health modifier
+         * @deprecated Not actually implemented, an oversight. Will be removed in API 8
          */
+        @Deprecated
         public HealthModifier build() {
             checkState(this.type != null, "The HealthModifierType must not be null!");
             checkState(this.cause != null, "The cause for the HealthModifier must not be null!");

--- a/src/main/java/org/spongepowered/api/event/cause/entity/health/HealthModifierTypes.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/health/HealthModifierTypes.java
@@ -35,6 +35,8 @@ import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.difficulty.Difficulty;
 
+@SuppressWarnings({"DeprecatedIsStillUsed", "deprecation"})
+@Deprecated
 public final class HealthModifierTypes {
 
     // SORTFIELDS:ON
@@ -44,18 +46,21 @@ public final class HealthModifierTypes {
      * the {@link PotionEffectTypes#ABSORPTION} level on the
      * {@link Entity}.
      */
+    @Deprecated
     public static final HealthModifierType ABSORPTION = DummyObjectProvider.createFor(HealthModifierType.class, "ABSORPTION");
 
     /**
      * Represents a {@link HealthModifier} that will reduce damage based on
      * the armor {@link ItemStack}s.
      */
+    @Deprecated
     public static final HealthModifierType ARMOR = DummyObjectProvider.createFor(HealthModifierType.class, "ARMOR");
 
     /**
      * Represents a {@link HealthModifier} that will modify the heal amount
      * from a {@link PotionEffect} affecting the target.
      */
+    @Deprecated
     public static final HealthModifierType DEFENSIVE_POTION_EFFECT = DummyObjectProvider.createFor(HealthModifierType.class,
             "DEFENSIVE_POTION_EFFECT");
 
@@ -63,18 +68,21 @@ public final class HealthModifierTypes {
      * Represents a {@link HealthModifier} that enhances damage based on the
      * current {@link Difficulty} of the {@link World}.
      */
+    @Deprecated
     public static final HealthModifierType DIFFICULTY = DummyObjectProvider.createFor(HealthModifierType.class, "DIFFICULTY");
 
     /**
      * Represents a {@link HealthModifier} that will modify damage based on
      * magic.
      */
+    @Deprecated
     public static final HealthModifierType MAGIC = DummyObjectProvider.createFor(HealthModifierType.class, "MAGIC");
 
     /**
      * Represents the {@link HealthModifier} that will increase heal amount
      * from a {@link PotionEffect} affecting the target.
      */
+    @Deprecated
     public static final HealthModifierType OFFENSIVE_POTION_EFFECT = DummyObjectProvider.createFor(HealthModifierType.class,
             "OFFENSIVE_POTION_EFFECT");
 
@@ -87,6 +95,7 @@ public final class HealthModifierTypes {
      * that the {@link EnchantmentType} of the {@link ItemStack} is modifying the
      * incoming/outgoing heal amount.</p>
      */
+    @Deprecated
     public static final HealthModifierType WEAPON_ENCHANTMENT = DummyObjectProvider.createFor(HealthModifierType.class, "WEAPON_ENCHANTMENT");
 
     // SORTFIELDS:OFF

--- a/src/main/java/org/spongepowered/api/event/entity/HealEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/HealEntityEvent.java
@@ -26,10 +26,6 @@ package org.spongepowered.api.event.entity;
 
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.cause.entity.health.HealthFunction;
-import org.spongepowered.api.event.cause.entity.health.HealthModifier;
-import org.spongepowered.api.event.cause.entity.health.source.HealingSource;
-import org.spongepowered.api.event.impl.AbstractHealEntityEvent;
 import org.spongepowered.api.util.Tuple;
 import org.spongepowered.api.util.annotation.eventgen.ImplementedBy;
 import org.spongepowered.api.util.annotation.eventgen.PropertySettings;
@@ -42,135 +38,160 @@ import java.util.function.DoubleUnaryOperator;
  * An event where an {@link Entity} is "healed". This can usually mean that
  * after a certain amount of "heal amount" the entity is destroyed. Similar to
  * the {@link DamageEntityEvent}, this event uses various modifiers
+ * @deprecated Not actually implemented, an oversight. Will be removed in API 8
  */
-@ImplementedBy(AbstractHealEntityEvent.class)
+@SuppressWarnings({"DeprecatedIsStillUsed", "deprecation"})
+@Deprecated
+@ImplementedBy(org.spongepowered.api.event.impl.AbstractHealEntityEvent.class)
 public interface HealEntityEvent extends TargetEntityEvent, Cancellable {
 
     /**
      * Gets the original amount to "heal" the targeted {@link Entity}.
      *
      * @return The original heal amount
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     double getOriginalHealAmount();
 
     /**
      * Gets the original "final" amount of healing after all original
-     * {@link HealthModifier}s are applied to {@link #getOriginalHealAmount()}.
+     * {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier}s are applied to {@link #getOriginalHealAmount()}.
      * The "final" heal amount is considered the amount gained by the
      * {@link Entity}, if health is tracked.
      *
      * @return The final amount of healing to originally deal
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     @PropertySettings(requiredParameter = false, generateMethods = false)
     double getOriginalFinalHealAmount();
 
     /**
-     * Gets an {@link Map} of all original {@link HealthModifier}s and their
+     * Gets an {@link Map} of all original {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier}s and their
      * associated "modified" heal amount. Note that ordering is not retained.
      *
      * @return An immutable map of the original modified heal amounts
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     @PropertySettings(requiredParameter = false, generateMethods = false)
-    Map<HealthModifier, Double> getOriginalHealingAmounts();
+    Map< org.spongepowered.api.event.cause.entity.health.HealthModifier, Double> getOriginalHealingAmounts();
 
     /**
      * Gets the final heal amount that will be applied to the entity. The final
      * heal amount is the end result of the {@link #getBaseHealAmount()} being
      * applied in {@link DoubleUnaryOperator#applyAsDouble(double)} available
-     * from all the {@link Tuple}s of {@link HealthModifier} to
+     * from all the {@link Tuple}s of {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier} to
      * {@link DoubleUnaryOperator} in {@link #getOriginalFunctions()}.
      *
      * @return The final heal amount to deal
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     @PropertySettings(requiredParameter = false, generateMethods = false)
     double getFinalHealAmount();
 
     /**
-     * Gets the original healing amount for the provided {@link HealthModifier}.
-     * If the provided {@link HealthModifier} was not included in
+     * Gets the original healing amount for the provided {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier}.
+     * If the provided {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier} was not included in
      * {@link #getOriginalHealingAmounts()}, an {@link IllegalArgumentException}
      * is thrown.
      *
      * @param healthModifier The original healing modifier
      * @return The original healing change
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
-    double getOriginalHealingModifierAmount(HealthModifier healthModifier);
+    @Deprecated
+    double getOriginalHealingModifierAmount( org.spongepowered.api.event.cause.entity.health.HealthModifier healthModifier);
 
     /**
-     * Gets the original {@link List} of {@link HealthFunction}s that was
+     * Gets the original {@link List} of {@link org.spongepowered.api.event.cause.entity.health.HealthFunction}s that was
      * originally passed into the event.
      *
      * @return The list of heal amount modifier functions
      */
-    List<HealthFunction> getOriginalFunctions();
+    List<org.spongepowered.api.event.cause.entity.health.HealthFunction> getOriginalFunctions();
 
     /**
      * Gets the "base" healing amount to apply to the targeted {@link Entity}.
      * The "base" heal amount is the original value before passing along the
      * chain of {@link DoubleUnaryOperator}s for all known
-     * {@link HealthModifier}s.
+     * {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier}s.
      *
      * @return The base heal amount
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     @PropertySettings(requiredParameter = false, generateMethods = false)
     double getBaseHealAmount();
 
     /**
      * Sets the "base" healing amount to apply to the targeted {@link Entity}.
      * The "base" heal amount is the original value passed along the chain of
-     * {@link DoubleUnaryOperator}s for all known {@link HealthModifier}s.
+     * {@link DoubleUnaryOperator}s for all known {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier}s.
      *
      * @param healAmount The base heal amount
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     void setBaseHealAmount(double healAmount);
 
     /**
-     * Checks whether the provided {@link HealthModifier} is applicable to the
-     * current available {@link HealthModifier}s.
+     * Checks whether the provided {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier} is applicable to the
+     * current available {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier}s.
      *
      * @param healthModifier The health modifier to check
      * @return True if the health modifier is relevant to this event
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
-    boolean isModifierApplicable(HealthModifier healthModifier);
+    @Deprecated
+    boolean isModifierApplicable( org.spongepowered.api.event.cause.entity.health.HealthModifier healthModifier);
 
     /**
-     * Gets the heal amount for the provided {@link HealthModifier}. Providing
-     * that {@link #isModifierApplicable(HealthModifier)} returns
+     * Gets the heal amount for the provided {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier}. Providing
+     * that {@link #isModifierApplicable( org.spongepowered.api.event.cause.entity.health.HealthModifier)} returns
      * <code>true</code>, the cached "heal amount" for the
-     * {@link HealthModifier} is returned.
+     * {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier} is returned.
      *
      * @param healthModifier The heal amount modifier to get the heal amount for
      * @return The modifier
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
-    double getHealAmount(HealthModifier healthModifier);
+    @Deprecated
+    double getHealAmount(org.spongepowered.api.event.cause.entity.health.HealthModifier healthModifier);
 
     /**
      * Sets the provided {@link DoubleUnaryOperator} to be used for the given
-     * {@link HealthModifier}. If the {@link HealthModifier} is already included
+     * {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier}. If the {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier} is already included
      * in {@link #getModifiers()}, the {@link DoubleUnaryOperator} replaces the
-     * existing function. If there is no {@link HealthFunction} for the
-     * {@link HealthModifier}, a new one is created and added to the end of the
+     * existing function. If there is no {@link org.spongepowered.api.event.cause.entity.health.HealthFunction} for the
+     * {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier}, a new one is created and added to the end of the
      * list of {@link DoubleUnaryOperator}s to be applied to the
      * {@link #getBaseHealAmount()}.
      *
-     * <p>If needing to create a custom {@link HealthModifier} is required,
+     * <p>If needing to create a custom {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier} is required,
      * usage of the
      * {@link org.spongepowered.api.event.cause.entity.health.HealthModifier.Builder}
      * is recommended.</p>
      *
      * @param healthModifier The heal amount modifier
      * @param function The function to map to the modifier
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
-    void setHealAmount(HealthModifier healthModifier, DoubleUnaryOperator function);
+    @Deprecated
+    void setHealAmount( org.spongepowered.api.event.cause.entity.health.HealthModifier healthModifier, DoubleUnaryOperator function);
 
     /**
-     * Gets a list of simple {@link HealthFunction}s. All {@link HealthModifier}
-     * s are applicable to the entity based on the {@link HealingSource} and any
-     * possible invulnerabilities due to the {@link HealingSource}.
+     * Gets a list of simple {@link org.spongepowered.api.event.cause.entity.health.HealthFunction}s. All {@link  org.spongepowered.api.event.cause.entity.health.HealthModifier}
+     * s are applicable to the entity based on the {@link org.spongepowered.api.event.cause.entity.health.source.HealingSource} and any
+     * possible invulnerabilities due to the {@link org.spongepowered.api.event.cause.entity.health.source.HealingSource}.
      *
      * @return A list of heal amount modifiers to functions
+     * @deprecated Not actually implemented, an oversight. Will be removed in API 8
      */
+    @Deprecated
     @PropertySettings(requiredParameter = false, generateMethods = false)
-    List<HealthFunction> getModifiers();
+    List<org.spongepowered.api.event.cause.entity.health.HealthFunction> getModifiers();
 
 }

--- a/src/main/java/org/spongepowered/api/event/entity/RegainHealthEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/RegainHealthEvent.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.cause.EventContextKeys;
+import org.spongepowered.api.event.impl.AbstractRegainHealthEvent;
+import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.util.annotation.eventgen.ImplementedBy;
+import org.spongepowered.api.util.annotation.eventgen.PropertySettings;
+
+/**
+ * An event thrown for {@link Entity entities} being healed in
+ * a manner that their {@link Keys#HEALTH health} is being increased
+ * by a game mechanic, but not by {@link PluginContainer plugins}.
+ * An expected context will contain {@link EventContextKeys#HEALING_TYPE}
+ * for some further specificity.
+ */
+@ImplementedBy(AbstractRegainHealthEvent.class)
+public interface RegainHealthEvent extends TargetEntityEvent, Cancellable {
+
+    @PropertySettings(requiredParameter = false, generateMethods = false)
+    double getOriginalAmount();
+
+    double getAmountToRegain();
+
+    void setAmountToRegain(double amount);
+
+    double getOriginalHealth();
+
+    @PropertySettings(requiredParameter = false, generateMethods = false)
+    default double getOriginalNewHealth() {
+        return getOriginalHealth() + getOriginalAmount();
+    }
+
+
+}

--- a/src/main/java/org/spongepowered/api/event/impl/AbstractHealEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/AbstractHealEntityEvent.java
@@ -28,9 +28,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.spongepowered.api.event.cause.entity.ModifierFunction;
-import org.spongepowered.api.event.cause.entity.health.HealthFunction;
-import org.spongepowered.api.event.cause.entity.health.HealthModifier;
-import org.spongepowered.api.event.entity.HealEntityEvent;
 import org.spongepowered.api.util.annotation.eventgen.UseField;
 
 import java.util.Iterator;
@@ -38,10 +35,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.DoubleUnaryOperator;
 
-public abstract class AbstractHealEntityEvent extends AbstractModifierEvent<HealthFunction, HealthModifier> implements HealEntityEvent {
+@Deprecated
+@SuppressWarnings("deprecation")
+public abstract class AbstractHealEntityEvent extends AbstractModifierEvent<org.spongepowered.api.event.cause.entity.health.HealthFunction, org.spongepowered.api.event.cause.entity.health.HealthModifier> implements org.spongepowered.api.event.entity.HealEntityEvent {
 
     @UseField protected double originalHealAmount;
-    @UseField protected List<HealthFunction> originalFunctions;
+    @UseField protected List<org.spongepowered.api.event.cause.entity.health.HealthFunction> originalFunctions;
     @UseField protected double baseHealAmount;
 
     @Override
@@ -51,7 +50,7 @@ public abstract class AbstractHealEntityEvent extends AbstractModifierEvent<Heal
     }
 
     @Override
-    public final double getOriginalHealingModifierAmount(HealthModifier healthModifier) {
+    public final double getOriginalHealingModifierAmount(org.spongepowered.api.event.cause.entity.health.HealthModifier healthModifier) {
         checkArgument(this.originalModifierMap.containsKey(checkNotNull(healthModifier)), "The provided damage modifier is not applicable : "
                                                                                           + healthModifier.toString());
         return this.originalModifierMap.get(checkNotNull(healthModifier));
@@ -63,7 +62,7 @@ public abstract class AbstractHealEntityEvent extends AbstractModifierEvent<Heal
     }
 
     @Override
-    public final Map<HealthModifier, Double> getOriginalHealingAmounts() {
+    public final Map<org.spongepowered.api.event.cause.entity.health.HealthModifier, Double> getOriginalHealingAmounts() {
         return this.originalModifierMap;
     }
 
@@ -73,25 +72,25 @@ public abstract class AbstractHealEntityEvent extends AbstractModifierEvent<Heal
     }
 
     @Override
-    public final boolean isModifierApplicable(HealthModifier healthModifier) {
+    public final boolean isModifierApplicable(org.spongepowered.api.event.cause.entity.health.HealthModifier healthModifier) {
         return this.modifiers.containsKey(checkNotNull(healthModifier));
     }
 
     @Override
-    public final double getHealAmount(HealthModifier healthModifier) {
+    public final double getHealAmount(org.spongepowered.api.event.cause.entity.health.HealthModifier healthModifier) {
         checkArgument(this.modifiers.containsKey(checkNotNull(healthModifier)), "The provided damage modifier is not applicable : "
                                                                                 + healthModifier.toString());
         return this.modifiers.get(checkNotNull(healthModifier));
     }
 
     @Override
-    public final void setHealAmount(HealthModifier healthModifier, DoubleUnaryOperator function) {
+    public final void setHealAmount(org.spongepowered.api.event.cause.entity.health.HealthModifier healthModifier, DoubleUnaryOperator function) {
         checkNotNull(healthModifier, "Damage modifier was null!");
         checkNotNull(function, "Function was null!");
         int indexToAddTo = 0;
         boolean addAtEnd = true;
-        for (Iterator<HealthFunction> iterator = this.modifierFunctions.iterator(); iterator.hasNext(); ) {
-            ModifierFunction<HealthModifier> tuple = iterator.next();
+        for (Iterator<org.spongepowered.api.event.cause.entity.health.HealthFunction> iterator = this.modifierFunctions.iterator(); iterator.hasNext(); ) {
+            ModifierFunction<org.spongepowered.api.event.cause.entity.health.HealthModifier> tuple = iterator.next();
             if (tuple.getModifier().equals(healthModifier)) {
                 iterator.remove();
                 addAtEnd = false;
@@ -100,9 +99,9 @@ public abstract class AbstractHealEntityEvent extends AbstractModifierEvent<Heal
             indexToAddTo++;
         }
         if (addAtEnd) {
-            this.modifierFunctions.add(new HealthFunction(healthModifier, function));
+            this.modifierFunctions.add(new org.spongepowered.api.event.cause.entity.health.HealthFunction(healthModifier, function));
         } else {
-            this.modifierFunctions.add(indexToAddTo, new HealthFunction(healthModifier, function));
+            this.modifierFunctions.add(indexToAddTo, new org.spongepowered.api.event.cause.entity.health.HealthFunction(healthModifier, function));
         }
         this.recalculateDamages(this.baseHealAmount);
     }
@@ -119,7 +118,7 @@ public abstract class AbstractHealEntityEvent extends AbstractModifierEvent<Heal
     }
 
     @Override
-    protected HealthFunction convertTuple(HealthModifier obj, DoubleUnaryOperator function) {
-        return new HealthFunction(obj, function);
+    protected org.spongepowered.api.event.cause.entity.health.HealthFunction convertTuple(org.spongepowered.api.event.cause.entity.health.HealthModifier obj, DoubleUnaryOperator function) {
+        return new org.spongepowered.api.event.cause.entity.health.HealthFunction(obj, function);
     }
 }

--- a/src/main/java/org/spongepowered/api/event/impl/AbstractRegainHealthEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/AbstractRegainHealthEvent.java
@@ -22,22 +22,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.cause.entity.health;
+package org.spongepowered.api.event.impl;
 
-import org.spongepowered.api.CatalogType;
-import org.spongepowered.api.event.cause.Cause;
-import org.spongepowered.api.util.annotation.CatalogedBy;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.event.entity.RegainHealthEvent;
 
-/**
- * A type of {@link HealthModifier} that can apply a "grouping" so to speak
- * for the damage modifier. The use case is being able to differentiate between
- * various {@link HealthModifier}s based on the {@link HealthModifierType}
- * without digging through the {@link Cause} provided by
- * {@link HealthModifier#getCause()}.
- */
-@SuppressWarnings({"DeprecatedIsStillUsed", "deprecation"})
-@Deprecated
-@CatalogedBy(HealthModifierTypes.class)
-public interface HealthModifierType extends CatalogType {
+public abstract class AbstractRegainHealthEvent extends AbstractEvent implements RegainHealthEvent {
+
+    private double originalAmount;
+
+    @Override
+    protected void init() {
+        this.originalAmount = getAmountToRegain();
+    }
+
+    @Override
+    public double getOriginalAmount() {
+        return this.originalAmount;
+    }
 
 }

--- a/src/test/java/org/spongepowered/api/event/SpongeAbstractHealEntityEventTest.java
+++ b/src/test/java/org/spongepowered/api/event/SpongeAbstractHealEntityEventTest.java
@@ -34,14 +34,12 @@ import org.junit.Test;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.EventContext;
-import org.spongepowered.api.event.cause.entity.health.HealthFunction;
-import org.spongepowered.api.event.cause.entity.health.HealthModifier;
-import org.spongepowered.api.event.entity.HealEntityEvent;
 
 import java.util.List;
 import java.util.Map;
 import java.util.function.DoubleUnaryOperator;
 
+@SuppressWarnings("deprecation")
 public class SpongeAbstractHealEntityEventTest {
 
     private static final double ERROR = 0.03;
@@ -51,7 +49,7 @@ public class SpongeAbstractHealEntityEventTest {
         Entity targetEntity = mockParam(Entity.class);
         int originalDamage = 5;
 
-        HealEntityEvent event = SpongeEventFactory.createHealEntityEvent(Cause.of(EventContext.empty(),"none"),
+        org.spongepowered.api.event.entity.HealEntityEvent event = SpongeEventFactory.createHealEntityEvent(Cause.of(EventContext.empty(),"none"),
                 Lists.newArrayList(), targetEntity, originalDamage);
 
         assertThat(event.getOriginalHealAmount(), is(closeTo(originalDamage, ERROR)));
@@ -66,7 +64,7 @@ public class SpongeAbstractHealEntityEventTest {
         Entity targetEntity = mockParam(Entity.class);
         int originalDamage = 5;
 
-        HealEntityEvent event = SpongeEventFactory.createHealEntityEvent(Cause.of(EventContext.empty(),"none"),
+        org.spongepowered.api.event.entity.HealEntityEvent event = SpongeEventFactory.createHealEntityEvent(Cause.of(EventContext.empty(),"none"),
                 Lists.newArrayList(), targetEntity, originalDamage);
 
         assertThat(event.getOriginalHealAmount(), is(closeTo(originalDamage, ERROR)));
@@ -91,13 +89,13 @@ public class SpongeAbstractHealEntityEventTest {
         final int firstModifierDamage = 2;
         final int secondModifierDamage = 15;
 
-        HealthModifier firstModifer = mockParam(HealthModifier.class);
-        HealthModifier secondModifier = mockParam(HealthModifier.class);
+        org.spongepowered.api.event.cause.entity.health.HealthModifier firstModifer = mockParam(org.spongepowered.api.event.cause.entity.health.HealthModifier.class);
+        org.spongepowered.api.event.cause.entity.health.HealthModifier secondModifier = mockParam(org.spongepowered.api.event.cause.entity.health.HealthModifier.class);
 
-        List<HealthFunction>
-                originalFunctions = Lists.newArrayList(HealthFunction.of(firstModifer, p -> p * 2), HealthFunction.of(secondModifier, p -> p * 5));
+        List<org.spongepowered.api.event.cause.entity.health.HealthFunction>
+                originalFunctions = Lists.newArrayList(org.spongepowered.api.event.cause.entity.health.HealthFunction.of(firstModifer, p -> p * 2), org.spongepowered.api.event.cause.entity.health.HealthFunction.of(secondModifier, p -> p * 5));
 
-        HealEntityEvent event = SpongeEventFactory.createHealEntityEvent(Cause.of(EventContext.empty(), "none"), originalFunctions, targetEntity,
+        org.spongepowered.api.event.entity.HealEntityEvent event = SpongeEventFactory.createHealEntityEvent(Cause.of(EventContext.empty(), "none"), originalFunctions, targetEntity,
                 originalDamage);
 
         assertThat(event.getOriginalFunctions(), is(Matchers.equalTo(originalFunctions)));
@@ -105,7 +103,7 @@ public class SpongeAbstractHealEntityEventTest {
         assertThat(event.getOriginalHealAmount(), is(closeTo(originalDamage, ERROR)));
         assertThat(event.getOriginalFinalHealAmount(), is(closeTo(originalFinalDamage, ERROR)));
 
-        Map<HealthModifier, Double> originalDamages = event.getOriginalHealingAmounts();
+        Map<org.spongepowered.api.event.cause.entity.health.HealthModifier, Double> originalDamages = event.getOriginalHealingAmounts();
 
         assertThat(originalDamages.size(), is(originalFunctions.size()));
 
@@ -133,13 +131,13 @@ public class SpongeAbstractHealEntityEventTest {
 
         final int modifiedFinalDamage = 12;
 
-        HealthModifier firstModifer = mockParam(HealthModifier.class);
-        HealthModifier secondModifier = mockParam(HealthModifier.class);
+        org.spongepowered.api.event.cause.entity.health.HealthModifier firstModifer = mockParam(org.spongepowered.api.event.cause.entity.health.HealthModifier.class);
+        org.spongepowered.api.event.cause.entity.health.HealthModifier secondModifier = mockParam(org.spongepowered.api.event.cause.entity.health.HealthModifier.class);
 
-        List<HealthFunction>
-                originalFunctions = Lists.newArrayList(HealthFunction.of(firstModifer, p -> p * 2), HealthFunction.of(secondModifier, p -> p * 5));
+        List<org.spongepowered.api.event.cause.entity.health.HealthFunction>
+                originalFunctions = Lists.newArrayList(org.spongepowered.api.event.cause.entity.health.HealthFunction.of(firstModifer, p -> p * 2), org.spongepowered.api.event.cause.entity.health.HealthFunction.of(secondModifier, p -> p * 5));
 
-        HealEntityEvent event = SpongeEventFactory.createHealEntityEvent(Cause.of(EventContext.empty(), "none"), originalFunctions, targetEntity,
+        org.spongepowered.api.event.entity.HealEntityEvent event = SpongeEventFactory.createHealEntityEvent(Cause.of(EventContext.empty(), "none"), originalFunctions, targetEntity,
                 originalDamage);
 
         assertThat(event.getOriginalFunctions(), is(Matchers.equalTo(originalFunctions)));
@@ -161,7 +159,7 @@ public class SpongeAbstractHealEntityEventTest {
         assertThat(event.getOriginalFunctions(), is(Matchers.equalTo(originalFunctions)));
 
         assertThat(event.getModifiers(),
-            is(Matchers.equalTo(Lists.newArrayList(HealthFunction.of(firstModifer, newFunction), originalFunctions.get(1)))));
+            is(Matchers.equalTo(Lists.newArrayList(org.spongepowered.api.event.cause.entity.health.HealthFunction.of(firstModifer, newFunction), originalFunctions.get(1)))));
     }
 
     @Test
@@ -178,19 +176,19 @@ public class SpongeAbstractHealEntityEventTest {
 
         final int thirdDamage = 18;
 
-        HealthModifier firstModifer = mockParam(HealthModifier.class);
-        HealthModifier secondModifier = mockParam(HealthModifier.class);
-        HealthModifier thirdModifier = mockParam(HealthModifier.class);
+        org.spongepowered.api.event.cause.entity.health.HealthModifier firstModifer = mockParam(org.spongepowered.api.event.cause.entity.health.HealthModifier.class);
+        org.spongepowered.api.event.cause.entity.health.HealthModifier secondModifier = mockParam(org.spongepowered.api.event.cause.entity.health.HealthModifier.class);
+        org.spongepowered.api.event.cause.entity.health.HealthModifier thirdModifier = mockParam(org.spongepowered.api.event.cause.entity.health.HealthModifier.class);
 
         DoubleUnaryOperator thirdFunction = p -> p;
 
-        List<HealthFunction>
-                originalFunctions = Lists.newArrayList(HealthFunction.of(firstModifer, p -> p * 2), HealthFunction.of(secondModifier, p -> p * 5));
+        List<org.spongepowered.api.event.cause.entity.health.HealthFunction>
+                originalFunctions = Lists.newArrayList(org.spongepowered.api.event.cause.entity.health.HealthFunction.of(firstModifer, p -> p * 2), org.spongepowered.api.event.cause.entity.health.HealthFunction.of(secondModifier, p -> p * 5));
 
-        List<HealthFunction> newFunctions = Lists.newArrayList(originalFunctions);
-        newFunctions.add(HealthFunction.of(thirdModifier, thirdFunction));
+        List<org.spongepowered.api.event.cause.entity.health.HealthFunction> newFunctions = Lists.newArrayList(originalFunctions);
+        newFunctions.add(org.spongepowered.api.event.cause.entity.health.HealthFunction.of(thirdModifier, thirdFunction));
 
-        HealEntityEvent event = SpongeEventFactory.createHealEntityEvent(Cause.of(EventContext.empty(), "none"), originalFunctions, targetEntity,
+        org.spongepowered.api.event.entity.HealEntityEvent event = SpongeEventFactory.createHealEntityEvent(Cause.of(EventContext.empty(), "none"), originalFunctions, targetEntity,
                 originalDamage);
 
         assertThat(event.getOriginalFunctions(), is(Matchers.equalTo(originalFunctions)));
@@ -219,25 +217,25 @@ public class SpongeAbstractHealEntityEventTest {
     public void testModifiersApplicable() {
         Entity targetEntity = mockParam(Entity.class);
 
-        HealthModifier firstModifer = mockParam(HealthModifier.class);
-        HealthModifier secondModifier = mockParam(HealthModifier.class);
+        org.spongepowered.api.event.cause.entity.health.HealthModifier firstModifer = mockParam(org.spongepowered.api.event.cause.entity.health.HealthModifier.class);
+        org.spongepowered.api.event.cause.entity.health.HealthModifier secondModifier = mockParam(org.spongepowered.api.event.cause.entity.health.HealthModifier.class);
 
-        List<HealthFunction>
-                originalFunctions = Lists.newArrayList(HealthFunction.of(firstModifer, p -> p), HealthFunction.of(secondModifier, p -> p));
+        List<org.spongepowered.api.event.cause.entity.health.HealthFunction>
+                originalFunctions = Lists.newArrayList(org.spongepowered.api.event.cause.entity.health.HealthFunction.of(firstModifer, p -> p), org.spongepowered.api.event.cause.entity.health.HealthFunction.of(secondModifier, p -> p));
 
-        HealEntityEvent event = SpongeEventFactory.createHealEntityEvent(Cause.of(EventContext.empty(), "none"), originalFunctions, targetEntity, 0);
+        org.spongepowered.api.event.entity.HealEntityEvent event = SpongeEventFactory.createHealEntityEvent(Cause.of(EventContext.empty(), "none"), originalFunctions, targetEntity, 0);
 
         assertThat(event.isModifierApplicable(firstModifer), is(true));
         assertThat(event.isModifierApplicable(secondModifier), is(true));
-        assertThat(event.isModifierApplicable(mockParam(HealthModifier.class)), is(false));
+        assertThat(event.isModifierApplicable(mockParam(org.spongepowered.api.event.cause.entity.health.HealthModifier.class)), is(false));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testNotApplicableModifer() {
-        HealEntityEvent event = SpongeEventFactory.createHealEntityEvent(Cause.of(EventContext.empty(), "none"), Lists.newArrayList(),
+        org.spongepowered.api.event.entity.HealEntityEvent event = SpongeEventFactory.createHealEntityEvent(Cause.of(EventContext.empty(), "none"), Lists.newArrayList(),
                 mockParam(Entity.class), 0);
 
-        HealthModifier modifier = mockParam(HealthModifier.class);
+        org.spongepowered.api.event.cause.entity.health.HealthModifier modifier = mockParam(org.spongepowered.api.event.cause.entity.health.HealthModifier.class);
 
         assertThat(event.isModifierApplicable(modifier), is(false));
 

--- a/src/test/java/org/spongepowered/api/event/SpongeEventFactoryTest.java
+++ b/src/test/java/org/spongepowered/api/event/SpongeEventFactoryTest.java
@@ -46,7 +46,6 @@ import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.EventContext;
 import org.spongepowered.api.event.entity.AttackEntityEvent;
 import org.spongepowered.api.event.entity.DamageEntityEvent;
-import org.spongepowered.api.event.entity.HealEntityEvent;
 import org.spongepowered.api.event.entity.ai.AITaskEvent;
 import org.spongepowered.api.event.game.GameRegistryEvent;
 import org.spongepowered.api.event.impl.AbstractEvent;
@@ -78,10 +77,11 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
+@SuppressWarnings("deprecation")
 @RunWith(Parameterized.class)
 public class SpongeEventFactoryTest {
 
-    private static final Set<Class<?>> excludedEvents = ImmutableSet.of(DamageEntityEvent.class, HealEntityEvent.class,
+    private static final Set<Class<?>> excludedEvents = ImmutableSet.of(DamageEntityEvent.class, org.spongepowered.api.event.entity.HealEntityEvent.class,
             AITaskEvent.class, AITaskEvent.Add.class, AITaskEvent.Remove.class, AttackEntityEvent.class,
             GameRegistryEvent.Register.class);
 


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2350)
Deprecates HealEntityEvent that is/was impossible to implement with modifiers and sources. 

Adds RegainHealthEvent with appropriate usages and `HealingType`s.
