### PR TITLE
Add DataValues to the BlockEntities where they belong. [API-8]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -125,7 +125,7 @@ val sortClasses = listOf(
         "org.spongepowered.api.data.type.CatTypes",
         "org.spongepowered.api.data.type.ChestAttachmentTypes",
         "org.spongepowered.api.data.type.DyeColors",
-        "org.spongepowered.api.data.type.ComparatorTypes",
+        "org.spongepowered.api.data.type.ComparatorModes",
         "org.spongepowered.api.data.type.FoxTypes",
         "org.spongepowered.api.data.type.HandTypes",
         "org.spongepowered.api.data.type.Hinges",

--- a/src/main/java/org/spongepowered/api/CatalogTypes.java
+++ b/src/main/java/org/spongepowered/api/CatalogTypes.java
@@ -135,7 +135,7 @@ public final class CatalogTypes {
 
     public static final Class<CollisionRule> COLLISION_RULE = CollisionRule.class;
 
-    public static final Class<ComparatorType> COMPARISON_TYPE = ComparatorType.class;
+    public static final Class<ComparatorMode> COMPARISON_MODE = ComparatorMode.class;
 
     public static final Class<ContainerType> CONTAINER_TYPE = ContainerType.class;
 

--- a/src/main/java/org/spongepowered/api/block/entity/Banner.java
+++ b/src/main/java/org/spongepowered/api/block/entity/Banner.java
@@ -33,7 +33,7 @@ import org.spongepowered.api.data.value.Value;
 /**
  * Represents a Banner {@link BlockEntity}.
  */
-public interface Banner extends BlockEntity {
+public interface Banner extends NameableBlockEntity {
 
     /**
      * Gets the {@link org.spongepowered.api.data.value.Value.Mutable} for the base {@link DyeColor}.

--- a/src/main/java/org/spongepowered/api/block/entity/BlockEntityTypes.java
+++ b/src/main/java/org/spongepowered/api/block/entity/BlockEntityTypes.java
@@ -87,11 +87,11 @@ public final class BlockEntityTypes {
 
     public static final Supplier<BlockEntityType> PISTON = Sponge.getRegistry().getCatalogRegistry().provideSupplier(BlockEntityType.class, "PISTON");
 
-    public static final Supplier<BlockEntityType> PLAYER_HEAD = Sponge.getRegistry().getCatalogRegistry().provideSupplier(BlockEntityType.class, "PLAYER_HEAD");
-
     public static final Supplier<BlockEntityType> SHULKER_BOX = Sponge.getRegistry().getCatalogRegistry().provideSupplier(BlockEntityType.class, "SHULKER_BOX");
 
     public static final Supplier<BlockEntityType> SIGN = Sponge.getRegistry().getCatalogRegistry().provideSupplier(BlockEntityType.class, "SIGN");
+
+    public static final Supplier<BlockEntityType> SKULL = Sponge.getRegistry().getCatalogRegistry().provideSupplier(BlockEntityType.class, "SKULL");
 
     public static final Supplier<BlockEntityType> SMOKER = Sponge.getRegistry().getCatalogRegistry().provideSupplier(BlockEntityType.class, "SMOKER");
 

--- a/src/main/java/org/spongepowered/api/block/entity/Comparator.java
+++ b/src/main/java/org/spongepowered/api/block/entity/Comparator.java
@@ -24,9 +24,20 @@
  */
 package org.spongepowered.api.block.entity;
 
+import org.spongepowered.api.data.Keys;
+import org.spongepowered.api.data.type.ComparatorMode;
+import org.spongepowered.api.data.value.Value;
+
 /**
  * Represents a Redstone Comparator.
  */
 public interface Comparator extends BlockEntity {
 
+    /**
+     * {@link Keys#COMPARATOR_MODE}
+     * @return The mode of the Comparator.
+     */
+    default Value.Mutable<ComparatorMode> mode() {
+        return this.requireValue(Keys.COMPARATOR_MODE).asMutable();
+    }
 }

--- a/src/main/java/org/spongepowered/api/block/entity/EnchantmentTable.java
+++ b/src/main/java/org/spongepowered/api/block/entity/EnchantmentTable.java
@@ -29,5 +29,5 @@ import org.spongepowered.api.item.enchantment.Enchantment;
 /**
  * Represents an {@link Enchantment} table.
  */
-public interface EnchantmentTable extends BlockEntity {
+public interface EnchantmentTable extends NameableBlockEntity {
 }

--- a/src/main/java/org/spongepowered/api/block/entity/Jukebox.java
+++ b/src/main/java/org/spongepowered/api/block/entity/Jukebox.java
@@ -25,12 +25,22 @@
 package org.spongepowered.api.block.entity;
 
 import org.spongepowered.api.data.Keys;
+import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 
 /**
- * Represents a jukebox, also know as a music disc player.
+ * Represents a jukebox, also known as a music disc player.
  */
 public interface Jukebox extends BlockEntity {
+
+    /**
+     * {@link Keys#ITEM_STACK_SNAPSHOT}
+     * @return A snapshot of the disc in the jukebox.
+     */
+    default Value.Mutable<ItemStackSnapshot> item() {
+        return this.requireValue(Keys.ITEM_STACK_SNAPSHOT).asMutable();
+    }
 
     /**
      * Attempts to play the currently stored music disc according to the

--- a/src/main/java/org/spongepowered/api/block/entity/Lectern.java
+++ b/src/main/java/org/spongepowered/api/block/entity/Lectern.java
@@ -24,6 +24,26 @@
  */
 package org.spongepowered.api.block.entity;
 
+import org.spongepowered.api.data.Keys;
+import org.spongepowered.api.data.value.Value;
+import org.spongepowered.api.item.ItemTypes;
+import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+
+/**
+ * Represents a Lectern.
+ */
 public interface Lectern extends BlockEntity {
 
+    /**
+     * {@link Keys#ITEM_STACK_SNAPSHOT}
+     *
+     * <p>Note that offering an item other than a
+     * {@link ItemTypes#WRITABLE_BOOK} or a {@link ItemTypes#WRITTEN_BOOK}
+     * will result in the lectern not opening when interacted with.</p>
+     *
+     * @return A snapshot of the book in the lectern.
+     */
+    default Value.Mutable<ItemStackSnapshot> item() {
+        return this.requireValue(Keys.ITEM_STACK_SNAPSHOT).asMutable();
+    }
 }

--- a/src/main/java/org/spongepowered/api/block/entity/NameableBlockEntity.java
+++ b/src/main/java/org/spongepowered/api/block/entity/NameableBlockEntity.java
@@ -22,31 +22,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.block.entity.carrier;
+package org.spongepowered.api.block.entity;
 
 import org.spongepowered.api.data.Keys;
-import org.spongepowered.api.data.value.BoundedValue;
+import org.spongepowered.api.data.value.Value;
+import org.spongepowered.api.text.Text;
 
 /**
- * Represents a Hopper.
+ * Represents a {@link BlockEntity} which may have a display name.
+ * @see Keys#DISPLAY_NAME
  */
-public interface Hopper extends NameableCarrierBlockEntity {
+public interface NameableBlockEntity extends BlockEntity {
 
     /**
-     * {@link Keys#COOLDOWN}
-     * @return The amount of time in ticks till the hopper can transfer another
-     * item.
+     * {@link Keys#DISPLAY_NAME}
+     * @return The display name of this {@link BlockEntity}.
      */
-    default BoundedValue.Mutable<Integer> cooldown() {
-        return this.requireValue(Keys.COOLDOWN).asMutable();
+    default Value.Mutable<Text> displayName() {
+        return this.requireValue(Keys.DISPLAY_NAME).asMutable();
     }
-
-    /**
-     * Requests this {@link Hopper} to transfer an item to the next carrier.
-     *
-     * <p>Since {@link Hopper}s normally send items to other
-     * {@link CarrierBlockEntity}s adjacent to themselves, if there is no
-     * available carrier to send an item to, this will perform nothing.</p>
-     */
-    void transferItem();
 }

--- a/src/main/java/org/spongepowered/api/block/entity/Piston.java
+++ b/src/main/java/org/spongepowered/api/block/entity/Piston.java
@@ -24,6 +24,10 @@
  */
 package org.spongepowered.api.block.entity;
 
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.data.Keys;
+import org.spongepowered.api.data.value.Value;
+
 /**
  * Represents a piston moving in the world.
  *
@@ -33,4 +37,19 @@ package org.spongepowered.api.block.entity;
  */
 public interface Piston extends BlockEntity {
 
+    /**
+     * {@link Keys#BLOCK_STATE}
+     * @return The BlockState representing the block being pushed.
+     */
+    default Value.Mutable<BlockState> blockState() {
+        return this.requireValue(Keys.BLOCK_STATE).asMutable();
+    }
+
+    /**
+     * {@link Keys#EXTENDED}
+     * @return Whether this piston is extending or retracting.
+     */
+    default Value.Mutable<Boolean> extending() {
+        return this.requireValue(Keys.EXTENDED).asMutable();
+    }
 }

--- a/src/main/java/org/spongepowered/api/block/entity/Skull.java
+++ b/src/main/java/org/spongepowered/api/block/entity/Skull.java
@@ -22,12 +22,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.type;
+package org.spongepowered.api.block.entity;
 
-import org.spongepowered.api.CatalogType;
-import org.spongepowered.api.util.annotation.CatalogedBy;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.data.Keys;
+import org.spongepowered.api.data.value.Value;
+import org.spongepowered.api.profile.GameProfile;
 
-@CatalogedBy(ComparatorTypes.class)
-public interface ComparatorType extends CatalogType {
+import java.util.Optional;
+
+/**
+ * Represents a head/skull from an entity.
+ */
+public interface Skull extends BlockEntity {
+
+    /**
+     * {@link Keys#GAME_PROFILE}
+     *
+     * <p>Gets the current represented player's {@link GameProfile} for this
+     * {@link Skull}.</p>
+     *
+     * <p>This value is only present when the Skull block entity on a
+     * {@link BlockTypes#PLAYER_HEAD} or
+     * {@link BlockTypes#PLAYER_WALL_HEAD}.</p>
+     *
+     * @return The current represented player value
+     */
+    default Optional<Value.Mutable<GameProfile>> gameProfile() {
+        return this.getValue(Keys.GAME_PROFILE).map(Value::asMutable);
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/block/entity/StructureBlock.java
+++ b/src/main/java/org/spongepowered/api/block/entity/StructureBlock.java
@@ -25,6 +25,15 @@
 package org.spongepowered.api.block.entity;
 
 import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.data.Keys;
+import org.spongepowered.api.data.type.StructureMode;
+import org.spongepowered.api.data.value.Value;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.gamemode.GameMode;
+import org.spongepowered.api.entity.living.player.gamemode.GameModes;
+import org.spongepowered.math.vector.Vector3i;
+
+import java.util.Optional;
 
 /**
  * Represents a StructureBlock.
@@ -34,4 +43,88 @@ import org.spongepowered.api.block.BlockTypes;
  */
 public interface StructureBlock extends BlockEntity {
 
+    /**
+     * {@link Keys#STRUCTURE_MODE}
+     * @return The structure mode of this structure block.
+     */
+    default Value.Mutable<StructureMode> mode() {
+        return this.requireValue(Keys.STRUCTURE_MODE).asMutable();
+    }
+
+    /**
+     * {@link Keys#STRUCTURE_POWERED}
+     * @return Whether this structure block is powered.
+     */
+    default Value.Mutable<Boolean> powered() {
+        return this.requireValue(Keys.STRUCTURE_POWERED).asMutable();
+    }
+
+    /**
+     * {@link Keys#STRUCTURE_SHOW_BOUNDING_BOX}
+     *
+     * <p>In vanilla, this is only visible to {@link Player}s whose
+     * {@link GameMode} is {@link GameModes#CREATIVE} or
+     * {@link GameModes#SPECTATOR}.</p>
+     *
+     * @return Whether the bounding box should be visible.
+     */
+    default Value.Mutable<Boolean> showBoundingBox() {
+        return this.requireValue(Keys.STRUCTURE_SHOW_BOUNDING_BOX).asMutable();
+    }
+
+    /**
+     * {@link Keys#STRUCTURE_SHOW_AIR}
+     * @return Whether the air within the structure should be visible.
+     */
+    default Value.Mutable<Boolean> showAir() {
+        return this.requireValue(Keys.STRUCTURE_SHOW_AIR).asMutable();
+    }
+
+    /**
+     * {@link Keys#STRUCTURE_IGNORE_ENTITIES}
+     * @return Whether this structure block should ignore entities.
+     */
+    default Value.Mutable<Boolean> ignoreEntities() {
+        return this.requireValue(Keys.STRUCTURE_IGNORE_ENTITIES).asMutable();
+    }
+
+    /**
+     * {@link Keys#STRUCTURE_SIZE}
+     * @return The size of the structure.
+     */
+    default Value.Mutable<Vector3i> size() {
+        return this.requireValue(Keys.STRUCTURE_SIZE).asMutable();
+    }
+
+    /**
+     * {@link Keys#STRUCTURE_POSITION}
+     * @return The position of the structure.
+     */
+    default Value.Mutable<Vector3i> position() {
+        return this.requireValue(Keys.STRUCTURE_POSITION).asMutable();
+    }
+
+    /**
+     * {@link Keys#STRUCTURE_SEED}
+     * @return The seed of the structure to be generated.
+     */
+    default Value.Mutable<Long> seed() {
+        return this.requireValue(Keys.STRUCTURE_SEED).asMutable();
+    }
+
+    /**
+     * {@link Keys#STRUCTURE_INTEGRITY}
+     * @return The integrity of the structure.
+     */
+    default Value.Mutable<Double> integrity() {
+        return this.requireValue(Keys.STRUCTURE_INTEGRITY).asMutable();
+    }
+
+    /**
+     * {@link Keys#STRUCTURE_AUTHOR}
+     * @return The author of the structure loaded by the structure block.
+     */
+    default Optional<Value.Mutable<String>> author() {
+        return this.getValue(Keys.STRUCTURE_AUTHOR).map(Value::asMutable);
+    }
 }

--- a/src/main/java/org/spongepowered/api/block/entity/carrier/Barrel.java
+++ b/src/main/java/org/spongepowered/api/block/entity/carrier/Barrel.java
@@ -24,6 +24,6 @@
  */
 package org.spongepowered.api.block.entity.carrier;
 
-public interface Barrel extends CarrierBlockEntity {
+public interface Barrel extends NameableCarrierBlockEntity {
 
 }

--- a/src/main/java/org/spongepowered/api/block/entity/carrier/Beacon.java
+++ b/src/main/java/org/spongepowered/api/block/entity/carrier/Beacon.java
@@ -37,7 +37,7 @@ import java.util.Optional;
  * Depending on the completed levels of the beacon, the effects may be applied
  * at a further range or shorter range.</p>
  */
-public interface Beacon extends CarrierBlockEntity {
+public interface Beacon extends NameableCarrierBlockEntity {
 
     /**
      * Gets the number of completed levels of valid beacon structure blocks

--- a/src/main/java/org/spongepowered/api/block/entity/carrier/BrewingStand.java
+++ b/src/main/java/org/spongepowered/api/block/entity/carrier/BrewingStand.java
@@ -24,10 +24,34 @@
  */
 package org.spongepowered.api.block.entity.carrier;
 
+import org.spongepowered.api.data.Keys;
+import org.spongepowered.api.data.value.BoundedValue;
+import org.spongepowered.api.data.value.Value;
+import org.spongepowered.api.item.ItemTypes;
+
 /**
  * Represents a Brewing Stand.
  */
-public interface BrewingStand extends CarrierBlockEntity {
+public interface BrewingStand extends NameableCarrierBlockEntity {
+
+    /**
+     * {@link Keys#BREWING_STAND_FUEL}
+     *
+     * <p>Note 1 {@link ItemTypes#BLAZE_POWDER} supplies 20 fuel</p>
+     *
+     * @return The amount of fuel left in the brewing stand.
+     */
+    default BoundedValue.Mutable<Integer> fuel() {
+        return this.requireValue(Keys.BREWING_STAND_FUEL).asMutable();
+    }
+
+    /**
+     * {@link Keys#REMAINING_BREW_TIME}
+     * @return The remaining brewing time in ticks.
+     */
+    default BoundedValue.Mutable<Integer> remainingBrewTime() {
+        return this.requireValue(Keys.REMAINING_BREW_TIME).asMutable();
+    }
 
     /**
      * Attempts to brew the current potions if possible.

--- a/src/main/java/org/spongepowered/api/block/entity/carrier/Campfire.java
+++ b/src/main/java/org/spongepowered/api/block/entity/carrier/Campfire.java
@@ -25,5 +25,4 @@
 package org.spongepowered.api.block.entity.carrier;
 
 public interface Campfire extends CarrierBlockEntity {
-
 }

--- a/src/main/java/org/spongepowered/api/block/entity/carrier/CarrierBlockEntity.java
+++ b/src/main/java/org/spongepowered/api/block/entity/carrier/CarrierBlockEntity.java
@@ -25,8 +25,12 @@
 package org.spongepowered.api.block.entity.carrier;
 
 import org.spongepowered.api.block.entity.BlockEntity;
+import org.spongepowered.api.data.Keys;
+import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.item.inventory.BlockCarrier;
 import org.spongepowered.api.item.inventory.type.BlockEntityInventory;
+
+import java.util.Optional;
 
 /**
  * Represents a {@link BlockEntity} that is a carrier of
@@ -39,4 +43,15 @@ public interface CarrierBlockEntity extends BlockEntity, BlockCarrier {
 
     @Override
     BlockEntityInventory<CarrierBlockEntity> getInventory();
+
+    /**
+     * {@link Keys#LOCK_TOKEN}
+     *
+     * <p>The absence of the value signifies this BlockEntity has no lock.</p>
+     *
+     * @return The lock token used for opening this {@link BlockEntity}.
+     */
+    default Optional<Value.Mutable<String>> lockToken() {
+        return this.getValue(Keys.LOCK_TOKEN).map(Value::asMutable);
+    }
 }

--- a/src/main/java/org/spongepowered/api/block/entity/carrier/Dispenser.java
+++ b/src/main/java/org/spongepowered/api/block/entity/carrier/Dispenser.java
@@ -29,5 +29,5 @@ import org.spongepowered.api.projectile.source.BlockProjectileSource;
 /**
  * Represents a Dispenser.
  */
-public interface Dispenser extends CarrierBlockEntity, BlockProjectileSource {
+public interface Dispenser extends NameableCarrierBlockEntity, BlockProjectileSource {
 }

--- a/src/main/java/org/spongepowered/api/block/entity/carrier/Dropper.java
+++ b/src/main/java/org/spongepowered/api/block/entity/carrier/Dropper.java
@@ -27,5 +27,5 @@ package org.spongepowered.api.block.entity.carrier;
 /**
  * Represents a Dropper.
  */
-public interface Dropper extends CarrierBlockEntity {
+public interface Dropper extends NameableCarrierBlockEntity {
 }

--- a/src/main/java/org/spongepowered/api/block/entity/carrier/NameableCarrierBlockEntity.java
+++ b/src/main/java/org/spongepowered/api/block/entity/carrier/NameableCarrierBlockEntity.java
@@ -22,24 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.block.entity;
+package org.spongepowered.api.block.entity.carrier;
 
-import org.spongepowered.api.data.Keys;
-import org.spongepowered.api.data.value.Value;
-import org.spongepowered.api.profile.GameProfile;
+import org.spongepowered.api.block.entity.NameableBlockEntity;
 
 /**
- * Represents a player head.
+ * Represents a {@link CarrierBlockEntity} which may have a display name.
  */
-public interface PlayerHead extends BlockEntity {
-
-    /**
-     * Gets the current represented player {@link GameProfile} for this {@link PlayerHead}.
-     *
-     * @return The current represented player value
-     */
-    default Value.Mutable<GameProfile> representedPlayer() {
-        return this.requireValue(Keys.REPRESENTED_PLAYER).asMutable();
-    }
-
+public interface NameableCarrierBlockEntity extends CarrierBlockEntity, NameableBlockEntity {
 }

--- a/src/main/java/org/spongepowered/api/block/entity/carrier/ShulkerBox.java
+++ b/src/main/java/org/spongepowered/api/block/entity/carrier/ShulkerBox.java
@@ -28,20 +28,22 @@ import org.spongepowered.api.data.Keys;
 import org.spongepowered.api.data.type.DyeColor;
 import org.spongepowered.api.data.value.Value;
 
+import java.util.Optional;
+
 /**
  * Represents a ShulkerBox. ShulkerBoxes are specific in that when they are
  * mined, they drop themselves with the contents added in themselves, so placing
  * them back as items will result in a restored inventory.
  */
-public interface ShulkerBox extends CarrierBlockEntity {
+public interface ShulkerBox extends NameableCarrierBlockEntity {
 
     /**
      * Gets the current {@link Value} of {@link DyeColor} for this
      * {@link ShulkerBox}.
      *
-     * @return The current value of dye color for this shulker box
+     * @return The current color of this shulker box.
      */
-    default Value.Mutable<DyeColor> color() {
-        return this.requireValue(Keys.DYE_COLOR).asMutable();
+    default Optional<Value.Mutable<DyeColor>> color() {
+        return this.getValue(Keys.DYE_COLOR).map(Value::asMutable);
     }
 }

--- a/src/main/java/org/spongepowered/api/block/entity/carrier/chest/Chest.java
+++ b/src/main/java/org/spongepowered/api/block/entity/carrier/chest/Chest.java
@@ -24,7 +24,10 @@
  */
 package org.spongepowered.api.block.entity.carrier.chest;
 
-import org.spongepowered.api.block.entity.carrier.CarrierBlockEntity;
+import org.spongepowered.api.block.entity.carrier.NameableCarrierBlockEntity;
+import org.spongepowered.api.data.Keys;
+import org.spongepowered.api.data.type.ChestAttachmentType;
+import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.item.inventory.Inventory;
 
 import java.util.Optional;
@@ -33,7 +36,7 @@ import java.util.Set;
 /**
  * Represents a Chest.
  */
-public interface Chest extends CarrierBlockEntity {
+public interface Chest extends NameableCarrierBlockEntity {
 
     /**
      * Returns the inventory representing the combination of this chest
@@ -52,5 +55,13 @@ public interface Chest extends CarrierBlockEntity {
      * @return The connected Chests, if available
      */
     Set<Chest> getConnectedChests();
+
+    /**
+     * {@link Keys#CHEST_ATTACHMENT}
+     * @return The attachment type of this chest.
+     */
+    default Value.Mutable<ChestAttachmentType> attachmentType() {
+        return this.requireValue(Keys.CHEST_ATTACHMENT).asMutable();
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/block/entity/carrier/furnace/FurnaceBlockEntity.java
+++ b/src/main/java/org/spongepowered/api/block/entity/carrier/furnace/FurnaceBlockEntity.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.block.entity.carrier.furnace;
 
-import org.spongepowered.api.block.entity.carrier.CarrierBlockEntity;
+import org.spongepowered.api.block.entity.carrier.NameableCarrierBlockEntity;
 import org.spongepowered.api.data.Keys;
 import org.spongepowered.api.data.value.BoundedValue;
 import org.spongepowered.api.item.recipe.Recipe;
@@ -32,7 +32,7 @@ import org.spongepowered.api.item.recipe.Recipe;
 /**
  * Represents the types of furnaces in Vanilla minecraft.
  */
-public interface FurnaceBlockEntity extends CarrierBlockEntity {
+public interface FurnaceBlockEntity extends NameableCarrierBlockEntity {
 
     /**
      * Attempts to process the {@link Recipe} for results.

--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.data;
 
 import org.spongepowered.api.Sponge;
-import org.spongepowered.api.advancement.Progressable;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.block.BlockTypes;
@@ -33,6 +32,8 @@ import org.spongepowered.api.block.entity.Banner;
 import org.spongepowered.api.block.entity.BlockEntity;
 import org.spongepowered.api.block.entity.CommandBlock;
 import org.spongepowered.api.block.entity.EndGateway;
+import org.spongepowered.api.block.entity.Jukebox;
+import org.spongepowered.api.block.entity.Lectern;
 import org.spongepowered.api.block.entity.MobSpawner;
 import org.spongepowered.api.block.entity.Piston;
 import org.spongepowered.api.block.entity.Sign;
@@ -49,7 +50,7 @@ import org.spongepowered.api.data.type.BodyPart;
 import org.spongepowered.api.data.type.BodyParts;
 import org.spongepowered.api.data.type.CatType;
 import org.spongepowered.api.data.type.ChestAttachmentType;
-import org.spongepowered.api.data.type.ComparatorType;
+import org.spongepowered.api.data.type.ComparatorMode;
 import org.spongepowered.api.data.type.DyeColor;
 import org.spongepowered.api.data.type.FoxType;
 import org.spongepowered.api.data.type.HandPreference;
@@ -66,6 +67,7 @@ import org.spongepowered.api.data.type.PandaGenes;
 import org.spongepowered.api.data.type.ParrotType;
 import org.spongepowered.api.data.type.PhantomPhase;
 import org.spongepowered.api.data.type.PickupRule;
+import org.spongepowered.api.data.type.PistonType;
 import org.spongepowered.api.data.type.PortionType;
 import org.spongepowered.api.data.type.Profession;
 import org.spongepowered.api.data.type.RabbitType;
@@ -594,6 +596,18 @@ public final class Keys {
     public static final Supplier<Key<Value<Integer>>> BREED_TIME = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "BREED_TIME");
 
     /**
+     * Represents the {@link Key} for the amount of fuel left in a
+     * {@link BrewingStand}.
+     *
+     * <p>One {@link ItemTypes#BLAZE_POWDER} adds 20 fuel to the brewing
+     * stand.</p>
+     *
+     * <p>The fuel value corresponds with the number of batches of potions that
+     * can be brewed.</p>
+     */
+    public static final Supplier<Key<BoundedValue<Integer>>> BREWING_STAND_FUEL = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "BREWING_STAND_FUEL");
+
+    /**
      * Represents the {@link Key} for if an {@link Animal} can breed. In Vanilla, animals can breed if their {@link Keys#BREED_TIME} is less than
      * or equal to 0.
      */
@@ -608,8 +622,8 @@ public final class Keys {
     /**
      * Represents the {@link Key} for whether a {@link Humanoid} can fly.
      *
-     * <p>For a {@link Player} this means he is able to toggle flight mode by
-     * double-tapping his jump button.</p>
+     * <p>For a {@link Player} this means they are able to toggle flight mode
+     * by double-tapping the jump button.</p>
      */
     public static final Supplier<Key<Value<Boolean>>> CAN_FLY = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "CAN_FLY");
 
@@ -672,10 +686,10 @@ public final class Keys {
     public static final Supplier<Key<Value<String>>> COMMAND = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "COMMAND");
 
     /**
-     * Represents the {@link Key} for representing the {@link ComparatorType}
+     * Represents the {@link Key} for representing the {@link ComparatorMode}
      * of a {@link BlockState}.
      */
-    public static final Supplier<Key<Value<ComparatorType>>> COMPARATOR_TYPE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "COMPARATOR_TYPE");
+    public static final Supplier<Key<Value<ComparatorMode>>> COMPARATOR_MODE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "COMPARATOR_MODE");
 
     /**
      * Represents the {@link Key} for representing the connected directions
@@ -1055,6 +1069,13 @@ public final class Keys {
      * has.
      */
     public static final Supplier<Key<Value<GameMode>>> GAME_MODE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "GAME_MODE");
+
+    /**
+     * Represents the {@link Key} for the player represented by a
+     * {@link BlockTypes#PLAYER_HEAD} (and {@link BlockTypes#PLAYER_WALL_HEAD})
+     * block or a {@link ItemTypes#PLAYER_HEAD} item stack.
+     */
+    public static final Supplier<Key<Value<GameProfile>>> GAME_PROFILE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "GAME_PROFILE");
 
     /**
      * Represents the {@link Key} for the generation of a
@@ -1559,7 +1580,9 @@ public final class Keys {
     public static final Supplier<Key<ListValue<Text>>> ITEM_LORE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "ITEM_LORE");
 
     /**
-     * Represents the {@link Key} for the {@link ItemStackSnapshot item} in an {@link Item}, {@link ItemFrame}, or {@link Potion}.
+     * Represents the {@link Key} for the {@link ItemStackSnapshot item} in an
+     * {@link Item}, {@link ItemFrame}, {@link Jukebox}, {@link Lectern} or
+     * {@link Potion}.
      */
     public static final Supplier<Key<Value<ItemStackSnapshot>>> ITEM_STACK_SNAPSHOT = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "ITEM_STACK_SNAPSHOT");
 
@@ -1639,7 +1662,8 @@ public final class Keys {
 
     /**
      * Represents the {@link Key} for the state that something is "lit",
-     * for example a {@link BlockTypes#FURNACE} or {@link BlockTypes#REDSTONE_TORCH}.
+     * for example a {@link BlockTypes#FURNACE}, {@link BlockTypes#CAMPFIRE}
+     * or {@link BlockTypes#REDSTONE_TORCH}.
      */
     public static final Supplier<Key<Value<Boolean>>> LIT = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "LIT");
 
@@ -1843,6 +1867,11 @@ public final class Keys {
     public static final Supplier<Key<Value<PickupRule>>> PICKUP_RULE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "PICKUP_RULE");
 
     /**
+     * Represents the {@link Key} for the piston type of an {@link Piston}.
+     */
+    public static final Supplier<Key<Value<PistonType>>> PISTON_TYPE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "PISTON_TYPE");
+
+    /**
      * Represents the {@link Key} for which block types an {@link ItemStack}
      * may be placed on.
      */
@@ -1945,13 +1974,6 @@ public final class Keys {
      * <p>If nothing is being brewed, the remaining brew time will be 0.</p>
      */
     public static final Supplier<Key<BoundedValue<Integer>>> REMAINING_BREW_TIME = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "REMAINING_BREW_TIME");
-
-    /**
-     * Represents the {@link Key} for the player represented by a
-     * {@link BlockTypes#PLAYER_HEAD} (and {@link BlockTypes#PLAYER_WALL_HEAD})
-     * block or a {@link ItemTypes#PLAYER_HEAD} item stack.
-     */
-    public static final Supplier<Key<Value<GameProfile>>> REPRESENTED_PLAYER = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "REPRESENTED_PLAYER");
 
     /**
      * Represents the {@link Key} for the spawn locations a {@link Player}
@@ -2144,17 +2166,19 @@ public final class Keys {
     public static final Supplier<Key<ListValue<Enchantment>>> STORED_ENCHANTMENTS = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "STORED_ENCHANTMENTS");
 
     /**
-     * Represents the {@link Key} for representing the mode of a {@link StructureBlock}.
+     * Represents the {@link Key} for representing the author of a structure
+     * from a {@link StructureBlock}.
      */
     public static final Supplier<Key<Value<String>>> STRUCTURE_AUTHOR = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "STRUCTURE_AUTHOR");
 
     /**
-     * Represents the {@link Key} for representing the mode of a {@link StructureBlock}.
+     * Represents the {@link Key} for whether a {@link StructureBlock} should
+     * ignore entities when saving a structure.
      */
     public static final Supplier<Key<Value<Boolean>>> STRUCTURE_IGNORE_ENTITIES = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "STRUCTURE_IGNORE_ENTITIES");
 
     /**
-     * Represents the {@link Key} for representing the mode of a {@link StructureBlock}.
+     * Represents the {@link Key} for representing the integrity of a {@link StructureBlock}.
      */
     public static final Supplier<Key<Value<Double>>> STRUCTURE_INTEGRITY = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "STRUCTURE_INTEGRITY");
 
@@ -2169,7 +2193,8 @@ public final class Keys {
     public static final Supplier<Key<Value<Vector3i>>> STRUCTURE_POSITION = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "STRUCTURE_POSITION");
 
     /**
-     * Represents the {@link Key} for representing the mode of a {@link StructureBlock}.
+     * Represents the {@link Key} for representing the powered state of a
+     * {@link StructureBlock}.
      */
     public static final Supplier<Key<Value<Boolean>>> STRUCTURE_POWERED = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "STRUCTURE_POWERED");
 
@@ -2179,7 +2204,9 @@ public final class Keys {
     public static final Supplier<Key<Value<Long>>> STRUCTURE_SEED = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "STRUCTURE_SEED");
 
     /**
-     * Represents the {@link Key} for representing the mode of a {@link StructureBlock}.
+     * Represents the {@link Key} for representing whether a
+     * {@link StructureBlock} should make all {@link BlockTypes#AIR},
+     * {@link BlockTypes#CAVE_AIR}, {@link BlockTypes#STRUCTURE_VOID} visible.
      */
     public static final Supplier<Key<Value<Boolean>>> STRUCTURE_SHOW_AIR = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "STRUCTURE_SHOW_AIR");
 

--- a/src/main/java/org/spongepowered/api/data/type/ComparatorMode.java
+++ b/src/main/java/org/spongepowered/api/data/type/ComparatorMode.java
@@ -22,31 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.block.entity.carrier;
+package org.spongepowered.api.data.type;
 
-import org.spongepowered.api.data.Keys;
-import org.spongepowered.api.data.value.BoundedValue;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
-/**
- * Represents a Hopper.
- */
-public interface Hopper extends NameableCarrierBlockEntity {
+@CatalogedBy(ComparatorModes.class)
+public interface ComparatorMode extends CatalogType {
 
-    /**
-     * {@link Keys#COOLDOWN}
-     * @return The amount of time in ticks till the hopper can transfer another
-     * item.
-     */
-    default BoundedValue.Mutable<Integer> cooldown() {
-        return this.requireValue(Keys.COOLDOWN).asMutable();
-    }
-
-    /**
-     * Requests this {@link Hopper} to transfer an item to the next carrier.
-     *
-     * <p>Since {@link Hopper}s normally send items to other
-     * {@link CarrierBlockEntity}s adjacent to themselves, if there is no
-     * available carrier to send an item to, this will perform nothing.</p>
-     */
-    void transferItem();
 }

--- a/src/main/java/org/spongepowered/api/data/type/ComparatorModes.java
+++ b/src/main/java/org/spongepowered/api/data/type/ComparatorModes.java
@@ -29,19 +29,19 @@ import org.spongepowered.api.Sponge;
 import java.util.function.Supplier;
 
 /**
- * An enumeration of vanilla {@link ComparatorType}s.
+ * An enumeration of vanilla {@link ComparatorMode}s.
  */
-public final class ComparatorTypes {
+public final class ComparatorModes {
 
     // SORTFIELDS:ON
 
-    public static final Supplier<ComparatorType> COMPARE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(ComparatorType.class, "COMPARE");
+    public static final Supplier<ComparatorMode> COMPARE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(ComparatorMode.class, "COMPARE");
 
-    public static final Supplier<ComparatorType> SUBTRACT = Sponge.getRegistry().getCatalogRegistry().provideSupplier(ComparatorType.class, "SUBTRACT");
+    public static final Supplier<ComparatorMode> SUBTRACT = Sponge.getRegistry().getCatalogRegistry().provideSupplier(ComparatorMode.class, "SUBTRACT");
 
     // SORTFIELDS:OFF
 
-    private ComparatorTypes() {
+    private ComparatorModes() {
         throw new AssertionError("You should not be attempting to instantiate this class.");
     }
 }

--- a/src/main/java/org/spongepowered/api/util/TypeTokens.java
+++ b/src/main/java/org/spongepowered/api/util/TypeTokens.java
@@ -35,7 +35,7 @@ import org.spongepowered.api.data.meta.PatternLayer;
 import org.spongepowered.api.data.type.ArtType;
 import org.spongepowered.api.data.type.BodyPart;
 import org.spongepowered.api.data.type.CatType;
-import org.spongepowered.api.data.type.ComparatorType;
+import org.spongepowered.api.data.type.ComparatorMode;
 import org.spongepowered.api.data.type.DyeColor;
 import org.spongepowered.api.data.type.HandPreference;
 import org.spongepowered.api.data.type.Hinge;
@@ -138,9 +138,9 @@ public final class TypeTokens {
 
     public static final TypeToken<Value<Color>> COLOR_VALUE_TOKEN = new TypeToken<Value<Color>>() {private static final long serialVersionUID = -1;};
 
-    public static final TypeToken<ComparatorType> COMPARATOR_TYPE_TOKEN = new TypeToken<ComparatorType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ComparatorMode> COMPARATOR_MODE_TOKEN = new TypeToken<ComparatorMode>() {private static final long serialVersionUID = -1;};
 
-    public static final TypeToken<Value<ComparatorType>> COMPARATOR_TYPE_VALUE_TOKEN = new TypeToken<Value<ComparatorType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<ComparatorMode>> COMPARATOR_MODE_VALUE_TOKEN = new TypeToken<Value<ComparatorMode>>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<Direction> DIRECTION_TOKEN = new TypeToken<Direction>() {private static final long serialVersionUID = -1;};
 
@@ -291,6 +291,8 @@ public final class TypeTokens {
     public static final TypeToken<Value<PickupRule>> PICKUP_VALUE_TOKEN = new TypeToken<Value<PickupRule>>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<PistonType> PISTON_TYPE_TOKEN = new TypeToken<PistonType>() {private static final long serialVersionUID = -1;};
+
+    public static final TypeToken<Value<PistonType>> PISTON_TYPE_VALUE_TOKEN = new TypeToken<Value<PistonType>>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<PortionType> PORTION_TOKEN = new TypeToken<PortionType>() {private static final long serialVersionUID = -1;};
 


### PR DESCRIPTION
This puts all the Value.Mutable blah blah blah in the BlockEntity classes. This is here to check incase I've added Values to things that don't apply to BlockEntities or some blatantly missing ones are not there.

~~So far there are two obvious values I have not done yet (DISPLAY_NAME for BlockEntities) and all of the `STRUCTURE` keys due to the optionality of the methods depending on the specific state of the Structure Block.~~

Renames `PlayerHead` -> `Skull` to match the vanilla impl since all heads/skulls share the same BlockEntityType. Also the `representedPlayer` data value is now `Optional`.

Renames `ComparatorType` -> `ComparatorMode` as per Zidane's request.

Changes `Keys#REPRESENTED_PLAYER` to a simple `Keys#GAME_PROFILE` for the Skull.