### PR TITLE
Fix duplicate class definition

### DIFF
--- a/src/main/java/org/spongepowered/api/util/generator/GeneratorUtils.java
+++ b/src/main/java/org/spongepowered/api/util/generator/GeneratorUtils.java
@@ -42,11 +42,7 @@ public final class GeneratorUtils {
      * @return The java class name equivalent with the provided classifier
      */
     public static String getClassName(String targetPackage, Class<?> clazz, String classifier) {
-        String name = clazz.getName();
-        while (clazz.getEnclosingClass() != null) {
-            clazz = clazz.getEnclosingClass();
-            name = clazz.getSimpleName() + "$" + name;
-        }
+        final String name = clazz.getName();
         return targetPackage + "." + name + "$" + classifier;
     }
 

--- a/src/main/java/org/spongepowered/api/util/generator/GeneratorUtils.java
+++ b/src/main/java/org/spongepowered/api/util/generator/GeneratorUtils.java
@@ -42,7 +42,7 @@ public final class GeneratorUtils {
      * @return The java class name equivalent with the provided classifier
      */
     public static String getClassName(String targetPackage, Class<?> clazz, String classifier) {
-        String name = clazz.getSimpleName();
+        String name = clazz.getName();
         while (clazz.getEnclosingClass() != null) {
             clazz = clazz.getEnclosingClass();
             name = clazz.getSimpleName() + "$" + name;

--- a/src/test/java/org/spongepowered/api/util/catalog/Career.java
+++ b/src/test/java/org/spongepowered/api/util/catalog/Career.java
@@ -24,20 +24,5 @@
  */
 package org.spongepowered.api.util.catalog;
 
-import org.junit.Test;
-import org.spongepowered.api.block.BlockType;
-import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
-
-public class DummyCatalogProviderTest {
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testCreate_BlockType() {
-        DummyObjectProvider.createFor(BlockType.class, "FOO").getDefaultState();
-    }
-
-    @Test()
-    public void testCreate_DuplicateName() {
-        DummyObjectProvider.createFor(org.spongepowered.api.data.type.Career.class, "FOO");
-        DummyObjectProvider.createFor(org.spongepowered.api.util.catalog.Career.class, "BAR");
-    }
+public interface Career {
 }


### PR DESCRIPTION
Both a plugin and sponge (this is an example, I don't have a plugin in mind) provide an interface named `Career`. Suppose they both use `DummyObjectProvider` to separate API and implementation.

Before:
`org.spongepowered.api.util.dummy.Career$DummyClass`
`org.spongepowered.api.util.dummy.Career$DummyClass`

Causing a duplicate class definition error (and chain of exception without a meaningful error)

After this PR:
`org.spongepowered.api.util.dummy.org.spongepowered.api.data.type.Career$DummyClass`
`
org.spongepowered.api.util.dummy.com.author.pluginname.Career$DummyClass`

I've also added a test to replicate the issue.