### PR TITLE
Fix completion with allOf element

### DIFF
--- a/src/main/java/org/spongepowered/api/command/args/CommandArgs.java
+++ b/src/main/java/org/spongepowered/api/command/args/CommandArgs.java
@@ -66,6 +66,22 @@ public final class CommandArgs {
     }
 
     /**
+     * Returns true if:
+     *
+     * <ul>
+     *     <li>The next element returned by {@link #next()} is the last</li>
+     *     <li>{@link #hasNext()} is false</li>
+     * </ul>
+     *
+     * Else returns false.
+     *
+     * @return True if a completion can occur
+     */
+    boolean canComplete() {
+        return this.index + 2 >= this.args.size();
+    }
+
+    /**
      * Try to read the next argument without advancing the current index.
      *
      * @return The next argument


### PR DESCRIPTION
Fixes #2126

@ImMorpheus please check that this works for you. I have written a couple of test commands (below) which work, but want to make sure it works with you too.

```java
        Sponge.getCommandManager().register(this.pluginContainer, CommandSpec.builder()
                .arguments(GenericArguments.allOf(GenericArguments.player(Text.of("player"))))
                .executor((src, args) -> {
                    Collection<Player> playerCollection = args.getAll("player");
                    src.sendMessage(Text.of("Selected players: ", playerCollection
                            .stream()
                            .map(User::getName)
                            .collect(Collectors.joining(", "))));
                    return CommandResult.success();
                })
                .build(), "allofplayers");

        final Collection<String> choices = ImmutableList.of("bacon", "eggs", "sausages", "beans", "spam", "sponge");
        Sponge.getCommandManager().register(this.pluginContainer, CommandSpec.builder()
                .arguments(GenericArguments.allOf(GenericArguments.choices(
                                    Text.of("choices"),
                                    () -> choices,
                                    input -> {
                                        if (choices.contains(input.toLowerCase())) {
                                            return input;
                                        }
                                        return null;
                                    }
                                )))
                .executor((src, args) -> {
                    Collection<String> playerCollection = args.getAll("choices");
                    src.sendMessage(Text.of("Selected choices: ", String.join(", ", playerCollection)));
                    return CommandResult.success();
                })
                .build(), "allofchoices");
```