### PR TITLE
Update Guice to 4.2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile 'com.google.code.findbugs:jsr305:3.0.1'
 
     // Dependency injection
-    compile 'com.google.inject:guice:4.1.0'
+    compile 'com.google.inject:guice:4.2.3'
 
     // Java 8 high performance cache (+ wrapper for Guava)
     compile 'com.github.ben-manes.caffeine:caffeine:2.5.4'


### PR DESCRIPTION
This PR updates the Guice dependency from 4.1.0 to 4.2.3. This is a minor version bump and so does not break backward compatibility.

Google does have some classes annotated with `@Beta` which make them exempt from any compatibility guarantees (Such as `TypeToken`). However, I looked here:

- https://github.com/google/guice/wiki/Guice42
- http://google.github.io/guice/api-docs/4.2/api-diffs/changes.html

and was unable to find any breaking changes.

I tested this change with the following plugins from ore on SpongeForge and everything worked as expected:

- Nucleus
- LuckPerms
- WorldEdit
- Anvil and OnTime (two of my plugins that rely heavily on Guice)
- Respect

Resolves #2122