### PR TITLE
Add supplier overloads to all builder methods and trait -> property

### DIFF
--- a/src/main/java/org/spongepowered/api/advancement/DisplayInfo.java
+++ b/src/main/java/org/spongepowered/api/advancement/DisplayInfo.java
@@ -31,6 +31,8 @@ import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.CopyableBuilder;
 
+import java.util.function.Supplier;
+
 public interface DisplayInfo {
 
     /**
@@ -110,6 +112,17 @@ public interface DisplayInfo {
          * @param advancementType The advancement type
          * @return This builder, for chaining
          */
+        default Builder type(Supplier<? extends AdvancementType> advancementType) {
+            return this.type(advancementType.get());
+        }
+
+        /**
+         * Sets the {@link AdvancementType}. Defaults
+         * to {@link AdvancementTypes#TASK}.
+         *
+         * @param advancementType The advancement type
+         * @return This builder, for chaining
+         */
         Builder type(AdvancementType advancementType);
 
         /**
@@ -135,8 +148,19 @@ public interface DisplayInfo {
          * @param itemType The item type
          * @return This builder, for chaining
          */
+        default Builder icon(Supplier<? extends ItemType> itemType) {
+            return icon(itemType.get());
+        }
+
+        /**
+         * Sets the icon of the advancement with the
+         * specified {@link ItemType}.
+         *
+         * @param itemType The item type
+         * @return This builder, for chaining
+         */
         default Builder icon(ItemType itemType) {
-            return icon(ItemStack.of(itemType, 1));
+            return this.icon(ItemStack.of(itemType, 1));
         }
 
         /**
@@ -147,7 +171,7 @@ public interface DisplayInfo {
          * @return This builder, for chaining
          */
         default Builder icon(ItemStack itemStack) {
-            return icon(itemStack.createSnapshot());
+            return this.icon(itemStack.createSnapshot());
         }
 
         /**

--- a/src/main/java/org/spongepowered/api/block/BlockState.java
+++ b/src/main/java/org/spongepowered/api/block/BlockState.java
@@ -34,6 +34,8 @@ import org.spongepowered.api.fluid.FluidState;
 import org.spongepowered.api.state.State;
 import org.spongepowered.api.world.Location;
 
+import java.util.function.Supplier;
+
 /**
  * Represents a particular "state" that can exist at a {@link Location} with
  * a particular {@link BlockType} and various {@link org.spongepowered.api.data.value.Value.Immutable}s defining
@@ -50,6 +52,16 @@ public interface BlockState extends State<BlockState>, DirectionRelativeDataHold
      */
     static Builder builder() {
         return Sponge.getRegistry().getBuilderRegistry().provideBuilder(Builder.class);
+    }
+
+    /**
+     * Constructs a new builder to construct a {@link BlockStateMatcher}.
+     *
+     * @param type The block type
+     * @return The builder
+     */
+    static BlockStateMatcher.Builder matcher(Supplier<? extends BlockType> type) {
+        return BlockState.matcher(type.get());
     }
 
     /**
@@ -102,6 +114,21 @@ public interface BlockState extends State<BlockState>, DirectionRelativeDataHold
      * of {@link DataManipulator}s, otherwise exceptions may be thrown.</p>
      */
     interface Builder extends SerializableDataHolderBuilder.Immutable<BlockState, Builder> {
+
+        /**
+         * Sets the {@link BlockType} for the {@link BlockState} to build.
+         *
+         * <p>The {@link BlockType} is used for some pre-validation on addition of
+         * {@link DataManipulator}s through {@link #add(DataManipulator)}. It is
+         * important to understand that not all manipulators are compatible with
+         * all {@link BlockType}s.</p>
+         *
+         * @param blockType The block type
+         * @return This builder, for chaining
+         */
+        default Builder blockType(Supplier<? extends BlockType> blockType) {
+            return this.blockType(blockType.get());
+        }
 
         /**
          * Sets the {@link BlockType} for the {@link BlockState} to build.

--- a/src/main/java/org/spongepowered/api/block/BlockStateMatcher.java
+++ b/src/main/java/org/spongepowered/api/block/BlockStateMatcher.java
@@ -32,14 +32,15 @@ import org.spongepowered.api.util.CopyableBuilder;
 
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * A {@link BlockState} matcher that will match various block states
  * according to a pre-built list of {@link StateProperty}s and their
  * values, such that not all {@link StateProperty}s contained in a
  * {@link BlockState} must be matched. (Such as if a block state
- * that contains 4 traits, and only 2 are wanting to be matched,
- * then the other two traits may be variable).
+ * that contains 4 properties, and only 2 are wanting to be matched,
+ * then the other two properties may be variable).
  */
 public interface BlockStateMatcher extends Predicate<BlockState>, DataSerializable {
 
@@ -85,7 +86,19 @@ public interface BlockStateMatcher extends Predicate<BlockState>, DataSerializab
         /**
          * Sets the root {@link BlockType} for the {@link BlockStateMatcher}.
          * <p>Note that the {@link BlockType type} <b>must be set prior</b>
-         * to setting various {@link StateProperty traits} and their values.</p>
+         * to setting various {@link StateProperty properties} and their values.</p>
+         *
+         * @param type The block type to use
+         * @return This builder, for chaining
+         */
+        default Builder type(Supplier<? extends BlockType> type) {
+            return this.type(type.get());
+        }
+
+        /**
+         * Sets the root {@link BlockType} for the {@link BlockStateMatcher}.
+         * <p>Note that the {@link BlockType type} <b>must be set prior</b>
+         * to setting various {@link StateProperty propeties} and their values.</p>
          *
          * @param type The block type to use
          * @return This builder, for chaining
@@ -97,18 +110,38 @@ public interface BlockStateMatcher extends Predicate<BlockState>, DataSerializab
          * builder, if the desired {@link StateProperty} does not belong to the
          * original {@link BlockType} as provided by {@link #type(BlockType)},
          * an exception is thrown. Likewise, if a {@code value} is not within
-         * the possible values for the desired trait of the desired type, an
+         * the possible values for the desired property of the desired type, an
          * exception is thrown.
          *
-         * @param trait The desired block trait
+         * @param property The desired block property
          * @param value the desired value
          * @param <T> The type of comparable
          * @return This builder
-         * @throws IllegalArgumentException If the block trait does not match
-         *     the block type, or if the value does not belong to the trait
+         * @throws IllegalArgumentException If the block property does not match
+         *     the block type, or if the value does not belong to the property
          *     with the desired block type
          */
-        <T extends Comparable<T>> Builder trait(StateProperty<T> trait, T value) throws IllegalArgumentException;
+        default <T extends Comparable<T>> Builder property(Supplier<? extends StateProperty<T>> property, T value) throws IllegalArgumentException {
+            return this.property(property.get(), value);
+        }
+
+        /**
+         * Adds the desired {@link StateProperty} and {code value} to this
+         * builder, if the desired {@link StateProperty} does not belong to the
+         * original {@link BlockType} as provided by {@link #type(BlockType)},
+         * an exception is thrown. Likewise, if a {@code value} is not within
+         * the possible values for the desired property of the desired type, an
+         * exception is thrown.
+         *
+         * @param property The desired block property
+         * @param value the desired value
+         * @param <T> The type of comparable
+         * @return This builder
+         * @throws IllegalArgumentException If the block property does not match
+         *     the block type, or if the value does not belong to the property
+         *     with the desired block type
+         */
+        <T extends Comparable<T>> Builder property(StateProperty<T> property, T value) throws IllegalArgumentException;
 
         /**
          * Creates a new {@link BlockStateMatcher}.

--- a/src/main/java/org/spongepowered/api/block/entity/BlockEntityArchetype.java
+++ b/src/main/java/org/spongepowered/api/block/entity/BlockEntityArchetype.java
@@ -37,6 +37,8 @@ import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.world.Archetype;
 import org.spongepowered.api.world.Location;
 
+import java.util.function.Supplier;
+
 /**
  * Represents the data of a {@link BlockEntity} which does not exist in the world
  * and may be used to create new {@link BlockEntity}s with the same data.
@@ -127,6 +129,10 @@ public interface BlockEntityArchetype extends Archetype<BlockSnapshot, BlockEnti
          * @return This builder, for chaining
          */
         Builder state(BlockState state);
+
+        default Builder blockEntity(Supplier<? extends BlockEntityType> type) {
+            return this.blockEntity(type.get());
+        }
 
         Builder blockEntity(BlockEntityType type);
 

--- a/src/main/java/org/spongepowered/api/boss/BossBar.java
+++ b/src/main/java/org/spongepowered/api/boss/BossBar.java
@@ -27,6 +27,8 @@ package org.spongepowered.api.boss;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.Identifiable;
 
+import java.util.function.Supplier;
+
 /**
  * Represents a boss bar.
  */
@@ -77,6 +79,16 @@ public interface BossBar extends Identifiable {
      * @param color The color of the boss bar
      * @return This boss bar
      */
+    default BossBar setColor(Supplier<? extends BossBarColor> color) {
+        return this.setColor(color.get());
+    }
+
+    /**
+     * Sets the color.
+     *
+     * @param color The color of the boss bar
+     * @return This boss bar
+     */
     BossBar setColor(BossBarColor color);
 
     /**
@@ -85,6 +97,16 @@ public interface BossBar extends Identifiable {
      * @return The overlay
      */
     BossBarOverlay getOverlay();
+
+    /**
+     * Sets the overlay.
+     *
+     * @param overlay The overlay
+     * @return This boss bar
+     */
+    default BossBar setOverlay(Supplier<? extends BossBarOverlay> overlay) {
+        return this.setOverlay(overlay.get());
+    }
 
     /**
      * Sets the overlay.

--- a/src/main/java/org/spongepowered/api/boss/ServerBossBar.java
+++ b/src/main/java/org/spongepowered/api/boss/ServerBossBar.java
@@ -34,6 +34,7 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.CopyableBuilder;
 
 import java.util.Collection;
+import java.util.function.Supplier;
 
 /**
  * Represents a boss bar controlled by a {@link Server}.
@@ -56,7 +57,17 @@ public interface ServerBossBar extends BossBar {
     ServerBossBar setPercent(float percent);
 
     @Override
+    default ServerBossBar setColor(Supplier<? extends BossBarColor> color) {
+        return this.setColor(color.get());
+    }
+
+    @Override
     ServerBossBar setColor(BossBarColor color);
+
+    @Override
+    default ServerBossBar setOverlay(Supplier<? extends BossBarOverlay> overlay) {
+        return this.setOverlay(overlay.get());
+    }
 
     @Override
     ServerBossBar setOverlay(BossBarOverlay overlay);
@@ -164,7 +175,27 @@ public interface ServerBossBar extends BossBar {
          * @param color The color
          * @return This builder
          */
+        default Builder color(Supplier<? extends BossBarColor> color) {
+            return this.color(color.get());
+        }
+
+        /**
+         * Sets the color.
+         *
+         * @param color The color
+         * @return This builder
+         */
         Builder color(BossBarColor color);
+
+        /**
+         * Sets the overlay.
+         *
+         * @param overlay The overlay
+         * @return This builder
+         */
+        default Builder overlay(Supplier<? extends BossBarOverlay> overlay) {
+            return this.overlay(overlay.get());
+        }
 
         /**
          * Sets the overlay.

--- a/src/main/java/org/spongepowered/api/entity/EntityArchetype.java
+++ b/src/main/java/org/spongepowered/api/entity/EntityArchetype.java
@@ -33,6 +33,8 @@ import org.spongepowered.api.data.persistence.Queries;
 import org.spongepowered.api.world.Archetype;
 import org.spongepowered.api.world.schematic.Schematic;
 
+import java.util.function.Supplier;
+
 public interface EntityArchetype extends Archetype<EntitySnapshot, Entity> {
 
     /**
@@ -42,6 +44,15 @@ public interface EntityArchetype extends Archetype<EntitySnapshot, Entity> {
      */
     static Builder builder() {
         return Sponge.getRegistry().getBuilderRegistry().provideBuilder(Builder.class);
+    }
+
+    /**
+     * Creates a new {@link EntityArchetype} with the specified {@link EntityType}.
+     * @param type Type of the entity
+     * @return An archetype of the given entity type
+     */
+    static EntityArchetype of(Supplier<? extends EntityType<?>> type) {
+        return builder().type(type).build();
     }
 
     /**
@@ -91,6 +102,16 @@ public interface EntityArchetype extends Archetype<EntitySnapshot, Entity> {
          * @return This builder, for chaining
          */
         Builder from(Entity entity);
+
+        /**
+         * Sets the desired {@link EntityType} of the produced {@link EntityArchetype}.
+         *
+         * @param type The type of entity type
+         * @return This builder, for chaining
+         */
+        default Builder type(Supplier<? extends EntityType<?>> type) {
+            return this.type(type.get());
+        }
 
         /**
          * Sets the desired {@link EntityType} of the produced {@link EntityArchetype}.

--- a/src/main/java/org/spongepowered/api/entity/EntitySnapshot.java
+++ b/src/main/java/org/spongepowered/api/entity/EntitySnapshot.java
@@ -38,6 +38,7 @@ import org.spongepowered.math.vector.Vector3i;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 /**
  * Represents a snapshot of an {@link Entity} and all of it's related data in
@@ -122,6 +123,16 @@ public interface EntitySnapshot extends LocatableSnapshot<EntitySnapshot> {
          * @return This builder, for chaining
          */
         Builder world(WorldProperties worldProperties);
+
+        /**
+         * Sets the {@link EntityType} for this {@link EntitySnapshot}.
+         *
+         * @param entityType The EntityType
+         * @return This builder, for chaining
+         */
+        default Builder type(Supplier<? extends EntityType<?>> entityType) {
+            return this.type(entityType.get());
+        }
 
         /**
          * Sets the {@link EntityType} for this {@link EntitySnapshot}.

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
@@ -40,6 +40,7 @@ import org.spongepowered.api.util.CopyableBuilder;
 
 import java.util.Optional;
 import java.util.function.DoubleUnaryOperator;
+import java.util.function.Supplier;
 
 /**
  * Represents a modifier that will apply a function on a damage value to deal
@@ -99,6 +100,17 @@ public interface DamageModifier {
         Builder() {
         }
 
+
+        /**
+         * Sets the {@link DamageModifierType} for the {@link DamageModifier} to
+         * build.
+         *
+         * @param damageModifierType The damage modifier type
+         * @return This builder, for chaining
+         */
+        public Builder type(Supplier<? extends DamageModifierType> damageModifierType) {
+            return this.type(damageModifierType.get());
+        }
 
         /**
          * Sets the {@link DamageModifierType} for the {@link DamageModifier} to

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSource.java
@@ -32,6 +32,8 @@ import org.spongepowered.api.event.cause.entity.damage.DamageTypes;
 import org.spongepowered.api.util.CopyableBuilder;
 import org.spongepowered.api.world.difficulty.Difficulty;
 
+import java.util.function.Supplier;
+
 /**
  * Represents a {@link Cause} for damage on the {@link Entity} being
  * damaged. Usually the {@link DamageSource} will have different properties
@@ -215,6 +217,18 @@ public interface DamageSource {
          * @return This builder
          */
         B exhaustion(double exhaustion);
+
+        /**
+         * Sets the {@link DamageType} of this source.
+         *
+         * <p>This is required to be set.</p>
+         *
+         * @param damageType The desired damage type
+         * @return This builder
+         */
+        default B type(Supplier<? extends DamageType> damageType) {
+            return this.type(damageType.get());
+        }
 
         /**
          * Sets the {@link DamageType} of this source.

--- a/src/main/java/org/spongepowered/api/fluid/FluidStack.java
+++ b/src/main/java/org/spongepowered/api/fluid/FluidStack.java
@@ -29,6 +29,8 @@ import org.spongepowered.api.data.SerializableDataHolder;
 import org.spongepowered.api.data.SerializableDataHolderBuilder;
 import org.spongepowered.api.item.ItemTypes;
 
+import java.util.function.Supplier;
+
 /**
  * Represents a stack of a particular {@link FluidType} and
  * volume measured in "milliBuckets" where <code>1000</code>mB is equal to
@@ -86,6 +88,16 @@ public interface FluidStack extends SerializableDataHolder.Mutable {
     FluidStack copy();
 
     interface Builder extends SerializableDataHolderBuilder.Mutable<FluidStack, Builder> {
+
+        /**
+         * Sets the {@link FluidType} to use to build the {@link FluidStack}.
+         *
+         * @param fluidType The fluid type
+         * @return This builder, for chaining
+         */
+        default Builder fluid(Supplier<? extends FluidType> fluidType) {
+            return this.fluid(fluidType.get());
+        }
 
         /**
          * Sets the {@link FluidType} to use to build the {@link FluidStack}.

--- a/src/main/java/org/spongepowered/api/fluid/FluidStackSnapshot.java
+++ b/src/main/java/org/spongepowered/api/fluid/FluidStackSnapshot.java
@@ -28,6 +28,8 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.SerializableDataHolder;
 import org.spongepowered.api.data.SerializableDataHolderBuilder;
 
+import java.util.function.Supplier;
+
 public interface FluidStackSnapshot extends SerializableDataHolder.Immutable<FluidStackSnapshot> {
 
     /**
@@ -65,6 +67,10 @@ public interface FluidStackSnapshot extends SerializableDataHolder.Immutable<Flu
     FluidStack createStack();
 
     interface Builder extends SerializableDataHolderBuilder.Immutable<FluidStackSnapshot, Builder> {
+
+        default Builder fluid(Supplier<? extends FluidType> fluidType) {
+            return this.fluid(fluidType.get());
+        }
 
         Builder fluid(FluidType fluidType);
 

--- a/src/main/java/org/spongepowered/api/fluid/FluidState.java
+++ b/src/main/java/org/spongepowered/api/fluid/FluidState.java
@@ -34,6 +34,8 @@ import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.schematic.Schematic;
 
+import java.util.function.Supplier;
+
 /**
  * Represents a particular "state" that can exist at a {@link Location} with
  * a particular {@link BlockType} and various {@link org.spongepowered.api.data.value.Value.Immutable}s defining
@@ -88,10 +90,15 @@ public interface FluidState extends State<FluidState> {
         /**
          * Sets the {@link FluidType} for the {@link FluidState} to build.
          *
-         * <p>The {@link FluidType} is used for some pre-validation on addition of
-         * {@link DataManipulator}s through {@link #add(DataManipulator)}. It is
-         * important to understand that not all manipulators are compatible with
-         * all {@link FluidType}s.</p>
+         * @param fluidType The fluid type
+         * @return This builder, for chaining
+         */
+        default Builder fluid(Supplier<? extends FluidType> fluidType) {
+            return this.fluid(fluidType.get());
+        }
+
+        /**
+         * Sets the {@link FluidType} for the {@link FluidState} to build.
          *
          * @param fluidType The fluid type
          * @return This builder, for chaining

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackGenerator.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackGenerator.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Random;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * A simple generator that takes a {@link Random} and generates
@@ -70,6 +71,17 @@ public interface ItemStackGenerator extends Function<Random, ItemStack> {
          * @return This builder, for chaining
          */
         Builder addAll(Collection<BiConsumer<ItemStack.Builder, Random>> collection);
+
+        /**
+         * Sets the base {@link ItemType} for the {@link ItemStackGenerator}. A
+         * base type must be set to avoid issues.
+         *
+         * @param itemType The base item type
+         * @return This builder, for chaining
+         */
+        default Builder baseItem(Supplier<? extends ItemType> itemType) {
+            return this.baseItem(itemType.get());
+        }
 
         /**
          * Sets the base {@link ItemType} for the {@link ItemStackGenerator}. A

--- a/src/main/java/org/spongepowered/api/scoreboard/Team.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Team.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.util.CopyableBuilder;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A team on a scoreboard that has a common display theme and other
@@ -299,6 +300,20 @@ public interface Team {
          * @param color The color to set
          * @return This builder
          */
+        default Builder color(Supplier<? extends TextColor> color) {
+            return this.color(color.get());
+        }
+
+        /**
+         * Sets the color of the {@link Team}.
+         *
+         * <p>The team's color is a distinct concept from its prefix or suffix.
+         * It is only used for colored sidebar display slots, and certain
+         * statistic criteria.</p>
+         *
+         * @param color The color to set
+         * @return This builder
+         */
         Builder color(TextColor color);
 
         /**
@@ -368,6 +383,18 @@ public interface Team {
          *     nametags
          * @return This builder
          */
+        default Builder nameTagVisibility(Supplier<? extends Visibility> visibility) {
+            return this.nameTagVisibility(visibility.get());
+        }
+
+        /**
+         * Sets the {@link Visibility} which controls to who nametags
+         * of players on the {@link Team} are visible to.
+         *
+         * @param visibility The {@link Visibility} for the {@link Team}'s
+         *     nametags
+         * @return This builder
+         */
         Builder nameTagVisibility(Visibility visibility);
 
         /**
@@ -378,7 +405,29 @@ public interface Team {
          *     death Texts
          * @return This builder
          */
+        default Builder deathTextVisibility(Supplier<? extends Visibility> visibility) {
+            return this.deathTextVisibility(visibility.get());
+        }
+
+        /**
+         * Sets the {@link Visibility} which controls who death Texts
+         * of players on the {@link Team} are visible to.
+         *
+         * @param visibility The {@link Visibility} for the {@link Team}'s
+         *     death Texts
+         * @return This builder
+         */
         Builder deathTextVisibility(Visibility visibility);
+
+        /**
+         * Sets the {@link CollisionRule} for this team's members.
+         *
+         * @param rule The {@link CollisionRule} for the {@link Team}'s members
+         * @return This builder
+         */
+        default Builder collisionRule(Supplier<? extends CollisionRule> rule) {
+            return this.collisionRule(rule);
+        }
 
         /**
          * Sets the {@link CollisionRule} for this team's members.

--- a/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
@@ -35,6 +35,7 @@ import org.spongepowered.api.util.CopyableBuilder;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * An objective tracks an integer score for each entry it contains.
@@ -195,7 +196,27 @@ public interface Objective {
          * @param criterion The {@link Criterion} to set
          * @return This builder
          */
+        default Builder criterion(Supplier<? extends Criterion> criterion) {
+            return this.criterion(criterion.get());
+        }
+
+        /**
+         * Sets the {@link Criterion} of the {@link Objective}.
+         *
+         * @param criterion The {@link Criterion} to set
+         * @return This builder
+         */
         Builder criterion(Criterion criterion);
+
+        /**
+         * Sets the {@link ObjectiveDisplayMode} of the {@link Objective}.
+         *
+         * @param objectiveDisplayMode The {@link ObjectiveDisplayMode} to set
+         * @return This builder
+         */
+        default Builder objectiveDisplayMode(Supplier<? extends ObjectiveDisplayMode> objectiveDisplayMode) {
+            return this.objectiveDisplayMode(objectiveDisplayMode.get());
+        }
 
         /**
          * Sets the {@link ObjectiveDisplayMode} of the {@link Objective}.

--- a/src/main/java/org/spongepowered/api/state/StateProperty.java
+++ b/src/main/java/org/spongepowered/api/state/StateProperty.java
@@ -96,7 +96,7 @@ public interface StateProperty<T extends Comparable<T>> extends NamedCatalogType
      * Gets the {@link Predicate} used to determine valid values for this.
      * {@link StateProperty}. Any "value" that returns <code>true</code> when
      * {@link Predicate#test(Object)} is called is valid. The
-     * {@link Predicate} is specific to this trait.
+     * {@link Predicate} is specific to this property.
      * 
      * @return The predicate
      */

--- a/src/main/java/org/spongepowered/api/state/package-info.java
+++ b/src/main/java/org/spongepowered/api/state/package-info.java
@@ -23,7 +23,7 @@
  * THE SOFTWARE.
  */
 /**
- * A fallback API for handling traits of
+ * A fallback API for handling properties of
  * {@link org.spongepowered.api.block.BlockState}s such that the values that
  * are not directly supported by the API can still be represented with a
  * {@link org.spongepowered.api.state.StateProperty}. Common cases where

--- a/src/main/java/org/spongepowered/api/text/selector/Selector.java
+++ b/src/main/java/org/spongepowered/api/text/selector/Selector.java
@@ -34,6 +34,7 @@ import org.spongepowered.api.world.Location;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Represents an immutable selector of targets, as used in commands.
@@ -193,6 +194,16 @@ public interface Selector {
     Builder toBuilder();
 
     interface Builder extends CopyableBuilder<Selector, Builder> {
+
+        /**
+         * Sets the type of this selector.
+         *
+         * @param type The type to set
+         * @return This selector builder
+         */
+        default Builder type(Supplier<? extends SelectorType> type) {
+            return this.type(type.get());
+        }
 
         /**
          * Sets the type of this selector.

--- a/src/main/java/org/spongepowered/api/world/WorldArchetype.java
+++ b/src/main/java/org/spongepowered/api/world/WorldArchetype.java
@@ -43,6 +43,8 @@ import org.spongepowered.api.world.server.WorldRegistration;
 import org.spongepowered.api.world.storage.WorldProperties;
 import org.spongepowered.api.world.teleport.PortalAgentType;
 
+import java.util.function.Supplier;
+
 /**
  * A representation of the settings which define a {@link WorldProperties} for creation.
  */
@@ -251,7 +253,29 @@ public interface WorldArchetype extends CatalogType {
          * @param gameMode The gamemode
          * @return The builder, for chaining
          */
+        default Builder gameMode(Supplier<? extends GameMode> gameMode) {
+            return this.gameMode(gameMode.get());
+        }
+
+        /**
+         * Sets the default {@link GameMode}. If not specified this
+         * will default to {@link GameModes#SURVIVAL}.
+         *
+         * @param gameMode The gamemode
+         * @return The builder, for chaining
+         */
         Builder gameMode(GameMode gameMode);
+
+        /**
+         * Sets the {@link DimensionType}. If not specified this will default
+         * to {@link DimensionTypes#OVERWORLD}
+         *
+         * @param type The type
+         * @return The builder, for chaining
+         */
+        default Builder dimensionType(Supplier<? extends DimensionType> type) {
+            return this.dimensionType(type.get());
+        }
 
         /**
          * Sets the {@link DimensionType}. If not specified this will default
@@ -269,7 +293,28 @@ public interface WorldArchetype extends CatalogType {
          * @param type The type
          * @return The builder, for chaining
          */
+        default Builder generatorType(Supplier<? extends GeneratorType> type) {
+            return this.generatorType(type.get());
+        }
+
+        /**
+         * Sets the generator type. If not specified this will default
+         * to {@link GeneratorTypes#DEFAULT}
+         *
+         * @param type The type
+         * @return The builder, for chaining
+         */
         Builder generatorType(GeneratorType type);
+
+        /**
+         * Sets the difficulty.
+         *
+         * @param difficulty The difficulty
+         * @return The builder, for chaining
+         */
+        default Builder difficulty(Supplier<? extends Difficulty> difficulty) {
+            return this.difficulty(difficulty.get());
+        }
 
         /**
          * Sets the difficulty.
@@ -304,6 +349,16 @@ public interface WorldArchetype extends CatalogType {
          * @param type The type
          * @return This builder, for chaining
          */
+        default Builder portalAgent(Supplier<? extends PortalAgentType> type) {
+            return this.portalAgent(type.get());
+        }
+
+        /**
+         * Sets the desired {@link PortalAgentType} for the world.
+         *
+         * @param type The type
+         * @return This builder, for chaining
+         */
         Builder portalAgent(PortalAgentType type);
 
         /**
@@ -330,6 +385,16 @@ public interface WorldArchetype extends CatalogType {
          * @return This builder, for chaining
          */
         Builder generateBonusChest(boolean state);
+
+        /**
+         * Sets the {@link SerializationBehavior} that will be used when saving.
+         *
+         * @param behavior The serialization behavior
+         * @return This builder, for chaining
+         */
+        default Builder serializationBehavior(Supplier<? extends SerializationBehavior> behavior) {
+            return this.serializationBehavior(behavior.get());
+        }
 
         /**
          * Sets the {@link SerializationBehavior} that will be used when saving.


### PR DESCRIPTION
Adds Supplier overloads in many methods for CatalogTypes, this one mainly covering builders. Of course more of these commits will come along in time to handle all the Supplier overloads.