### PR TITLE
[Draft] Add new 1.14 Merchant, Raid and Villager related features. #2068 #2069

### DIFF
--- a/src/main/java/org/spongepowered/api/event/block/entity/RingBellEvent.java
+++ b/src/main/java/org/spongepowered/api/event/block/entity/RingBellEvent.java
@@ -1,0 +1,30 @@
+package org.spongepowered.api.event.block.entity;
+
+import org.spongepowered.api.block.entity.Bell;
+import org.spongepowered.api.effect.potion.PotionEffectTypes;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.Event;
+
+import java.util.List;
+
+/**
+ * An event when a {@link Bell} is rung.
+ */
+public interface RingBellEvent extends Event, Cancellable {
+
+	/**
+	 * The {@link Bell} which was rung.
+	 *
+	 * @return The bell which was rung.
+	 */
+	Bell getBell();
+
+	/**
+	 * The {@link Entity}s which will get a {@link PotionEffectTypes#GLOWING} effect because the {@link Bell} was rung.
+	 *
+	 * @return A list of Entities that will get the glowing effect.
+	 */
+	List<Entity> entitiesToGlow();
+
+}

--- a/src/main/java/org/spongepowered/api/event/entity/living/trader/VillagerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/trader/VillagerEvent.java
@@ -1,0 +1,104 @@
+package org.spongepowered.api.event.entity.living.trader;
+
+import org.spongepowered.api.data.type.Profession;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.Hostile;
+import org.spongepowered.api.entity.living.golem.IronGolem;
+import org.spongepowered.api.entity.living.monster.raider.Raider;
+import org.spongepowered.api.entity.living.monster.zombie.ZombieEntity;
+import org.spongepowered.api.entity.living.trader.Villager;
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.Event;
+import org.spongepowered.api.raid.Raid;
+import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
+
+/**
+ * An event which involves a {@link Villager}.
+ */
+public interface VillagerEvent extends Event {
+
+	/**
+	 * Gets the {@link Villager} involved with this event.\
+	 *
+	 * @return The villager.
+	 */
+	Villager getVillager();
+
+	/**
+	 * Fired when a {@link Villager}'s profession changes.
+	 *
+	 * <p>This can include both gaining an losing a {@link Profession}.</p>
+	 */
+	@GenerateFactoryMethod
+	interface ProfessionChange extends VillagerEvent, Cancellable {
+
+		/**
+		 * Gets the {@link Profession} the villager will change to.
+		 *
+		 * @return The {@link Villager}'s next {@link Profession}.
+		 */
+		Profession getNextProfession();
+
+		/**
+		 * Sets the {@link Villager}'s next {@link Profession}.
+		 */
+		void setNextProfession(Profession profession);
+	}
+
+	/**
+	 * Fired when a {@link Villager} levels up it's {@link Profession}.
+	 */
+	@GenerateFactoryMethod
+	interface ProfessionLevelUp extends VillagerEvent, Cancellable {
+
+		/**
+		 * Gets the {@link Villager}'s current {@link Profession} level.
+		 *
+		 * @return The {@link Profession} level.
+		 */
+		int getCurrentProfessionLevel();
+
+		/**
+		 * Gets the {@link Villager}'s next {@link Profession} level.
+		 *
+		 * @return The {@link Profession} level.
+		 */
+		int getNextProfessionLevel();
+
+		/**
+		 * Sets the profession level of this {@link Villager}.
+		 *
+		 * @param level The level to set the {@link Villager}'s {@link Profession} to.
+		 *
+		 * <p>Note that any level above 5 will usually be ignored.</p>
+		 */
+		void setProfessionLevel(int level);
+	}
+
+	/**
+	 * Fired when a {@link Villager} starts panicking.
+	 *
+	 * <p>This can occur because of a {@link Raid} or a {@link ZombieEntity}/{@link Raider}
+	 * or both a {@link Raid} and {@link Entity}.</p>
+	 *
+	 * <p>The {@link Villager}'s Panic task will always prioritize the last {@link Entity} which attacked before considering any nearby {@link Hostile} agents.</>
+	 *
+	 */
+	@GenerateFactoryMethod
+	interface Panic extends VillagerEvent, Cancellable {
+
+		/**
+		 * Checks if an {@link IronGolem} will be summoned.
+		 *
+		 * @return True if an {@link IronGolem} will be summoned.
+		 */
+		boolean willSpawnGolem();
+
+		/**
+		 * Sets if the {@link Villager} should summon an {@link IronGolem}.
+		 *
+		 * @param spawnGolem If the {@link Villager} should summon an {@link IronGolem}.
+		 */
+		void setShouldSpawnGolem(boolean spawnGolem);
+	}
+}

--- a/src/main/java/org/spongepowered/api/event/item/merchant/TradeMerchantEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/merchant/TradeMerchantEvent.java
@@ -1,0 +1,35 @@
+package org.spongepowered.api.event.item.merchant;
+
+import org.spongepowered.api.entity.living.Humanoid;
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.Event;
+import org.spongepowered.api.item.merchant.Merchant;
+import org.spongepowered.api.item.merchant.TradeOffer;
+
+/**
+ * An event when a {@link Humanoid} trades with a {@link Merchant}.
+ */
+public interface TradeMerchantEvent extends Event, Cancellable {
+
+	/**
+	 * Gets the {@link Merchant} which is trading.
+	 *
+	 * @return The trading merchant.
+	 */
+	Merchant getMerchant();
+
+	/**
+	 * Gets the selected {@link TradeOffer} a {@link Humanoid} could buy.
+	 *
+	 * @return The trade offer.
+	 */
+	TradeOffer getSelectedOffer();
+
+	/**
+	 * Gets the {@link Humanoid} who is the customer of this transaction.
+	 *
+	 * @return The customer.
+	 */
+	Humanoid getCustomer();
+
+}

--- a/src/main/java/org/spongepowered/api/event/raid/RaidEvent.java
+++ b/src/main/java/org/spongepowered/api/event/raid/RaidEvent.java
@@ -1,0 +1,56 @@
+package org.spongepowered.api.event.raid;
+
+import org.spongepowered.api.data.type.RaidStatuses;
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.Event;
+import org.spongepowered.api.raid.Raid;
+import org.spongepowered.api.raid.Wave;
+import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
+
+/**
+ * An event when a raid changes it's current state. Always involves
+ * a {@link Raid}.
+ */
+public interface RaidEvent extends Event {
+
+	/**
+	 * Gets the {@link Raid} involved with this event.
+	 *
+	 * @return The raid.
+	 */
+	Raid getRaid();
+
+	/**
+	 * An event where the {@link Raid} is started.
+	 *
+	 * <p>This is fired before any {@link Wave}s have started.</p>
+	 */
+	@GenerateFactoryMethod
+	interface Start extends RaidEvent, Cancellable {}
+
+	/**
+	 * An event where a {@link Wave} in a {@link Raid} has started.
+	 */
+	@GenerateFactoryMethod
+	interface StartWave extends RaidEvent, Cancellable {
+
+		/**
+		 * The {@link Wave} which is starting.
+		 *
+		 * @return The current wave.
+		 */
+		default Wave getWave() {
+			return this.getRaid().getCurrentWave().get();
+		}
+
+	}
+
+	/**
+	 * An event for when a {@link Raid} has ended.
+	 *
+	 * <p>The raid's state could be either a {@link RaidStatuses#VICTORY}
+	 * or {@link RaidStatuses#LOSS}</p>
+	 */
+	@GenerateFactoryMethod
+	interface End extends RaidEvent {}
+}


### PR DESCRIPTION
**This adds some new events (#2068):**

RingBellEvent (Needs to have a way to get a list of all villagers which will hear the bell ring).

VillagerEvent.ProfessionChange 
VillagerEvent.ProfessionLevelUp
VillagerEvent.Panic

TradeMerchantEvent

RaidEvent.Start
RaidEvent.StartWave
RaidEvent.End

**TODO List:**
When Zidane and gabizou finish nuking Keys, a Key needs to be added to get a Villager's Profession Level. (Maybe a BoundedKey since the Vanilla Profession levels are 0-5)

Add a way to reference all the Raids within a world, most likely inside of ServerWorld. (#2069)

Possibly more events if needed.