### PR TITLE
Add command flags

### DIFF
--- a/src/main/java/org/spongepowered/api/command/Command.java
+++ b/src/main/java/org/spongepowered/api/command/Command.java
@@ -33,6 +33,7 @@ import org.spongepowered.api.command.exception.ArgumentParseException;
 import org.spongepowered.api.command.exception.CommandException;
 import org.spongepowered.api.command.parameter.CommandContext;
 import org.spongepowered.api.command.parameter.Parameter;
+import org.spongepowered.api.command.parameter.managed.Flag;
 import org.spongepowered.api.command.registrar.tree.CommandTreeBuilder;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.EventContext;
@@ -210,6 +211,13 @@ public interface Command {
     interface Parameterized extends Command, CommandExecutor {
 
         /**
+         * The {@link List} of {@link Flag}s that this {@link Command} contains.
+         *
+         * @return A copy of the collection of {@link Flag}s.
+         */
+        List<Flag> flags();
+
+        /**
          * The {@link List} of {@link Parameter}s that this {@link Command}
          * contains.
          *
@@ -309,9 +317,8 @@ public interface Command {
          * <p>Children added here will be added to the beginning of the
          * {@link Parameter}s. Note that if you wish to add a subcommand
          * in the middle of the parameters, you can do so by creating a
-         * {@link org.spongepowered.api.command.parameter.Parameter.Subcommand}
-         * and adding that as a {@link #parameter(Parameter)} at the
-         * appropriate time.</p>
+         * {@link Parameter.Subcommand} and adding that as a
+         * {@link #parameter(Parameter)} at the appropriate time.</p>
          *
          * @param children The {@link Map} that contains a mapping of keys to
          *                 their respective {@link Command} children.
@@ -326,6 +333,19 @@ public interface Command {
 
             return this;
         }
+
+        /**
+         * Adds a flag to this command. Flags are always the first arguments of
+         * a command. There are no set rules for the order of execution of
+         * flags (unlike {@link #parameter(Parameter)}), and all flags are
+         * considered optional.
+         *
+         * <p>Duplicate keys and/or duplicate aliases may not be provided.</p>
+         *
+         * @param flag The {@link Flag} to support
+         * @return Ths builder, for chaining
+         */
+        Builder flag(Flag flag);
 
         /**
          * Adds a parameter for use when parsing arguments. When executing a

--- a/src/main/java/org/spongepowered/api/command/parameter/ArgumentReader.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/ArgumentReader.java
@@ -26,7 +26,10 @@ package org.spongepowered.api.command.parameter;
 
 import com.google.gson.JsonObject;
 import net.kyori.adventure.text.Component;
+import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.command.exception.ArgumentParseException;
+import org.spongepowered.api.command.parameter.managed.ValueParser;
+import org.spongepowered.api.command.parameter.managed.clientcompletion.ClientCompletionTypes;
 
 /**
  * An {@link ArgumentReader} allows for sequential reading of an input
@@ -147,6 +150,11 @@ public interface ArgumentReader {
          *
          * <p>Numbers may begin with "-" to indicate a negative number</p>
          *
+         * <p>When using this in your parser, you should set
+         * {@link ValueParser#getClientCompletionType()} to
+         * {@link ClientCompletionTypes#WHOLE_NUMBER} to tell the client that
+         * the client completion should be an integer.</p>
+         *
          * @return The integer
          * @throws ArgumentParseException if the cursor is not at a number
          *                                character
@@ -160,6 +168,11 @@ public interface ArgumentReader {
          *
          * <p>Numbers may begin with "-" to indicate a negative number, and one
          * period (".") may be present in the string.</p>
+         *
+         * <p>When using this in your parser, you should set
+         * {@link ValueParser#getClientCompletionType()} to
+         * {@link ClientCompletionTypes#DECIMAL_NUMBER} to tell the client that
+         * the client completion should be a floating point number.</p>
          *
          * @return The double
          * @throws ArgumentParseException if the cursor is not at a number
@@ -175,11 +188,55 @@ public interface ArgumentReader {
          * <p>Numbers may begin with "-" to indicate a negative number, and one
          * period (".") may be present in the string.</p>
          *
+         * <p>When using this in your parser, you should set
+         * {@link ValueParser#getClientCompletionType()} to
+         * {@link ClientCompletionTypes#DECIMAL_NUMBER} to tell the client that
+         * the client completion should be a floating point number.</p>
+         *
          * @return The double
          * @throws ArgumentParseException if the cursor is not at a number
          *                                character
          */
         float parseFloat() throws ArgumentParseException;
+
+        /**
+         * Attempts to read a string that is in a {@link ResourceKey} format,
+         * which is {@code namespace:identifier}.
+         *
+         * <p>This parser is a <strong>strict parser</strong>. If the input is
+         * not of the format specified above, this will fail. If you are
+         * potentially expecting a non-namespaced key, but would like to accept
+         * such strings with a default namespace, use
+         * {@link #parseResourceKey(String)}</p>
+         *
+         * <p>When using this in your parser, you should set
+         * {@link ValueParser#getClientCompletionType()} to
+         * {@link ClientCompletionTypes#RESOURCE_KEY} to tell the client that
+         * the client completion should be a {@link ResourceKey}, so that your
+         * users will not be told to put their argument in quotation marks.</p>
+         *
+         * @return The {@link ResourceKey}
+         * @throws ArgumentParseException if a key could not be parsed
+         */
+        ResourceKey parseResourceKey() throws ArgumentParseException;
+
+        /**
+         * Attempts to read a string that is in a {@link ResourceKey} format,
+         * which is {@code namespace:identifier}.
+         *
+         * <p>If no colon is encountered, the default namespace defined below
+         * will be used as the namespace.</p>
+         *
+         * <p>When using this in your parser, you should set
+         * {@link ValueParser#getClientCompletionType()} to
+         * {@link ClientCompletionTypes#RESOURCE_KEY} to tell the client that
+         * the client completion should be a {@link ResourceKey}, so that your
+         * users will not be told to put their argument in quotation marks.</p>
+         *
+         * @return The {@link ResourceKey}
+         * @throws ArgumentParseException if a key could not be parsed
+         */
+        ResourceKey parseResourceKey(String defaultNamespace) throws ArgumentParseException;
 
         /**
          * Gets the next word in the input from the position of the cursor. This
@@ -196,6 +253,23 @@ public interface ArgumentReader {
          * instead <strong>unless</strong> you are expecting a double quote
          * mark at the beginning of your string and this is part of the
          * argument you wish to return.</p>
+         *
+         * <p>The following characters will be parsed as part of a valid string
+         * without the need for quotation marks.</p>
+         *
+         * <ul>
+         * <li>Alphanumeric symbols</li>
+         * <li>Underscores (_)</li>
+         * <li>Hyphens (-)</li>
+         * <li>Periods (.)</li>
+         * <li>Plus signs (+)</li>
+         * </ul>
+         *
+         * <p>If you require other symbols, use {@link #parseString()} and ensure
+         * that users are aware they need to surround their inputs with double
+         * quotation marks. Alternatively, consider whether other parse types are
+         * suitable (for example, if you are expecting a {@link ResourceKey}, use
+         * {@link #parseResourceKey()} or {@link #parseResourceKey(String)}.</p>
          *
          * @return The parsed {@link String}
          * @throws ArgumentParseException if a {@link String} could not be read
@@ -252,6 +326,11 @@ public interface ArgumentReader {
         /**
          * Parses a Json string, returning that string.
          *
+         * <p>When using this in your parser, you should set
+         * {@link ValueParser#getClientCompletionType()} to
+         * {@link ClientCompletionTypes#JSON} to tell the client that
+         * the client completion should be a JSON string.</p>
+         *
          * @return The string
          * @throws ArgumentParseException if a Json string could not be read
          */
@@ -259,6 +338,11 @@ public interface ArgumentReader {
 
         /**
          * Parses a {@link JsonObject}, else throws an exception.
+         *
+         * <p>When using this in your parser, you should set
+         * {@link ValueParser#getClientCompletionType()} to
+         * {@link ClientCompletionTypes#JSON} to tell the client that
+         * the client completion should be a JSON string.</p>
          *
          * @return A {@link JsonObject}
          * @throws ArgumentParseException if a {@link JsonObject} could not be

--- a/src/main/java/org/spongepowered/api/command/parameter/CommandContext.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/CommandContext.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.command.parameter;
 
 import org.spongepowered.api.command.CommandCause;
+import org.spongepowered.api.command.parameter.managed.Flag;
 import org.spongepowered.api.event.cause.Cause;
 
 import java.util.Collection;
@@ -40,6 +41,48 @@ import java.util.Optional;
  * {@link Cause} of the command.</p>
  */
 public interface CommandContext extends CommandCause {
+
+    /**
+     * Gets if a flag with given alias was specified at least once.
+     *
+     * <p>If the flag has multiple aliases, (for example, {@code -f} and
+     * {@code --flag}, passing {@code f} or {@code flag} to this method will
+     * return the same result, regardless of the alias specified by the user.
+     * </p>
+     *
+     * @param flagAlias The flag's alias (without a prefixed dash)
+     * @return If the flag was specified
+     */
+    boolean hasFlag(String flagAlias);
+
+    /**
+     * Gets if the given flag was specified once.
+     *
+     * @param flag The {@link Flag}
+     * @return If the flag was specified
+     */
+    boolean hasFlag(Flag flag);
+
+    /**
+     * Returns how many times a given flag was invoked for this command.
+     *
+     * <p>If the flag has multiple aliases, (for example, {@code -f} and
+     * {@code --flag}, passing {@code f} or {@code flag} to this method will
+     * return the same result, regardless of the alias specified by the user.
+     * </p>
+     *
+     * @param flagKey The flag's alias (without a prefixed dash)
+     * @return The number of times the flag was specified
+     */
+    int getFlagInvocationCount(String flagKey);
+
+    /**
+     * Returns how many times a given {@link Flag} was invoked for this command.
+     *
+     * @param flag The {@link Flag}
+     * @return The number of times the flag was specified
+     */
+    int getFlagInvocationCount(Flag flag);
 
     /**
      * Returns whether this context has any value for the given argument key.
@@ -127,6 +170,13 @@ public interface CommandContext extends CommandCause {
      * A builder for creating this context.
      */
     interface Builder extends CommandContext {
+
+        /**
+         * Adds a flag invocation to the context.
+         *
+         * @param flag The flag to add the invocation for.
+         */
+        void addFlagInvocation(Flag flag);
 
         /**
          * Adds a parsed object into the context, for use by commands.

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/Flag.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/Flag.java
@@ -1,0 +1,184 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.parameter.managed;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.Command;
+import org.spongepowered.api.command.CommandCause;
+import org.spongepowered.api.command.parameter.CommandContext;
+import org.spongepowered.api.command.parameter.Parameter;
+import org.spongepowered.api.util.ResettableBuilder;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * Represents a flag on a {@link Command}
+ *
+ * <p>A flag is a parameter is either:</p>
+ *
+ * <ul>
+ *     <li>a single dash, follows by a single character (e.g. {@code -a}, or
+ *     </li>
+ *     <li>two dashes, followed by multiple characters (e.g. {@code --all}).</li>
+ * </ul>
+ *
+ * <p>In both cases, a flag may have an execution requirement upon them
+ * restricting who may use the flag (typically a permission) and/or an
+ * associated {@link Parameter} that occurs after the flag definition, which
+ * may or may not be optional. Flags may be specified more than once in a
+ * command string, but may only appear at the beginning of a {@link Command}.
+ * For {@link Parameter.Subcommand}s, this is directly after the literal which
+ * starts that subcommand.</p>
+ *
+ * <p>To check whether the flag was specified in the command, call
+ * {@link CommandContext#getFlagInvocationCount(String)}, where the string is a
+ * flag's alias without the preceding dashes.</p>
+ */
+public interface Flag {
+
+    /**
+     * Gets a {@link Builder} for creating a {@link Flag}
+     *
+     * @return A {@link Builder}
+     */
+    static Flag.Builder builder() {
+        return Sponge.getRegistry().getBuilderRegistry().provideBuilder(Flag.Builder.class);
+    }
+
+    /**
+     * Gets the aliases that were supplied to this flag.
+     *
+     * <p>Aliases returned here will <strong>not</strong> be prefixed with the
+     * appropriate dashes.</p>
+     */
+    Collection<String> getUnprefixedAliases();
+
+    /**
+     * Gets the aliases that this flag will act upon.
+     *
+     * <p>Aliases returned here <strong>will</strong> be prefixed with the
+     * appropriate dashes.</p>
+     *
+     * @return The aliases.
+     */
+    Collection<String> getAliases();
+
+    /**
+     * Gets the {@link Predicate} that will be checked in order for this flag
+     * to be usable by a {@link CommandCause}
+     *
+     * @return The {@link Predicate}
+     */
+    Predicate<CommandCause> getRequirement();
+
+    /**
+     * Gets the {@link Parameter} that should be parsed if this flag is
+     * invoked.
+     *
+     * <p>This parameter may be optional if it exists.</p>
+     *
+     * @return The {@link Parameter}, if it exists.
+     */
+    Optional<Parameter> getAssociatedParameter();
+
+    /**
+     * A builder for creating {@link Flag}s.
+     */
+    interface Builder extends ResettableBuilder<Flag, Builder> {
+
+        /**
+         * Specifies an alias for this flag. The alias must not start with a
+         * dash, this will be handled by the builder.
+         *
+         * <p>If the alias is a single character, a single dash will be prefixed
+         * to the alias (e.g. an alias of {@code a} will become {@code -a} upon
+         * invocation. Otherwise, two dashes will be prefixed to the alias (e.g.
+         * {@code all} will become {@code --all}.</p>
+         *
+         * @param alias The alias that this flag will have
+         * @return This builder, for chaining
+         */
+        Builder alias(String alias);
+
+        /**
+         * Specifies the permission required to use this flag. A null permission
+         * indicates that anyone will be able to use the flag.
+         *
+         * <p>This will overwrite anything provided in
+         * {@link #setRequirement(Predicate)}</p>
+         *
+         * @param permission The permission to check for
+         * @return This builder, for chaining
+         */
+        Builder setPermission(@Nullable String permission);
+
+        /**
+         * Specifies the requirement to use this flag. A null requirement
+         * indicates that anyone will be able to use the flag.
+         *
+         * <p>This will overwrite anything provided in
+         * {@link #setPermission(String)}</p>
+         *
+         * @param requirement A {@link Predicate} that checks whether a
+         *      {@link CommandCause} meets the requirement for invocation.
+         * @return This builder, for chaining
+         */
+        Builder setRequirement(@Nullable Predicate<CommandCause> requirement);
+
+        /**
+         * Sets a {@link Parameter} that may be executed after the flag.
+         *
+         * <p>This will allow you to set a parameter that is conditional on
+         * this flag being specified. It is always required directly after the
+         * flag, separated by a space. Thus, setting this on a flag will result
+         * in the usage of form:</p>
+         *
+         * <pre>--flag &lt;parameter&gt;</pre>
+         *
+         * <p>The {@link Parameter} may be optional and may have its own
+         * requirements like any standard parameter. It is important to note,
+         * however, that as a flag may be invoked more than once, a
+         * {@link CommandContext} may also have more than one entry under the
+         * given {@link Parameter.Key}.</p>
+         *
+         * @param parameter The parameter to parse after this flag
+         * @return This builder, for chaining
+         */
+        Builder setParameter(@Nullable Parameter parameter);
+
+        /**
+         * Validates this builder and builds this {@link Flag}.
+         *
+         * @return A {@link Flag}
+         * @throws IllegalStateException if no key or no alias is specified
+         */
+        Flag build() throws IllegalStateException;
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/clientcompletion/ClientCompletionTypes.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/clientcompletion/ClientCompletionTypes.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.command.parameter.managed.clientcompletion;
 
+import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.parameter.managed.ValueParser;
 
@@ -55,6 +56,13 @@ public final class ClientCompletionTypes {
      */
     public static final Supplier<ClientCompletionType> NONE =
             Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionType.class, "NONE");
+
+    /**
+     * Indicates to the client that the {@link ValueParser} is a
+     * {@link ResourceKey}.
+     */
+    public static final Supplier<ClientCompletionType> RESOURCE_KEY =
+            Sponge.getRegistry().getCatalogRegistry().provideSupplier(ClientCompletionType.class, "RESOURCE_KEY");
 
     /**
      * Indicates to the client that the {@link ValueParser} is a standard

--- a/src/main/java/org/spongepowered/api/command/registrar/CommandRegistrar.java
+++ b/src/main/java/org/spongepowered/api/command/registrar/CommandRegistrar.java
@@ -52,10 +52,10 @@ import java.util.function.Predicate;
  * CommandRegistrar, PluginContainer, CommandTreeBuilder.Basic, Predicate,
  * String, String...)} to indicate that they wish to take control of certain
  * aliases. Beyond this call, the {@link CommandRegistrar} will only need to
- * retain the link between the primary alias and the command to execute, as the
- * {@link CommandManager} will always supply the primary alias of the command to
- * invoke at runtime, regardless of the aliases that were registered and/or
- * invoked by the invoker of the command.</p>
+ * retain the link between the primary alias and its {@link CommandMapping} to
+ * execute, as the {@link CommandManager} will always supply the mapping of the
+ * command being invoked at runtime. The alias that was matched will also be
+ * supplied.</p>
  *
  * <p>For command that wishes to investigate the command string that was
  * executed, they may investigate the context in
@@ -110,8 +110,8 @@ public interface CommandRegistrar<T> extends CatalogType {
      *
      * @param cause The {@link CommandCause} that caused the command to be
      *              executed
-     * @param command The primary alias that is associated with the command to
-     *                be executed
+     * @param mapping The {@link CommandMapping} for the command being invoked
+     * @param command The alias that was used to invoke the command
      * @param arguments The arguments of the command (that is, the raw string
      *                  with the command alias removed, so if
      *                  {@code /sponge test test2} is invoked, arguments will
@@ -119,37 +119,37 @@ public interface CommandRegistrar<T> extends CatalogType {
      * @return The {@link CommandResult}
      * @throws CommandException if there is an error executing the command
      */
-    CommandResult process(CommandCause cause, String command, String arguments) throws CommandException;
+    CommandResult process(CommandCause cause, CommandMapping mapping, String command, String arguments) throws CommandException;
 
     /**
      * Provides a list of suggestions associated with the provided argument
      * string.
      *
-     * <p>See {@link #process(CommandCause, String, String)} for any
+     * <p>See {@link #process(CommandCause, CommandMapping, String, String)} for any
      * implementation notes.</p>
      *
      * @param cause The {@link CommandCause} that caused the command to be
      *              executed
-     * @param command The primary alias that is associated with the command to
-     *                be executed
+     * @param mapping The {@link CommandMapping} for the command being invoked
+     * @param command The alias that was used to invoke the command
      * @param arguments The arguments of the command (that is, the raw string
      *                  with the command alias removed, so if
      *                  {@code /sponge test test2} is invoked, arguments will
      *                  contain {@code test test2}.)
      * @return The suggestions
      */
-    List<String> suggestions(CommandCause cause, String command, String arguments) throws CommandException;
+    List<String> suggestions(CommandCause cause, CommandMapping mapping, String command, String arguments) throws CommandException;
 
     /**
      * Returns help text for the invoked command.
      *
      * @param cause The {@link CommandCause} that caused the command to be
      *              executed
-     * @param command The primary alias that is associated with the command to
-     *                be executed
+     * @param mapping The {@link CommandMapping} that is associated with the
+     *                command
      * @return The help, if any
      */
-    Optional<Component> help(CommandCause cause, String command);
+    Optional<Component> help(CommandCause cause, CommandMapping mapping);
 
     /**
      * Called when the {@link CommandManager} is clearing all of the

--- a/src/main/java/org/spongepowered/api/util/TypeTokens.java
+++ b/src/main/java/org/spongepowered/api/util/TypeTokens.java
@@ -125,6 +125,7 @@ import org.spongepowered.api.util.weighted.WeightedTable;
 import org.spongepowered.api.world.LocatableBlock;
 import org.spongepowered.api.world.ServerLocation;
 import org.spongepowered.api.world.server.ServerWorld;
+import org.spongepowered.api.world.storage.WorldProperties;
 import org.spongepowered.math.vector.Vector2i;
 import org.spongepowered.math.vector.Vector3d;
 import org.spongepowered.math.vector.Vector3i;
@@ -555,6 +556,8 @@ public final class TypeTokens {
     public static final TypeToken<WoodType> WOOD_TYPE_TOKEN = new TypeToken<WoodType>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<Value<WoodType>> WOOD_TYPE_VALUE_TOKEN = new TypeToken<Value<WoodType>>() {private static final long serialVersionUID = -1;};
+
+    public static final TypeToken<WorldProperties> WORLD_PROPERTIES_TOKEN = new TypeToken<WorldProperties>() {private static final long serialVersionUID = -1;};
 
     public static final TypeToken<LocatableBlock> LOCATABLE_BLOCK_TOKEN = new TypeToken<LocatableBlock>() {private static final long serialVersionUID = -1;};
 


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/3083)

Also CommandRegistrars will now need to either keep hold of mappings, or the primary alias, as this enables us to pass the invoked command down rather than the namespaced alias all the time.