### PR TITLE
[API8] Allow regular gradle dsl to have spongeapi's kotlin dsl subproject

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,9 +2,9 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 
 plugins {
-    org.spongepowered.gradle.sponge.dev
-    org.spongepowered.gradle.sponge.deploy
-    org.spongepowered.gradle.sort
+    id("org.spongepowered.gradle.sponge.dev")
+    id("org.spongepowered.gradle.sponge.deploy")
+    id("org.spongepowered.gradle.sort")
 
     id("org.spongepowered.event-impl-gen") version "5.7.0"
 }


### PR DESCRIPTION
Without these 3 id declarations, the groovy-based regular gradle dsl will error out when encountering these lines, trying to resolve these as class names instead of gradle plugin ids.

Signed-off-by: liach <liach@users.noreply.github.com>