### PR TITLE
Add new functions to replace stopFilter and skipFilter

### DIFF
--- a/src/main/java/org/spongepowered/api/util/blockray/BlockRay.java
+++ b/src/main/java/org/spongepowered/api/util/blockray/BlockRay.java
@@ -83,9 +83,11 @@ import java.util.function.Predicate;
  * at based on some metric, like transparency, block model, or even distance.
  * The standard Bukkit-like behavior for finding the target block can be
  * achieved with using {@link BlockRay#ONLY_AIR_FILTER} as the
- * {@code stopFilter}, combined with
+ * continue filter, combined with
  * {@link #continueAfterFilter(Predicate, int)} with a second argument of 1, to
- * obtain the block just after the last air.</p>
+ * enable the ray to iterate such that it can select the block just after the
+ * last air. A {@link #notAirFilter()} can then be used as the select filter
+ * to select the non-air block.</p>
  *
  * <p>To get a block ray for an entities' line of sight, use
  * <pre>{@code BlockRay.from(entity);}</pre></p>

--- a/src/main/java/org/spongepowered/api/util/blockray/BlockRay.java
+++ b/src/main/java/org/spongepowered/api/util/blockray/BlockRay.java
@@ -847,7 +847,8 @@ public class BlockRay<E extends Extent> implements Iterator<BlockRayHit<E>> {
     /**
      * A filter that returns {@code true} for any input.
      *
-     * <p>This is the default filter applied to:</p>
+     * <p>In the absence of any other filter, this is the default filter applied
+     * to:</p>
      *
      * <ul>
      *     <li>{@link BlockRayBuilder#continueWhen(Predicate)}</li>
@@ -855,7 +856,10 @@ public class BlockRay<E extends Extent> implements Iterator<BlockRayHit<E>> {
      * </ul>
      *
      * <p><strong>Be careful:</strong> if no other constraints are placed on
-     * a {@link BlockRayBuilder}, such a ray will continue endlessly.</p>
+     * {@link BlockRayBuilder#continueWhen(Predicate)} and
+     * {@link BlockRayBuilder#selectWhen(Predicate)} is given a {@link Predicate}
+     * that has a narrower focus, a ray may never find a match and therefore
+     * continue endlessly.</p>
      *
      * @param <E> The extent to be applied in
      * @return A filter that accepts all blocks

--- a/src/main/java/org/spongepowered/api/util/blockray/BlockRay.java
+++ b/src/main/java/org/spongepowered/api/util/blockray/BlockRay.java
@@ -56,16 +56,23 @@ import java.util.function.Predicate;
  * that block is never returned because it is never entered (the ray is already
  * inside).
  *
- * <p>This class implements the
- * {@link Iterator} interface with the exception of {@link Iterator#remove()}.
- * </p>
+ * <p>This class implements the {@link Iterator} interface with the exception
+ * of {@link Iterator#remove()}.</p>
  *
  * <p>Filters determine what blocks the {@link BlockRay} should accept. First
- * the stop filter is called. If it returns false then the iterator ends there.
- * Otherwise the skip filter is called. If it returns false then the iterator
- * proceeds to the next block and it is never returned. Otherwise the block is
- * returned. If the distance limit is enabled then it is applied before both
- * filters and acts like the stop filter.</p>
+ * the continuation filter(s) (provided by
+ * {@link BlockRayBuilder#continueWhen(Predicate)}) are checked. If any of the
+ * provided filters return {@code false} then the iterator ends there - no more
+ * matches may be made by this ray.</p>
+ *
+ * <p>If this ray has not been stopped, the selection filter(s) (provided by
+ * {@link BlockRayBuilder#selectWhen(Predicate)}) are called. If any of the
+ * provided filters returns {@code false} then the iterator proceeds to the
+ * next block and it is never returned as a {@link BlockRayHit}. Otherwise
+ * the block is returned and the iterator is paused, awaiting a {@link #next()}
+ * call to resume tracing. If the distance limit is enabled then it is applied
+ * before both continuation and select checks and acts like the a {@code false}
+ * result has been returned by a continuation filter.</p>
  *
  * <p>Any one instance of a {@link Predicate} should only be run on one path.
  * It is not specified that {@link Predicate}s have to be stateless, pure

--- a/src/main/java/org/spongepowered/api/util/blockray/BlockRay.java
+++ b/src/main/java/org/spongepowered/api/util/blockray/BlockRay.java
@@ -626,12 +626,6 @@ public class BlockRay<E extends Extent> implements Iterator<BlockRayHit<E>> {
          * being returned by virtue of this predicate may be continued by
          * calling {@link #next()} on the associated {@link BlockRay}.
          *
-         * <p>This filters provided in this method are always the last
-         * to be checked. A {@code true} returned here will
-         * <strong>always</strong> stop a {@link BlockRay} trace and return this
-         * {@link BlockRayHit} to the consumer, while a false will ensure that
-         * the trace will continue, ignoring this result.</p>
-         *
          * <p>In the case that there are multiple filters,
          * <strong>all</strong> provided filters must succeed in order for
          * a ray to complete.</p>

--- a/src/main/java/org/spongepowered/api/util/blockray/BlockRay.java
+++ b/src/main/java/org/spongepowered/api/util/blockray/BlockRay.java
@@ -936,8 +936,9 @@ public class BlockRay<E extends Extent> implements Iterator<BlockRayHit<E>> {
      */
     public static <E extends Extent> Predicate<BlockRayHit<E>> blockTypeFilter(final BlockType... types) {
         return lastHit -> {
-            for (BlockType type : types) {
-                if (lastHit.getExtent().getBlockType(lastHit.getBlockX(), lastHit.getBlockY(), lastHit.getBlockZ()).equals(type)) {
+            final BlockType targetBlockType = lastHit.getExtent().getBlockType(lastHit.getBlockX(), lastHit.getBlockY(), lastHit.getBlockZ());
+            for (final BlockType type : types) {
+                if (targetBlockType.equals(type)) {
                     return true;
                 }
             }


### PR DESCRIPTION
These functions have been deprecated and replaced with `whilst` and `select`, along with clearer javadocs.

~~* Fix bug where a BlockRay containing a ContinueAfterFilter will give a different result upon ray reset.~~

@Zidane - I did see your comments, but I mostly used Github for the diff! This is a better thing to review.

Note that `selectWhen` is what you suggested `completeWhen` should be. In my first iteration, I got the function of `skipFilter` wrong... - `selectWhen` is meant to indicate there can be multiple selections, they just have a `BlockRay#next()` call between them.