### PR TITLE
Improve the effects API. Added SoundEffect.

### DIFF
--- a/src/main/java/org/spongepowered/api/CatalogTypes.java
+++ b/src/main/java/org/spongepowered/api/CatalogTypes.java
@@ -52,7 +52,7 @@ import org.spongepowered.api.event.cause.entity.dismount.DismountType;
 import org.spongepowered.api.event.cause.entity.spawn.SpawnType;
 import org.spongepowered.api.event.cause.entity.teleport.TeleportType;
 import org.spongepowered.api.fluid.FluidType;
-import org.spongepowered.api.item.FireworkShape;
+import org.spongepowered.api.effect.firework.FireworkShape;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.enchantment.EnchantmentType;
 import org.spongepowered.api.item.inventory.ContainerType;

--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -184,7 +184,7 @@ import org.spongepowered.api.entity.weather.LightningBolt;
 import org.spongepowered.api.entity.weather.WeatherEffect;
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSources;
 import org.spongepowered.api.fluid.FluidStackSnapshot;
-import org.spongepowered.api.item.FireworkEffect;
+import org.spongepowered.api.effect.firework.FireworkEffect;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.enchantment.Enchantment;
 import org.spongepowered.api.item.inventory.ItemStack;

--- a/src/main/java/org/spongepowered/api/effect/PlayableEffect.java
+++ b/src/main/java/org/spongepowered/api/effect/PlayableEffect.java
@@ -22,34 +22,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.item;
+package org.spongepowered.api.effect;
 
-import org.spongepowered.api.Sponge;
-
-import java.util.function.Supplier;
+import org.spongepowered.math.vector.Vector3d;
 
 /**
- * A class containing known {@link FireworkShape}s.
+ * Represents an effect that can be played to a {@link Viewer}
+ * through {@link Viewer#play(PlayableEffect, Vector3d)}.
  */
-public final class FireworkShapes {
-
-    // SORTFIELDS:ON
-
-    public static final Supplier<FireworkShape> BALL = Sponge.getRegistry().getCatalogRegistry().provideSupplier(FireworkShape.class, "BALL");
-
-    public static final Supplier<FireworkShape> BURST = Sponge.getRegistry().getCatalogRegistry().provideSupplier(FireworkShape.class, "BURST");
-
-    public static final Supplier<FireworkShape> CREEPER = Sponge.getRegistry().getCatalogRegistry().provideSupplier(FireworkShape.class, "CREEPER");
-
-    public static final Supplier<FireworkShape> LARGE_BALL = Sponge.getRegistry().getCatalogRegistry().provideSupplier(FireworkShape.class, "LARGE_BALL");
-
-    public static final Supplier<FireworkShape> STAR = Sponge.getRegistry().getCatalogRegistry().provideSupplier(FireworkShape.class, "STAR");
-
-    // SORTFIELDS:OFF
-
-    // Suppress default constructor to ensure non-instantiability.
-    private FireworkShapes() {
-        throw new AssertionError("You should not be attempting to instantiate this class.");
-    }
+public interface PlayableEffect {
 
 }

--- a/src/main/java/org/spongepowered/api/effect/Viewer.java
+++ b/src/main/java/org/spongepowered/api/effect/Viewer.java
@@ -27,9 +27,6 @@ package org.spongepowered.api.effect;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.spongepowered.api.block.BlockState;
-import org.spongepowered.api.effect.particle.ParticleEffect;
-import org.spongepowered.api.effect.sound.SoundCategories;
-import org.spongepowered.api.effect.sound.SoundCategory;
 import org.spongepowered.api.effect.sound.SoundType;
 import org.spongepowered.api.effect.sound.music.MusicDisc;
 import org.spongepowered.api.text.BookView;
@@ -48,260 +45,21 @@ import java.util.function.Supplier;
 public interface Viewer {
 
     /**
-     * Spawn a {@link ParticleEffect} at a given position.
-     * All players within a default radius around the position will see the
-     * particles.
+     * Plays the effect at the given position.
      *
-     * @param particleEffect The particle effect to spawn
-     * @param position The position at which to spawn the particle effect
+     * @param effect The effect to play
+     * @param position The position
      */
-    default void spawnParticles(ParticleEffect particleEffect, Vector3d position) {
-        this.spawnParticles(particleEffect, position, Integer.MAX_VALUE);
-    }
+    void play(PlayableEffect effect, Vector3d position);
 
     /**
-     * Spawn a {@link ParticleEffect} at a given position.
-     * All players within a given radius around the position will see the
-     * particles.
+     * Plays the effect at the given position. The effect will only be
+     * visible if it's within the given radius to the viewer.
      *
-     * @param particleEffect The particle effect to spawn
-     * @param position The position at which to spawn the particle effect
-     * @param radius The radius around the position where the particles can be
-     *            seen by players
+     * @param effect The effect to play
+     * @param position The position
      */
-    void spawnParticles(ParticleEffect particleEffect, Vector3d position, int radius);
-
-    /**
-     * Plays the given {@link SoundType} at the given position, with the
-     * category {@link SoundCategories#MASTER}. All players within range
-     * will hear the sound with the given volume.
-     *
-     * @param sound The sound to play
-     * @param position The position to play the sound
-     * @param volume The volume to play the sound at, usually between 0 and 2
-     */
-    default void playSound(SoundType sound, Vector3d position, double volume) {
-        this.playSound(sound, SoundCategories.MASTER.get(), position, volume, 1, 0);
-    }
-
-    /**
-     * Plays the given {@link SoundType} at the given position, with the
-     * category {@link SoundCategories#MASTER}. All players within range
-     * will hear the sound with the given volume.
-     *
-     * @param sound The sound to play
-     * @param position The position to play the sound
-     * @param volume The volume to play the sound at, usually between 0 and 2
-     */
-    default void playSound(Supplier<? extends SoundType> sound, Vector3d position, double volume) {
-        this.playSound(sound, SoundCategories.MASTER, position, volume, 1, 0);
-    }
-
-    /**
-     * Plays the given {@link SoundType} at the given position. All
-     * players within range will hear the sound with the given volume.
-     *
-     * @param sound The sound to play
-     * @param category The category to play the sound with
-     * @param position The position to play the sound
-     * @param volume The volume to play the sound at, usually between 0 and 2
-     */
-    default void playSound(SoundType sound, SoundCategory category, Vector3d position, double volume) {
-        this.playSound(sound, category, position, volume, 1, 0);
-    }
-
-    /**
-     * Plays the given {@link SoundType} at the given position. All
-     * players within range will hear the sound with the given volume.
-     *
-     * @param sound The sound to play
-     * @param category The category to play the sound with
-     * @param position The position to play the sound
-     * @param volume The volume to play the sound at, usually between 0 and 2
-     */
-    default void playSound(Supplier<? extends SoundType> sound, Supplier<? extends SoundCategory> category, Vector3d position, double volume) {
-        this.playSound(sound, category, position, volume, 1, 0);
-    }
-
-    /**
-     * Plays the given {@link SoundType} at the given position, with the
-     * category {@link SoundCategories#MASTER}. All players within range
-     * will hear the sound with the given volume.
-     *
-     * @param sound The sound to play
-     * @param position The position to play the sound
-     * @param volume The volume to play the sound at, usually between 0 and 2
-     * @param pitch The modulation of the sound to play at, usually between 0
-     *        and 2
-     */
-    default void playSound(SoundType sound, Vector3d position, double volume, double pitch) {
-        this.playSound(sound, SoundCategories.MASTER.get(), position, volume, pitch, 0);
-    }
-
-    /**
-     * Plays the given {@link SoundType} at the given position, with the
-     * category {@link SoundCategories#MASTER}. All players within range
-     * will hear the sound with the given volume.
-     *
-     * @param sound The sound to play
-     * @param position The position to play the sound
-     * @param volume The volume to play the sound at, usually between 0 and 2
-     * @param pitch The modulation of the sound to play at, usually between 0
-     *        and 2
-     */
-    default void playSound(Supplier<? extends SoundType> sound, Vector3d position, double volume, double pitch) {
-        this.playSound(sound, SoundCategories.MASTER, position, volume, pitch, 0);
-    }
-
-    /**
-     * Plays the given {@link SoundType} at the given position, with the
-     * category {@link SoundCategories#MASTER}. All players within range
-     * will hear the sound with the given volume.
-     *
-     * @param sound The sound to play
-     * @param category The category to play the sound with
-     * @param position The position to play the sound
-     * @param volume The volume to play the sound at, usually between 0 and 2
-     * @param pitch The modulation of the sound to play at, usually between 0
-     *        and 2
-     */
-    default void playSound(SoundType sound, SoundCategory category, Vector3d position, double volume, double pitch) {
-        this.playSound(sound, category, position, volume, pitch, 0);
-    }
-    /**
-     * Plays the given {@link SoundType} at the given position, with the
-     * category {@link SoundCategories#MASTER}. All players within range
-     * will hear the sound with the given volume.
-     *
-     * @param sound The sound to play
-     * @param category The category to play the sound with
-     * @param position The position to play the sound
-     * @param volume The volume to play the sound at, usually between 0 and 2
-     * @param pitch The modulation of the sound to play at, usually between 0
-     *        and 2
-     */
-    default void playSound(Supplier<? extends SoundType> sound, Supplier<? extends SoundCategory> category, Vector3d position, double volume, double pitch) {
-        this.playSound(sound, category, position, volume, pitch, 0);
-    }
-
-    /**
-     * Plays the given {@link SoundType} at the given position, with the
-     * category {@link SoundCategories#MASTER}. All players within range
-     * will hear the sound with the given volume.
-     *
-     * @param sound The sound to play
-     * @param position The position to play the sound
-     * @param volume The volume to play the sound at, usually between 0 and 2
-     * @param pitch The modulation of the sound to play at, usually between 0
-     *        and 2
-     * @param minVolume The minimum volume to play the sound at, usually between
-     *        0 and 2
-     */
-    default void playSound(SoundType sound, Vector3d position, double volume, double pitch, double minVolume) {
-        this.playSound(sound, SoundCategories.MASTER.get(), position, volume, pitch, minVolume);
-    }
-
-    /**
-     * Plays the given {@link SoundType} at the given position, with the
-     * category {@link SoundCategories#MASTER}. All players within range
-     * will hear the sound with the given volume.
-     *
-     * @param sound The sound to play
-     * @param position The position to play the sound
-     * @param volume The volume to play the sound at, usually between 0 and 2
-     * @param pitch The modulation of the sound to play at, usually between 0
-     *        and 2
-     * @param minVolume The minimum volume to play the sound at, usually between
-     *        0 and 2
-     */
-    default void playSound(Supplier<? extends SoundType> sound, Vector3d position, double volume, double pitch, double minVolume) {
-        this.playSound(sound, SoundCategories.MASTER, position, volume, pitch, minVolume);
-    }
-
-    /**
-     * Plays the given {@link SoundType} at the given position. All
-     * players within range will hear the sound with the given volume.
-     *
-     * @param sound The sound to play
-     * @param category The category to play the sound with
-     * @param position The position to play the sound
-     * @param volume The volume to play the sound at, usually between 0 and 2
-     * @param pitch The modulation of the sound to play at, usually between 0
-     *        and 2
-     * @param minVolume The minimum volume to play the sound at, usually between
-     *        0 and 2
-     */
-    void playSound(SoundType sound, SoundCategory category, Vector3d position, double volume, double pitch, double minVolume);
-
-    /**
-     * Plays the given {@link SoundType} at the given position. All
-     * players within range will hear the sound with the given volume.
-     *
-     * @param sound The sound to play
-     * @param category The category to play the sound with
-     * @param position The position to play the sound
-     * @param volume The volume to play the sound at, usually between 0 and 2
-     * @param pitch The modulation of the sound to play at, usually between 0
-     *        and 2
-     * @param minVolume The minimum volume to play the sound at, usually between
-     *        0 and 2
-     */
-    default void playSound(Supplier<? extends SoundType> sound, Supplier<? extends SoundCategory> category, Vector3d position, double volume, double pitch, double minVolume) {
-        playSound(sound.get(), category.get(), position, volume, pitch, minVolume);
-    }
-
-    /**
-     * Stops all the sounds.
-     */
-    void stopSounds();
-
-    /**
-     * Stops all the sounds of the given {@link SoundType}.
-     *
-     * @param sound The sound type
-     */
-    void stopSounds(SoundType sound);
-
-    /**
-     * Stops all the sounds of the given {@link SoundType}.
-     *
-     * @param sound The sound type
-     */
-    void stopSoundTypes(Supplier<? extends SoundType> sound);
-
-    /**
-     * Stops all the sounds that are played in the
-     * given {@link SoundCategory}.
-     *
-     * @param category The sound category
-     */
-    void stopSounds(SoundCategory category);
-
-    /**
-     * Stops all the sounds that are played in the
-     * given {@link SoundCategory}.
-     *
-     * @param category The sound category
-     */
-    void stopSoundCategoriess(Supplier<? extends SoundCategory> category);
-
-    /**
-     * Stops all the sounds of the given {@link SoundType} that
-     * are played in the given {@link SoundCategory}.
-     *
-     * @param sound The sound type
-     * @param category The sound category
-     */
-    void stopSounds(SoundType sound, SoundCategory category);
-
-    /**
-     * Stops all the sounds of the given {@link SoundType} that
-     * are played in the given {@link SoundCategory}.
-     *
-     * @param sound The sound type
-     * @param category The sound category
-     */
-    void stopSounds(Supplier<? extends SoundType> sound, Supplier<? extends SoundCategory> category);
+    void playWithinRadius(PlayableEffect effect, Vector3d position, double radius);
 
     /**
      * Plays the given {@link MusicDisc} at the given position. The benefit of playing

--- a/src/main/java/org/spongepowered/api/effect/firework/FireworkEffect.java
+++ b/src/main/java/org/spongepowered/api/effect/firework/FireworkEffect.java
@@ -22,10 +22,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.item;
+package org.spongepowered.api.effect.firework;
 
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.persistence.DataSerializable;
+import org.spongepowered.api.effect.PlayableEffect;
 import org.spongepowered.api.util.Color;
 import org.spongepowered.api.util.CopyableBuilder;
 
@@ -38,7 +39,7 @@ import java.util.function.Supplier;
  * <p>{@link FireworkEffect}s are immutable once created. To change one
  * or create one, use {@link Builder}.</p>
  */
-public interface FireworkEffect extends DataSerializable {
+public interface FireworkEffect extends PlayableEffect, DataSerializable {
 
     /**
      * Creates a new {@link Builder} to build a {@link FireworkEffect}.
@@ -48,7 +49,6 @@ public interface FireworkEffect extends DataSerializable {
     static Builder builder() {
         return Sponge.getRegistry().getBuilderRegistry().provideBuilder(Builder.class);
     }
-
 
     /**
      * Gets whether this {@link FireworkEffect} will flicker when

--- a/src/main/java/org/spongepowered/api/effect/firework/FireworkShape.java
+++ b/src/main/java/org/spongepowered/api/effect/firework/FireworkShape.java
@@ -22,7 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.item;
+package org.spongepowered.api.effect.firework;
 
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;

--- a/src/main/java/org/spongepowered/api/effect/firework/FireworkShapes.java
+++ b/src/main/java/org/spongepowered/api/effect/firework/FireworkShapes.java
@@ -22,25 +22,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.entity.projectile.explosive;
+package org.spongepowered.api.effect.firework;
 
-import org.spongepowered.api.data.Keys;
-import org.spongepowered.api.data.value.ListValue;
-import org.spongepowered.api.entity.explosive.fused.FusedExplosive;
-import org.spongepowered.api.entity.projectile.Projectile;
-import org.spongepowered.api.effect.firework.FireworkEffect;
+import org.spongepowered.api.Sponge;
+
+import java.util.function.Supplier;
 
 /**
- * Represents a Firework.
+ * A class containing known {@link FireworkShape}s.
  */
-public interface FireworkRocket extends Projectile, FusedExplosive {
+public final class FireworkShapes {
 
-    /**
-     * {@link Keys#FIREWORK_EFFECTS}
-     * @return The firework effects
-     */
-    default ListValue.Mutable<FireworkEffect> effects() {
-        return this.requireValue(Keys.FIREWORK_EFFECTS).asMutable();
+    // SORTFIELDS:ON
+
+    public static final Supplier<FireworkShape> BALL = Sponge.getRegistry().getCatalogRegistry().provideSupplier(FireworkShape.class, "BALL");
+
+    public static final Supplier<FireworkShape> BURST = Sponge.getRegistry().getCatalogRegistry().provideSupplier(FireworkShape.class, "BURST");
+
+    public static final Supplier<FireworkShape> CREEPER = Sponge.getRegistry().getCatalogRegistry().provideSupplier(FireworkShape.class, "CREEPER");
+
+    public static final Supplier<FireworkShape> LARGE_BALL = Sponge.getRegistry().getCatalogRegistry().provideSupplier(FireworkShape.class, "LARGE_BALL");
+
+    public static final Supplier<FireworkShape> STAR = Sponge.getRegistry().getCatalogRegistry().provideSupplier(FireworkShape.class, "STAR");
+
+    // SORTFIELDS:OFF
+
+    // Suppress default constructor to ensure non-instantiability.
+    private FireworkShapes() {
+        throw new AssertionError("You should not be attempting to instantiate this class.");
     }
 
 }

--- a/src/main/java/org/spongepowered/api/effect/firework/package-info.java
+++ b/src/main/java/org/spongepowered/api/effect/firework/package-info.java
@@ -22,25 +22,5 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.entity.projectile.explosive;
-
-import org.spongepowered.api.data.Keys;
-import org.spongepowered.api.data.value.ListValue;
-import org.spongepowered.api.entity.explosive.fused.FusedExplosive;
-import org.spongepowered.api.entity.projectile.Projectile;
-import org.spongepowered.api.effect.firework.FireworkEffect;
-
-/**
- * Represents a Firework.
- */
-public interface FireworkRocket extends Projectile, FusedExplosive {
-
-    /**
-     * {@link Keys#FIREWORK_EFFECTS}
-     * @return The firework effects
-     */
-    default ListValue.Mutable<FireworkEffect> effects() {
-        return this.requireValue(Keys.FIREWORK_EFFECTS).asMutable();
-    }
-
-}
+@org.checkerframework.framework.qual.DefaultQualifier(org.checkerframework.checker.nullness.qual.NonNull.class)
+package org.spongepowered.api.effect.firework;

--- a/src/main/java/org/spongepowered/api/effect/particle/ParticleEffect.java
+++ b/src/main/java/org/spongepowered/api/effect/particle/ParticleEffect.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.effect.particle;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.persistence.DataSerializable;
 import org.spongepowered.api.data.persistence.DataBuilder;
+import org.spongepowered.api.effect.PlayableEffect;
 import org.spongepowered.api.util.CopyableBuilder;
 import org.spongepowered.math.vector.Vector3d;
 
@@ -37,7 +38,7 @@ import java.util.function.Supplier;
 /**
  * Represents a particle effect that can be send to the Minecraft client.
  */
-public interface ParticleEffect extends DataSerializable {
+public interface ParticleEffect extends PlayableEffect, DataSerializable {
 
     /**
      * Creates a new {@link Builder} to build a {@link ParticleEffect}.

--- a/src/main/java/org/spongepowered/api/effect/particle/ParticleOptions.java
+++ b/src/main/java/org/spongepowered/api/effect/particle/ParticleOptions.java
@@ -28,7 +28,7 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.data.type.NotePitch;
 import org.spongepowered.api.effect.potion.PotionEffectType;
-import org.spongepowered.api.item.FireworkEffect;
+import org.spongepowered.api.effect.firework.FireworkEffect;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.util.Color;
 import org.spongepowered.api.util.Direction;

--- a/src/main/java/org/spongepowered/api/effect/sound/PitchModulation.java
+++ b/src/main/java/org/spongepowered/api/effect/sound/PitchModulation.java
@@ -24,12 +24,9 @@
  */
 package org.spongepowered.api.effect.sound;
 
-import org.spongepowered.api.effect.Viewer;
-import org.spongepowered.math.vector.Vector3d;
-
 /**
  * Represents a value to supply to
- * {@link Viewer#playSound(SoundType, Vector3d, double)} to modulate the pitch
+ * {@link org.spongepowered.api.effect.sound.SoundEffect.Builder#pitch(double)} to modulate the pitch
  * to a specified note.
  */
 public final class PitchModulation {

--- a/src/main/java/org/spongepowered/api/effect/sound/SoundEffect.java
+++ b/src/main/java/org/spongepowered/api/effect/sound/SoundEffect.java
@@ -1,0 +1,291 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.effect.sound;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.persistence.DataBuilder;
+import org.spongepowered.api.data.persistence.DataSerializable;
+import org.spongepowered.api.effect.PlayableEffect;
+import org.spongepowered.api.util.ResettableBuilder;
+
+import java.util.function.Supplier;
+
+/**
+ * Represents a sound effect that can be played.
+ */
+public interface SoundEffect extends PlayableEffect, DataSerializable {
+
+    /**
+     * Constructs a new {@link SoundEffect}.
+     *
+     * @param type The type
+     * @param category The category
+     * @param volume The volume
+     * @param pitch The pitch
+     * @return The sound effect
+     */
+    static SoundEffect of(SoundType type, SoundCategory category, double volume, double pitch) {
+        return builder().type(type).category(category).volume(volume).pitch(pitch).build();
+    }
+
+    /**
+     * Constructs a new {@link SoundEffect}.
+     *
+     * @param type The type
+     * @param category The category
+     * @param volume The volume
+     * @return The sound effect
+     */
+    static SoundEffect of(SoundType type, SoundCategory category, double volume) {
+        return builder().type(type).category(category).volume(volume).build();
+    }
+
+    /**
+     * Constructs a new {@link SoundEffect}.
+     *
+     * @param type The type
+     * @param category The category
+     * @param volume The volume
+     * @param pitch The pitch
+     * @return The sound effect
+     */
+    static SoundEffect of(Supplier<? extends SoundType> type, SoundCategory category, double volume, double pitch) {
+        return builder().type(type).category(category).volume(volume).pitch(pitch).build();
+    }
+
+    /**
+     * Constructs a new {@link SoundEffect}.
+     *
+     * @param type The type
+     * @param category The category
+     * @param volume The volume
+     * @return The sound effect
+     */
+    static SoundEffect of(Supplier<? extends SoundType> type, SoundCategory category, double volume) {
+        return builder().type(type).category(category).volume(volume).build();
+    }
+
+    /**
+     * Constructs a new {@link SoundEffect}.
+     *
+     * @param type The type
+     * @param category The category
+     * @param volume The volume
+     * @param pitch The pitch
+     * @return The sound effect
+     */
+    static SoundEffect of(Supplier<? extends SoundType> type, Supplier<? extends SoundCategory> category, double volume, double pitch) {
+        return builder().type(type).category(category).volume(volume).pitch(pitch).build();
+    }
+
+    /**
+     * Constructs a new {@link SoundEffect}.
+     *
+     * @param type The type
+     * @param category The category
+     * @param volume The volume
+     * @return The sound effect
+     */
+    static SoundEffect of(Supplier<? extends SoundType> type, Supplier<? extends SoundCategory> category, double volume) {
+        return builder().type(type).category(category).volume(volume).build();
+    }
+
+    /**
+     * Constructs a new {@link SoundEffect}.
+     *
+     * @param type The type
+     * @param category The category
+     * @param volume The volume
+     * @param pitch The pitch
+     * @return The sound effect
+     */
+    static SoundEffect of(SoundType type, Supplier<? extends SoundCategory> category, double volume, double pitch) {
+        return builder().type(type).category(category).volume(volume).pitch(pitch).build();
+    }
+
+    /**
+     * Constructs a new {@link SoundEffect}.
+     *
+     * @param type The type
+     * @param category The category
+     * @param volume The volume
+     * @return The sound effect
+     */
+    static SoundEffect of(SoundType type, Supplier<? extends SoundCategory> category, double volume) {
+        return builder().type(type).category(category).volume(volume).build();
+    }
+
+    /**
+     * Constructs a new {@link SoundEffect}.
+     *
+     * @param type The type
+     * @param volume The volume
+     * @param pitch The pitch
+     * @return The sound effect
+     */
+    static SoundEffect of(SoundType type, double volume, double pitch) {
+        return builder().type(type).volume(volume).pitch(pitch).build();
+    }
+
+    /**
+     * Constructs a new {@link SoundEffect}.
+     *
+     * @param type The type
+     * @param volume The volume
+     * @return The sound effect
+     */
+    static SoundEffect of(SoundType type, double volume) {
+        return builder().type(type).volume(volume).build();
+    }
+
+    /**
+     * Constructs a new {@link SoundEffect}.
+     *
+     * @param type The type
+     * @param volume The volume
+     * @param pitch The pitch
+     * @return The sound effect
+     */
+    static SoundEffect of(Supplier<? extends SoundType> type, double volume, double pitch) {
+        return builder().type(type).volume(volume).pitch(pitch).build();
+    }
+
+    /**
+     * Constructs a new {@link SoundEffect}.
+     *
+     * @param type The type
+     * @param volume The volume
+     * @return The sound effect
+     */
+    static SoundEffect of(Supplier<? extends SoundType> type, double volume) {
+        return builder().type(type).volume(volume).build();
+    }
+
+    /**
+     * Gets a new {@link SoundEffect} builder.
+     *
+     * @return The builder
+     */
+    static Builder builder() {
+        return Sponge.getRegistry().getBuilderRegistry().provideBuilder(Builder.class);
+    }
+
+    /**
+     * Gets the {@link SoundType} of the effect.
+     *
+     * @return The sound type
+     */
+    SoundType getType();
+
+    /**
+     * Gets the {@link SoundCategory} to play the sound in.
+     *
+     * @return The sound category
+     */
+    SoundCategory getCategory();
+
+    /**
+     * The volume to play the sound at, usually between 0 and 2.
+     *
+     * @return The volume
+     */
+    double getVolume();
+
+    /**
+     * The modulation of the sound to play at, usually between 0 and 2.
+     *
+     * @return The pitch
+     */
+    double getPitch();
+
+    /**
+     * A builder for {@link SoundEffect}s.
+     */
+    interface Builder extends ResettableBuilder<SoundEffect, Builder>, DataBuilder<SoundEffect> {
+
+        /**
+         * Sets the {@link SoundType} of the effect.
+         *
+         * @param type The sound type
+         * @return This builder, for chaining
+         */
+        default Builder type(Supplier<? extends SoundType> type) {
+            return this.type(type.get());
+        }
+
+        /**
+         * Sets the {@link SoundType} of the effect.
+         *
+         * @param type The sound type
+         * @return This builder, for chaining
+         */
+        Builder type(SoundType type);
+
+        /**
+         * Sets the {@link SoundCategory} to play the sound in.
+         *
+         * <p>Defaults to {@link SoundCategories#MASTER}.</p>
+         *
+         * @param category The sound category
+         * @return This builder, for chaining
+         */
+        default Builder category(Supplier<? extends SoundCategory> category) {
+            return this.category(category.get());
+        }
+
+        /**
+         * Sets the {@link SoundCategory} to play the sound in.
+         *
+         * @param category The sound category
+         * @return This builder, for chaining
+         */
+        Builder category(SoundCategory category);
+
+        /**
+         * Sets the volume to play the sound at, usually between 0 and 2.
+         *
+         * @param volume The volume
+         * @return This builder, for chaining
+         */
+        Builder volume(double volume);
+
+        /**
+         * Sets the modulation of the sound to play at, usually between 0 and 2.
+         *
+         * <p>Defaults to 1.</p>
+         *
+         * @param pitch The pitch
+         * @return This builder, for chaining
+         */
+        Builder pitch(double pitch);
+
+        /**
+         * Builds the {@link SoundEffect}.
+         *
+         * @return The sound effect
+         */
+        SoundEffect build();
+    }
+}

--- a/src/main/java/org/spongepowered/api/effect/sound/StopSoundEffects.java
+++ b/src/main/java/org/spongepowered/api/effect/sound/StopSoundEffects.java
@@ -1,0 +1,172 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.effect.sound;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.persistence.DataBuilder;
+import org.spongepowered.api.data.persistence.DataSerializable;
+import org.spongepowered.api.effect.PlayableEffect;
+import org.spongepowered.api.util.ResettableBuilder;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Represents an effect that can be used to stop {@link SoundEffect}s.
+ */
+public interface StopSoundEffects extends PlayableEffect, DataSerializable {
+
+    /**
+     * Constructs a {@link StopSoundEffects} that stops all sound effects.
+     *
+     * @return The stop sound effects
+     */
+    static StopSoundEffects all() {
+        return builder().build();
+    }
+
+    /**
+     * Constructs a {@link StopSoundEffects} that stops all sound effects
+     * with the given {@link SoundType} played in the given {@link SoundCategory}.
+     *
+     * @param type The sound type
+     * @param category The sound category
+     * @return The stop sound effects
+     */
+    static StopSoundEffects withTypeAndCategory(Supplier<? extends SoundType> type, Supplier<? extends SoundCategory> category) {
+        return builder().withType(type).withCategory(category).build();
+    }
+
+    /**
+     * Constructs a {@link StopSoundEffects} that stops all sound effects
+     * with the given {@link SoundType} played in the given {@link SoundCategory}.
+     *
+     * @param type The sound type
+     * @param category The sound category
+     * @return The stop sound effects
+     */
+    static StopSoundEffects withTypeAndCategory(Supplier<? extends SoundType> type, SoundCategory category) {
+        return builder().withType(type).withCategory(category).build();
+    }
+
+    /**
+     * Constructs a {@link StopSoundEffects} that stops all sound effects
+     * with the given {@link SoundType} played in the given {@link SoundCategory}.
+     *
+     * @param type The sound type
+     * @param category The sound category
+     * @return The stop sound effects
+     */
+    static StopSoundEffects withTypeAndCategory(SoundType type, Supplier<? extends SoundCategory> category) {
+        return builder().withType(type).withCategory(category).build();
+    }
+
+    /**
+     * Constructs a {@link StopSoundEffects} that stops all sound effects
+     * with the given {@link SoundType} played in the given {@link SoundCategory}.
+     *
+     * @param type The sound type
+     * @param category The sound category
+     * @return The stop sound effects
+     */
+    static StopSoundEffects withTypeAndCategory(SoundType type, SoundCategory category) {
+        return builder().withType(type).withCategory(category).build();
+    }
+
+    /**
+     * Constructs a {@link StopSoundEffects} that stops all sound effects
+     * with the given {@link SoundType}.
+     *
+     * @param type The sound type
+     * @return The stop sound effects
+     */
+    static StopSoundEffects withType(Supplier<? extends SoundType> type) {
+        return builder().withType(type).build();
+    }
+
+    /**
+     * Constructs a {@link StopSoundEffects} that stops all sound effects
+     * with the given {@link SoundType}.
+     *
+     * @param type The sound type
+     * @return The stop sound effects
+     */
+    static StopSoundEffects withType(SoundType type) {
+        return builder().withType(type).build();
+    }
+
+    /**
+     * Constructs a {@link StopSoundEffects} that stops all sound effects
+     * played in the given {@link SoundCategory}.
+     *
+     * @param category The sound category
+     * @return The stop sound effects
+     */
+    static StopSoundEffects withCategory(Supplier<? extends SoundCategory> category) {
+        return builder().withCategory(category).build();
+    }
+
+    /**
+     * Constructs a {@link StopSoundEffects} that stops all sound effects
+     * played in the given {@link SoundCategory}.
+     *
+     * @param category The sound category
+     * @return The stop sound effects
+     */
+    static StopSoundEffects withCategory(SoundCategory category) {
+        return builder().withCategory(category).build();
+    }
+
+    /**
+     * Constructs a new stop sounds effects {@link Builder}.
+     *
+     * @return The builder
+     */
+    static Builder builder() {
+        return Sponge.getRegistry().getBuilderRegistry().provideBuilder(Builder.class);
+    }
+
+    Optional<SoundType> getType();
+
+    Optional<SoundCategory> getCategory();
+
+    interface Builder extends ResettableBuilder<StopSoundEffects, Builder>, DataBuilder<StopSoundEffects> {
+
+        default Builder withCategory(@Nullable Supplier<? extends SoundCategory> category) {
+            return this.withCategory(category == null ? null : category.get());
+        }
+
+        Builder withCategory(@Nullable SoundCategory category);
+
+        default Builder withType(@Nullable Supplier<? extends SoundType> type) {
+            return this.withType(type == null ? null : type.get());
+        }
+
+        Builder withType(@Nullable SoundType type);
+
+        StopSoundEffects build();
+    }
+}

--- a/src/main/java/org/spongepowered/api/util/TypeTokens.java
+++ b/src/main/java/org/spongepowered/api/util/TypeTokens.java
@@ -74,7 +74,7 @@ import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.fluid.FluidStack;
 import org.spongepowered.api.fluid.FluidStackSnapshot;
 import org.spongepowered.api.fluid.FluidState;
-import org.spongepowered.api.item.FireworkEffect;
+import org.spongepowered.api.effect.firework.FireworkEffect;
 import org.spongepowered.api.item.enchantment.Enchantment;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;


### PR DESCRIPTION
This makes it easy and consistent to play effects, previously you had to use `playSound`, `spawnParticles`, `stopSounds`, or create a particle effect with firework effects.

This PR cleans that up and now there's a single method for `Viewer.play(PlayableEffect)`, supported `PlayableEffect` types are `SoundEffect`, `ParticleEffect`, `FireworkEffect`, `StopSoundEffects` (possibly a music disc related one, still TODO). `SoundEffect`, `StopSoundEffects` is also serializable, which makes it easy to use in config files.