### PR TITLE
Add ability to change potion color

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -1671,6 +1671,13 @@ public final class Keys {
     public static final Key<Value<PortionType>> PORTION_TYPE = DummyObjectProvider.createExtendedFor(Key.class,"PORTION_TYPE");
 
     /**
+     * Represents the {@link Key} for the color of an {@link ItemStack} potion.
+     *
+     * @see PotionColorData#color()
+     */
+    public static final Key<Value<Color>> POTION_COLOR = DummyObjectProvider.createExtendedFor(Key.class, "POTION_COLOR");
+
+    /**
      * Represents the {@link Key} for which potion effects are present on an
      * {@link Entity} or stored on an {@link ItemStack}.
      *

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutablePotionColorData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/ImmutablePotionColorData.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable;
+
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.PotionColorData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.util.Color;
+
+/**
+ * An {@link ImmutableDataManipulator} that handles the color of a potion.
+ */
+public interface ImmutablePotionColorData extends ImmutableDataManipulator<ImmutablePotionColorData, PotionColorData> {
+
+    /**
+     * Gets the {@link ImmutableValue} of the color.
+     *
+     * @return The immutable value of the color
+     */
+    ImmutableValue<Color> color();
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/PotionColorData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/PotionColorData.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.ImmutablePotionColorData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.util.Color;
+
+/**
+ * Represents the {@link Color} of a potion.
+ */
+public interface PotionColorData extends DataManipulator<PotionColorData, ImmutablePotionColorData> {
+
+    /**
+     * Gets the {@link Value} of the color.
+     *
+     * @return The value of the color
+     * @see Keys#POTION_COLOR
+     */
+    Value<Color> color();
+}


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2370)

This PR introduces a new Key: `POTION_COLOR`. 

- It is used to change the color of an ItemStack potion.
- Getting the value will return the custom color if set, or the default color for the attached effects.
- Thrown potions color can be changed by updating their represented item.
- It is possible to remove the custom color.

Resolves #1961