### PR TITLE
Cleanup data builders.

### DIFF
--- a/src/main/java/org/spongepowered/api/block/BlockSnapshot.java
+++ b/src/main/java/org/spongepowered/api/block/BlockSnapshot.java
@@ -27,12 +27,12 @@ package org.spongepowered.api.block;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.entity.BlockEntity;
 import org.spongepowered.api.block.entity.BlockEntityArchetype;
+import org.spongepowered.api.data.DataHolderBuilder;
 import org.spongepowered.api.data.persistence.DataContainer;
 import org.spongepowered.api.data.persistence.DataView;
-import org.spongepowered.api.world.LocatableSnapshot;
-import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
 import org.spongepowered.api.world.BlockChangeFlag;
+import org.spongepowered.api.world.LocatableSnapshot;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.schematic.Schematic;
 import org.spongepowered.api.world.storage.WorldProperties;
@@ -134,7 +134,7 @@ public interface BlockSnapshot extends LocatableSnapshot<BlockSnapshot> {
     /**
      * Creates a new {@link BlockEntityArchetype} for use with {@link Schematic}s
      * and placing the archetype in multiple locations.
-     * 
+     *
      * <p>If this blocksnapshot does not contain a block entity then this will
      * return {@link Optional#empty()}.</p>
      *
@@ -142,7 +142,7 @@ public interface BlockSnapshot extends LocatableSnapshot<BlockSnapshot> {
      */
     Optional<BlockEntityArchetype> createArchetype();
 
-    interface Builder extends DataBuilder.Immutable<BlockSnapshot, Builder> {
+    interface Builder extends DataHolderBuilder.Immutable<BlockSnapshot, Builder> {
 
         /**
          * Sets the {@link WorldProperties} for this {@link BlockSnapshot}.

--- a/src/main/java/org/spongepowered/api/block/BlockState.java
+++ b/src/main/java/org/spongepowered/api/block/BlockState.java
@@ -26,12 +26,12 @@ package org.spongepowered.api.block;
 
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.entity.BlockEntity;
+import org.spongepowered.api.data.DataHolderBuilder;
 import org.spongepowered.api.data.DataManipulator;
-import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.data.property.DirectionRelativePropertyHolder;
+import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.fluid.FluidState;
 import org.spongepowered.api.state.State;
-import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.world.Location;
 
 /**
@@ -94,14 +94,14 @@ public interface BlockState extends State<BlockState>, DirectionRelativeProperty
     BlockSnapshot snapshotFor(Location location);
 
     /**
-     * An {@link org.spongepowered.api.data.persistence.DataBuilder.Immutable} for a {@link BlockState}. Just like the
-     * {@link org.spongepowered.api.data.persistence.DataBuilder.Immutable}, the {@link Value}s passed in to
+     * An {@link org.spongepowered.api.data.DataHolderBuilder.Immutable} for a {@link BlockState}. Just like the
+     * {@link org.spongepowered.api.data.DataHolderBuilder.Immutable}, the {@link Value}s passed in to
      * create a {@link BlockState} are copied on creation.
      *
      * <p>Note that upon creation, the {@link BlockType} must be set for validation
      * of {@link DataManipulator}s, otherwise exceptions may be thrown.</p>
      */
-    interface Builder extends DataBuilder.Immutable<BlockState, Builder> {
+    interface Builder extends DataHolderBuilder.Immutable<BlockState, Builder> {
 
         /**
          * Sets the {@link BlockType} for the {@link BlockState} to build.

--- a/src/main/java/org/spongepowered/api/data/DataHolder.java
+++ b/src/main/java/org/spongepowered/api/data/DataHolder.java
@@ -36,6 +36,7 @@ import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.util.ResettableBuilder;
 
 import java.util.Collection;
 import java.util.Map;

--- a/src/main/java/org/spongepowered/api/data/DataHolderBuilder.java
+++ b/src/main/java/org/spongepowered/api/data/DataHolderBuilder.java
@@ -1,0 +1,122 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data;
+
+import org.spongepowered.api.data.persistence.DataBuilder;
+import org.spongepowered.api.data.value.Value;
+import org.spongepowered.api.util.CopyableBuilder;
+
+public interface DataHolderBuilder<H extends DataHolder, B extends DataHolderBuilder<H, B>> extends CopyableBuilder<H, B>, DataBuilder<H> {
+
+    /**
+     * Adds the given {@link Value} to the builder. The
+     * {@link Value} is copied when the {@link DataHolder}
+     * is created.
+     *
+     * @param value The value to add
+     * @return This builder, for chaining
+     */
+    @SuppressWarnings("unchecked")
+    default B add(Value<?> value) {
+        return (B) add((Key) value.getKey(), value.get());
+    }
+
+    /**
+     * Adds all the {@link Value}s to the builder. The
+     * {@link Value}s are copied when the {@link DataHolder}
+     * is created.
+     *
+     * @param values The values to add
+     * @return This builder, for chaining
+     */
+    @SuppressWarnings("unchecked")
+    default B add(Iterable<? extends Value<?>> values) {
+        values.forEach(this::add);
+        return (B) this;
+    }
+
+    /**
+     * Adds all the {@link Value}s from the {@link DataManipulator}
+     * to the builder. The {@link Value}s are copied when the
+     * {@link DataHolder} is created.
+     *
+     * @param manipulator The manipulator to add
+     * @return This builder, for chaining
+     */
+    default B add(DataManipulator manipulator) {
+        return add(manipulator.getValues());
+    }
+
+    /**
+     * Adds all the {@link Value}s from the {@link DataHolder}
+     * to the builder. The {@link Value}s are copied when the
+     * {@link DataHolder} is created.
+     *
+     * @param dataHolder The data holder to add data from
+     * @return This builder, for chaining
+     */
+    default B addFrom(DataHolder dataHolder) {
+        return add(dataHolder.getValues());
+    }
+
+    /**
+     * Adds the given {@link Key} with the given value.
+     *
+     * @param key The key to assign the value with
+     * @param value The value to assign with the key
+     * @param <V> The type of the value
+     * @return This builder, for chaining
+     */
+    <V> B add(Key<? extends Value<V>> key, V value);
+
+    /**
+     * Copies all known {@link DataManipulator}s from the given
+     * {@link DataHolder} of type {@link H}. This is a
+     * defensive copy as {@link DataManipulator} is mutable.
+     *
+     * @param holder The {@link DataHolder} to copy from
+     * @return This builder for chaining
+     */
+    @Override
+    B from(H holder);
+
+    /**
+     * Attempts to build a new {@link DataHolder} of type {@link H}.
+     *
+     * @return The new data holder
+     */
+    H build();
+
+    @Override
+    B reset();
+
+    interface Mutable<H extends DataHolder.Mutable, B extends Mutable<H, B>> extends DataHolderBuilder<H, B> {
+
+    }
+
+    interface Immutable<H extends DataHolder.Immutable<H>, B extends Immutable<H, B>> extends DataHolderBuilder<H, B> {
+
+    }
+}

--- a/src/main/java/org/spongepowered/api/data/DataManager.java
+++ b/src/main/java/org/spongepowered/api/data/DataManager.java
@@ -115,7 +115,7 @@ public interface DataManager {
 
     /**
      * Registers the given {@link org.spongepowered.api.data.DataHolder.Immutable} class with it's
-     * associated {@link org.spongepowered.api.data.persistence.DataBuilder.Immutable}. The builder can be used to
+     * associated {@link org.spongepowered.api.data.DataHolderBuilder.Immutable}. The builder can be used to
      * create new instances of the given {@link org.spongepowered.api.data.DataHolder.Immutable} for data
      * retrieval, data representation, etc.
      *
@@ -124,7 +124,7 @@ public interface DataManager {
      * @param <T> The type of immutable data holder
      * @param <B> The type of immutable data builder
      */
-    <T extends DataHolder.Immutable<T>, B extends DataBuilder.Immutable<T, B>> void register(Class<T> holderClass, B builder);
+    <T extends DataHolder.Immutable<T>, B extends DataHolderBuilder.Immutable<T, B>> void register(Class<T> holderClass, B builder);
 
     /**
      * Registers a legacy {@code id} that is used by a previous version of
@@ -148,8 +148,7 @@ public interface DataManager {
      * @param <B> The type of immutable data builder
      * @return The builder, if available
      */
-    <T extends DataHolder.Immutable<T>, B extends DataBuilder.Immutable<T, B>> Optional<B> getImmutableBuilder(Class<T> holderClass);
-
+    <T extends DataHolder.Immutable<T>, B extends DataHolderBuilder.Immutable<T, B>> Optional<B> getImmutableBuilder(Class<T> holderClass);
 
     /**
      * Gets the desired {@link DataTranslator} for the provided class.

--- a/src/main/java/org/spongepowered/api/data/persistence/DataBuilder.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/DataBuilder.java
@@ -24,12 +24,6 @@
  */
 package org.spongepowered.api.data.persistence;
 
-import org.spongepowered.api.data.DataHolder;
-import org.spongepowered.api.data.DataManipulator;
-import org.spongepowered.api.data.Key;
-import org.spongepowered.api.data.value.Value;
-import org.spongepowered.api.util.CopyableBuilder;
-
 import java.util.Optional;
 
 /**
@@ -42,7 +36,7 @@ import java.util.Optional;
  *
  * @param <T> The type of data serializable this builder can build
  */
-public interface DataBuilder<T extends DataSerializable> extends CopyableBuilder<T, DataBuilder<T>> {
+public interface DataBuilder<T extends DataSerializable> {
 
     /**
      * Attempts to build the provided {@link DataSerializable} from the given
@@ -56,75 +50,4 @@ public interface DataBuilder<T extends DataSerializable> extends CopyableBuilder
      *     properly construct the data serializable from the data view
      */
     Optional<T> build(DataView container) throws InvalidDataException;
-
-    @Override
-    default DataBuilder<T> reset() {
-        return this;
-    }
-
-    @Override
-    default DataBuilder<T> from(T value) {
-        return this;
-    }
-
-    /**
-     * A builder, much like a normal {@link DataBuilder} except that it builds
-     * {@link org.spongepowered.api.data.DataHolder.Immutable}s. While the {@link org.spongepowered.api.data.DataHolder.Immutable} is like
-     * a {@link DataHolder}, it is immutable.
-     *
-     * @param <H> The type of {@link org.spongepowered.api.data.DataHolder.Immutable}
-     * @param <E> The extended {@link Immutable}
-     */
-    interface Immutable<H extends DataHolder.Immutable<H>, E extends Immutable<H, E>> extends DataBuilder<H> {
-
-        /**
-         * Adds the given {@link Value} to the builder. The
-         * {@link Value} is copied when the {@link org.spongepowered.api.data.DataHolder.Immutable}
-         * is created.
-         *
-         * @param value The value to add
-         * @return This builder, for chaining
-         */
-        @SuppressWarnings("unchecked")
-        default E add(Value<?> value) {
-            return (E) add((Key) value.getKey(), value.get());
-        }
-
-        @SuppressWarnings("unchecked")
-        default E add(DataManipulator manipulator) {
-            manipulator.getValues().forEach(this::add);
-            return (E) this;
-        }
-
-        /**
-         * Adds the given {@link Key} with the given value.
-         *
-         * @param key The key to assign the value with
-         * @param value The value to assign with the key
-         * @param <V> The type of the value
-         * @return This builder, for chaining
-         */
-        <V> E add(Key<? extends Value<V>> key, V value);
-
-        /**
-         * Copies all known {@link DataManipulator}s from the given
-         * {@link org.spongepowered.api.data.DataHolder.Immutable}. This is a defensive copy as
-         * {@link DataManipulator} is mutable.
-         *
-         * @param holder The {@link org.spongepowered.api.data.DataHolder.Immutable} to copy from
-         * @return This builder for chaining
-         */
-        @Override
-        E from(H holder);
-
-        /**
-         * Attempts to build a new {@link org.spongepowered.api.data.DataHolder.Immutable}.
-         *
-         * @return The new immutable data holder
-         */
-        H build();
-
-        @Override
-        E reset();
-    }
 }

--- a/src/main/java/org/spongepowered/api/effect/particle/ParticleEffect.java
+++ b/src/main/java/org/spongepowered/api/effect/particle/ParticleEffect.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.effect.particle;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.persistence.DataSerializable;
 import org.spongepowered.api.data.persistence.DataBuilder;
+import org.spongepowered.api.util.CopyableBuilder;
 import org.spongepowered.math.vector.Vector3d;
 
 import java.util.Map;
@@ -86,13 +87,7 @@ public interface ParticleEffect extends DataSerializable {
     /**
      * Represents a builder to create a {@link ParticleEffect}.
      */
-    interface Builder extends DataBuilder<ParticleEffect> {
-
-        @Override
-        Builder from(ParticleEffect particleEffect);
-
-        @Override
-        Builder reset();
+    interface Builder extends CopyableBuilder<ParticleEffect, Builder>, DataBuilder<ParticleEffect> {
 
         /**
          * Sets the particle type for the particle effect.

--- a/src/main/java/org/spongepowered/api/effect/potion/PotionEffect.java
+++ b/src/main/java/org/spongepowered/api/effect/potion/PotionEffect.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.data.Keys;
 import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.data.property.PropertyHolder;
 import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.util.CopyableBuilder;
 
 /**
  * Represents an effect of a {@link PotionEffectType} for a specified
@@ -105,10 +106,7 @@ public interface PotionEffect extends DataSerializable, PropertyHolder {
     /**
      * Represents a builder interface to create a {@link PotionEffect}.
      */
-    interface Builder extends DataBuilder<PotionEffect> {
-
-        @Override
-        Builder from(PotionEffect potionEffect);
+    interface Builder extends CopyableBuilder<PotionEffect, Builder>, DataBuilder<PotionEffect> {
 
         /**
          * Sets the {@link PotionEffectType} of the potion.
@@ -160,8 +158,5 @@ public interface PotionEffect extends DataSerializable, PropertyHolder {
          * @throws IllegalStateException If the potion effect is not completed
          */
         PotionEffect build() throws IllegalStateException;
-
-        @Override
-        Builder reset();
     }
 }

--- a/src/main/java/org/spongepowered/api/entity/EntityArchetype.java
+++ b/src/main/java/org/spongepowered/api/entity/EntityArchetype.java
@@ -25,15 +25,12 @@
 package org.spongepowered.api.entity;
 
 import org.spongepowered.api.Sponge;
-import org.spongepowered.api.world.Archetype;
+import org.spongepowered.api.data.DataHolderBuilder;
 import org.spongepowered.api.data.persistence.DataContainer;
 import org.spongepowered.api.data.persistence.DataView;
-import org.spongepowered.api.data.persistence.Queries;
-import org.spongepowered.api.data.Key;
-import org.spongepowered.api.data.DataManipulator;
-import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.data.persistence.InvalidDataException;
-import org.spongepowered.api.data.value.Value;
+import org.spongepowered.api.data.persistence.Queries;
+import org.spongepowered.api.world.Archetype;
 import org.spongepowered.api.world.schematic.Schematic;
 
 public interface EntityArchetype extends Archetype<EntitySnapshot, Entity> {
@@ -58,7 +55,7 @@ public interface EntityArchetype extends Archetype<EntitySnapshot, Entity> {
 
     /**
      * Gets the {@link EntityType} of the entity contained in this archetype.
-     * 
+     *
      * @return The entity type
      */
     EntityType<?> getType();
@@ -85,13 +82,7 @@ public interface EntityArchetype extends Archetype<EntitySnapshot, Entity> {
     /**
      * A builder for {@link EntityArchetype}s.
      */
-    interface Builder extends DataBuilder<EntityArchetype> {
-
-        @Override
-        Builder reset();
-
-        @Override
-        Builder from(EntityArchetype value);
+    interface Builder extends DataHolderBuilder.Mutable<EntityArchetype, Builder> {
 
         /**
          * Sets all possible bits of information from the provided {@link Entity}.
@@ -118,35 +109,11 @@ public interface EntityArchetype extends Archetype<EntitySnapshot, Entity> {
         Builder entityData(DataView view);
 
         /**
-         * Sets the desired {@link EntityType} of the produced {@link EntityArchetype}.
-         *
-         * @param manipulator The manipulator to set for the archetype
-         * @return This builder, for chaining
-         */
-        Builder set(DataManipulator manipulator);
-
-        /**
-         * Sets the desired {@link EntityType} of the produced {@link EntityArchetype}.
-         *
-         * @param value The type of entity type
-         * @return This builder, for chaining
-         */
-        <E, V extends Value<E>> Builder set(V value);
-
-        /**
-         * Sets the desired {@link EntityType} of the produced {@link EntityArchetype}.
-         *
-         * @param key The key
-         * @param value The value to set
-         * @return This builder, for chaining
-         */
-        <E, V extends Value<E>> Builder set(Key<V> key, E value);
-
-        /**
          * Constructs a new {@link EntityArchetype}.
          *
          * @return The new entity archetype
          */
+        @Override
         EntityArchetype build();
     }
 

--- a/src/main/java/org/spongepowered/api/entity/EntitySnapshot.java
+++ b/src/main/java/org/spongepowered/api/entity/EntitySnapshot.java
@@ -26,9 +26,9 @@ package org.spongepowered.api.entity;
 
 import org.spongepowered.api.Game;
 import org.spongepowered.api.Sponge;
-import org.spongepowered.api.world.LocatableSnapshot;
-import org.spongepowered.api.data.persistence.DataBuilder;
+import org.spongepowered.api.data.DataHolderBuilder;
 import org.spongepowered.api.util.Transform;
+import org.spongepowered.api.world.LocatableSnapshot;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.schematic.Schematic;
@@ -107,10 +107,10 @@ public interface EntitySnapshot extends LocatableSnapshot<EntitySnapshot> {
     EntityArchetype createArchetype();
 
     /**
-     * An {@link org.spongepowered.api.data.persistence.DataBuilder.Immutable} for building {@link EntitySnapshot}s. The
+     * An {@link org.spongepowered.api.data.DataHolderBuilder.Immutable} for building {@link EntitySnapshot}s. The
      * requirements
      */
-    interface Builder extends DataBuilder.Immutable<EntitySnapshot, Builder> {
+    interface Builder extends DataHolderBuilder.Immutable<EntitySnapshot, Builder> {
 
         /**
          * Sets the {@link WorldProperties} for this {@link EntitySnapshot}.

--- a/src/main/java/org/spongepowered/api/fluid/FluidStack.java
+++ b/src/main/java/org/spongepowered/api/fluid/FluidStack.java
@@ -26,7 +26,7 @@ package org.spongepowered.api.fluid;
 
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.DataHolder;
-import org.spongepowered.api.data.persistence.DataBuilder;
+import org.spongepowered.api.data.DataHolderBuilder;
 import org.spongepowered.api.item.ItemTypes;
 
 /**
@@ -85,7 +85,7 @@ public interface FluidStack extends DataHolder.Mutable {
     @Override
     FluidStack copy();
 
-    interface Builder extends DataBuilder<FluidStack> {
+    interface Builder extends DataHolderBuilder.Mutable<FluidStack, Builder> {
 
         /**
          * Sets the {@link FluidType} to use to build the {@link FluidStack}.
@@ -114,6 +114,7 @@ public interface FluidStack extends DataHolder.Mutable {
          *
          * @return The newly created fluid stack
          */
+        @Override
         FluidStack build();
 
         /**
@@ -124,13 +125,6 @@ public interface FluidStack extends DataHolder.Mutable {
          * @return This builder, for chaining
          */
         Builder from(FluidStackSnapshot fluidStackSnapshot);
-
-        @Override
-        Builder from(FluidStack value);
-
-        @Override
-        Builder reset();
-
     }
 
 }

--- a/src/main/java/org/spongepowered/api/fluid/FluidStackSnapshot.java
+++ b/src/main/java/org/spongepowered/api/fluid/FluidStackSnapshot.java
@@ -26,7 +26,7 @@ package org.spongepowered.api.fluid;
 
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.DataHolder;
-import org.spongepowered.api.data.persistence.DataBuilder;
+import org.spongepowered.api.data.DataHolderBuilder;
 
 public interface FluidStackSnapshot extends DataHolder.Immutable<FluidStackSnapshot> {
 
@@ -64,7 +64,7 @@ public interface FluidStackSnapshot extends DataHolder.Immutable<FluidStackSnaps
      */
     FluidStack createStack();
 
-    interface Builder extends DataBuilder.Immutable<FluidStackSnapshot, Builder> {
+    interface Builder extends DataHolderBuilder.Immutable<FluidStackSnapshot, Builder> {
 
         Builder fluid(FluidType fluidType);
 

--- a/src/main/java/org/spongepowered/api/fluid/FluidState.java
+++ b/src/main/java/org/spongepowered/api/fluid/FluidState.java
@@ -27,8 +27,8 @@ package org.spongepowered.api.fluid;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.data.DataHolderBuilder;
 import org.spongepowered.api.data.DataManipulator;
-import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.state.State;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
@@ -76,14 +76,14 @@ public interface FluidState extends State<FluidState> {
     boolean isEmpty();
 
     /**
-     * An {@link org.spongepowered.api.data.persistence.DataBuilder.Immutable} for a {@link FluidState}. Just like the
-     * {@link org.spongepowered.api.data.persistence.DataBuilder.Immutable}, the {@link DataManipulator}s passed in to
+     * An {@link org.spongepowered.api.data.DataHolderBuilder.Immutable} for a {@link FluidState}. Just like the
+     * {@link org.spongepowered.api.data.DataHolderBuilder.Immutable}, the {@link DataManipulator}s passed in to
      * create a {@link FluidState} are copied on creation.
      *
      * <p>Note that upon creation, the {@link FluidType} must be set for validation
      * of {@link DataManipulator}s, otherwise exceptions may be thrown.</p>
      */
-    interface Builder extends DataBuilder.Immutable<FluidState, Builder> {
+    interface Builder extends DataHolderBuilder.Immutable<FluidState, Builder> {
 
         /**
          * Sets the {@link FluidType} for the {@link FluidState} to build.

--- a/src/main/java/org/spongepowered/api/item/enchantment/Enchantment.java
+++ b/src/main/java/org/spongepowered/api/item/enchantment/Enchantment.java
@@ -28,6 +28,7 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.persistence.DataSerializable;
 import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.util.CopyableBuilder;
 import org.spongepowered.api.util.ResettableBuilder;
 
 import java.util.List;
@@ -91,7 +92,7 @@ public interface Enchantment extends DataSerializable {
      * Represents a builder interface which can be used
      * to create a {@link Enchantment}.
      */
-    interface Builder extends DataBuilder<Enchantment> {
+    interface Builder extends CopyableBuilder<Enchantment, Builder>, DataBuilder<Enchantment> {
 
         /**
          * Sets the {@link EnchantmentType} for this enchantment.

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
@@ -33,10 +33,9 @@ import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.block.entity.BlockEntity;
 import org.spongepowered.api.data.DataHolder;
-import org.spongepowered.api.data.persistence.DataView;
+import org.spongepowered.api.data.DataHolderBuilder;
 import org.spongepowered.api.data.Key;
-import org.spongepowered.api.data.DataManipulator;
-import org.spongepowered.api.data.persistence.DataBuilder;
+import org.spongepowered.api.data.persistence.DataView;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.item.ItemType;
@@ -167,10 +166,7 @@ public interface ItemStack extends DataHolder.Mutable, Translatable {
     @Override
     ItemStack copy();
 
-    interface Builder extends DataBuilder<ItemStack> {
-
-        @Override
-        Builder from(ItemStack value);
+    interface Builder extends DataHolderBuilder.Mutable<ItemStack, Builder> {
 
         /**
          * Sets the {@link ItemType} of the item stack.
@@ -191,33 +187,6 @@ public interface ItemStack extends DataHolder.Mutable, Translatable {
          *      allowed bounds
          */
         Builder quantity(int quantity) throws IllegalArgumentException;
-
-        /**
-         * Sets the {@link DataManipulator} to add to the {@link ItemStack}.
-         *
-         * @param itemData The item data to set
-         * @return This builder, for chaining
-         * @throws IllegalArgumentException If the item data is incompatible
-         *      with the item
-         */
-        Builder add(DataManipulator itemData) throws IllegalArgumentException;
-
-        /**
-         * Adds a {@link Key} and related {@link Object} value to apply to the
-         * resulting {@link ItemStack}. Note that the resulting
-         * {@link ItemStack} may not actually accept the provided {@code Key}
-         * for various reasons due to support or simply that the value itself
-         * is not supported.
-         *
-         * @param key The key to assign the value with
-         * @param value The value to assign with the key
-         * @param <V> The type of the value
-         * @return This builder, for chaining
-         * @throws IllegalArgumentException If the item data is incompatible
-         */
-        <V> Builder add(Key<? extends Value<V>> key, V value) throws IllegalArgumentException;
-
-        <V extends Value<E>, E> Builder add(V value) throws IllegalArgumentException;
 
         /**
          * Sets all the settings in this builder from the item stack blueprint.
@@ -279,7 +248,6 @@ public interface ItemStack extends DataHolder.Mutable, Translatable {
             }
             return this;
         }
-
 
         /**
          * Builds an instance of an ItemStack.

--- a/src/main/java/org/spongepowered/api/item/merchant/TradeOffer.java
+++ b/src/main/java/org/spongepowered/api/item/merchant/TradeOffer.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.entity.living.Humanoid;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.util.CopyableBuilder;
 
 import java.util.Optional;
 
@@ -130,7 +131,7 @@ public interface TradeOffer extends DataSerializable {
     /**
      * Represents a builder to generate immutable {@link TradeOffer}s.
      */
-    interface Builder extends DataBuilder<TradeOffer> {
+    interface Builder extends CopyableBuilder<TradeOffer, Builder>, DataBuilder<TradeOffer> {
 
         /**
          * <p>Sets the first selling item of the trade offer to be
@@ -194,24 +195,6 @@ public interface TradeOffer extends DataSerializable {
          *      invalid
          */
         TradeOffer build() throws IllegalStateException;
-
-        /**
-         * Sets all the settings of this builder with the provided trade offer
-         * as a blueprint.
-         *
-         * @param offer The offer to copy
-         * @return This builder
-         */
-        @Override
-        Builder from(TradeOffer offer);
-
-        /**
-         * Clears all settings of this builder.
-         *
-         * @return This builder
-         */
-        @Override
-        Builder reset();
 
     }
 }

--- a/src/main/java/org/spongepowered/api/state/State.java
+++ b/src/main/java/org/spongepowered/api/state/State.java
@@ -49,13 +49,13 @@ public interface State<S extends State<S>> extends DataHolder.Immutable<S>, Cata
 
     /**
      * Attempts to retrieve the {@link StateProperty} instance associated with
-     * this {@link State}s {@link StateContainer} by string id. If there is no
+     * this {@link State}s {@link StateContainer} by name. If there is no
      * {@link StateProperty} available, {@link Optional#empty()} is returned.
      *
-     * @param statePropertyId The state property id
+     * @param name The state property name
      * @return The state property, if available
      */
-    Optional<StateProperty<?>> getStatePropertyByName(String statePropertyId);
+    Optional<StateProperty<?>> getStatePropertyByName(String name);
 
     /**
      * Gets the {@link State} with the appropriate value for the given

--- a/src/main/java/org/spongepowered/api/state/StateContainer.java
+++ b/src/main/java/org/spongepowered/api/state/StateContainer.java
@@ -39,12 +39,12 @@ public interface StateContainer<S extends State<S>> {
 
     /**
      * Attempts to retrieve the {@link StateProperty} instance associated with
-     * this {@link StateContainer} by string id. If there is no
+     * this {@link StateContainer} by name. If there is no
      * {@link StateProperty} available, {@link Optional#empty()} is returned.
      *
-     * @param statePropertyId The state property id
+     * @param name The state property name
      * @return The state property, if available
      */
-    Optional<StateProperty<?>> getStatePropertyByName(String statePropertyId);
+    Optional<StateProperty<?>> getStatePropertyByName(String name);
 
 }

--- a/src/main/java/org/spongepowered/api/world/LocatableSnapshot.java
+++ b/src/main/java/org/spongepowered/api/world/LocatableSnapshot.java
@@ -33,7 +33,7 @@ import java.util.UUID;
 /**
  * A type of {@link org.spongepowered.api.data.DataHolder.Immutable} that may be linked to a particular
  * {@link Location}. Being that a {@link LocatableSnapshot} may be built
- * by an {@link org.spongepowered.api.data.persistence.DataBuilder.Immutable}, the {@link Location} may be
+ * by an {@link org.spongepowered.api.data.DataHolderBuilder.Immutable}, the {@link Location} may be
  * <code>null</code> such that {@link #getLocation()} returns
  * {@link Optional#empty()}.
  *


### PR DESCRIPTION
Added a common builder interface for mutable and immutable data holders. This reduces some duplication with data related builders.

`DataBuilder<T extends DataSerializable>` is now only used to reconstruct data objects from a data container/view. This is to prevent conflicts between the new interface and data builder.

@gabizou 