### PR TITLE
Updates to the Command API to support implementation

### DIFF
--- a/src/main/java/org/spongepowered/api/command/CommandCause.java
+++ b/src/main/java/org/spongepowered/api/command/CommandCause.java
@@ -28,17 +28,27 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.SystemSubject;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.EventContext;
 import org.spongepowered.api.event.cause.EventContextKeys;
+import org.spongepowered.api.service.context.Context;
 import org.spongepowered.api.service.permission.Subject;
+import org.spongepowered.api.service.permission.SubjectCollection;
+import org.spongepowered.api.service.permission.SubjectData;
+import org.spongepowered.api.service.permission.SubjectReference;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.channel.MessageChannel;
 import org.spongepowered.api.text.channel.MessageReceiver;
+import org.spongepowered.api.util.Tristate;
 import org.spongepowered.api.world.Locatable;
 import org.spongepowered.api.world.ServerLocation;
 import org.spongepowered.math.vector.Vector3d;
 import org.spongepowered.plugin.PluginContainer;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * The {@link CommandCause} represents the {@link Cause} of a command, and
@@ -61,6 +71,9 @@ import java.util.Optional;
  * plate, the direct cause will be the command block. However, the player
  * in question will also be present in the cause stack, allowing command
  * providers to obtain richer information about the invocation of their command.
+ * This is inline with how {@link Cause}s work in Sponge and its events, for
+ * more information about how Causes work, see the {@link Cause} and
+ * {@link CauseStackManager} javadocs and associated documentation.
  * </p>
  *
  * <p>The {@link EventContext} that is attached to {@link Cause#getContext()}
@@ -68,7 +81,7 @@ import java.util.Optional;
  * be handled, in addition to using the provided cause stack:</p>
  *
  * <ul>
- *     <li>{@link EventContextKeys#MESSAGE_TARGET}, which indicates the
+ *     <li>{@link EventContextKeys#MESSAGE_CHANNEL}, which indicates the
  *     where messages that should be sent back to the invoker should be sent
  *     to (typically messages indicating the status of the command execution);
  *     </li>
@@ -82,6 +95,10 @@ import java.util.Optional;
  *     the command should take into account when executing.</li>
  * </ul>
  *
+ * <p>This object acts as a {@link Subject}, and simply redirects all calls
+ * inherited by this interface to the subject returned by {@link #getSubject()}.
+ * </p>
+ *
  * <p>There are utility methods on this interface that provide hints as to what
  * the implementation will select for different tasks, for example, the
  * implementation will use the result of {@link #getSubject()} for permission
@@ -93,7 +110,7 @@ import java.util.Optional;
  * be taken a guarantee of what may be present, however, they indicate what
  * typically would be of interest to command API consumers.</p>
  */
-public interface CommandCause {
+public interface CommandCause extends Subject {
 
     /**
      * Creates a {@link CommandCause} from the provided {@link Cause}
@@ -101,7 +118,7 @@ public interface CommandCause {
      * @param cause The {@link Cause}
      * @return The {@link CommandCause}
      */
-    static CommandCause of(Cause cause) {
+    static CommandCause of(final Cause cause) {
         return Sponge.getRegistry().getFactoryRegistry().provideFactory(Factory.class).create(cause);
     }
 
@@ -141,14 +158,14 @@ public interface CommandCause {
     }
 
     /**
-     * Gets the {@link MessageReceiver} that should be the target for any
+     * Gets the {@link MessageChannel} that should be the target for any
      * messages sent by the command (by default).
      *
-     * <p>The {@link MessageReceiver} will be selected in the following way
+     * <p>The {@link MessageChannel} will be selected in the following way
      * from the {@link Cause} in {@link #getCause()}:</p>
      *
      * <ul>
-     *    <li>The {@link EventContextKeys#MESSAGE_TARGET}, if any</li>
+     *    <li>The {@link EventContextKeys#MESSAGE_CHANNEL}, if any</li>
      *    <li>A message channel containing the <strong>first</strong>
      *    {@link MessageReceiver} in the {@link Cause}</li>
      *    <li>The SystemSubject {@link MessageReceiver}</li>
@@ -161,10 +178,10 @@ public interface CommandCause {
      *
      * @return The {@link MessageReceiver} to send any messages to.
      */
-    default MessageReceiver getMessageReceiver() {
-        return getCause().getContext()
-            .get(EventContextKeys.MESSAGE_TARGET)
-            .orElseGet(() -> getCause().first(MessageReceiver.class).orElseGet(Sponge::getSystemSubject));
+    default MessageChannel getMessageChannel() {
+        return this.getCause().getContext()
+            .get(EventContextKeys.MESSAGE_CHANNEL)
+            .orElseGet(() -> MessageChannel.to(this.getCause().first(MessageReceiver.class).orElseGet(Sponge::getSystemSubject)));
     }
 
     /**
@@ -175,29 +192,24 @@ public interface CommandCause {
      * <ul>
      *     <li>The {@link EventContextKeys#LOCATION}, if any</li>
      *     <li>{@link #getTargetBlock()}</li>
-     *     <li>The {@link EventContextKeys#MESSAGE_TARGET}, if it is
-     *     {@link Locatable}</li>
      *     <li>the location of the first locatable in the {@link Cause}</li>
      * </ul>
      *
      * @return The {@link ServerLocation}, if it exists
      */
-    @SuppressWarnings("unchecked")
     default Optional<ServerLocation> getLocation() {
-        Cause cause = getCause();
-        EventContext eventContext = cause.getContext();
+        final Cause cause = this.getCause();
+        final EventContext eventContext = cause.getContext();
         if (eventContext.containsKey(EventContextKeys.LOCATION)) {
             return eventContext.get(EventContextKeys.LOCATION);
         }
 
-        Optional<ServerLocation> optionalLocation = getTargetBlock().flatMap(BlockSnapshot::getLocation);
+        final Optional<ServerLocation> optionalLocation = this.getTargetBlock().flatMap(BlockSnapshot::getLocation);
         if (optionalLocation.isPresent()) {
             return optionalLocation;
         }
 
-        return eventContext.get(EventContextKeys.MESSAGE_TARGET)
-            .filter(x -> x instanceof Locatable)
-            .flatMap(x -> ((Locatable) x).getLocation().onServer());
+        return cause.first(Locatable.class).map(Locatable::getServerLocation);
     }
 
     /**
@@ -207,25 +219,19 @@ public interface CommandCause {
      *
      * <ul>
      *     <li>The {@link EventContextKeys#ROTATION}, if any</li>
-     *     <li>The {@link EventContextKeys#MESSAGE_TARGET}, if it has a
-     *     rotation</li>
      *     <li>the rotation of the first {@link Entity} in the {@link Cause}</li>
      * </ul>
      *
      * @return The {@link Vector3d} rotation, if it exists
      */
     default Optional<Vector3d> getRotation() {
-        Cause cause = getCause();
-        EventContext eventContext = cause.getContext();
+        final Cause cause = this.getCause();
+        final EventContext eventContext = cause.getContext();
         if (eventContext.containsKey(EventContextKeys.ROTATION)) {
             return eventContext.get(EventContextKeys.ROTATION);
         }
 
-        return Optional.ofNullable(
-            eventContext.get(EventContextKeys.MESSAGE_TARGET)
-                .filter(x -> x instanceof Entity)
-                .map(x -> ((Entity) x).getRotation())
-                .orElseGet(() -> cause.first(Entity.class).map(Entity::getRotation).orElse(null)));
+        return cause.first(Entity.class).map(Entity::getRotation);
     }
 
     /**
@@ -241,8 +247,73 @@ public interface CommandCause {
      * @return The {@link BlockSnapshot} if applicable, or an empty optional.
      */
     default Optional<BlockSnapshot> getTargetBlock() {
-        return Optional.ofNullable(getCause().getContext().get(EventContextKeys.BLOCK_TARGET)
-            .orElseGet(() -> getCause().first(BlockSnapshot.class).orElse(null)));
+        return Optional.ofNullable(this.getCause().getContext().get(EventContextKeys.BLOCK_TARGET)
+            .orElseGet(() -> this.getCause().first(BlockSnapshot.class).orElse(null)));
+    }
+
+    @Override
+    default SubjectCollection getContainingCollection() {
+        return getSubject().getContainingCollection();
+    }
+
+    @Override
+    default SubjectReference asSubjectReference() {
+        return getSubject().asSubjectReference();
+    }
+
+    @Override
+    default boolean isSubjectDataPersisted() {
+        return getSubject().isSubjectDataPersisted();
+    }
+
+    @Override
+    default SubjectData getSubjectData() {
+        return getSubject().getSubjectData();
+    }
+
+    @Override
+    default SubjectData getTransientSubjectData() {
+        return getSubject().getTransientSubjectData();
+    }
+
+    @Override
+    default Tristate getPermissionValue(Set<Context> contexts, String permission) {
+        return getSubject().getPermissionValue(contexts, permission);
+    }
+
+    @Override
+    default boolean isChildOf(Set<Context> contexts, SubjectReference parent) {
+        return getSubject().isChildOf(contexts, parent);
+    }
+
+    @Override
+    default List<SubjectReference> getParents(Set<Context> contexts) {
+        return getSubject().getParents();
+    }
+
+    @Override
+    default Optional<String> getOption(Set<Context> contexts, String key) {
+        return getSubject().getOption(contexts, key);
+    }
+
+    @Override
+    default String getIdentifier() {
+        return getSubject().getIdentifier();
+    }
+
+    @Override
+    default Set<Context> getActiveContexts() {
+        return getSubject().getActiveContexts();
+    }
+
+    /**
+     * Sends a message to the {@link MessageChannel} as given by
+     * {@link #getMessageChannel()}.
+     *
+     * @param message The message to send.
+     */
+    default void sendMessage(Text message) {
+        getMessageChannel().send(message);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/command/exception/ArgumentParseException.java
+++ b/src/main/java/org/spongepowered/api/command/exception/ArgumentParseException.java
@@ -44,7 +44,7 @@ public class ArgumentParseException extends CommandException {
      * @param source The source string being parsed
      * @param position The current position in the source string
      */
-    public ArgumentParseException(Text message, String source, int position) {
+    public ArgumentParseException(final Text message, final String source, final int position) {
         super(message, true);
         this.source = source;
         this.position = position;
@@ -58,7 +58,7 @@ public class ArgumentParseException extends CommandException {
      * @param source The source string being parsed
      * @param position The current position in the source string
      */
-    public ArgumentParseException(Text message, Throwable cause, String source, int position) {
+    public ArgumentParseException(final Text message, final Throwable cause, final String source, final int position) {
         super(message, cause, true);
         this.source = source;
         this.position = position;
@@ -66,7 +66,7 @@ public class ArgumentParseException extends CommandException {
 
     @Override
     public Text getText() {
-        Text superText = super.getText();
+        final Text superText = super.getText();
         if (this.source == null || this.source.isEmpty()) {
             return super.getText();
         } else if (superText == null) {
@@ -91,8 +91,8 @@ public class ArgumentParseException extends CommandException {
         int position = this.position;
         if (source.length() > 80) {
             if (position >= 37) {
-                int startPos = position - 37;
-                int endPos = Math.min(source.length(), position + 37);
+                final int startPos = position - 37;
+                final int endPos = Math.min(source.length(), position + 37);
                 if (endPos < source.length()) {
                     source = "..." + source.substring(startPos, endPos) + "...";
                 } else {

--- a/src/main/java/org/spongepowered/api/command/manager/CommandFailedRegistrationException.java
+++ b/src/main/java/org/spongepowered/api/command/manager/CommandFailedRegistrationException.java
@@ -22,22 +22,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.command.parameter.managed;
-
-import org.spongepowered.api.text.Text;
+package org.spongepowered.api.command.manager;
 
 /**
- * Defines the usage string for the parameter.
+ * Indicates that a command could not be registered.
  */
-@FunctionalInterface
-public interface ValueUsage {
+public class CommandFailedRegistrationException extends RuntimeException {
 
-    /**
-     * Gets the usage string for the argument.
-     *
-     * @param key The {@link Text} that defines the parameter key
-     * @return The usage
-     */
-    Text getUsage(Text key);
+    private static final long serialVersionUID = -783923658025L;
+
+    public CommandFailedRegistrationException(String message) {
+        super(message);
+    }
+
+    public CommandFailedRegistrationException(String message, Throwable inner) {
+        super(message, inner);
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/command/manager/CommandMapping.java
+++ b/src/main/java/org/spongepowered/api/command/manager/CommandMapping.java
@@ -74,6 +74,6 @@ public interface CommandMapping {
      *
      * @return The {@link CommandRegistrar}
      */
-    CommandRegistrar getRegistrar();
+    CommandRegistrar<?> getRegistrar();
 
 }

--- a/src/main/java/org/spongepowered/api/command/manager/CommandMapping.java
+++ b/src/main/java/org/spongepowered/api/command/manager/CommandMapping.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.command.manager;
 
 import org.spongepowered.api.command.Command;
+import org.spongepowered.api.command.registrar.CommandRegistrar;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.plugin.PluginContainer;
 
@@ -38,7 +39,10 @@ import java.util.function.Predicate;
 public interface CommandMapping {
 
     /**
-     * Gets the primary alias.
+     * Gets the primary alias that will be passed to the registered
+     * {@link CommandRegistrar}. Note that this alias may not correspond to
+     * an alias in {@link #getAllAliases()}, it is used as an identifier to
+     * the underlying {@link CommandRegistrar}.
      *
      * @return The primary alias
      */
@@ -66,24 +70,10 @@ public interface CommandMapping {
     PluginContainer getPlugin();
 
     /**
-     * Gets the {@link Command} associated with this mapping, if associated
-     * with the Sponge system.
+     * Gets the {@link CommandRegistrar} that registered this command.
      *
-     * <p>An {@link Optional#empty()} does not indicate no command, rather
-     * it infers that an object has registered a command via the underlying
-     * engine.</p>
-     *
-     * @return The {@link Command}, if applicable
+     * @return The {@link CommandRegistrar}
      */
-    Optional<Command> getCommand();
-
-    /**
-     * Gets a {@link Predicate} that checks whether a given {@link Cause}
-     * should be able to execute the command represented by this mapping.
-     *
-     * @return A {@link Predicate} that determines whether the command can be
-     *         run by the given {@link Cause}.
-     */
-    Predicate<Cause> getRequirements();
+    CommandRegistrar getRegistrar();
 
 }

--- a/src/main/java/org/spongepowered/api/command/parameter/CommandContext.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/CommandContext.java
@@ -71,7 +71,7 @@ public interface CommandContext extends CommandCause {
      * @throws IllegalArgumentException if more than one value for the key was
      *                                  found
      */
-    <T> Optional<T> getOne(Parameter.Key<T> key) throws IllegalArgumentException;
+    <T> Optional<T> getOne(Parameter.Key<? super T> key) throws IllegalArgumentException;
 
     /**
      * Gets the value for the given key if the key has only one value,
@@ -99,7 +99,7 @@ public interface CommandContext extends CommandCause {
      * @throws IllegalArgumentException if more than one value for the key was
      *                                  found
      */
-    <T> T requireOne(Parameter.Key<T> key) throws NoSuchElementException, IllegalArgumentException;
+    <T> T requireOne(Parameter.Key<? super T> key) throws NoSuchElementException, IllegalArgumentException;
 
     /**
      * Gets all values for the given argument. May return an empty list if no
@@ -121,7 +121,7 @@ public interface CommandContext extends CommandCause {
      * @param <T> the type of value to get
      * @return the collection of all values
      */
-    <T> Collection<? extends T> getAll(Parameter.Key<T> key);
+    <T> Collection<? extends T> getAll(Parameter.Key<? super T> key);
 
     /**
      * A builder for creating this context.

--- a/src/main/java/org/spongepowered/api/command/parameter/CommandContext.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/CommandContext.java
@@ -26,7 +26,6 @@ package org.spongepowered.api.command.parameter;
 
 import org.spongepowered.api.command.CommandCause;
 import org.spongepowered.api.event.cause.Cause;
-import org.spongepowered.api.util.ResettableBuilder;
 
 import java.util.Collection;
 import java.util.NoSuchElementException;
@@ -41,7 +40,6 @@ import java.util.Optional;
  * {@link Cause} of the command.</p>
  */
 public interface CommandContext extends CommandCause {
-
 
     /**
      * Returns whether this context has any value for the given argument key.
@@ -60,8 +58,8 @@ public interface CommandContext extends CommandCause {
      * @throws IllegalArgumentException if more than one value for the key was
      *                                  found
      */
-    default <T> Optional<T> getOne(Parameter.Value<T> parameter) throws IllegalArgumentException {
-        return getOne(parameter.getKey());
+    default <T> Optional<T> getOne(final Parameter.Value<T> parameter) throws IllegalArgumentException {
+        return this.getOne(parameter.getKey());
     }
 
     /**
@@ -86,8 +84,8 @@ public interface CommandContext extends CommandCause {
      * @throws IllegalArgumentException if more than one value for the key was
      *                                  found
      */
-    default  <T> T requireOne(Parameter.Value<T> parameter) throws NoSuchElementException, IllegalArgumentException {
-        return requireOne(parameter.getKey());
+    default  <T> T requireOne(final Parameter.Value<T> parameter) throws NoSuchElementException, IllegalArgumentException {
+        return this.requireOne(parameter.getKey());
     }
 
     /**
@@ -111,8 +109,8 @@ public interface CommandContext extends CommandCause {
      * @param <T> the expected type of the argument
      * @return the argument
      */
-    default <T> Collection<? extends T> getAll(Parameter.Value<T> parameter) {
-        return getAll(parameter.getKey());
+    default <T> Collection<? extends T> getAll(final Parameter.Value<T> parameter) {
+        return this.getAll(parameter.getKey());
     }
 
     /**
@@ -128,7 +126,7 @@ public interface CommandContext extends CommandCause {
     /**
      * A builder for creating this context.
      */
-    interface Builder extends ResettableBuilder<CommandContext, Builder>, CommandContext {
+    interface Builder extends CommandContext {
 
         /**
          * Adds a parsed object into the context, for use by commands.
@@ -137,8 +135,8 @@ public interface CommandContext extends CommandCause {
          * @param parameter The key to store the entry under.
          * @param value The collection of objects to store.
          */
-        default <T> void putEntry(Parameter.Value<T> parameter, T value) {
-            putEntry(parameter.getKey(), value);
+        default <T> void putEntry(final Parameter.Value<? super T> parameter, final T value) {
+            this.putEntry(parameter.getKey(), value);
         }
 
         /**
@@ -148,8 +146,8 @@ public interface CommandContext extends CommandCause {
          * @param parameter The key to store the entry under.
          * @param value The collection of objects to store.
          */
-        default <T> void putEntries(Parameter.Value<T> parameter, Collection<T> value) {
-            value.forEach(val -> putEntry(parameter, val));
+        default <T> void putEntries(final Parameter.Value<? super T> parameter, final Collection<T> value) {
+            value.forEach(val -> this.putEntry(parameter, val));
         }
 
         /**
@@ -159,8 +157,8 @@ public interface CommandContext extends CommandCause {
          * @param parameter The key to store the entry under.
          * @param value The collection of objects to store.
          */
-        default <T> void putEntries(Parameter.Key<T> parameter, Collection<T> value) {
-            value.forEach(val -> putEntry(parameter, val));
+        default <T> void putEntries(final Parameter.Key<? super T> parameter, final Collection<T> value) {
+            value.forEach(val -> this.putEntry(parameter, val));
         }
 
         /**
@@ -170,30 +168,60 @@ public interface CommandContext extends CommandCause {
          * @param key The key to store the entry under.
          * @param object The object to store.
          */
-        <T> void putEntry(Parameter.Key<T> key, T object);
+        <T> void putEntry(Parameter.Key<? super T> key, T object);
 
         /**
-         * Creates a snapshot of this context and returns a state object that can
-         * be used to restore the context to this state.
+         * Starts a {@link Transaction} which allows for this builder to be
+         * returned to a previous state if necessary.
+         *
+         * <p>Multiple transactions can be started on the same builder, however,
+         * they must be either {@link #commit(Transaction) committed} or
+         * {@link #rollback(Transaction) rolledback} in reverse order (that is,
+         * the last transaction must be committed first)</p>
+         *
+         * <p>Transactions must not be held on to for longer than necessary.</p>
          *
          * @return The state.
          */
-        State getState();
+        Transaction startTransaction();
 
         /**
-         * Uses a previous snapshot of the context and restores it to that state.
+         * Creates a {@link CommandContext}.
          *
-         * @param state The state obtained from {@link #getState()}
+         * <p>If {@link Transaction}s are still open at this point, they will all
+         * be {@link #commit(Transaction) committed}.</p>
+         *
+         * @param input The input argument string.
+         * @return The context
          */
-        void setState(State state);
+        CommandContext build(String input);
 
         /**
-         * An immutable snapshot of a {@link CommandContext.Builder}.
+         * Commits the specified {@link Transaction} if it was the most recently
+         * created transaction.
          *
-         * <p>No assumptions should be made about the form of this state object,
-         * it is not defined in the API and may change at any time.</p>
+         * @param transaction The transaction to commit.
+         * @throws IllegalArgumentException Thrown if there are newer
+         *  transactions to commit first, if this transaction is not active, or
+         *  if this transaction is not part of this builder.
          */
-        interface State {}
+        void commit(Transaction transaction) throws IllegalArgumentException;
+
+        /**
+         * Cancels the specified {@link Transaction} if it was the most recently
+         * created transaction.
+         *
+         * @param transaction The transaction to rollback.
+         * @throws IllegalArgumentException Thrown if there are newer
+         *  transactions to commit first, if this transaction is not active, or
+         *  if this transaction is not part of this builder.
+         */
+        void rollback(Transaction transaction) throws IllegalArgumentException;
+
+        /**
+         * A transaction on a context builder.
+         */
+        interface Transaction { }
     }
 
 }

--- a/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.api.command.parameter;
 
+import com.google.common.reflect.TypeToken;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
@@ -63,6 +65,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -85,7 +88,7 @@ import java.util.function.Supplier;
  *     <li>{@link Subcommand}s can be placed anywhere in a parameter
  *     chain where a {@link Parameter} can be added, if successfully parsed,
  *     any containing {@link Command} would take precedence and its
- *     {@link Command#process(org.spongepowered.api.command.CommandCause, String)} method will be called instead
+ *     {@link Command#process(CommandCause, String)} method will be called instead
  *     of any parent.</li>
  * </ul>
  *
@@ -98,23 +101,64 @@ public interface Parameter {
      * Creates a {@link Parameter.Key} for storing values against.
      *
      * @param key The string key
-     * @param valueClass The type of value that this key represents
+     * @param typeToken The type of value that this key represents
      * @param <T> The type
      * @return The {@link Key}
      */
-    static <T> Key<T> key(String key, Class<T> valueClass) {
-        return Sponge.getRegistry().getBuilderRegistry().provideBuilder(Key.Builder.class).build(key, valueClass);
+    static <T> Key<T> key(@NonNull final String key, @NonNull final TypeToken<T> typeToken) {
+        return Sponge.getRegistry().getBuilderRegistry().provideBuilder(Key.Builder.class).build(key, typeToken);
+    }
+
+    /**
+     * Gets a builder that builds a {@link Parameter.Value}.
+     *
+     * <p>If your parameter type is generic, use
+     * {@link #builder(TypeToken)} instead.</p>
+     *
+     * @param <T> The type of parameter
+     * @param valueClass The type of value class
+     * @return The {@link Value.Builder}
+     */
+    static <T> Value.Builder<T> builder(@NonNull final Class<T> valueClass) {
+        return builder(TypeToken.of(valueClass));
     }
 
     /**
      * Gets a builder that builds a {@link Parameter.Value}.
      *
      * @param <T> The type of parameter
-     * @param valueClass The type of value class
+     * @param typeToken The type of value class as a {@link TypeToken}
      * @return The {@link Value.Builder}
      */
-    static <T> Value.Builder<T> builder(Class<T> valueClass) {
-        return Sponge.getRegistry().getFactoryRegistry().provideFactory(Factory.class).createParameterBuilder(valueClass);
+    static <T> Value.Builder<T> builder(@NonNull final TypeToken<T> typeToken) {
+        return Sponge.getRegistry().getFactoryRegistry().provideFactory(Factory.class).createParameterBuilder(typeToken);
+    }
+
+    /**
+     * Gets a builder that builds a {@link Parameter.Value}.
+     *
+     * <p>If your parameter type is generic, use
+     * {@link #builder(TypeToken, ValueParameter)} instead.</p>
+     *
+     * @param <T> The type of parameter
+     * @param valueClass The type of value class as a {@link Class}
+     * @param parameter The value parameter
+     * @return The {@link Value.Builder}
+     */
+    static <T> Value.Builder<T> builder(@NonNull final Class<T> valueClass, @NonNull final ValueParameter<T> parameter) {
+        return builder(TypeToken.of(valueClass), parameter);
+    }
+
+    /**
+     * Gets a builder that builds a {@link Parameter.Value}.
+     *
+     * @param <T> The type of parameter
+     * @param typeToken The type of value class as a {@link TypeToken}
+     * @param parameter The value parameter
+     * @return The {@link Value.Builder}
+     */
+    static <T> Value.Builder<T> builder(@NonNull final TypeToken<T> typeToken, @NonNull final ValueParameter<T> parameter) {
+        return builder(typeToken).parser(parameter);
     }
 
     /**
@@ -125,20 +169,20 @@ public interface Parameter {
      * @param valueClass The type of value class
      * @return The {@link Value.Builder}
      */
-    static <T> Value.Builder<T> builder(Class<T> valueClass, ValueParameter<T> parameter) {
-        return builder(valueClass).parser(parameter);
-    }
-
-    /**
-     * Gets a builder that builds a {@link Parameter.Value}.
-     *
-     * @param <T> The type of parameter
-     * @param parameter The value parameter
-     * @param valueClass The type of value class
-     * @return The {@link Value.Builder}
-     */
-    static <T, V extends ValueParameter<T>> Value.Builder<T> builder(Class<T> valueClass, Supplier<V> parameter) {
+    static <T, V extends ValueParameter<T>> Value.Builder<T> builder(@NonNull final Class<T> valueClass, @NonNull final Supplier<V> parameter) {
         return builder(valueClass, parameter.get());
+    }
+
+    /**
+     * Gets a builder that builds a {@link Parameter.Value}.
+     *
+     * @param <T> The type of parameter
+     * @param parameter The value parameter
+     * @param typeToken The type of value class as a {@link TypeToken}
+     * @return The {@link Value.Builder}
+     */
+    static <T, V extends ValueParameter<T>> Value.Builder<T> builder(@NonNull final TypeToken<T> typeToken, @NonNull final Supplier<V> parameter) {
+        return builder(typeToken, parameter.get());
     }
 
     /**
@@ -155,12 +199,12 @@ public interface Parameter {
      * @param aliases Subsequent aliases, if any
      * @return The {@link Subcommand} for use in a {@link Parameter} chain
      */
-    static Subcommand subcommand(Command subcommand, String alias, String... aliases) {
-        Subcommand.Builder builder = Sponge.getRegistry()
+    static Subcommand subcommand(final Command.@NonNull Parameterized subcommand, @NonNull final String alias, final String @NonNull... aliases) {
+        final Subcommand.Builder builder = Sponge.getRegistry()
                 .getBuilderRegistry().provideBuilder(Subcommand.Builder.class)
                 .setSubcommand(subcommand)
                 .alias(alias);
-        for (String a : aliases) {
+        for (final String a : aliases) {
             builder.alias(a);
         }
 
@@ -176,7 +220,7 @@ public interface Parameter {
      * @param parameter The first {@link Parameter}
      * @return The {@link Parameter.FirstOfBuilder} to continue chaining
      */
-    static Parameter.FirstOfBuilder firstOf(Parameter parameter) {
+    static Parameter.FirstOfBuilder firstOf(@NonNull final Parameter parameter) {
         return Sponge.getRegistry().getBuilderRegistry().provideBuilder(FirstOfBuilder.class).or(parameter);
     }
 
@@ -191,7 +235,7 @@ public interface Parameter {
      * @param parameters The remaining {@link Parameter}s
      * @return The {@link Parameter}
      */
-    static Parameter firstOf(Parameter first, Parameter second, Parameter... parameters) {
+    static Parameter firstOf(@NonNull final Parameter first, @NonNull final Parameter second, final Parameter @NonNull... parameters) {
         return Sponge.getRegistry().getBuilderRegistry().provideBuilder(FirstOfBuilder.class).or(first).or(second).orFirstOf(parameters).build();
     }
 
@@ -203,7 +247,7 @@ public interface Parameter {
      * @param parameters The {@link Parameter}s
      * @return The {@link Parameter}
      */
-    static Parameter firstOf(Iterable<Parameter> parameters) {
+    static Parameter firstOf(@NonNull final Iterable<Parameter> parameters) {
         return Sponge.getRegistry().getBuilderRegistry().provideBuilder(FirstOfBuilder.class).orFirstOf(parameters).build();
     }
 
@@ -215,7 +259,7 @@ public interface Parameter {
      * @return The {@link Parameter.SequenceBuilder}, to continue building the
      *         chain
      */
-    static Parameter.SequenceBuilder seq(Parameter parameter) {
+    static Parameter.SequenceBuilder seq(@NonNull final Parameter parameter) {
         return Sponge.getRegistry().getBuilderRegistry().provideBuilder(SequenceBuilder.class).then(parameter);
     }
 
@@ -229,7 +273,7 @@ public interface Parameter {
      * @param parameters The subsequent {@link Parameter}s to parse
      * @return The {@link Parameter}
      */
-    static Parameter seq(Parameter first, Parameter second, Parameter... parameters) {
+    static Parameter seq(@NonNull final Parameter first, @NonNull final Parameter second, final Parameter @NonNull... parameters) {
         return Sponge.getRegistry().getBuilderRegistry().provideBuilder(SequenceBuilder.class).then(first).then(second).then(parameters).build();
     }
 
@@ -240,7 +284,7 @@ public interface Parameter {
      * @param parameters The {@link Parameter}s
      * @return The {@link Parameter}
      */
-    static Parameter seq(Iterable<Parameter> parameters) {
+    static Parameter seq(@NonNull final Iterable<Parameter> parameters) {
         return Sponge.getRegistry().getBuilderRegistry().provideBuilder(SequenceBuilder.class).then(parameters).build();
     }
 
@@ -614,7 +658,7 @@ public interface Parameter {
      * @param <T> The type of {@link CatalogType}
      * @return A {@link Parameter.Value.Builder}
      */
-    static <T extends CatalogType> Parameter.Value.Builder<T> catalogedElement(Class<T> type) {
+    static <T extends CatalogType> Parameter.Value.Builder<T> catalogedElement(@NonNull final Class<T> type) {
         return Parameter.builder(type, VariableValueParameters.catalogedElementParameterBuilder(type)
                 .prefix("minecraft")
                 .prefix("sponge")
@@ -630,11 +674,11 @@ public interface Parameter {
      * @param choices The choices
      * @return A {@link Parameter.Value.Builder}
      */
-    static Parameter.Value.Builder<String> choices(String... choices) {
-        VariableValueParameters.StaticChoicesBuilder<String> builder = VariableValueParameters
+    static Parameter.Value.Builder<String> choices(final String @NonNull... choices) {
+        final VariableValueParameters.StaticChoicesBuilder<String> builder = VariableValueParameters
                 .staticChoicesBuilder(String.class)
                 .setShowInUsage(true);
-        for (String choice : choices) {
+        for (final String choice : choices) {
             builder.choice(choice, choice);
         }
 
@@ -653,7 +697,7 @@ public interface Parameter {
      * @param choices The choices
      * @return A {@link Parameter.Value.Builder}
      */
-    static <T> Parameter.Value.Builder<T> choices(Class<T> returnType, Map<String, ? extends T> choices) {
+    static <T> Parameter.Value.Builder<T> choices(@NonNull final Class<T> returnType, @NonNull final Map<String, ? extends T> choices) {
         return Parameter.builder(returnType, VariableValueParameters.staticChoicesBuilder(returnType)
                 .choices(choices)
                 .setShowInUsage(true).build());
@@ -674,9 +718,9 @@ public interface Parameter {
      * @return A {@link Parameter.Value.Builder}
      */
     static <T> Parameter.Value.Builder<T> choices(
-            Class<T> returnType,
-            Function<String, ? extends T> valueFunction,
-            Supplier<Iterable<String>> choices) {
+            @NonNull final Class<T> returnType,
+            @NonNull final Function<String, ? extends T> valueFunction,
+            @NonNull final Supplier<Iterable<String>> choices) {
 
         return Parameter.builder(returnType,
                 VariableValueParameters
@@ -695,7 +739,7 @@ public interface Parameter {
      * @param <T> The type of {@link Enum}
      * @return A {@link Parameter.Value.Builder}
      */
-    static <T extends Enum<T>> Parameter.Value.Builder<T> enumValue(Class<T> enumClass) {
+    static <T extends Enum<T>> Parameter.Value.Builder<T> enumValue(@NonNull final Class<T> enumClass) {
         return Parameter.builder(enumClass, VariableValueParameters.enumChoices(enumClass));
     }
 
@@ -711,8 +755,11 @@ public interface Parameter {
      * @param <T> The type of value
      * @return A {@link Parameter.Value.Builder}
      */
-    static <T> Parameter.Value.Builder<T> literal(Class<T> returnType, T returnedValue, String... literal) {
-        Iterable<String> iterable = Arrays.asList(literal);
+    static <T> Parameter.Value.Builder<T> literal(
+            @NonNull final Class<T> returnType,
+            @NonNull final T returnedValue,
+            final String @NonNull... literal) {
+        final Iterable<String> iterable = Arrays.asList(literal);
         return literal(returnType, returnedValue, () -> iterable);
     }
 
@@ -728,7 +775,10 @@ public interface Parameter {
      * @param returnType The type of return
      * @return A {@link Parameter.Value.Builder}
      */
-    static <T> Parameter.Value.Builder<T> literal(Class<T> returnType, T returnedValue, Supplier<Iterable<String>> literalSupplier) {
+    static <T> Parameter.Value.Builder<T> literal(
+            @NonNull final Class<T> returnType,
+            @NonNull final T returnedValue,
+            @NonNull final Supplier<Iterable<String>> literalSupplier) {
         return Parameter.builder(returnType,
                 VariableValueParameters.literalBuilder(returnType)
                         .setReturnValue(() -> returnedValue)
@@ -736,37 +786,14 @@ public interface Parameter {
     }
 
     /**
-     * Parses the next element(s) in the {@link CommandContext}
+     * Gets whether this parameter is optional.
      *
-     * @param reader The {@link ArgumentReader.Mutable} containing the strings
-     *               that need to be parsed
-     * @param context The {@link CommandContext.Builder} that contains the
-     *                current state of the execution
-     * @throws ArgumentParseException thrown if the parameter could not be
-     *      parsed
-     */
-    void parse(ArgumentReader.Mutable reader, CommandContext.Builder context) throws ArgumentParseException;
-
-    /**
-     * Returns potential completions of the current tokenized argument.
+     * <p>An optional parameter will not throw an exception if it cannot parse
+     * an input, instead passing control to another parameter.</p>
      *
-     * @param reader The {@link ArgumentReader} containing the strings that need
-     *               to be parsed
-     * @param context The {@link CommandContext} that contains the
-     *                current state of the execution.
-     * @return The potential completions.
-     * @throws ArgumentParseException thrown if the parameter could not be
-     *      parsed
+     * @return true if optional, else false.
      */
-    List<String> complete(ArgumentReader.Immutable reader, CommandContext context) throws ArgumentParseException;
-
-    /**
-     * Gets the usage of this parameter.
-     *
-     * @param cause The {@link CommandCause} that requested the usage
-     * @return The usage
-     */
-    Text getUsage(CommandCause cause);
+    boolean isOptional();
 
     /**
      * A {@link Key}
@@ -783,12 +810,12 @@ public interface Parameter {
         String key();
 
         /**
-         * Gets the {@link Class} of the type of object that this parameter
+         * Gets the {@link TypeToken} of the type of object that this parameter
          * should return from parsing.
          *
-         * @return The {@link Class}
+         * @return The {@link TypeToken}
          */
-        Class<T> getValueClass();
+        TypeToken<T> getTypeToken();
 
         /**
          * A "builder" that allows for keys to be built.
@@ -800,12 +827,12 @@ public interface Parameter {
              * represents.
              *
              * @param key The key
-             * @param valueClass The {@link Class} that represents the
+             * @param typeToken The {@link TypeToken} that represents the
              *                   type of value it stores
              * @param <T> The type of the value represented by the key
              * @return The built {@link Key}
              */
-            <T> Key<T> build(String key, Class<T> valueClass);
+            <T> Key<T> build(@NonNull String key, @NonNull TypeToken<T> typeToken);
         }
 
     }
@@ -830,7 +857,7 @@ public interface Parameter {
          *
          * @return The key.
          */
-        Key<T> getKey();
+        Key<? super T> getKey();
 
         /**
          * The {@link ValueParser}s to use when parsing an argument. They will be
@@ -860,11 +887,58 @@ public interface Parameter {
         Predicate<CommandCause> getRequirement();
 
         /**
-         * Gets whether this parameter is optional.
+         * Gets whether this parameter is known to be able to be explicitly
+         * considered a terminal parameter without regarding its place in a
+         * command.
          *
-         * @return true if optional, else false.
+         * <p>A terminal parameter will pass control to the command's associated
+         * {@link CommandExecutor} if the parameter consumes the end of an input
+         * string.</p>
+         *
+         * <p>Because this parameter may be reused across multiple commands, there
+         * may be some circumstances where this parameter will act as a terminal
+         * parameter but this is false, such as when this is at the end of a
+         * parameter chain or the following parameters are all optional. The return
+         * value from this method generally will return whether this element is
+         * terminal <strong>without</strong> regard to other parameters in a
+         * command.</p>
+         *
+         * @return true if known to be terminal.
          */
-        boolean isOptional();
+        boolean isTerminal();
+
+        /**
+         * Parses the next element(s) in the {@link CommandContext}
+         *
+         * @param reader The {@link ArgumentReader.Mutable} containing the strings
+         *               that need to be parsed
+         * @param context The {@link CommandContext.Builder} that contains the
+         *                current state of the execution
+         * @throws ArgumentParseException thrown if the parameter could not be
+         *      parsed
+         */
+        void parse(ArgumentReader.@NonNull Mutable reader, CommandContext.@NonNull Builder context) throws ArgumentParseException;
+
+        /**
+         * Returns potential completions of the current tokenized argument.
+         *
+         * @param reader The {@link ArgumentReader} containing the strings that need
+         *               to be parsed
+         * @param context The {@link CommandContext} that contains the
+         *                current state of the execution.
+         * @return The potential completions.
+         * @throws ArgumentParseException thrown if the parameter could not be
+         *      parsed
+         */
+        List<String> complete(ArgumentReader.@NonNull Immutable reader, @NonNull CommandContext context) throws ArgumentParseException;
+
+        /**
+         * Gets the usage of this parameter.
+         *
+         * @param cause The {@link CommandCause} that requested the usage
+         * @return The usage
+         */
+        Text getUsage(CommandCause cause);
 
         /**
          * Builds a {@link Parameter} from constituent components.
@@ -913,7 +987,7 @@ public interface Parameter {
              * @param parser The {@link ValueParameter} to use
              * @return This builder, for chaining
              */
-            default <V extends ValueParser<? extends T>> Builder<T> parser(Supplier<V> parser) {
+            default <V extends ValueParser<? extends T>> Builder<T> parser(@NonNull final Supplier<V> parser) {
                 return this.parser(parser.get());
             }
 
@@ -1028,7 +1102,7 @@ public interface Parameter {
              *                     enter a value into the {@link CommandContext}
              * @return This builder, for chaining
              */
-            default Builder<T> orDefault(T defaultValue) {
+            default Builder<T> orDefault(@NonNull final T defaultValue) {
                 return orDefault(cause -> defaultValue);
             }
 
@@ -1060,15 +1134,30 @@ public interface Parameter {
              * parameter's key, otherwise, an {@link ArgumentParseException} is
              * thrown.
              *
-             * @param defaultValueFunction A {@link Function} that returns an object
-             *                             to insert into the context if this
-             *                             parameter cannot parse the argument. If
-             *                             the supplier returns a null,
-             *                             the parameter will throw an exception, as
-             *                             if the parameter is not optional.
+             * @param defaultValueFunction A {@link Function} that returns an
+             *      object to insert into the context if this parameter cannot
+             *      parse the argument. If the supplier returns a null, the
+             *      parameter will throw an exception, as if the parameter is
+             *      not optional.
              * @return This builder, for chaining
              */
             Builder<T> orDefault(Function<CommandCause, T> defaultValueFunction);
+
+            /**
+             * Marks this parameter as a <em>terminal</em> parameter. Any
+             * terminal parameter can be considered as a point where argument
+             * parsing can stop, allowing control to pass to the command's
+             * associated {@link CommandExecutor}.
+             *
+             * <p>Note that a parameter may be considered terminal even if this
+             * isn't set, including if the parameter will consume the rest of
+             * the argument string, or if all following arguments are
+             * {@link #optional()}. In these scenarios, the built parameter
+             * <strong>may</strong> not be aware of its terminal status.</p>
+             *
+             * @return This builder, for chaining.
+             */
+            Builder<T> terminal();
 
             /**
              * Creates a {@link Parameter} from the builder.
@@ -1095,7 +1184,14 @@ public interface Parameter {
          *
          * @return The command to run.
          */
-        Command getCommand();
+        Command.Parameterized getCommand();
+
+        /**
+         * The alias for the subcommand.
+         *
+         * @return The subcommand.
+         */
+        Set<String> getAliases();
 
         interface Builder extends ResettableBuilder<Subcommand, Builder> {
 
@@ -1109,12 +1205,12 @@ public interface Parameter {
             Builder alias(String alias);
 
             /**
-             * Sets the {@link Command} to execute for this subcommand.
+             * Sets the {@link Command.Parameterized} to execute for this subcommand.
              *
-             * @param command The {@link Command}
+             * @param command The {@link Command.Parameterized}
              * @return This builder, for chaining.
              */
-            Builder setSubcommand(Command command);
+            Builder setSubcommand(Command.Parameterized command);
 
             /**
              * Builds this subcommand parameter.
@@ -1144,7 +1240,7 @@ public interface Parameter {
          *
          * @return This builder, for chaining
          */
-        SequenceBuilder optional();
+        SequenceBuilder terminal();
 
         /**
          * Sets that this parameter is weak optional and will be ignored if it
@@ -1152,7 +1248,7 @@ public interface Parameter {
          *
          * @return This builder, for chaining
          */
-        SequenceBuilder optionalWeak();
+        SequenceBuilder optional();
 
         /**
          * Defines the next parameter in the parameter sequence.
@@ -1170,8 +1266,8 @@ public interface Parameter {
          * @param parameters The parameters to add
          * @return This builder, for chaining
          */
-        default SequenceBuilder then(Parameter... parameters) {
-            return then(Arrays.asList(parameters));
+        default SequenceBuilder then(final Parameter @NonNull... parameters) {
+            return this.then(Arrays.asList(parameters));
         }
 
         /**
@@ -1182,9 +1278,9 @@ public interface Parameter {
          * @param parameters The parameters to add
          * @return This builder, for chaining
          */
-        default SequenceBuilder then(Iterable<Parameter> parameters) {
-            for (Parameter parameter : parameters) {
-                then(parameter);
+        default SequenceBuilder then(@NonNull final Iterable<Parameter> parameters) {
+            for (final Parameter parameter : parameters) {
+                this.then(parameter);
             }
 
             return this;
@@ -1213,7 +1309,7 @@ public interface Parameter {
          *
          * @return This builder, for chaining
          */
-        FirstOfBuilder optional();
+        FirstOfBuilder terminal();
 
         /**
          * Sets that this parameter is weak optional and will be ignored if it
@@ -1221,7 +1317,7 @@ public interface Parameter {
          *
          * @return This builder, for chaining
          */
-        FirstOfBuilder optionalWeak();
+        FirstOfBuilder optional();
 
         /**
          * Adds a parameter that can be used to parse an argument. Parameters
@@ -1241,8 +1337,8 @@ public interface Parameter {
          * @param parameters The parameters to add
          * @return This builder, for chaining
          */
-        default FirstOfBuilder orFirstOf(Parameter... parameters) {
-            return orFirstOf(Arrays.asList(parameters));
+        default FirstOfBuilder orFirstOf(final Parameter @NonNull... parameters) {
+            return this.orFirstOf(Arrays.asList(parameters));
         }
 
         /**
@@ -1254,9 +1350,9 @@ public interface Parameter {
          * @param parameters The parameters to add
          * @return This builder, for chaining
          */
-        default FirstOfBuilder orFirstOf(Iterable<Parameter> parameters) {
-            for (Parameter parameter : parameters) {
-                or(parameter);
+        default FirstOfBuilder orFirstOf(@NonNull final Iterable<Parameter> parameters) {
+            for (final Parameter parameter : parameters) {
+                this.or(parameter);
             }
 
             return this;
@@ -1284,7 +1380,7 @@ public interface Parameter {
          *            {@link Parameter.Value}
          * @return The builder.
          */
-        <T> Value.Builder<T> createParameterBuilder(Class<T> parameterClass);
+        <T> Value.Builder<T> createParameterBuilder(TypeToken<T> parameterClass);
 
     }
 

--- a/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
@@ -43,6 +43,7 @@ import org.spongepowered.api.data.persistence.DataContainer;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.network.RemoteConnection;
 import org.spongepowered.api.service.permission.Subject;
@@ -521,8 +522,8 @@ public interface Parameter {
      *
      * @return A {@link Parameter.Value.Builder}
      */
-    static Parameter.Value.Builder<Player> player() {
-        return Parameter.builder(Player.class, CatalogedValueParameters.PLAYER);
+    static Parameter.Value.Builder<ServerPlayer> player() {
+        return Parameter.builder(ServerPlayer.class, CatalogedValueParameters.PLAYER);
     }
 
     /**
@@ -532,8 +533,8 @@ public interface Parameter {
      *
      * @return A {@link Parameter.Value.Builder}
      */
-    static Parameter.Value.Builder<Player> playerOrSource() {
-        return player().orDefault(cause -> cause.getCause().root() instanceof Player ? (Player) cause.getCause().root() : null);
+    static Parameter.Value.Builder<ServerPlayer> playerOrSource() {
+        return player().orDefault(cause -> cause.getCause().root() instanceof ServerPlayer ? (ServerPlayer) cause.getCause().root() : null);
     }
 
     /**
@@ -542,7 +543,7 @@ public interface Parameter {
      *
      * @return A {@link Parameter.Value.Builder}
      */
-    static Parameter.Value.Builder<Player> playerOrTarget() {
+    static Parameter.Value.Builder<ServerPlayer> playerOrTarget() {
         return player().parser(CatalogedValueParameters.TARGET_PLAYER);
     }
 

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/ValueCompleter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/ValueCompleter.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.command.parameter.managed;
 
-import org.spongepowered.api.command.parameter.ArgumentReader;
 import org.spongepowered.api.command.parameter.CommandContext;
 
 import java.util.List;
@@ -36,13 +35,11 @@ import java.util.List;
 public interface ValueCompleter {
 
     /**
-     * Gets valid completions for this command.
+     * Gets valid completions for this element.
      *
-     * @param reader The {@link org.spongepowered.api.command.parameter.ArgumentReader.Immutable} containing the arguments
-     *               that needs to be completed.
      * @param context The {@link CommandContext} that contains the parsed arguments
      * @return The list of values
      */
-    List<String> complete(ArgumentReader.Immutable reader, CommandContext context);
+    List<String> complete(CommandContext context);
 
 }

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/ValueParameter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/ValueParameter.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.command.parameter.managed;
 
-import org.spongepowered.api.command.CommandCause;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.api.text.Text;
 
 /**
@@ -41,7 +41,7 @@ import org.spongepowered.api.text.Text;
 public interface ValueParameter<T> extends ValueCompleter, ValueParser<T>, ValueUsage {
 
     @Override
-    default Text getUsage(CommandCause cause, Text key) {
+    default Text getUsage(@NonNull final Text key) {
         return key;
     }
 

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/ValueParser.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/ValueParser.java
@@ -70,7 +70,7 @@ public interface ValueParser<T> {
      * @throws ArgumentParseException if a parameter could not be parsed
      */
     Optional<? extends T> getValue(
-            Parameter.Key<T> parameterKey,
+            Parameter.Key<? super T> parameterKey,
             ArgumentReader.Mutable reader,
             CommandContext.Builder context) throws ArgumentParseException;
 

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/standard/CatalogedValueParameters.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/standard/CatalogedValueParameters.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.data.persistence.DataContainer;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.profile.GameProfile;
 import org.spongepowered.api.text.Text;
@@ -49,6 +50,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -182,7 +184,7 @@ public final class CatalogedValueParameters {
             Sponge.getRegistry().getCatalogRegistry().provideSupplier(CatalogedValueParameter.class, "DURATION");
 
     /**
-     * Require an argument to select one or more {@link Entity} objects.
+     * Require an argument to select one {@link Entity}.
      *
      * <p>This parameter accepts selectors.</p>
      *
@@ -241,6 +243,30 @@ public final class CatalogedValueParameters {
             Sponge.getRegistry().getCatalogRegistry().provideSupplier(CatalogedValueParameter.class, "LONG");
 
     /**
+     * Require an argument to select many {@link Entity entities}.
+     *
+     * <p>This parameter accepts selectors.</p>
+     *
+     * <p>Returns many {@link Entity} objects.</p>
+     *
+     * @see #ENTITY
+     */
+    public static final Supplier<CatalogedValueParameter<List<Entity>>> MANY_ENTITIES =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(CatalogedValueParameter.class, "MANY_ENTITIES");
+
+    /**
+     * Require an argument to select many {@link ServerPlayer players}.
+     *
+     * <p>This parameter accepts selectors.</p>
+     *
+     * <p>Returns many {@link Player} objects.</p>
+     *
+     * @see #PLAYER
+     */
+    public static final Supplier<CatalogedValueParameter<List<ServerPlayer>>> MANY_PLAYERS =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(CatalogedValueParameter.class, "MANY_PLAYERS");
+
+    /**
      * Does not parse any arguments, returning nothing.
      *
      * <p>Returns nothing - no entry will be placed into any provided key.</p>
@@ -253,9 +279,9 @@ public final class CatalogedValueParameters {
      *
      * <p>This parameter accepts selectors.</p>
      *
-     * <p>Returns a {@link Player}.</p>
+     * <p>Returns a {@link ServerPlayer}.</p>
      */
-    public static final Supplier<CatalogedValueParameter<Player>> PLAYER =
+    public static final Supplier<CatalogedValueParameter<ServerPlayer>> PLAYER =
             Sponge.getRegistry().getCatalogRegistry().provideSupplier(CatalogedValueParameter.class, "PLAYER");
 
     /**
@@ -319,15 +345,15 @@ public final class CatalogedValueParameters {
             Sponge.getRegistry().getCatalogRegistry().provideSupplier(CatalogedValueParameter.class, "TARGET_ENTITY");
 
     /**
-     * Does not parse any arguments, but instead returns a {@link Player} if the
-     * current root of the {@link Cause} is as such (which thus
-     * must be a {@link org.spongepowered.api.world.Locatable}).
+     * Does not parse any arguments, but instead returns a {@link ServerPlayer}
+     * if the current root of the {@link Cause} is as such (which thus must be
+     * a {@link org.spongepowered.api.world.Locatable}).
      *
      * <p>This will always fail for non-locatable sources</p>
      *
-     * <p>Returns a {@link Player}.</p>
+     * <p>Returns a {@link ServerPlayer}.</p>
      */
-    public static final Supplier<CatalogedValueParameter<Player>> TARGET_PLAYER =
+    public static final Supplier<CatalogedValueParameter<ServerPlayer>> TARGET_PLAYER =
             Sponge.getRegistry().getCatalogRegistry().provideSupplier(CatalogedValueParameter.class, "TARGET_PLAYER");
 
     /**

--- a/src/main/java/org/spongepowered/api/command/registrar/CommandRegistrar.java
+++ b/src/main/java/org/spongepowered/api/command/registrar/CommandRegistrar.java
@@ -1,0 +1,147 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.registrar;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.command.Command;
+import org.spongepowered.api.command.CommandCause;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.exception.CommandException;
+import org.spongepowered.api.command.manager.CommandFailedRegistrationException;
+import org.spongepowered.api.command.manager.CommandManager;
+import org.spongepowered.api.command.manager.CommandMapping;
+import org.spongepowered.api.command.registrar.tree.CommandTreeBuilder;
+import org.spongepowered.api.event.cause.EventContextKeys;
+import org.spongepowered.api.event.registry.RegistryEvent;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.plugin.PluginContainer;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * {@link CommandRegistrar}s are the entry point for plugins wishing to provide
+ * their own command framework. The {@link CommandManager} will proxy calls to
+ * the correct registrar amd will handle the final {@link CommandResult}.
+ *
+ * <p>This interface defines a way to register commands. This registration
+ * method <strong>must</strong> call {@link CommandManager#registerAlias(
+ * CommandRegistrar, PluginContainer, CommandTreeBuilder.Basic, Predicate,
+ * String, String...)} to indicate that they wish to take control of certain
+ * aliases. Beyond this call, the {@link CommandRegistrar} will only need to
+ * retain the link between the primary alias and the command to execute, as the
+ * {@link CommandManager} will always supply the primary alias of the command to
+ * invoke at runtime, regardless of the aliases that were registered and/or
+ * invoked by the invoker of the command.</p>
+ *
+ * <p>For command that wishes to investigate the command string that was
+ * executed, they may investigate the context in
+ * {@link CommandCause#getCause()}, looking for the
+ * {@link EventContextKeys#COMMAND_STRING} context key.</p>
+ *
+ * <p>Command frameworks are free to choose how they parse commands. However,
+ * a framework's {@link CommandRegistrar} <strong>must</strong> do the following
+ * in order to be successfully registered and receive their commands:</p>
+ *
+ * <ul>
+ *     <li>The registrar <strong>must</strong> be registered during the
+ *     {@link RegistryEvent} for {@link CommandRegistrar}s; and</li>
+ *     <li>Commands registered through the registrar must be synced back
+ *     to the {@link CommandManager}, otherwise such commands will not
+ *     be passed back to this registrar.</li>
+ * </ul>
+ *
+ * @param <T> The type of command interface this handles.
+ */
+public interface CommandRegistrar<T> extends CatalogType {
+
+    /**
+     * Registers a command.
+     *
+     * @param container The {@link PluginContainer} performing the registration
+     * @param command The command to register
+     * @param primaryAlias The primary alias
+     * @param secondaryAliases Any secondary aliases. May be empty.
+     * @return The {@link CommandMapping}
+     * @throws CommandFailedRegistrationException if the registration failed
+     */
+    CommandMapping register(
+            PluginContainer container,
+            T command,
+            String primaryAlias,
+            String... secondaryAliases) throws CommandFailedRegistrationException;
+
+    /**
+     * Process the provided command.
+     *
+     * <p>Note for implementors: the provided {@code command} will be the one
+     * registered as the primary alias when registering with the
+     * {@link CommandManager}.</p>
+     *
+     * @param cause The {@link CommandCause} that caused the command to be
+     *              executed
+     * @param command The primary alias that is associated with the command to
+     *                be executed
+     * @param arguments The arguments of the command (that is, the raw string
+     *                  with the command alias removed, so if
+     *                  {@code /sponge test test2} is invoked, arguments will
+     *                  contain {@code test test2}.)
+     * @return The {@link CommandResult}
+     * @throws CommandException if there is an error executing the command
+     */
+    CommandResult process(CommandCause cause, String command, String arguments) throws CommandException;
+
+    /**
+     * Provides a list of suggestions associated with the provided argument
+     * string.
+     *
+     * <p>See {@link #process(CommandCause, String, String)} for any
+     * implementation notes.</p>
+     *
+     * @param cause The {@link CommandCause} that caused the command to be
+     *              executed
+     * @param command The primary alias that is associated with the command to
+     *                be executed
+     * @param arguments The arguments of the command (that is, the raw string
+     *                  with the command alias removed, so if
+     *                  {@code /sponge test test2} is invoked, arguments will
+     *                  contain {@code test test2}.)
+     * @return The suggestions
+     */
+    List<String> suggestions(CommandCause cause, String command, String arguments) throws CommandException;
+
+    /**
+     * Returns help text for the invoked command.
+     *
+     * @param cause The {@link CommandCause} that caused the command to be
+     *              executed
+     * @param command The primary alias that is associated with the command to
+     *                be executed
+     * @return The help, if any
+     */
+    Optional<Text> help(CommandCause cause, String command);
+
+}

--- a/src/main/java/org/spongepowered/api/command/registrar/StandardCommandRegistrar.java
+++ b/src/main/java/org/spongepowered/api/command/registrar/StandardCommandRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of Sponge, licensed under the MIT License (MIT).
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
  *
  * Copyright (c) SpongePowered <https://www.spongepowered.org>
  * Copyright (c) contributors

--- a/src/main/java/org/spongepowered/api/command/registrar/StandardCommandRegistrar.java
+++ b/src/main/java/org/spongepowered/api/command/registrar/StandardCommandRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ * This file is part of Sponge, licensed under the MIT License (MIT).
  *
  * Copyright (c) SpongePowered <https://www.spongepowered.org>
  * Copyright (c) contributors
@@ -22,21 +22,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.command.manager;
+package org.spongepowered.api.command.registrar;
+
+import org.spongepowered.api.command.Command;
+import org.spongepowered.api.event.lifecycle.RegisterCommandEvent;
 
 /**
- * Indicates that a command could not be registered.
+ * A {@link CommandRegistrar} for registering Sponge commands. Plugins using the
+ * standard Sponge {@link Command} interface should register their commands using
+ * {@link RegisterCommandEvent} with this registrar.
  */
-public class FailedRegistrationException extends RuntimeException {
-
-    private static final long serialVersionUID = -783923658025L;
-
-    public FailedRegistrationException(String message) {
-        super(message);
-    }
-
-    public FailedRegistrationException(String message, Throwable inner) {
-        super(message, inner);
-    }
-
+public interface StandardCommandRegistrar extends CommandRegistrar<Command> {
 }

--- a/src/main/java/org/spongepowered/api/command/registrar/tree/ClientCompletionKey.java
+++ b/src/main/java/org/spongepowered/api/command/registrar/tree/ClientCompletionKey.java
@@ -22,22 +22,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.command.parameter.managed;
+package org.spongepowered.api.command.registrar.tree;
 
-import org.spongepowered.api.text.Text;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
 /**
- * Defines the usage string for the parameter.
+ * Represents the client-side behaviour of a command parameter.
  */
-@FunctionalInterface
-public interface ValueUsage {
+@CatalogedBy(ClientCompletionKeys.class)
+public interface ClientCompletionKey<T extends CommandTreeBuilder<T>> extends CatalogType {
 
     /**
-     * Gets the usage string for the argument.
+     * Creates a {@link CommandTreeBuilder} that represents this
+     * {@link ClientCompletionKey}
      *
-     * @param key The {@link Text} that defines the parameter key
-     * @return The usage
+     * @return The new {@link CommandTreeBuilder}
      */
-    Text getUsage(Text key);
+    T createCommandTreeBuilder();
 
 }

--- a/src/main/java/org/spongepowered/api/command/registrar/tree/ClientCompletionKeys.java
+++ b/src/main/java/org/spongepowered/api/command/registrar/tree/ClientCompletionKeys.java
@@ -1,0 +1,220 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.registrar.tree;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.profile.GameProfile;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.Color;
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+
+import java.util.function.Supplier;
+
+public class ClientCompletionKeys {
+
+    // SORTFIELDS: ON
+
+    /**
+     * Indicates that tab completing this element should query the server for
+     * potential completions.
+     *
+     * <p><strong>Important note:</strong> if you wish to have any control
+     * over the completion process, you should use this key.</p>
+     */
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.StringParser>> ASK_SERVER =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "ASK_SERVER");
+
+    /**
+     * Completions will attempt to return arguments that represent
+     * {@link BlockState}s
+     */
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> BLOCK_STATE =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "BLOCK_STATE");
+
+    /**
+     * Completions will attempt to return arguments that represent
+     * {@link BlockState}s - // TODO: Predicate
+     */
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> BLOCK_PREDICATE =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "BLOCK_PREDICATE");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> BOOLEAN =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "BOOLEAN");
+
+    /**
+     * Completions will attempt to return arguments that represent
+     * {@link Color}s
+     */
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> COLOR =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "COLOR");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> DIMENSION =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "DIMENSION");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> DOUBLE =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "DOUBLE");
+
+    /**
+     * Completions will attempt to return arguments that represent
+     * {@link Entity}s
+     */
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.EntitySelection>> ENTITY =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "ENTITY");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> ENTITY_ANCHOR =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "ENTITY_ANCHOR");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> ENTITY_SUMMON =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "ENTITY_SUMMON");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> FLOAT =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "FLOAT");
+
+    public static Supplier<ClientCompletionKey<CommandTreeBuilder.Range<Float>>> FLOAT_RANGE =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "FLOAT_RANGE");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> FUNCTION =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "FUNCTION");
+
+    /**
+     * Completions will attempt to return arguments that represent
+     * {@link GameProfile}s
+     */
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> GAME_PROFILE =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "GAME_PROFILE");
+
+    public static Supplier<ClientCompletionKey<CommandTreeBuilder.Range<Integer>>> INT_RANGE =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "INT_RANGE");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> INTEGER =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "INTEGER");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> ITEM_ENCHANTMENT =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "ITEM_ENCHANTMENT");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> ITEM_SLOT =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "ITEM_SLOT");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> LONG =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "LONG");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> MESSAGE =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "MESSAGE");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> MOB_EFFECT =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "MOB_EFFECT");
+
+    // TODO -> dataview?
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> NBT_COMPOUND =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "NBT_COMPOUND");
+
+    // TODO -> datapath?
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> NBT_PATH =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "NBT_PATH");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> NBT_TAG =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "NBT_TAG");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> OBJECTIVE =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "OBJECTIVE");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> OBJECTIVE_CRITERIA =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "OBJECTIVE_CRITERIA");
+
+    // TODO -> check
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> OPERATION =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "OPERATION");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> PARTICLE =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "PARTICLE");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> RESOURCE_LOCATION =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "RESOURCE_LOCATION");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> ROTATION =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "ROTATION");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Amount>> SCORE_HOLDER =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "SCORE_HOLDER");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> SCOREBOARD_SLOT =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "SCOREBOARD_SLOT");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.StringParser>> STRING =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "STRING");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> SWIZZLE =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "SWIZZLE");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> TEAM =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "TEAM");
+
+    /**
+     * Completions will attempt to return arguments that represent
+     * {@link Text}s
+     */
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> TEXT =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "TEXT");
+
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> TIME =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "TIME");
+
+    /**
+     * Completions will attempt to return arguments that represent a
+     * real-space position (that is, two-dimensional decimal co-ordinates).
+     */
+    public static final Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> VECTOR_2D =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "VECTOR_2D");
+
+    /**
+     * Completions will attempt to return arguments that represent a
+     * block position (that is, two-dimensional integer co-ordinates).
+     */
+    public static Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> VECTOR_2I =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "VECTOR_2I");
+
+    /**
+     * Completions will attempt to return arguments that represent a
+     * real-space position (that is, three-dimensional decimal co-ordinates).
+     */
+    public static Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> VECTOR_3D =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "VECTOR_3D");
+
+    /**
+     * Completions will attempt to return arguments that represent a
+     * block position (that is, three-dimensional integer co-ordinates).
+     */
+    public static Supplier<ClientCompletionKey<CommandTreeBuilder.Basic>> VECTOR_3I =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionKey.class, "VECTOR_3I");
+
+    // SORTFIELDS: OFF
+
+    private ClientCompletionKeys() {
+        throw new AssertionError("This cannot be instantiated.");
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/command/registrar/tree/CommandTreeBuilder.java
+++ b/src/main/java/org/spongepowered/api/command/registrar/tree/CommandTreeBuilder.java
@@ -1,0 +1,276 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.registrar.tree;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.registrar.CommandRegistrar;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Builds a tree of command parameters for sending to clients. For use with
+ * custom {@link CommandRegistrar}s.
+ */
+public interface CommandTreeBuilder<T extends CommandTreeBuilder<T>> {
+
+    /**
+     * Creates a root node for the tree.
+     *
+     * @return The root node.
+     */
+    static CommandTreeBuilder<Basic> root() {
+        return Sponge.getRegistry().getFactoryRegistry().provideFactory(RootNodeFactory.class).create();
+    }
+
+    /**
+     * Creates a child that accepts a literal only.
+     *
+     * @param key The name of the child node
+     * @param childNode A {@link Supplier} that contains a
+     *                  {@link CommandTreeBuilder} for the newly created child.
+     * @return This, for chaining.
+     */
+    T child(String key, Consumer<Basic> childNode);
+
+    /**
+     * Creates a child of this node with the given key that accepts a
+     * non-literal argument.
+     *
+     * <p>The builder returned by this method is the same builder as that
+     * invoked on. The child builder is provided in the {@code childNode}
+     * node.</p>
+     *
+     * @param key The name of the child node
+     * @param completionKey The {@link ClientCompletionKey} that indicates to
+     *                      the client how a tab completion should be handled
+     * @param childNode A consumer containing the child node
+     * @return This, for chaining.
+     */
+    <S extends CommandTreeBuilder<S>> T child(String key, ClientCompletionKey<S> completionKey, Consumer<S> childNode);
+
+    /**
+     * Creates a child of this node with the given key that accepts a
+     * non-literal argument.
+     *
+     * <p>The builder returned by this method is the same builder as that
+     * invoked on. The child builder is provided in the {@code childNode}
+     * node.</p>
+     *
+     * @param key The name of the child node
+     * @param completionKey The {@link ClientCompletionKey} that indicates to
+     *                      the client how a tab completion should be handled
+     * @param childNode A consumer containing the child node
+     * @return This, for chaining.
+     */
+    default <S extends CommandTreeBuilder<S>> T child(
+            final String key,
+            final Supplier<ClientCompletionKey<S>> completionKey,
+            final Consumer<S> childNode) {
+        return this.child(key, completionKey.get(), childNode);
+    }
+
+    /**
+     * Declares that this element will redirect processing to the given node
+     * <strong>after</strong> this node has been processed.
+     *
+     * @param to The node to redirect to
+     * @return This, for chaining
+     */
+    T redirect(String to);
+
+    /**
+     * Declares that the node this {@link CommandTreeBuilder} represents is
+     * executable, meaning that a command string that stops here is considered
+     * complete.
+     *
+     * @return This, for chaining
+     */
+    T executable();
+
+    /**
+     * Declares that this node uses custom suggestions and, as such, tab
+     * completions should query the server.
+     *
+     * @return This, for chaining.
+     */
+    T customSuggestions();
+
+    /**
+     * Sets an arbitrary property for this node with a string based value.
+     *
+     * @param key The property key.
+     * @param value The property value.
+     * @return This, for chaining.
+     */
+    T property(String key, String value);
+
+    /**
+     * Sets an arbitrary property for this node with a long based value.
+     *
+     * @param key The property key.
+     * @param value The property value.
+     * @return This, for chaining.
+     */
+    T property(String key, long value);
+
+    /**
+     * Sets an arbitrary property for this node with a double based value.
+     *
+     * @param key The property key.
+     * @param value The property value.
+     * @return This, for chaining.
+     */
+    T property(String key, double value);
+
+    /**
+     * Sets an arbitrary property for this node with a boolean based value.
+     *
+     * @param key The property key.
+     * @param value The property value.
+     * @return This, for chaining.
+     */
+    T property(String key, boolean value);
+
+    /**
+     * A {@link CommandTreeBuilder} with no known properties to set.
+     */
+    interface Basic extends CommandTreeBuilder<Basic> { }
+
+    /**
+     * A {@link CommandTreeBuilder} that allows for a min-max range to be set.
+     */
+    interface Range<S extends Number> extends CommandTreeBuilder<Range<S>> {
+
+        /**
+         * Sets the minimum {@link S} acceptable for this parameter.
+         *
+         * @param min The minimum, or {@code null} if there is no minimum
+         * @return This, for chaining
+         */
+        Range<S> min(@Nullable S min);
+
+        /**
+         * Sets the maximum {@link S} acceptable for this parameter.
+         *
+         * @param max The maximum, or {@code null} if there is no maximum
+         * @return This, for chaining
+         */
+        Range<S> max(@Nullable S max);
+
+    }
+
+    /**
+     * A {@link CommandTreeBuilder} that controls whether multiple entries
+     * can be parsed.
+     */
+    interface Amount extends CommandTreeBuilder<Amount>, AmountBase<Amount> { }
+
+    /**
+     * A {@link CommandTreeBuilder} that augments entity based parameters.
+     */
+    interface EntitySelection extends CommandTreeBuilder<EntitySelection>, AmountBase<EntitySelection> {
+
+        /**
+         * Indicates that only players can be selected. If not called, all
+         * entities may selected by this element.
+         *
+         * @return This, for chaining.
+         */
+        EntitySelection playersOnly();
+
+    }
+
+    /**
+     * A {@link CommandTreeBuilder} that allows for the setting of how
+     * a string based parser will behave.
+     */
+    interface StringParser extends CommandTreeBuilder<StringParser> {
+
+        /**
+         * Determines how the string parser will parse a string.
+         *
+         * @param type The type
+         * @return This, for chaining.
+         */
+        StringParser type(Types type);
+
+        /**
+         * The behaviors available to the string parser.
+         */
+        enum Types {
+
+            /**
+             * Will parse the next word
+             */
+            WORD,
+
+            /**
+             * Will parse the next word, or, if quoted, the quoted string
+             */
+            PHRASE,
+
+            /**
+             * Will parse the remainder of the argument string
+             */
+            GREEDY
+
+        }
+    }
+
+    /**
+     * Indicates that a {@link CommandTreeBuilder} supports marking a parameter
+     * as having a single target only.
+     *
+     * @param <T> The type of {@link CommandTreeBuilder} this extends
+     */
+    interface AmountBase<T> {
+
+        /**
+         * Indicates that only one object can be selected by this parameter.
+         * If this is not called, this element will default to allowing the
+         * selection of multiple objects.
+         *
+         * @return This, for chaining.
+         */
+        T single();
+    }
+
+    /**
+     * Factory to create a root node.
+     */
+    interface RootNodeFactory {
+
+        /**
+         * Creates a root {@link CommandTreeBuilder}.
+         *
+         * @return The node
+         */
+        CommandTreeBuilder<Basic> create();
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/event/cause/EventContextKeys.java
+++ b/src/main/java/org/spongepowered/api/event/cause/EventContextKeys.java
@@ -43,6 +43,7 @@ import org.spongepowered.api.profile.GameProfile;
 import org.spongepowered.api.projectile.source.ProjectileSource;
 import org.spongepowered.api.service.ServiceManager;
 import org.spongepowered.api.service.permission.Subject;
+import org.spongepowered.api.text.channel.MessageChannel;
 import org.spongepowered.api.text.channel.MessageReceiver;
 import org.spongepowered.api.world.LocatableBlock;
 import org.spongepowered.api.world.ServerLocation;
@@ -98,6 +99,11 @@ public final class EventContextKeys {
      * the block event without relying on existing in the {@link Cause} stack.
      */
     public static final Supplier<EventContextKey<ChangeBlockEvent.Break>> BREAK_EVENT = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "BREAK_EVENT");
+
+    /**
+     * Represents the command string that was provided to the command processor.
+     */
+    public static final Supplier<EventContextKey<String>> COMMAND_STRING = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "COMMAND_STRING");
 
     /**
      * Represents the creator of an {@link Entity}.
@@ -189,10 +195,10 @@ public final class EventContextKeys {
     public static final Supplier<EventContextKey<ServerLocation>> LOCATION = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "LOCATION");
 
     /**
-     * Used during command execution, indicates the {@link MessageReceiver} to
+     * Used during command execution, indicates the {@link MessageChannel} to
      * send any messages to.
      */
-    public static final Supplier<EventContextKey<MessageReceiver>> MESSAGE_TARGET = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "MESSAGE_TARGET");
+    public static final Supplier<EventContextKey<MessageChannel>> MESSAGE_CHANNEL = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "MESSAGE_CHANNEL");
 
     /**
      * Used for {@link org.spongepowered.api.event.block.ChangeBlockEvent.Post} to provide

--- a/src/main/java/org/spongepowered/api/event/lifecycle/RegisterCommandEvent.java
+++ b/src/main/java/org/spongepowered/api/event/lifecycle/RegisterCommandEvent.java
@@ -22,22 +22,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.command.parameter.managed;
+package org.spongepowered.api.event.lifecycle;
 
-import org.spongepowered.api.text.Text;
+import org.spongepowered.api.command.registrar.CommandRegistrar;
+import org.spongepowered.api.event.GenericEvent;
 
 /**
- * Defines the usage string for the parameter.
+ * Lifecycle event to indicate when commands should be registered.
+ *
+ * @param <T> The {@link CommandRegistrar} that is handling this event.
  */
-@FunctionalInterface
-public interface ValueUsage {
+public interface RegisterCommandEvent<T extends CommandRegistrar<?>> extends GenericEvent<T> {
 
     /**
-     * Gets the usage string for the argument.
+     * Gets the {@link CommandRegistrar} that handles the command registration
+     * for this event. Commands should be registered via the appropriate method
+     * on the registrar.
      *
-     * @param key The {@link Text} that defines the parameter key
-     * @return The usage
+     * @return The {@link CommandRegistrar}
      */
-    Text getUsage(Text key);
+    T getRegistrar();
 
 }

--- a/src/main/java/org/spongepowered/api/event/lifecycle/RegisterCommandEvent.java
+++ b/src/main/java/org/spongepowered/api/event/lifecycle/RegisterCommandEvent.java
@@ -32,7 +32,7 @@ import org.spongepowered.api.event.GenericEvent;
  *
  * @param <T> The {@link CommandRegistrar} that is handling this event.
  */
-public interface RegisterCommandEvent<T extends CommandRegistrar<?>> extends GenericEvent<T> {
+public interface RegisterCommandEvent<T extends CommandRegistrar<?>> extends GenericEvent<T>, LifecycleEvent {
 
     /**
      * Gets the {@link CommandRegistrar} that handles the command registration

--- a/src/main/java/org/spongepowered/api/util/TypeTokens.java
+++ b/src/main/java/org/spongepowered/api/util/TypeTokens.java
@@ -278,6 +278,8 @@ public final class TypeTokens {
 
     public static final TypeToken<Value<NotePitch>> NOTE_VALUE_TOKEN = new TypeToken<Value<NotePitch>>() {private static final long serialVersionUID = -1;};
 
+    public static final TypeToken<Object> OBJECT = TypeToken.of(Object.class);
+
     public static final TypeToken<ParrotType> PARROT_TYPE_TOKEN = new TypeToken<ParrotType>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<Value<ParrotType>> PARROT_TYPE_VALUE_TOKEN = new TypeToken<Value<ParrotType>>() {private static final long serialVersionUID = -1;};


### PR DESCRIPTION
The big thing here is the addition of a "CommandRegistrar". This is meant to be a lightweight interface that tries to give external command frameworks (Aikar's ACF, Katrix's Scammander, Faith's Butler, amongst others) a simple way to add their commands to Sponge. The idea of registrars was originally an implementation one - if you look at that code, you'll see that the vanilla brig system is separated from the Sponge one - it takes little work to add support for arbitary registrars, so why not add them?

The Javadocs should provide a fair amount of explanation. There will be more for client completions, I'm sure - though enabling that is the thing that is missing right now. That'll come later - it'll likely mimic Brig's suggestion provider with a tree like format to build the command elements up with.

This is simply for review of code style and Javadocs.