### PR TITLE
[API-8] Add missing Living value accessors

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/living/Living.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Living.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.effect.potion.PotionEffect;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.attribute.Attribute;
 import org.spongepowered.api.entity.attribute.AttributeHolder;
+import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.projectile.source.EntityProjectileSource;
 import org.spongepowered.api.scoreboard.TeamMember;
 import org.spongepowered.math.imaginary.Quaterniond;
@@ -45,6 +46,22 @@ import java.util.Optional;
  * invisible.</p>
  */
 public interface Living extends AttributeHolder, Entity, EntityProjectileSource, TeamMember {
+
+    /**
+     * {@link Keys#ABSORPTION}
+     * @return The amount of {@link org.spongepowered.api.effect.potion.PotionEffectTypes#ABSORPTION}
+     */
+    default Value.Mutable<Double> absorption() {
+        return this.requireValue(Keys.ABSORPTION).asMutable();
+    }
+
+    /**
+     * {@link Keys#ACTIVE_ITEM}
+     * @return The active item, such as food being eaten
+     */
+    default Value.Mutable<ItemStackSnapshot> activeItem() {
+        return this.requireValue(Keys.ACTIVE_ITEM).asMutable();
+    }
 
     /**
      * {@link Keys#HEALTH}
@@ -108,6 +125,38 @@ public interface Living extends AttributeHolder, Entity, EntityProjectileSource,
      */
     default Value.Mutable<Double> fallDistance() {
         return this.requireValue(Keys.FALL_DISTANCE).asMutable();
+    }
+
+    /**
+     * {@link Keys#MAX_AIR}
+     * @return The max air supply
+     */
+    default Value.Mutable<Integer> maxAir() {
+        return this.requireValue(Keys.MAX_AIR).asMutable();
+    }
+
+    /**
+     * {@link Keys#REMAINING_AIR}
+     * @return The remaining air supply
+     */
+    default Value.Mutable<Integer> remainingAir() {
+        return this.requireValue(Keys.REMAINING_AIR).asMutable();
+    }
+
+    /**
+     * {@link Keys#STUCK_ARROWS}
+     * @return The amount of stuck arrows
+     */
+    default Value.Mutable<Integer> stuckArrows() {
+        return this.requireValue(Keys.STUCK_ARROWS).asMutable();
+    }
+
+    /**
+     * {@link Keys#WALKING_SPEED}
+     * @return The base walking speed
+     */
+    default Value.Mutable<Double> walkingSpeed() {
+        return this.requireValue(Keys.WALKING_SPEED).asMutable();
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/living/Living.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Living.java
@@ -82,24 +82,24 @@ public interface Living extends AttributeHolder, Entity, EntityProjectileSource,
      * {@link Keys#EYE_HEIGHT}
      * @return The height of the eyes
      */
-    default Value.Immutable<Double> eyeHeight() {
-        return this.requireValue(Keys.EYE_HEIGHT).asImmutable();
+    default Value<Double> eyeHeight() {
+        return this.requireValue(Keys.EYE_HEIGHT);
     }
 
     /**
      * {@link Keys#EYE_POSITION}
      * @return The position of the eyes
      */
-    default Value.Immutable<Vector3d> eyePosition() {
-        return this.requireValue(Keys.EYE_POSITION).asImmutable();
+    default Value<Vector3d> eyePosition() {
+        return this.requireValue(Keys.EYE_POSITION);
     }
 
     /**
      * {@link Keys#LAST_DAMAGE_RECEIVED}
      * @return The last damage received
      */
-    default Optional<Value.Immutable<Double>> lastDamageReceived() {
-        return this.getValue(Keys.LAST_DAMAGE_RECEIVED).map(Value::asImmutable);
+    default Optional<Value<Double>> lastDamageReceived() {
+        return this.getValue(Keys.LAST_DAMAGE_RECEIVED);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/living/Living.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Living.java
@@ -103,6 +103,14 @@ public interface Living extends AttributeHolder, Entity, EntityProjectileSource,
     }
 
     /**
+     * {@link Keys#FALL_DISTANCE}
+     * @return The fall distance
+     */
+    default Value.Mutable<Double> fallDistance() {
+        return this.requireValue(Keys.FALL_DISTANCE).asMutable();
+    }
+
+    /**
      * Makes the entity look at the specified target position.
      *
      * @param targetPos Position to target

--- a/src/main/java/org/spongepowered/api/entity/living/Living.java
+++ b/src/main/java/org/spongepowered/api/entity/living/Living.java
@@ -79,6 +79,22 @@ public interface Living extends AttributeHolder, Entity, EntityProjectileSource,
     }
 
     /**
+     * {@link Keys#EYE_HEIGHT}
+     * @return The height of the eyes
+     */
+    default Value.Immutable<Double> eyeHeight() {
+        return this.requireValue(Keys.EYE_HEIGHT).asImmutable();
+    }
+
+    /**
+     * {@link Keys#EYE_POSITION}
+     * @return The position of the eyes
+     */
+    default Value.Immutable<Vector3d> eyePosition() {
+        return this.requireValue(Keys.EYE_POSITION).asImmutable();
+    }
+
+    /**
      * {@link Keys#LAST_DAMAGE_RECEIVED}
      * @return The last damage received
      */


### PR DESCRIPTION
Adds value accessors for the following keys to `Living`:
- `ABSORPTION`
- `ACTIVE_ITEM`
- `EYE_HEIGHT`
- `EYE_POSITION`
- `FALL_DISTANCE`
- `MAX_AIR`
- `REMAINING_AIR`
- `STUCK_ARROWS`
- `WALKING_SPEED`