### PR TITLE
Ensure command completion checks source permission

### DIFF
--- a/src/main/java/org/spongepowered/api/command/dispatcher/SimpleDispatcher.java
+++ b/src/main/java/org/spongepowered/api/command/dispatcher/SimpleDispatcher.java
@@ -300,7 +300,7 @@ public final class SimpleDispatcher implements Dispatcher {
         if (results.size() == 1) {
             result = Optional.of(results.get(0));
         } else if (results.size() > 1) {
-            result = disambiguatorFunc.disambiguate(source, alias, results);
+            result = this.disambiguatorFunc.disambiguate(source, alias, results);
         }
         if (source != null) {
             result = result.filter(m -> m.getCallable().testPermission(source));

--- a/src/main/java/org/spongepowered/api/command/dispatcher/SimpleDispatcher.java
+++ b/src/main/java/org/spongepowered/api/command/dispatcher/SimpleDispatcher.java
@@ -296,13 +296,16 @@ public final class SimpleDispatcher implements Dispatcher {
     @Override
     public synchronized Optional<CommandMapping> get(String alias, @Nullable CommandSource source) {
         List<CommandMapping> results = this.commands.get(alias.toLowerCase());
+        Optional<CommandMapping> result = Optional.empty();
         if (results.size() == 1) {
-            return Optional.of(results.get(0));
-        } else if (results.size() == 0) {
-            return Optional.empty();
-        } else {
-            return this.disambiguatorFunc.disambiguate(source, alias, results);
+            result = Optional.of(results.get(0));
+        } else if (results.size() > 1) {
+            result = disambiguatorFunc.disambiguate(source, alias, results);
         }
+        if (source != null) {
+            result = result.filter(m -> m.getCallable().testPermission(source));
+        }
+        return result;
     }
 
     @Override


### PR DESCRIPTION
Currently, completion ignores whether a source has permission for a particular command. This results in the unexpected behavior that players can complete commands they can't execute and can view help commands they don't have permission for (I feel like there's an issue for this, but I couldn't find it).

This PR adds a permission check to the `SimpleDispatcher#get(String, CommandSource)` method when the source is not null. The source should only be able to 'get' mappings for which they have permission for and thus aware of. This appears to be the intended behavior of the method.