### PR TITLE
Add view-distance setter

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/living/player/server/ServerPlayer.java
+++ b/src/main/java/org/spongepowered/api/entity/living/player/server/ServerPlayer.java
@@ -123,6 +123,14 @@ public interface ServerPlayer extends Player, Subject {
     int getViewDistance();
 
     /**
+     * Sets the view distance setting of the player. This value represents the
+     * radius (around the player) in unit chunks.
+     *
+     * @param distance The player's view distance
+     */
+    void setViewDistance(int distance);
+
+    /**
      * Gets the current player chat visibility setting.
      *
      * @return Chat visibility setting


### PR DESCRIPTION
Fix https://github.com/SpongePowered/SpongeAPI/issues/1682

In stable-7 `Player#getViewDistance` was used on the client to get the clientside view-distance setting. In api-8 the method was moved to `ServerPlayer` but the setter was missing.