### PR TITLE
Add support for centralised Placeholders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -198,6 +198,7 @@ sortClassFields {
     add 'main', 'org.spongepowered.api.text.chat.ChatVisibilities'
     add 'main', 'org.spongepowered.api.text.format.TextColors'
     add 'main', 'org.spongepowered.api.text.format.TextStyles'
+    add 'main', 'org.spongepowered.api.text.placeholder.PlaceholderParsers'
     add 'main', 'org.spongepowered.api.text.selector.SelectorTypes'
     add 'main', 'org.spongepowered.api.util.TypeTokens'
     add 'main', 'org.spongepowered.api.util.ban.BanTypes'

--- a/src/main/java/org/spongepowered/api/CatalogTypes.java
+++ b/src/main/java/org/spongepowered/api/CatalogTypes.java
@@ -70,6 +70,7 @@ import org.spongepowered.api.scoreboard.displayslot.DisplaySlot;
 import org.spongepowered.api.scoreboard.objective.displaymode.ObjectiveDisplayMode;
 import org.spongepowered.api.service.economy.Currency;
 import org.spongepowered.api.service.economy.transaction.TransactionType;
+import org.spongepowered.api.text.placeholder.PlaceholderParser;
 import org.spongepowered.api.statistic.BlockStatistic;
 import org.spongepowered.api.statistic.EntityStatistic;
 import org.spongepowered.api.statistic.ItemStatistic;
@@ -268,6 +269,8 @@ public final class CatalogTypes {
     public static final Class<PickupRule> PICKUP_RULE = PickupRule.class;
 
     public static final Class<PistonType> PISTON_TYPE = PistonType.class;
+
+    public static final Class<PlaceholderParser> PLACEHOLDER_PARSER = PlaceholderParser.class;
 
     public static final Class<PlantType> PLANT_TYPE = PlantType.class;
 

--- a/src/main/java/org/spongepowered/api/text/placeholder/PlaceholderContext.java
+++ b/src/main/java/org/spongepowered/api/text/placeholder/PlaceholderContext.java
@@ -1,0 +1,172 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.text.placeholder;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.ResettableBuilder;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+/**
+ * Contains the context that a {@link PlaceholderParser} can use to determine
+ * what to display.
+ */
+public interface PlaceholderContext {
+
+    /**
+     * Creates a {@link PlaceholderContext} for a {@link PlaceholderParser} to
+     * consume.
+     *
+     * @return The builder.
+     */
+    static Builder builder() {
+        return Sponge.getRegistry().createBuilder(Builder.class);
+    }
+
+    /**
+     * If provided, the {@link Object} which to pull information from
+     * when building the placeholder text.
+     *
+     * <p>Examples of how this might affect a placeholder are:</p>
+     *
+     * <ul>
+     *     <li>
+     *         For a "name" placeholder that prints out the source's name,
+     *         the name would be selected from this source.
+     *     </li>
+     *     <li>
+     *         For a "current world" placeholder that returns a player's current
+     *         world, this would pull the name of that current world from the
+     *         player.
+     *     </li>
+     * </ul>
+     *
+     * <p>It is important to note that the associated context does not
+     * necessarily have to be the sender/invoker of a message, nor does it
+     * have to be the recipient. The source is selected by the context of
+     * builder. It is up to plugins that use such placeholders to be aware
+     * of the context of which the placeholder is used.
+     * {@link PlaceholderParser}s should make no assumption about the origin of
+     * the context.</p>
+     *
+     * <p>If an invalid {@link Object} is provided for the context
+     * of the placeholder, then the associated {@link PlaceholderParser} must
+     * return a {@link Text#EMPTY}.</p>
+     *
+     * @return The associated {@link Object}, if any.
+     */
+    Optional<Object> getAssociatedObject();
+
+    /**
+     * The variable string passed to this token to provide contextual
+     * information.
+     *
+     * @return The argument, if any
+     */
+    Optional<String> getArgumentString();
+
+    /**
+     * A builder for {@link PlaceholderText} objects.
+     */
+    interface Builder extends ResettableBuilder<PlaceholderContext, Builder> {
+
+        /**
+         * Sets the {@link Object} to use as a source of information
+         * for this {@link PlaceholderText} to the supplied {@link Player}.
+         *
+         * @param player The player to associate this text with.
+         * @return This, for chaining
+         *
+         * @see #getAssociatedObject()
+         */
+        default Builder setAssociatedObject(Player player) {
+            final UUID uuid = player.getUniqueId();
+            return setAssociatedObject(() -> Sponge.getServer().getPlayer(uuid).orElse(null));
+        }
+
+        /**
+         * Sets the {@link Object} to use as a source of information
+         * for this {@link PlaceholderText}. If {@code null}, removes this
+         * source.
+         *
+         * <p>If you are intending to keep the associated
+         * {@link PlaceholderText} for any period of time and that you wish to
+         * associate a game object with the placeholder, use
+         * {@link #setAssociatedObject(Supplier)} instead, supplying a function
+         * that can recreate the object if necessary.</p>
+         *
+         * <p>If supplying a {@link Player}, use
+         * {@link #setAssociatedObject(Player)}, which will handle creating the
+         * correct supplier for you.</p>
+         *
+         * @param object The {@link Object} to associate this text with.
+         * @return This, for chaining
+         *
+         * @see #getAssociatedObject()
+         */
+        Builder setAssociatedObject(@Nullable Object object);
+
+        /**
+         * Sets the {@link Object} to use as a source of information
+         * for this {@link PlaceholderText}. If {@code null}, removes this source.
+         *
+         * @param supplier A {@link Supplier} that provides the {@link Object}
+         * @return This, for chaining
+         *
+         * @see #getAssociatedObject()
+         */
+        Builder setAssociatedObject(@Nullable Supplier<Object> supplier);
+
+        /**
+         * Sets a string that represents variables for the supplied token.
+         * The format of this argument string is dependent on the parser
+         * that consumes this string and thus is not prescribed here.
+         *
+         * @param string The argument string, may be null to reset to
+         *      the default argument string
+         * @return This, for chaining
+         *
+         * @see #getArgumentString()
+         */
+        Builder setArgumentString(@Nullable String string);
+
+        /**
+         * Builds and returns the placeholder.
+         *
+         * @return The appropriate {@link PlaceholderText}
+         * @throws IllegalStateException if the builder has not been completed,
+         *  or the associated {@link PlaceholderParser} could not validate the
+         *  built {@link PlaceholderText}, if applicable.
+         */
+        PlaceholderContext build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/placeholder/PlaceholderParser.java
+++ b/src/main/java/org/spongepowered/api/text/placeholder/PlaceholderParser.java
@@ -1,0 +1,115 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.text.placeholder;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.ResettableBuilder;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
+import java.util.function.Function;
+
+/**
+ * Provides the logic of how to parse a placeholder token.
+ */
+@CatalogedBy(PlaceholderParsers.class)
+public interface PlaceholderParser extends CatalogType {
+
+    /**
+     * Returns a {@link Builder} that allows for the creation of simple
+     * {@link PlaceholderParser}s.
+     *
+     * @return The {@link Builder}
+     */
+    static Builder builder() {
+        return Sponge.getRegistry().createBuilder(Builder.class);
+    }
+
+    /**
+     * Creates a {@link Text} based on the provided {@link PlaceholderContext}.
+     *
+     * <p>This method should not throw an error, instead returning
+     * {@link Text#EMPTY} if the supplied {@link PlaceholderContext} is not
+     * valid.</p>
+     *
+     * @param placeholderContext The {@link PlaceholderContext}
+     * @return The {@link Text}
+     */
+    Text parse(PlaceholderContext placeholderContext);
+
+    /**
+     * A builder that creates {@link PlaceholderParser}
+     */
+    interface Builder extends ResettableBuilder<PlaceholderParser, Builder> {
+
+        /**
+         * The plugin instance or {@link PluginContainer} that this parser is
+         * being provided by.
+         *
+         * @param plugin The plugin or {@link PluginContainer}
+         * @return This builder, for chaining
+         */
+        PlaceholderParser.Builder plugin(Object plugin);
+
+        /**
+         * The un-namespaced ID of the parser.
+         *
+         * <p>This will reject any ID that contains a colon.</p>
+         *
+         * @param id The un-namespaced ID
+         * @return This builder, for chaining
+         */
+        PlaceholderParser.Builder id(String id);
+
+        /**
+         * The human friendly name of this parser
+         *
+         * @param name The name
+         * @return This builder, for chaining
+         */
+        PlaceholderParser.Builder name(String name);
+
+        /**
+         * The function that converts a {@link PlaceholderContext} to {@link Text}
+         *
+         * @param parser The function
+         * @return This builder, for chaining
+         */
+        PlaceholderParser.Builder parser(Function<PlaceholderContext, Text> parser);
+
+        /**
+         * Builds a {@link PlaceholderParser}
+         *
+         * @return The parser
+         * @throws IllegalStateException if the plugin, ID or parser has not
+         *      been has not been specified.
+         */
+        PlaceholderParser build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/placeholder/PlaceholderParsers.java
+++ b/src/main/java/org/spongepowered/api/text/placeholder/PlaceholderParsers.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.text.placeholder;
+
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+
+/**
+ * Contains Sponge provided {@link PlaceholderParser}s.
+ */
+public class PlaceholderParsers {
+
+    // SORTFIELDS: ON
+
+    /**
+     * A parser that returns the associated source's current world, if
+     * applicable, else the default world.
+     */
+    static PlaceholderParser CURRENT_WORLD = DummyObjectProvider.createFor(PlaceholderParser.class, "CURRENT_WORLD");
+
+    /**
+     * A parser that returns the associated source's name.
+     */
+    static PlaceholderParser NAME = DummyObjectProvider.createFor(PlaceholderParser.class, "NAME");
+
+    // SORTFIELDS: OFF
+
+    private PlaceholderParsers() {
+        throw new AssertionError("This should not be instantiated.");
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/text/placeholder/PlaceholderText.java
+++ b/src/main/java/org/spongepowered/api/text/placeholder/PlaceholderText.java
@@ -1,0 +1,130 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.text.placeholder;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.TextRepresentable;
+import org.spongepowered.api.util.ResettableBuilder;
+
+/**
+ * A {@link TextRepresentable} that can be used in {@link Text} building methods
+ * that represents a placeholder in text.
+ *
+ * <p>A {@link PlaceholderText} is the collection of a {@link PlaceholderParser}
+ * along with contextual data in the supplied {@link PlaceholderContext},
+ * enabling its use in a {@link Text} object.</p>
+ *
+ * <p>Such placeholders will generally be built from tokenized strings, however
+ * these objects make no assumption about the format of text templating. Such a
+ * system can therefore be used by other templating engines without conforming
+ * to a particular standard.</p>
+ *
+ * <p>The {@link PlaceholderContext} is fixed when this object is created, but
+ * {@link PlaceholderParser#parse(PlaceholderContext)} is not called until
+ * {@link #toText()} is called. Thus, any {@link Text} object that is created
+ * will reflect the time that the {@link Text} object was requested, and not when
+ * this object itself was created. It therefore follows that implementations must
+ * not cache the result of {@link #toText()} unless it is known that the supplied
+ * parser is <strong>not</strong> sensitive to the time of invocation.</p>
+ */
+public interface PlaceholderText extends TextRepresentable {
+
+    /**
+     * Gets a builder for creating {@link PlaceholderText}.
+     *
+     * @return A {@link Builder}
+     */
+    static PlaceholderText.Builder builder() {
+        return Sponge.getRegistry().createBuilder(Builder.class);
+    }
+
+    /**
+     * Gets the {@link PlaceholderContext} that is to be supplied to the
+     * {@link PlaceholderParser} to create the {@link Text}.
+     *
+     * @return The {@link PlaceholderContext}
+     */
+    PlaceholderContext getContext();
+
+    /**
+     * Gets the {@link PlaceholderParser} that handles this placeholder.
+     *
+     * @return The {@link PlaceholderParser}
+     */
+    PlaceholderParser getParser();
+
+    /**
+     * Creates a {@link Text} from the supplied {@link PlaceholderParser} in the
+     * context of the supplied {@link PlaceholderContext}.
+     *
+     * <p>This will always return a {@link Text} object, however, if the parser
+     * could not handle the provided context, this will be {@link Text#EMPTY}.
+     * </p>
+     *
+     * @return The parsed {@link Text}
+     */
+    @Override
+    default Text toText() {
+        return getParser().parse(getContext());
+    }
+
+    /**
+     * A builder for {@link PlaceholderText} objects.
+     */
+    interface Builder extends ResettableBuilder<PlaceholderText, Builder> {
+
+        /**
+         * Sets the token that represents a {@link PlaceholderParser} for use
+         * in this {@link PlaceholderText}.
+         *
+         * @param parser The {@link PlaceholderParser} to use
+         * @return This, for chaining
+         */
+        Builder setParser(PlaceholderParser parser);
+
+        /**
+         * Sets the {@link PlaceholderContext} that will be provided to the
+         * {@link PlaceholderParser} to create the {@link Text} when
+         * {@link TextRepresentable#toText()} is called.
+         *
+         * @param context The {@link PlaceholderContext} to use.
+         * @return This, for chaining
+         */
+        Builder setContext(PlaceholderContext context);
+
+        /**
+         * Builds and returns the placeholder.
+         *
+         * @return The appropriate {@link PlaceholderText}
+         * @throws IllegalStateException if the builder has not been completed,
+         *  or the associated {@link PlaceholderParser} could not validate the
+         *  built {@link PlaceholderText}, if applicable.
+         */
+        PlaceholderText build() throws IllegalStateException;
+
+    }
+
+}


### PR DESCRIPTION
**Sponge API (that's here!)** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2588) | [SpongeDocs](https://github.com/SpongePowered/SpongeDocs/pull/834)

The intent behind this is to harmonise the various templating systems to use a common bank of placeholders, and comes from initial ideas from when trying to rebuild my placeholder system for Nucleus. I thought that this would be valuable to have in Sponge some time ago (akin to Econ and Permissions), but [this forum post](https://forums.spongepowered.org/t/help-best-approach-for-a-chat-plugin/36135) kicked me into actually doing it. 

This simply provides `PlaceholderParsers` that plugins can supply to the Sponge registry, and `PlaceholderContext` and `PlaceholderText` objects that templating engines can use 

* `PlaceholderParser`s will be registered centrally using the Sponge registry system such that there is a standard way for all plugins to get a placeholder, along with a standard way to include them in text constructions.
* Consumers wanting a placeholder grab the appropriate `PlaceholderParser` from the Sponge Registry, and create `PlaceholderContext` objects to supply to the parser to get a concrete `Text`.
* `PlaceholderText`s are `TextRepresentable`s that bundle the `PlaceholderParser` along with a `PlaceholderContext` so can be used easily within `Text.of(...)` or `Text.Builder`, minimising the effort required on the plugin side. The `Text` is evaluated at the time the text is built.

Part of the ideas are from #1891, but notably, this PR does NOT include a templating system. This is intentional, to allow plugins to provide their own systems as they do now.

---

<details> 
  <summary>The original text from this PR is here, when there was also a service.</summary>

The text below is from the previous iteration of the PR, the service no longer exists, but the idea is about the same.

The intent behind such a service is to harmonise the various templating systems to use a common bank of placeholders, and comes from initial ideas from when trying to rebuild my placeholder system for Nucleus. I thought that this would be valuable to have in Sponge some time ago (akin to Econ and Permissions), but [this forum post](https://forums.spongepowered.org/t/help-best-approach-for-a-chat-plugin/36135) kicked me into actually doing it. 

This is for discussion, particularly javadocs - is there anything I could do there to make them clearer?

* `PlaceholderParser`s will be registered centrally using the Sponge registry system such that there is a standard way for all plugins to get a placeholder, along with a standard way to include them in text constructions.
* Consumers wanting a placeholder can use this service to either parse a token, or they can go for a more DIY approach and supplying a builder (which is supplied by the service, rather than the normal thing of `PlaceholderText.builder()`, though I could do that I guess and just reference back to the service)
* `PlaceholderText`s are `TextRepresentable`s so can be used easily within `Text.of(...)` or `Text.Builder`, minimising the effort required on the plugin side.

The basic idea is that you build a `PlaceholderText` with a `PlaceholderParser` and use that in `Text.of(...)` or ` Text.builder()` objects.

This service is replaceable, allowing for a plugin to support a superset of the required base - so for example, I could add my more advanced stuff in, or a dedicated placeholder plugin could make use of the service. Other plugins can also just make use of the parser registry if they wish - they don't need to parse via the service if they don't want to.

Part of the ideas are from #1891, but notably, this PR does NOT include a templating system. This is intentional, to allow plugins to provide their own systems as they do now.
</details>