### PR TITLE
Remove EconomyService#getCurrencies

### DIFF
--- a/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
+++ b/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
@@ -57,21 +57,6 @@ public interface EconomyService extends ContextualService<Account> {
     Currency getDefaultCurrency();
 
     /**
-     * Returns the {@link Set} of supported {@link Currency} objects that are
-     * implemented by this EconomyService.
-     *
-     * <p>The economy service provider may only support one currency, in which
-     * case {@link #getDefaultCurrency()} will be the only member of the set.
-     * </p>
-     *
-     * <p>The set returned is a read-only a view of all currencies available in
-     * the EconomyService.</p>
-     *
-     * @return The {@link Set} of all {@link Currency}s
-     */
-    Set<Currency> getCurrencies();
-
-    /**
      * Returns whether a {@link UniqueAccount} exists with the specified
      * {@link UUID}.
      *


### PR DESCRIPTION
Back when the Economy API was added `Currency` was not a Catalog type and there was no CurrencyRegistryModule.

Later (https://github.com/SpongePowered/SpongeAPI/commit/c6fa6a62961784a7ca7e0e047c8071544ca770d4) `Currency` was made a Catalog type with a `PluginProvidedRegistryModule`. This PR removes the old method.