### PR TITLE
Remove blocktype from location#tocontainer

### DIFF
--- a/src/main/java/org/spongepowered/api/world/Location.java
+++ b/src/main/java/org/spongepowered/api/world/Location.java
@@ -783,13 +783,11 @@ public final class Location<E extends Extent> implements DataHolder {
         final DataContainer container = DataContainer.createNew();
         container.set(Queries.CONTENT_VERSION, getContentVersion());
         if (getExtent() instanceof World) {
-            container.set(Queries.WORLD_NAME, ((World) getExtent()).getName());
             container.set(Queries.WORLD_ID, getExtent().getUniqueId().toString());
         } else if (getExtent() instanceof Chunk) {
             container.set(Queries.CHUNK_X, ((Chunk) getExtent()).getPosition().getX())
                 .set(Queries.CHUNK_Y, ((Chunk) getExtent()).getPosition().getY())
                 .set(Queries.CHUNK_Z, ((Chunk) getExtent()).getPosition().getZ())
-                .set(Queries.WORLD_NAME, ((Chunk) getExtent()).getWorld().getName())
                 .set(Queries.WORLD_ID, ((Chunk) getExtent()).getWorld().getUniqueId().toString());
         }
         container

--- a/src/main/java/org/spongepowered/api/world/Location.java
+++ b/src/main/java/org/spongepowered/api/world/Location.java
@@ -792,7 +792,7 @@ public final class Location<E extends Extent> implements DataHolder {
                 .set(Queries.WORLD_NAME, ((Chunk) getExtent()).getWorld().getName())
                 .set(Queries.WORLD_ID, ((Chunk) getExtent()).getWorld().getUniqueId().toString());
         }
-        container.set(Queries.BLOCK_TYPE, this.getExtent().getBlockType(getBlockPosition()).getId())
+        container
             .set(Queries.POSITION_X, this.getX())
             .set(Queries.POSITION_Y, this.getY())
             .set(Queries.POSITION_Z, this.getZ());

--- a/src/main/java/org/spongepowered/api/world/Location.java
+++ b/src/main/java/org/spongepowered/api/world/Location.java
@@ -775,7 +775,7 @@ public final class Location<E extends Extent> implements DataHolder {
 
     @Override
     public int getContentVersion() {
-        return 1;
+        return 2;
     }
 
     @Override


### PR DESCRIPTION
Location#toContainer() calls World#getBlockType, leading to an Illegal Async Chunk Load if you try to serialize a location asynchronously.
It's also lost when deserializing* a location object (the blocktype is saved but it's ignored by locationbuilder) so there's no need for a contentupdater.

*https://github.com/SpongePowered/SpongeCommon/blob/0b6e0819d266e9f92770a6024fd26458b7264a90/src/main/java/org/spongepowered/common/data/builder/world/LocationBuilder.java#L46