### PR TITLE
[API-8] Add ExplosionEvent.Detonate#filterAffectedLocations

### DIFF
--- a/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
@@ -33,7 +33,10 @@ import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.explosion.Explosion;
 import org.spongepowered.api.world.server.ServerWorld;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Called when an {@link Explosion} occurs in a {@link World}.
@@ -94,6 +97,32 @@ public interface ExplosionEvent extends Event {
          * @return The list of blocks that will be affected by the explosion
          */
         List<ServerLocation> getAffectedLocations();
+
+        /**
+         * Filters out {@link ServerLocation}'s from
+         * {@link #getAffectedLocations()} to be affected by this event.
+         *
+         * <p>Locations for which the predicate returns <code>false</code> will
+         * be removed from {@link #getAffectedLocations()}.</p>
+         *
+         * @param predicate The predicate to use for filtering
+         * @return The locations removed from {@link #getAffectedLocations()}
+         */
+        default List<ServerLocation> filterAffectedLocations(Predicate<ServerLocation> predicate) {
+            final List<ServerLocation> removedLocations = new ArrayList<>();
+
+            final Iterator<ServerLocation> iter = this.getAffectedLocations().iterator();
+            while (iter.hasNext()) {
+                final ServerLocation location = iter.next();
+
+                if (!predicate.test(location)) {
+                    iter.remove();
+                    removedLocations.add(location);
+                }
+            }
+
+            return removedLocations;
+        }
     }
 
     /**


### PR DESCRIPTION
This makes it easier for protection plugins to remove locations, and mirrors `AffectEntityEvent#filterEntityLocations(Predicate<ServerLocation>)`.