### PR TITLE
Update Chest API for new merging logic.

### DIFF
--- a/src/main/java/org/spongepowered/api/block/entity/carrier/chest/Chest.java
+++ b/src/main/java/org/spongepowered/api/block/entity/carrier/chest/Chest.java
@@ -31,7 +31,6 @@ import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.item.inventory.Inventory;
 
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Represents a Chest.
@@ -50,11 +49,14 @@ public interface Chest extends NameableCarrierBlockEntity {
     Optional<Inventory> getDoubleChestInventory();
 
     /**
-     * Returns the connected {@link Chest}s, if available.
+     * Returns the connected {@link Chest}, if available.
      *
-     * @return The connected Chests, if available
+     * <p>If this chest is not part of a double chest, then this method
+     * will return {@link Optional#empty()}.</p>
+     *
+     * @return The connected {@link Chest}, if available
      */
-    Set<Chest> getConnectedChests();
+    Optional<Chest> getConnectedChest();
 
     /**
      * {@link Keys#CHEST_ATTACHMENT}


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2554)
Chests can only be connected to one other chest now in Vanilla.