### PR TITLE
Add economy account deletion

### DIFF
--- a/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
+++ b/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
@@ -26,6 +26,8 @@ package org.spongepowered.api.service.economy;
 
 import org.spongepowered.api.service.context.ContextualService;
 import org.spongepowered.api.service.economy.account.Account;
+import org.spongepowered.api.service.economy.account.AccountDeletionResultType;
+import org.spongepowered.api.service.economy.account.AccountDeletionResultTypes;
 import org.spongepowered.api.service.economy.account.UniqueAccount;
 import org.spongepowered.api.service.economy.account.VirtualAccount;
 
@@ -115,4 +117,32 @@ public interface EconomyService extends ContextualService<Account> {
      * @return The {@link Account}, if available.
      */
     Optional<Account> getOrCreateAccount(String identifier);
+
+    /**
+     * Deletes the account for the user with the specified {@link UUID}.
+     *
+     * <p>Deletion might fail if the provided {@link UUID} does not correspond to
+     * an actual player, or for an implementation-defined reason.</p>
+     *
+     * @param uuid The {@link UUID} of the account to delete.
+     * @return The result of the deletion.
+     */
+    default AccountDeletionResultType deleteAccount(UUID uuid) {
+        return AccountDeletionResultTypes.UNSUPPORTED;
+    }
+
+    /**
+     * Deletes the account with the specified identifier.
+     *
+     * <p>If an account exists with the specified identifier,
+     * it will be deleted.</p>
+     *
+     * <p>Deletion may fail for an implementation-defined reason.</p>
+     *
+     * @param identifier The identifier of the account to delete.
+     * @return The result of the deletion.
+     */
+    default AccountDeletionResultType deleteAccount(String identifier) {
+        return AccountDeletionResultTypes.UNSUPPORTED;
+    }
 }

--- a/src/main/java/org/spongepowered/api/service/economy/account/AccountDeletionResultType.java
+++ b/src/main/java/org/spongepowered/api/service/economy/account/AccountDeletionResultType.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.economy.account;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
+@CatalogedBy(AccountDeletionResultTypes.class)
+public interface AccountDeletionResultType extends CatalogType {
+
+    /**
+     * Returns whether the deletion was successful. This is an easy way to check if an account deletion went through.
+     *
+     * @return Whether the deletion was successful.
+     */
+    boolean isSuccess();
+}

--- a/src/main/java/org/spongepowered/api/service/economy/account/AccountDeletionResultTypes.java
+++ b/src/main/java/org/spongepowered/api/service/economy/account/AccountDeletionResultTypes.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.economy.account;
+
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+
+public class AccountDeletionResultTypes {
+    // SORTFIELDS:ON
+
+    /**
+     * Represents an account deletion where the account does not exist.
+     */
+    public static final AccountDeletionResultType ABSENT = DummyObjectProvider.createFor(AccountDeletionResultType.class, "ABSENT");
+
+    /**
+     * Represents an account deletion where the deletion failed.
+     */
+    public static final AccountDeletionResultType FAILED = DummyObjectProvider.createFor(AccountDeletionResultType.class, "FAILED");
+
+    /**
+     * Represents an account deletion where the deletion was successful.
+     */
+    public static final AccountDeletionResultType SUCCESS = DummyObjectProvider.createFor(AccountDeletionResultType.class, "SUCCESS");
+
+    /**
+     * Represents an account deletion where the deletion feature is unsupported.
+     */
+    public static final AccountDeletionResultType UNSUPPORTED = DummyObjectProvider.createFor(AccountDeletionResultType.class, "UNSUPPORTED");
+
+    /**
+     * Represents an account deletion where the account could not be deleted.
+     */
+    public static final AccountDeletionResultType UNDELETABLE = DummyObjectProvider.createFor(AccountDeletionResultType.class, "UNDELETABLE");
+
+    // SORTFIELDS:OFF
+
+    // Suppress default constructor to ensure non-instantiability.
+    private AccountDeletionResultTypes() {
+        throw new AssertionError("You should not be attempting to instantiate this class.");
+    }
+
+}


### PR DESCRIPTION
**API only**

Adds support for deleting economy accounts. Left as a default method so as to not break any existing economy plugins.

@ItsDoot ;)