### PR TITLE
Revert "Update Guice to 4.2.3"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile 'com.google.code.findbugs:jsr305:3.0.1'
 
     // Dependency injection
-    compile 'com.google.inject:guice:4.2.3'
+    compile 'com.google.inject:guice:4.1.0'
 
     // Java 8 high performance cache (+ wrapper for Guava)
     compile 'com.github.ben-manes.caffeine:caffeine:2.5.4'


### PR DESCRIPTION
Reverts SpongePowered/SpongeAPI#2123

What we hadn't realised is that some of the new features of Guice 4.2.x rely on a newer version of Guava (23) that Mojang ships (21). While we didn't encounter this issue in testing because we don't/won't use any of these features, if we're on this version, a plugin might. It is therefore unsafe to remain on this version.

We're kind of tied to the version of Guava that Mojang uses on this one.

As the change is only in API snapshots, we can do this.