### PR TITLE
Redo some of the Parameter.Key generics

### DIFF
--- a/src/main/java/org/spongepowered/api/command/manager/CommandManager.java
+++ b/src/main/java/org/spongepowered/api/command/manager/CommandManager.java
@@ -37,6 +37,7 @@ import org.spongepowered.plugin.PluginContainer;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 
 /**
@@ -113,6 +114,13 @@ public interface CommandManager {
      * @return The completions
      */
     List<String> suggest(Subject subject, Audience receiver, String arguments);
+
+    /**
+     * Gets all the command aliases known to this command manager.
+     *
+     * @return The known aliases
+     */
+    Set<String> getKnownAliases();
 
     /**
      * Registers a set of command aliases with this manager.

--- a/src/main/java/org/spongepowered/api/command/parameter/CommandContext.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/CommandContext.java
@@ -71,7 +71,7 @@ public interface CommandContext extends CommandCause {
      * @throws IllegalArgumentException if more than one value for the key was
      *                                  found
      */
-    <T> Optional<T> getOne(Parameter.Key<? super T> key) throws IllegalArgumentException;
+    <T> Optional<T> getOne(Parameter.Key<T> key) throws IllegalArgumentException;
 
     /**
      * Gets the value for the given key if the key has only one value,
@@ -99,7 +99,7 @@ public interface CommandContext extends CommandCause {
      * @throws IllegalArgumentException if more than one value for the key was
      *                                  found
      */
-    <T> T requireOne(Parameter.Key<? super T> key) throws NoSuchElementException, IllegalArgumentException;
+    <T> T requireOne(Parameter.Key<T> key) throws NoSuchElementException, IllegalArgumentException;
 
     /**
      * Gets all values for the given argument. May return an empty list if no
@@ -121,7 +121,7 @@ public interface CommandContext extends CommandCause {
      * @param <T> the type of value to get
      * @return the collection of all values
      */
-    <T> Collection<? extends T> getAll(Parameter.Key<? super T> key);
+    <T> Collection<? extends T> getAll(Parameter.Key<T> key);
 
     /**
      * A builder for creating this context.
@@ -168,7 +168,7 @@ public interface CommandContext extends CommandCause {
          * @param key The key to store the entry under.
          * @param object The object to store.
          */
-        <T> void putEntry(Parameter.Key<? super T> key, T object);
+        <T> void putEntry(Parameter.Key<T> key, T object);
 
         /**
          * Starts a {@link Transaction} which allows for this builder to be

--- a/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
@@ -848,7 +848,7 @@ public interface Parameter {
          *
          * @return The key.
          */
-        Key<? super T> getKey();
+        Key<T> getKey();
 
         /**
          * The {@link ValueParser}s to use when parsing an argument. They will be

--- a/src/main/java/org/spongepowered/api/util/TypeTokens.java
+++ b/src/main/java/org/spongepowered/api/util/TypeTokens.java
@@ -33,6 +33,7 @@ import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.block.entity.BlockEntity;
 import org.spongepowered.api.block.entity.BlockEntityArchetype;
+import org.spongepowered.api.command.manager.CommandMapping;
 import org.spongepowered.api.data.persistence.DataSerializable;
 import org.spongepowered.api.data.meta.BannerPatternLayer;
 import org.spongepowered.api.data.type.ArmorMaterial;
@@ -196,6 +197,8 @@ public final class TypeTokens {
     public static final TypeToken<Color> COLOR_TOKEN = new TypeToken<Color>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<Value<Color>> COLOR_VALUE_TOKEN = new TypeToken<Value<Color>>() {private static final long serialVersionUID = -1;};
+
+    public static final TypeToken<CommandMapping> COMMAND_MAPPING = new TypeToken<CommandMapping>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<ComparatorMode> COMPARATOR_MODE_TOKEN = new TypeToken<ComparatorMode>() {private static final long serialVersionUID = -1;};
 


### PR DESCRIPTION
Turns out that what I had meant that you'd lose all the type safety that I sought to bring. The generics are functionally equivalent to what we had now.

Also, added getKnownAliases to the command manager.