### PR TITLE
Fix unsafe copy method for Location

### DIFF
--- a/src/main/java/org/spongepowered/api/world/Location.java
+++ b/src/main/java/org/spongepowered/api/world/Location.java
@@ -884,7 +884,7 @@ public final class Location<E extends Extent> implements DataHolder {
 
     @Override
     public Location<E> copy() {
-        return new Location<>(getExtent(), getPosition());
+        return new Location<>(getExtent(), getPosition().clone());
     }
 
     @Override


### PR DESCRIPTION
In the super method for copy it says the following:
![image](https://user-images.githubusercontent.com/33832062/83155841-92e4f200-a0f9-11ea-8b65-f8cf99a8a312.png)
However, the current implementation doesn't clone the Vector object holding the position of the location.