### PR TITLE
Use a double for damage related keys.

### DIFF
--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -585,7 +585,7 @@ public final class Keys {
      * The damage absorbed by an armor {@link ItemStack}.
      * Readonly
      */
-    public static final Supplier<Key<Value<Integer>>> DAMAGE_ABSORPTION = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "DAMAGE_ABSORPTION");
+    public static final Supplier<Key<Value<Double>>> DAMAGE_ABSORPTION = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "DAMAGE_ABSORPTION");
 
     /**
      * How much damage a {@link FallingBlock} deals to {@link Living} entities
@@ -1756,7 +1756,7 @@ public final class Keys {
     /**
      * The maximum damage a {@link FallingBlock} can deal.
      */
-    public static final Supplier<Key<Value<Integer>>> MAX_FALL_DAMAGE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "MAX_FALL_DAMAGE");
+    public static final Supplier<Key<Value<Double>>> MAX_FALL_DAMAGE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "MAX_FALL_DAMAGE");
 
     /**
      * The maximum health of a {@link Living}.

--- a/src/main/java/org/spongepowered/api/entity/FallingBlock.java
+++ b/src/main/java/org/spongepowered/api/entity/FallingBlock.java
@@ -54,7 +54,7 @@ public interface FallingBlock extends Entity {
      * {@link Keys#MAX_FALL_DAMAGE}
      * @return The maximum fall damage
      */
-    default Value.Mutable<Integer> maxFallDamage() {
+    default Value.Mutable<Double> maxFallDamage() {
         return this.requireValue(Keys.MAX_FALL_DAMAGE).asMutable();
     }
 


### PR DESCRIPTION
API | [Common](https://github.com/SpongePowered/SpongeCommon/pull/3095)

Using an int is an impl detail, damage is represented as doubles.