### PR TITLE
New Explosion Event for BlockExplosionResistance

### DIFF
--- a/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
@@ -24,18 +24,14 @@
  */
 package org.spongepowered.api.event.world;
 
-import com.flowpowered.math.vector.Vector3i;
-import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.block.ChangeBlockEvent;
 import org.spongepowered.api.event.entity.AffectEntityEvent;
-import org.spongepowered.api.util.Tuple;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.explosion.Explosion;
 
-import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -93,19 +89,4 @@ public interface ExplosionEvent extends Event {
      * updated and/or changed.
      */
     interface Post extends ExplosionEvent, ChangeBlockEvent.Post {}
-
-    /**
-     * An event that is fired when the Explosion fetches the explosion resistance of a block.
-     * Provides the world, block position, block state, and default and current explosion resistance.
-     */
-    interface BlockResistance extends ExplosionEvent, TargetWorldEvent {
-
-        /**
-         * Gets the block positions that will potentially be effected as Vector3i mapped to a Pair containing the BlockState and
-         * explosion resistance of the block located at that position.
-         *
-         * @return The blocks that the explosion may effect
-         */
-        HashMap<Vector3i, Tuple<BlockState, Float>> getBlocks();
-    }
 }

--- a/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
@@ -25,12 +25,12 @@
 package org.spongepowered.api.event.world;
 
 import com.flowpowered.math.vector.Vector3i;
-import org.apache.commons.lang3.tuple.Pair;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.block.ChangeBlockEvent;
 import org.spongepowered.api.event.entity.AffectEntityEvent;
+import org.spongepowered.api.util.Tuple;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.explosion.Explosion;
@@ -106,6 +106,6 @@ public interface ExplosionEvent extends Event {
          *
          * @return The blocks that the explosion may effect
          */
-        HashMap<Vector3i, Pair<BlockState, Float>> getBlocks();
+        HashMap<Vector3i, Tuple<BlockState, Float>> getBlocks();
     }
 }

--- a/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
@@ -25,7 +25,7 @@
 package org.spongepowered.api.event.world;
 
 import com.flowpowered.math.vector.Vector3i;
-import javafx.util.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;

--- a/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
@@ -88,5 +88,6 @@ public interface ExplosionEvent extends Event {
      * affected blocks) will be included. This is where the block changes can be
      * updated and/or changed.
      */
-    interface Post extends ExplosionEvent, ChangeBlockEvent.Post {}
+    interface Post extends ExplosionEvent, ChangeBlockEvent.Post {
+    }
 }

--- a/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.api.event.world;
 
+import com.flowpowered.math.vector.Vector3i;
+import javafx.util.Pair;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
@@ -33,6 +35,7 @@ import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.explosion.Explosion;
 
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -93,36 +96,16 @@ public interface ExplosionEvent extends Event {
 
     /**
      * An event that is fired when the Explosion fetches the explosion resistance of a block.
-     * Provides the world, block position, block state, and current explosion resistance.
+     * Provides the world, block position, block state, and default and current explosion resistance.
      */
-    interface FetchBlockExplosionResistance extends ExplosionEvent, TargetWorldEvent {
+    interface BlockResistance extends ExplosionEvent, TargetWorldEvent {
 
         /**
-         * Gets the explosion resistance of the block which may have already been altered.
+         * Gets the block positions that will potentially be effected as Vector3i mapped to a Pair containing the BlockState and
+         * explosion resistance of the block located at that position.
          *
-         * @return The current explosion resistance of the block
+         * @return The blocks that the explosion may effect
          */
-        float getResistance();
-
-        /**
-         * Sets the explosion resistance of the block.
-         *
-         * @param resistance The new explosion resistance of the block
-         */
-        void setResistance(float resistance);
-
-        /**
-         * Gets the location of the block being affected.
-         *
-         * @return The location of the block
-         */
-        Location<World> getLocation();
-
-        /**
-         * Gets the BlockState of the block being affected.
-         *
-         * @return The BlockState of the block
-         */
-        BlockState getBlockState();
+        HashMap<Vector3i, Pair<BlockState, Float>> getBlocks();
     }
 }

--- a/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.event.world;
 
+import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.block.ChangeBlockEvent;
@@ -89,4 +90,39 @@ public interface ExplosionEvent extends Event {
      * updated and/or changed.
      */
     interface Post extends ExplosionEvent, ChangeBlockEvent.Post {}
+
+    /**
+     * An event that is fired when the Explosion fetches the explosion resistance of a block.
+     * Provides the world, block position, block state, and current explosion resistance.
+     */
+    interface FetchBlockExplosionResistance extends ExplosionEvent, TargetWorldEvent {
+
+        /**
+         * Gets the explosion resistance of the block which may have already been altered.
+         *
+         * @return The current explosion resistance of the block
+         */
+        float getResistance();
+
+        /**
+         * Sets the explosion resistance of the block.
+         *
+         * @param resistance The new explosion resistance of the block
+         */
+        void setResistance(float resistance);
+
+        /**
+         * Gets the location of the block being affected.
+         *
+         * @return The location of the block
+         */
+        Location<World> getLocation();
+
+        /**
+         * Gets the BlockState of the block being affected.
+         *
+         * @return The BlockState of the block
+         */
+        BlockState getBlockState();
+    }
 }

--- a/src/main/java/org/spongepowered/api/world/explosion/Explosion.java
+++ b/src/main/java/org/spongepowered/api/world/explosion/Explosion.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.world.explosion;
 
 import org.spongepowered.api.Sponge;
-import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.explosive.Explosive;
 import org.spongepowered.api.util.ResettableBuilder;
 import org.spongepowered.api.world.Locatable;
@@ -133,6 +132,15 @@ public interface Explosion extends Locatable {
     }
 
     /**
+     * Gets the {@link ResistanceCalculator} of the Explosion.
+     *
+     * @return The ResistanceCalculator or null if not supported by the implementation
+     */
+    default Optional<ResistanceCalculator> getResistanceCalculator() {
+        return Optional.empty();
+    }
+
+    /**
      * A builder for {@link Explosion}.
      */
     interface Builder extends ResettableBuilder<Explosion, Builder> {
@@ -232,6 +240,17 @@ public interface Explosion extends Locatable {
          * @return This builder, for chaining
          */
         default Builder knockback(double knockback) {
+            return this;
+        }
+
+        /**
+         * Sets the method by which the explosion resistance of an affected block can be obtained or calculated.
+         * Expects a lambda in the form of (BlockState, Vector3i, Explosion) that returns a float.
+         *
+         * @param resistanceCalculator The lambda to use
+         * @return This builder, for chaining
+         */
+        default Builder resistanceCalculator(ResistanceCalculator resistanceCalculator) {
             return this;
         }
 

--- a/src/main/java/org/spongepowered/api/world/explosion/Explosion.java
+++ b/src/main/java/org/spongepowered/api/world/explosion/Explosion.java
@@ -31,8 +31,9 @@ import org.spongepowered.api.world.Locatable;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
+
+import javax.annotation.Nullable;
 
 /**
  * Represents an explosion in a {@link World}.
@@ -104,8 +105,8 @@ public interface Explosion extends Locatable {
      *
      * <p>This value indicates how close to being symmetrical the explosion is.
      * A value of zero indicates a completely symmetrical blast (in all three
-     * dimensions). A larger value indicates a lower likelihood of symmetry. A
-     * value of one indicates the platform default.</p>
+     * dimensions). A larger value indicates a lower likelihood of symmetry.
+     * A value of one indicates the platform default.</p>
      *
      * <p>Note, this is a hint to the implementation. Implementations may not
      * provide the means to produce semi-random form explosions.</p>
@@ -120,8 +121,8 @@ public interface Explosion extends Locatable {
      * Gets the relative strength of the knockback applied to nearby
      * objects that can be knocked back.
      *
-     * <p>Note that the default behavior and strength is not defined here. A
-     * return value of 1 simply indicates the default behavior which is
+     * <p>Note that the default behavior and strength is not defined here.
+     * A return value of 1 simply indicates the default behavior which is
      * implementation dependent.</p>
      *
      * @return The multiple by which the knockback of entities will be changed
@@ -216,11 +217,11 @@ public interface Explosion extends Locatable {
          *
          * <p>This value indicates how close to being symmetrical the explosion is.
          * A value of zero indicates a completely symmetrical blast (in all three
-         * dimensions). A larger value indicates a lower likelihood of symmetry. A
-         * value of one indicates the platform default.</p>
+         * dimensions). A larger value indicates a lower likelihood of symmetry.
+         * A value of one indicates the platform default.</p>
          *
-         * <p>Note, this is a hint to the implementation. Implementations may not
-         * provide the means to produce semi-random form explosions.</p>
+         * <p>Note, this is a hint to the implementation. Implementations might
+         * not provide the means to produce semi-random form explosions.</p>
          *
          * @return This builder, for chaining
          */
@@ -232,8 +233,8 @@ public interface Explosion extends Locatable {
          * Sets the relative strength of the knockback applied to nearby
          * objects that can be knocked back.
          *
-         * <p>Note that the default behavior and strength is not defined here. A
-         * return value of 1 simply indicates the default behavior which is
+         * <p>Note that the default behavior and strength is not defined here.
+         * A return value of 1 simply indicates the default behavior which is
          * implementation dependent.</p>
          *
          * @param knockback The knockback multiple
@@ -244,7 +245,8 @@ public interface Explosion extends Locatable {
         }
 
         /**
-         * Sets the method by which the explosion resistance of an affected block can be obtained or calculated.
+         * Sets the method by which the explosion resistance of an affected
+         * block can be obtained or calculated.
          *
          * @param resistanceCalculator The calculator
          * @return This builder, for chaining

--- a/src/main/java/org/spongepowered/api/world/explosion/Explosion.java
+++ b/src/main/java/org/spongepowered/api/world/explosion/Explosion.java
@@ -31,9 +31,8 @@ import org.spongepowered.api.world.Locatable;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
-import java.util.Optional;
-
 import javax.annotation.Nullable;
+import java.util.Optional;
 
 /**
  * Represents an explosion in a {@link World}.

--- a/src/main/java/org/spongepowered/api/world/explosion/Explosion.java
+++ b/src/main/java/org/spongepowered/api/world/explosion/Explosion.java
@@ -132,8 +132,9 @@ public interface Explosion extends Locatable {
 
     /**
      * Gets the {@link ResistanceCalculator} of the Explosion.
+     * Optional#empty() indicates default behaviour.
      *
-     * @return The ResistanceCalculator or null if not supported by the implementation
+     * @return The ResistanceCalculator
      */
     default Optional<ResistanceCalculator> getResistanceCalculator() {
         return Optional.empty();
@@ -244,9 +245,8 @@ public interface Explosion extends Locatable {
 
         /**
          * Sets the method by which the explosion resistance of an affected block can be obtained or calculated.
-         * Expects a lambda in the form of (BlockState, Vector3i, Explosion) that returns a float.
          *
-         * @param resistanceCalculator The lambda to use
+         * @param resistanceCalculator The calculator
          * @return This builder, for chaining
          */
         default Builder resistanceCalculator(ResistanceCalculator resistanceCalculator) {

--- a/src/main/java/org/spongepowered/api/world/explosion/ResistanceCalculator.java
+++ b/src/main/java/org/spongepowered/api/world/explosion/ResistanceCalculator.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.world.explosion;
+
+import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.block.BlockState;
+
+@FunctionalInterface
+/**
+ * A Functional Interface for the fetching of a Block's explosion resistance during an explosion
+ */
+public interface ResistanceCalculator {
+    /**
+     * A blueprint for a lambda that takes the
+     *
+     * @param blockState
+     * @param blockPosition
+     * @param explosion
+     *
+     * @return
+     */
+    float calculateResistance(final BlockState blockState, final Vector3i blockPosition, final Explosion explosion);
+}

--- a/src/main/java/org/spongepowered/api/world/explosion/ResistanceCalculator.java
+++ b/src/main/java/org/spongepowered/api/world/explosion/ResistanceCalculator.java
@@ -28,17 +28,23 @@ import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.block.BlockState;
 
 /**
- * A Functional Interface for the fetching of a Block's explosion resistance during an explosion
+ * Calculates a Block's resistance to a {@link Explosion}.
  */
 @FunctionalInterface
 public interface ResistanceCalculator {
+
     /**
-     * A blueprint for a lambda that takes three variables; BlockState, Vector3i, and Explosion and returns a float.
+     * Sets the explosion resistance for a block at a given location during an {@link Explosion}.
      *
-     * @param blockState    The state of the block
-     * @param blockPosition The position of the block in the World
-     * @param explosion     The explosion affecting the block
+     * <p>For a list of default Minecraft values see https://minecraft.gamepedia.com/Explosion#Blast_resistance
+     * Returning a negative value is not advised as it will increase the range of the explosion.</p>
+     *
+     * @param blockState        The state of the block
+     * @param blockPosition     The position of the block in the World
+     * @param currentResistance The current resistance of the block
+     * @param explosion         The explosion affecting the block
      * @return The explosion resistance of the block
      */
-    float calculateResistance(final BlockState blockState, final Vector3i blockPosition, final Explosion explosion);
+    float calculateResistance(final BlockState blockState, final Vector3i blockPosition, final float currentResistance, final Explosion explosion);
+
 }

--- a/src/main/java/org/spongepowered/api/world/explosion/ResistanceCalculator.java
+++ b/src/main/java/org/spongepowered/api/world/explosion/ResistanceCalculator.java
@@ -34,10 +34,13 @@ import org.spongepowered.api.block.BlockState;
 public interface ResistanceCalculator {
 
     /**
-     * Sets the explosion resistance for a block at a given location during an {@link Explosion}.
+     * Sets the explosion resistance for a block at a given location
+     * during an {@link Explosion}.
      *
-     * <p>For a list of default Minecraft values see https://minecraft.gamepedia.com/Explosion#Blast_resistance
-     * Returning a negative value is not advised as it will increase the range of the explosion.</p>
+     * <p>For a list of default Minecraft values see
+     * https://minecraft.gamepedia.com/Explosion#Blast_resistance
+     * Returning a negative value is not advised as it will increase
+     * the range of the explosion.</p>
      *
      * @param blockState        The state of the block
      * @param blockPosition     The position of the block in the World

--- a/src/main/java/org/spongepowered/api/world/explosion/ResistanceCalculator.java
+++ b/src/main/java/org/spongepowered/api/world/explosion/ResistanceCalculator.java
@@ -27,19 +27,18 @@ package org.spongepowered.api.world.explosion;
 import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.block.BlockState;
 
-@FunctionalInterface
 /**
  * A Functional Interface for the fetching of a Block's explosion resistance during an explosion
  */
+@FunctionalInterface
 public interface ResistanceCalculator {
     /**
-     * A blueprint for a lambda that takes the
+     * A blueprint for a lambda that takes three variables; BlockState, Vector3i, and Explosion and returns a float.
      *
-     * @param blockState
-     * @param blockPosition
-     * @param explosion
-     *
-     * @return
+     * @param blockState    The state of the block
+     * @param blockPosition The position of the block in the World
+     * @param explosion     The explosion affecting the block
+     * @return The explosion resistance of the block
      */
     float calculateResistance(final BlockState blockState, final Vector3i blockPosition, final Explosion explosion);
 }


### PR DESCRIPTION
[ **SpongeAPI** | [SpongeCommon ](https://github.com/SpongePowered/SpongeCommon/pull/2640)]

Resolves https://github.com/SpongePowered/SpongeAPI/issues/2093

The intention of this PR is to allow plugins to intercept the fetching of a block's explosion resistance and adjust the value dynamically based on the block's location and type.

Example Usage:
```
   public void changeBlockResistance(ExplosionEvent.BlockResistance event) {

        for (Map.Entry<Vector3i, Pair<BlockState, Float>> entry : event.getBlocks().entrySet()) {
            Vector3i blockPos = entry.getKey();
            Pair<BlockState, Float> pair = entry.getValue();


            float newResistance = pair.getValue();
            if (Settings.DurabilityOverride != null && Settings.DurabilityOverride.containsKey(pair.getKey().getType())) {
                newResistance = Settings.DurabilityOverride.get(pair.getKey().getType());
            }

            for (Craft craft : CraftManager.getInstance().getCraftsFromLocation(new Location<>(event.getTargetWorld(), blockPos))) {
                float testNum = pair.getValue() * (1F + ((float) craft.getSize() / 50000F));

                if (testNum > newResistance) {
                    newResistance = testNum;
                }
            }

            event.getBlocks().put(entry.getKey(), Pair.of(pair.getKey(), newResistance));
        }
    }
```