### PR TITLE
Refactor EconomyTransactionEvent

### DIFF
--- a/src/main/java/org/spongepowered/api/event/economy/EconomyTransactionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/economy/EconomyTransactionEvent.java
@@ -24,20 +24,71 @@
  */
 package org.spongepowered.api.event.economy;
 
+import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
+import org.spongepowered.api.service.economy.Currency;
 import org.spongepowered.api.service.economy.EconomyService;
+import org.spongepowered.api.service.economy.account.Account;
 import org.spongepowered.api.service.economy.transaction.TransactionResult;
+import org.spongepowered.api.service.economy.transaction.TransactionType;
+
+import java.math.BigDecimal;
 
 /**
- * Fired when the {@link EconomyService} has processed a transaction.
+ * Fired when the {@link EconomyService} is processing a transaction.
  */
 public interface EconomyTransactionEvent extends Event {
 
     /**
-     * Gets the {@link TransactionResult} for the transaction that occurred.
-     *
-     * @return The {@link TransactionResult}
+     * Called before processing a transaction
      */
-    TransactionResult transactionResult();
+    interface Pre extends EconomyTransactionEvent, Cancellable {
+
+        /**
+         * Gets the {@link Account} involved in the transaction.
+         *
+         * @return The {@link Account}
+         */
+        Account getTargetAccount();
+
+        /**
+         * Gets the {@link Currency} involved in the transaction.
+         *
+         * @return The {@link Currency}
+         */
+        Currency getCurrency();
+
+        /**
+         * Gets the amount of the {@link Currency} involved in the transaction.
+         *
+         * @return The amount
+         */
+        BigDecimal getAmount();
+
+        /**
+         * Sets the amount of the {@link Currency} involved in the transaction.
+         */
+        void setAmount(BigDecimal amount);
+
+        /**
+         * Returns the {@link TransactionType} of this transaction.
+         *
+         * @return type of Transaction
+         */
+        TransactionType getType();
+    }
+
+    /**
+     * Called after processing a transaction
+     */
+    interface Post extends EconomyTransactionEvent {
+
+        /**
+         * Gets the {@link TransactionResult} for the transaction that occurred.
+         *
+         * @return The {@link TransactionResult}
+         */
+        TransactionResult transactionResult();
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/event/economy/EconomyTransactionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/economy/EconomyTransactionEvent.java
@@ -59,6 +59,13 @@ public interface EconomyTransactionEvent extends Event {
         Currency getCurrency();
 
         /**
+         * Gets the original amount of the {@link Currency} involved in the transaction.
+         *
+         * @return The amount
+         */
+        BigDecimal getOriginalAmount();
+
+        /**
          * Gets the amount of the {@link Currency} involved in the transaction.
          *
          * @return The amount

--- a/src/main/java/org/spongepowered/api/event/economy/EconomyTransactionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/economy/EconomyTransactionEvent.java
@@ -49,7 +49,7 @@ public interface EconomyTransactionEvent extends Event {
          *
          * @return The {@link Account}
          */
-        Account getTargetAccount();
+        Account getAccount();
 
         /**
          * Gets the {@link Currency} involved in the transaction.


### PR DESCRIPTION
Part of the Economy API refactor.

Fix https://github.com/SpongePowered/SpongeAPI/issues/1501

`EconomyTransactionEvent` is now split between

Pre: is fired **BEFORE** the transaction has been processed (it can still fails and is cancellable).
Post: is fired **AFTER** the transaction has been processed. This is read-only and the transaction result can be used to reliably check the result of the transaction.
