### PR TITLE
Add SerializationBehaviors.METADATA_ONLY.

### DIFF
--- a/src/main/java/org/spongepowered/api/world/SerializationBehaviors.java
+++ b/src/main/java/org/spongepowered/api/world/SerializationBehaviors.java
@@ -41,6 +41,11 @@ public class SerializationBehaviors {
     public static final SerializationBehavior MANUAL = DummyObjectProvider.createFor(SerializationBehavior.class, "manual");
 
     /**
+     * A {@link SerializationBehavior} where metadata is saved, but chunks are not saved.
+     */
+    public static final SerializationBehavior METADATA_ONLY = DummyObjectProvider.createFor(SerializationBehavior.class, "metadata_only");
+
+    /**
      * A {@link SerializationBehavior} where data is not saved to disk.
      */
     public static final SerializationBehavior NONE = DummyObjectProvider.createFor(SerializationBehavior.class, "none");


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2454) | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/3048)

Similar to the existing `SerializationBehaviors.NONE`, except it continues to store all information other than chunks. Useful for cases when `NONE` causes mods to break.