### PR TITLE
Add new 1.14 Merchant, Raid and Villager related features. #2068 #2069

### DIFF
--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -1799,6 +1799,11 @@ public final class Keys {
     public static final Supplier<Key<Value<Profession>>> PROFESSION = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "PROFESSION");
 
     /**
+     * Represents the {@link Key} for the {@link Villager}'s {@link Profession} level.
+     */
+    public static final Supplier<Key<Value<Integer>>> PROFESSION_LEVEL = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "PROFESSION_LEVEL");
+
+    /**
      * Represents the {@link Key} for the type of a {@link Rabbit}.
      */
     public static final Supplier<Key<Value<RabbitType>>> RABBIT_TYPE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "RABBIT_TYPE");

--- a/src/main/java/org/spongepowered/api/event/block/entity/RingBellEvent.java
+++ b/src/main/java/org/spongepowered/api/event/block/entity/RingBellEvent.java
@@ -22,42 +22,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.entity.living.trader;
+package org.spongepowered.api.event.block.entity;
 
-import org.spongepowered.api.data.Keys;
-import org.spongepowered.api.data.type.Profession;
-import org.spongepowered.api.data.type.VillagerType;
-import org.spongepowered.api.data.value.Value;
-import org.spongepowered.api.entity.living.Ageable;
+import org.spongepowered.api.block.entity.Bell;
+import org.spongepowered.api.effect.potion.PotionEffectTypes;
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.entity.AffectEntityEvent;
 
 /**
- * Represents a Villager.
+ * An event when a {@link Bell} is rung.
+ *
+ * <p>Entities which are affected by this event will be given a {@link PotionEffectTypes#GLOWING} effect.</p>
  */
-public interface Villager extends Trader, Ageable {
+public interface RingBellEvent extends AffectEntityEvent, Cancellable {
 
-    /**
-     * {@link Keys#VILLAGER_TYPE}
-     * @return The villager type
-     * @see org.spongepowered.api.data.type.VillagerTypes
-     */
-    default Value.Mutable<VillagerType> type() {
-        return getValue(Keys.VILLAGER_TYPE.get()).get().asMutable();
-    }
+	/**
+	 * The {@link Bell} which was rung.
+	 *
+	 * @return The bell which was rung.
+	 */
+	Bell getBell();
 
-    /**
-     * {@link Keys#PROFESSION}
-     * @return The profession of this villager
-     * @see org.spongepowered.api.data.type.Professions
-     */
-    default Value.Mutable<Profession> profession() {
-        return getValue(Keys.PROFESSION.get()).get().asMutable();
-    }
-
-    /**
-     * {@link Keys#PROFESSION_LEVEL}
-     * @return The profession level of this villager
-     */
-    default Value.Mutable<Integer> professionLevel() {
-        return getValue(Keys.PROFESSION_LEVEL).get().asMutable();
-    }
 }

--- a/src/main/java/org/spongepowered/api/event/entity/living/trader/VillagerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/trader/VillagerEvent.java
@@ -1,0 +1,135 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.entity.living.trader;
+
+import org.spongepowered.api.data.type.Profession;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.Hostile;
+import org.spongepowered.api.entity.living.golem.IronGolem;
+import org.spongepowered.api.entity.living.monster.raider.Raider;
+import org.spongepowered.api.entity.living.monster.zombie.ZombieEntity;
+import org.spongepowered.api.entity.living.trader.Villager;
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.Event;
+import org.spongepowered.api.raid.Raid;
+import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
+
+/**
+ * An event which involves a {@link Villager}.
+ */
+public interface VillagerEvent extends Event {
+
+	/**
+	 * Gets the {@link Villager} involved with this event.
+	 *
+	 * @return The villager.
+	 */
+	Villager getVillager();
+
+	/**
+	 * Fired when a {@link Villager}'s profession changes.
+	 *
+	 * <p>This can include both gaining or losing a {@link Profession}.</p>
+	 */
+	@GenerateFactoryMethod
+	interface ChangeProfession extends VillagerEvent, Cancellable {
+
+		/**
+		 * Gets the villager's original {@link Profession}.
+		 *
+		 * @return The {@link Profession} the {@link Villager}'s will take.
+		 */
+		Profession getOriginalProfession();
+
+		/**
+		 * Gets the {@link Profession} the villager will change to.
+		 *
+		 * @return The {@link Villager}'s next {@link Profession}.
+		 */
+		Profession getProfession();
+
+		/**
+		 * Sets the {@link Villager}'s next {@link Profession}.
+		 */
+		void setProfession(Profession profession);
+	}
+
+	/**
+	 * Fired when a {@link Villager} levels up it's {@link Profession}.
+	 */
+	@GenerateFactoryMethod
+	interface LevelUpProfession extends VillagerEvent, Cancellable {
+
+		/**
+		 * Gets the {@link Villager}'s original {@link Profession} level.
+		 *
+		 * @return The {@link Profession} level.
+		 */
+		int getOriginalProfessionLevel();
+
+		/**
+		 * Gets the {@link Profession} level this {@link Villager}'s will level up to.
+		 *
+		 * @return The {@link Profession} level.
+		 */
+		int getProfessionLevel();
+
+		/**
+		 * Sets the profession level of this {@link Villager} will reach.
+		 *
+		 * @param level The level to set the {@link Villager}'s {@link Profession} to.
+		 *
+		 * <p>Please note that any level above 5 usually does not define TradeOfferGenerators and is therefore ignored.</p>
+		 */
+		void setProfessionLevel(int level);
+	}
+
+	/**
+	 * Fired when a {@link Villager} starts panicking.
+	 *
+	 * <p>This can occur because of a {@link Raid} or a {@link ZombieEntity}/{@link Raider}
+	 * or both a {@link Raid} and {@link Entity}.</p>
+	 *
+	 * <p>The {@link Villager}'s Panic task will always prioritize the last {@link Entity} which attacked before considering any nearby {@link Hostile} agents.</>
+	 *
+	 */
+	@GenerateFactoryMethod
+	interface Panic extends VillagerEvent, Cancellable {
+
+		/**
+		 * Checks if an {@link IronGolem} will be summoned.
+		 *
+		 * @return True if an {@link IronGolem} will be summoned.
+		 */
+		boolean willSpawnGolem();
+
+		/**
+		 * Sets if the {@link Villager} should summon an {@link IronGolem}.
+		 *
+		 * @param spawnGolem If the {@link Villager} should summon an {@link IronGolem}.
+		 */
+		void setShouldSpawnGolem(boolean spawnGolem);
+	}
+}

--- a/src/main/java/org/spongepowered/api/event/item/merchant/TradeWithMerchantEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/merchant/TradeWithMerchantEvent.java
@@ -22,42 +22,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.entity.living.trader;
+package org.spongepowered.api.event.item.merchant;
 
-import org.spongepowered.api.data.Keys;
-import org.spongepowered.api.data.type.Profession;
-import org.spongepowered.api.data.type.VillagerType;
-import org.spongepowered.api.data.value.Value;
-import org.spongepowered.api.entity.living.Ageable;
+import org.spongepowered.api.entity.living.Humanoid;
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.Event;
+import org.spongepowered.api.item.merchant.Merchant;
+import org.spongepowered.api.item.merchant.TradeOffer;
 
 /**
- * Represents a Villager.
+ * An event when a {@link Humanoid} trades with a {@link Merchant}.
  */
-public interface Villager extends Trader, Ageable {
+public interface TradeWithMerchantEvent extends Event, Cancellable {
 
-    /**
-     * {@link Keys#VILLAGER_TYPE}
-     * @return The villager type
-     * @see org.spongepowered.api.data.type.VillagerTypes
-     */
-    default Value.Mutable<VillagerType> type() {
-        return getValue(Keys.VILLAGER_TYPE.get()).get().asMutable();
-    }
+	/**
+	 * Gets the {@link Merchant} which is trading.
+	 *
+	 * @return The trading merchant.
+	 */
+	Merchant getMerchant();
 
-    /**
-     * {@link Keys#PROFESSION}
-     * @return The profession of this villager
-     * @see org.spongepowered.api.data.type.Professions
-     */
-    default Value.Mutable<Profession> profession() {
-        return getValue(Keys.PROFESSION.get()).get().asMutable();
-    }
+	/**
+	 * The TradeOffer being traded.
+	 *
+	 * @return The trade offer.
+	 */
+	TradeOffer getTradeOffer();
 
-    /**
-     * {@link Keys#PROFESSION_LEVEL}
-     * @return The profession level of this villager
-     */
-    default Value.Mutable<Integer> professionLevel() {
-        return getValue(Keys.PROFESSION_LEVEL).get().asMutable();
-    }
+	/**
+	 * Gets the {@link Humanoid} who is the customer of this transaction.
+	 *
+	 * @return The customer.
+	 */
+	Humanoid getCustomer();
+
 }

--- a/src/main/java/org/spongepowered/api/event/raid/RaidEvent.java
+++ b/src/main/java/org/spongepowered/api/event/raid/RaidEvent.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.raid;
+
+import org.spongepowered.api.data.type.RaidStatuses;
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.Event;
+import org.spongepowered.api.raid.Raid;
+import org.spongepowered.api.raid.Wave;
+import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
+
+/**
+ * An event when a raid changes it's current state. Always involves
+ * a {@link Raid}.
+ */
+public interface RaidEvent extends Event {
+
+	/**
+	 * Gets the {@link Raid} involved with this event.
+	 *
+	 * @return The raid.
+	 */
+	Raid getRaid();
+
+	/**
+	 * An event where the {@link Raid} is started.
+	 *
+	 * <p>This is fired before any {@link Wave}s have started.</p>
+	 */
+	@GenerateFactoryMethod
+	interface Start extends RaidEvent, Cancellable {}
+
+	/**
+	 * An event where a {@link Wave} in a {@link Raid} has started.
+	 */
+	@GenerateFactoryMethod
+	interface StartWave extends RaidEvent, Cancellable {
+
+		/**
+		 * The {@link Wave} which is starting.
+		 *
+		 * @return The current wave.
+		 */
+		Wave getWave();
+
+	}
+
+	/**
+	 * An event for when a {@link Raid} has ended.
+	 *
+	 * <p>The raid's state could be either a {@link RaidStatuses#VICTORY}
+	 * or {@link RaidStatuses#LOSS}</p>
+	 */
+	@GenerateFactoryMethod
+	interface End extends RaidEvent {}
+}

--- a/src/main/java/org/spongepowered/api/raid/Wave.java
+++ b/src/main/java/org/spongepowered/api/raid/Wave.java
@@ -24,7 +24,9 @@
  */
 package org.spongepowered.api.raid;
 
+import org.spongepowered.api.effect.potion.PotionEffectTypes;
 import org.spongepowered.api.entity.living.monster.raider.Raider;
+import org.spongepowered.api.world.difficulty.Difficulty;
 
 import java.util.Optional;
 
@@ -40,12 +42,20 @@ public interface Wave {
     /**
      * Determines if this wave was a bonus of the {@link Raid}.
      *
+     * <p>Bonus waves are always spawned after the final wave.
+     *
+     * <p>Bonus waves exist because {@link PotionEffectTypes#BAD_OMEN} had a level greater than 1.
+     *
      * @return True if bonus, false if not
      */
     boolean isBonus();
 
     /**
      * Determines if this wave was the final wave of the {@link Raid}.
+     *
+     * <p>Whether a wave is final depends on the {@link Difficulty} of the world.
+     *
+     * <p>If this wave is final, there may be bonus waves after the wave finishes.
      *
      * @return True if the final wave, false if not
      */

--- a/src/main/java/org/spongepowered/api/world/server/ServerWorld.java
+++ b/src/main/java/org/spongepowered/api/world/server/ServerWorld.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.world.server;
 
 import org.spongepowered.api.Server;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
+import org.spongepowered.api.raid.Raid;
 import org.spongepowered.api.util.Identifiable;
 import org.spongepowered.api.world.ChunkRegenerateFlag;
 import org.spongepowered.api.world.ChunkRegenerateFlags;
@@ -33,6 +34,8 @@ import org.spongepowered.api.world.SerializationBehavior;
 import org.spongepowered.api.world.SerializationBehaviors;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.chunk.Chunk;
+import org.spongepowered.api.world.dimension.DimensionType;
+import org.spongepowered.api.world.dimension.DimensionTypes;
 import org.spongepowered.api.world.explosion.Explosion;
 import org.spongepowered.api.world.storage.WorldProperties;
 import org.spongepowered.api.world.storage.WorldStorage;
@@ -112,7 +115,7 @@ public interface ServerWorld extends World<ServerWorld>, Identifiable, Interacta
     /**
      * Instructs the world to save all data.
      *
-     * @return True if save was successfull, or false if
+     * @return True if save was successful, or false if
      *     {@link SerializationBehavior} is {@link SerializationBehaviors#NONE}
      * @throws IOException If the save failed
      */
@@ -147,4 +150,23 @@ public interface ServerWorld extends World<ServerWorld>, Identifiable, Interacta
 
     @Override
     Collection<ServerPlayer> getPlayers();
+
+    /**
+     * Gets all {@link Raid}s occuring in this {@link ServerWorld}.
+     *
+     * <p>Please note by default, some {@link DimensionType}s such as {@link DimensionTypes#THE_NETHER}
+     * will not contain any Raids because the game prevents Raids from starting in the nether.</p>
+     *
+     * @return All the raids in this world.
+     */
+    Collection<Raid> getRaids();
+
+    /**
+     * Gets the {@link Raid} occurring at a position in the world.
+     *
+     * @param blockPosition The location of the Raid.
+     * @return The raid at that location, if present
+     */
+    Optional<Raid> getRaidAt(Vector3i blockPosition);
+
 }


### PR DESCRIPTION
**This adds some new events (#2068):**

RingBellEvent (Needs to have a way to get a list of all villagers which will hear the bell ring).

VillagerEvent.ProfessionChange
VillagerEvent.ProfessionLevelUp
VillagerEvent.Panic

TradeMerchantEvent

RaidEvent.Start
RaidEvent.StartWave
RaidEvent.End

**Other additions:**

Adds a new Key to get a Villager's Profession level.

Add a way to reference all the Raids within a world, inside of ServerWorld. (#2069)