### PR TITLE
[API-8] Adjust NamedCatalogType and NamedCatalogBuilder interfaces for expectations

### DIFF
--- a/src/main/java/org/spongepowered/api/NamedCatalogType.java
+++ b/src/main/java/org/spongepowered/api/NamedCatalogType.java
@@ -38,7 +38,5 @@ public interface NamedCatalogType extends CatalogType {
      *
      * @return The human-readable name of this dummy type
      */
-    default String getName() {
-        return this.getKey().getValue();
-    }
+    String getName();
 }

--- a/src/main/java/org/spongepowered/api/util/NamedCatalogBuilder.java
+++ b/src/main/java/org/spongepowered/api/util/NamedCatalogBuilder.java
@@ -31,5 +31,7 @@ public interface NamedCatalogBuilder<C extends NamedCatalogType, B extends Reset
 
     B name(String name);
 
-    B name(Translation translation);
+    default B name(Translation translation) {
+        return this.name(translation.get());
+    }
 }


### PR DESCRIPTION
Two things this PR does:

> Remove the default implementation of `NamedCatalogType#getName`

If we were to keep this default implementation, we're right back at the issue of api 7's `CatalogType`. If plugin devs want their catalog types to have names, the names should be meaningful.

> Make `NamedCatalogBuilder#name(Translation)` default implemented

I expect that most plugin devs will not care about translations for their catalog type names, and will just want quick and dirty (yet still meaningful) names.