### PR TITLE
[API-8] Add direction methods on Entity and Living

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -46,7 +46,9 @@ import org.spongepowered.api.world.TeleportHelper;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.schematic.Schematic;
 import org.spongepowered.api.world.server.ServerWorld;
+import org.spongepowered.math.imaginary.Quaterniond;
 import org.spongepowered.math.vector.Vector3d;
+import org.spongepowered.math.vector.Vector3i;
 
 import java.util.Collection;
 import java.util.EnumSet;
@@ -156,6 +158,16 @@ public interface Entity extends Identifiable, Locatable, SerializableDataHolder.
      * @param rotation The rotation to set the entity to
      */
     void setRotation(Vector3d rotation);
+
+    /**
+     * Gets the unit vector representing the direction of this entity.
+     *
+     * @return The direction
+     */
+    default Vector3d getDirection() {
+        Vector3d rotation = this.getRotation();
+        return Quaterniond.fromAxesAnglesDeg(rotation.getX(), -rotation.getY(), rotation.getZ()).getDirection();
+    }
 
     /**
      * Moves the entity to the specified location and sets the rotation.

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -165,7 +165,7 @@ public interface Entity extends Identifiable, Locatable, SerializableDataHolder.
      * @return The direction
      */
     default Vector3d getDirection() {
-        Vector3d rotation = this.getRotation();
+        final Vector3d rotation = this.getRotation();
         return Quaterniond.fromAxesAnglesDeg(rotation.getX(), -rotation.getY(), rotation.getZ()).getDirection();
     }
 

--- a/src/main/java/org/spongepowered/api/entity/living/Living.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Living.java
@@ -99,7 +99,7 @@ public interface Living extends Entity, EntityProjectileSource, TeamMember {
      * @return The direction of the head
      */
     default Vector3d getHeadDirection() {
-        Vector3d headRotation = this.headRotation().get();
+        final Vector3d headRotation = this.headRotation().get();
         return Quaterniond.fromAxesAnglesDeg(headRotation.getX(), -headRotation.getY(), headRotation.getZ()).getDirection();
     }
 }

--- a/src/main/java/org/spongepowered/api/entity/living/Living.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Living.java
@@ -31,6 +31,7 @@ import org.spongepowered.api.effect.potion.PotionEffect;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.projectile.source.EntityProjectileSource;
 import org.spongepowered.api.scoreboard.TeamMember;
+import org.spongepowered.math.imaginary.Quaterniond;
 import org.spongepowered.math.vector.Vector3d;
 
 import java.util.Optional;
@@ -91,4 +92,14 @@ public interface Living extends Entity, EntityProjectileSource, TeamMember {
      * @param targetPos Position to target
      */
     void lookAt(Vector3d targetPos);
+
+    /**
+     * Converts the {@link Living}'s head rotation into a quaternion direction unit vector.
+     *
+     * @return The direction of the head
+     */
+    default Vector3d getHeadDirection() {
+        Vector3d headRotation = this.headRotation().get();
+        return Quaterniond.fromAxesAnglesDeg(headRotation.getX(), -headRotation.getY(), headRotation.getZ()).getDirection();
+    }
 }


### PR DESCRIPTION
This PR adds `Entity#getDirection()` and `Living#getHeadDirection()`, analogous to Bukkit's `getDirection()` methods. This has become a common enough use case that I've added a trick to the Discord bot that shows how to get the direction currently. Therefore, I think it's finally time for Sponge to have the methods builtin.

I'm open to also adding `Transform#getDirection()`, but unsure if there's much point to it, if you can just do `transform.getRotationAsQuaternion().getDirection()`.