### PR TITLE
Make generic ExplosionEvent cancellable

### DIFF
--- a/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/ExplosionEvent.java
@@ -41,7 +41,7 @@ import java.util.function.Predicate;
 /**
  * Called when an {@link Explosion} occurs in a {@link World}.
  */
-public interface ExplosionEvent extends Event {
+public interface ExplosionEvent extends Event, Cancellable {
 
     /**
      * Gets the {@link Explosion}.
@@ -53,7 +53,7 @@ public interface ExplosionEvent extends Event {
     /**
      * An event that is fired before the explosion occurs.
      */
-    interface Pre extends ExplosionEvent, Cancellable {
+    interface Pre extends ExplosionEvent {
 
         /**
          * Gets the {@link ServerWorld world}.


### PR DESCRIPTION
Fix https://github.com/SpongePowered/SpongeAPI/issues/1408

The related issue explained it very well:

> All of the sub-events of ExplosionEvent extend Cancellable in some way, shape or form.
> 
> It would make sense to declare ExplosionEvent as Cancellable to make it easier to work with if a listener is just listening for the base event.