### PR TITLE
Remove the concept of read-only orders

### DIFF
--- a/src/main/java/org/spongepowered/api/event/Order.java
+++ b/src/main/java/org/spongepowered/api/event/Order.java
@@ -30,33 +30,33 @@ package org.spongepowered.api.event;
  * <p>Event handlers are called the order given in the following table.</p>
  *
  * <table summary="Order Recommendations">
- *     <tr><td>Order</td>       <td>Cancellation Allowed</td>
+ *     <tr><td>Order</td>
  *         <td>Recommendation</td></tr>
- *     <tr><td>PRE</td>         <td>NO</td>
+ *     <tr><td>PRE</td>
  *         <td>Initialisation and registration actions</td></tr>
- *     <tr><td>AFTER_PRE</td>   <td>NO</td>
+ *     <tr><td>AFTER_PRE</td>
  *         <td>Immediate responses to actions in PRE</td></tr>
- *     <tr><td>FIRST</td>       <td>YES</td>
+ *     <tr><td>FIRST</td>
  *         <td>
  *             Cancellation by protection plugins for informational purposes
  *         </td>
  *     </tr>
- *     <tr><td>EARLY</td>       <td>YES</td>
+ *     <tr><td>EARLY</td>
  *         <td>Standard actions that should happen before other plugins react to
  *         the event</td>
  *     </tr>
- *     <tr><td>DEFAULT</td>     <td>YES</td>
+ *     <tr><td>DEFAULT</td>
  *         <td>The default action order</td></tr>
- *     <tr><td>LATE</td>        <td>YES</td>
+ *     <tr><td>LATE</td>
  *         <td>Standard actions that should happen after other plugins react to
  *         the event</td>
  *     </tr>
- *     <tr><td>LAST</td>        <td>YES</td>
+ *     <tr><td>LAST</td>
  *         <td>Final cancellation by protection plugins</td></tr>
- *     <tr><td>BEFORE_POST</td> <td>NO</td>
+ *     <tr><td>BEFORE_POST</td>
  *         <td>Actions that need to respond to cancelled events before POST</td>
  *     </tr>
- *     <tr><td>POST</td>        <td>NO</td>
+ *     <tr><td>POST</td>
  *         <td>Actions that need to react to the final and stable effects of
  *         event</td>
  *     </tr>

--- a/src/main/java/org/spongepowered/api/event/Order.java
+++ b/src/main/java/org/spongepowered/api/event/Order.java
@@ -30,33 +30,33 @@ package org.spongepowered.api.event;
  * <p>Event handlers are called the order given in the following table.</p>
  *
  * <table summary="Order Recommendations">
- *     <tr><td>Order</td>       <td>Read Only</td> <td>Cancellation Allowed</td>
+ *     <tr><td>Order</td>       <td>Cancellation Allowed</td>
  *         <td>Recommendation</td></tr>
- *     <tr><td>PRE</td>         <td>YES</td>       <td>NO</td>
+ *     <tr><td>PRE</td>         <td>NO</td>
  *         <td>Initialisation and registration actions</td></tr>
- *     <tr><td>AFTER_PRE</td>   <td>YES</td>       <td>NO</td>
+ *     <tr><td>AFTER_PRE</td>   <td>NO</td>
  *         <td>Immediate responses to actions in PRE</td></tr>
- *     <tr><td>FIRST</td>       <td>YES</td>       <td>YES</td>
+ *     <tr><td>FIRST</td>       <td>YES</td>
  *         <td>
  *             Cancellation by protection plugins for informational purposes
  *         </td>
  *     </tr>
- *     <tr><td>EARLY</td>       <td>NO</td>        <td>YES</td>
+ *     <tr><td>EARLY</td>       <td>YES</td>
  *         <td>Standard actions that should happen before other plugins react to
  *         the event</td>
  *     </tr>
- *     <tr><td>DEFAULT</td>     <td>NO</td>        <td>YES</td>
+ *     <tr><td>DEFAULT</td>     <td>YES</td>
  *         <td>The default action order</td></tr>
- *     <tr><td>LATE</td>        <td>NO</td>        <td>YES</td>
+ *     <tr><td>LATE</td>        <td>YES</td>
  *         <td>Standard actions that should happen after other plugins react to
  *         the event</td>
  *     </tr>
- *     <tr><td>LAST</td>        <td>YES</td>       <td>YES</td>
+ *     <tr><td>LAST</td>        <td>YES</td>
  *         <td>Final cancellation by protection plugins</td></tr>
- *     <tr><td>BEFORE_POST</td> <td>YES</td>       <td>NO</td>
+ *     <tr><td>BEFORE_POST</td> <td>NO</td>
  *         <td>Actions that need to respond to cancelled events before POST</td>
  *     </tr>
- *     <tr><td>POST</td>        <td>YES</td>       <td>NO</td>
+ *     <tr><td>POST</td>        <td>NO</td>
  *         <td>Actions that need to react to the final and stable effects of
  *         event</td>
  *     </tr>
@@ -66,58 +66,55 @@ public enum Order {
 
     /**
      * The order point of PRE handles setting up things that need to be done
-     * before other things are handled PRE is read only and cannot cancel the
-     * events.
+     * before other things are handled.
      */
     PRE,
 
     /**
      * The order point of AFTER_PRE handles things that need to be done after
-     * PRE AFTER_PRE is read only and cannot cancel the events.
+     * PRE.
      */
     AFTER_PRE,
 
     /**
      * The order point of FIRST handles cancellation by protection plugins for
-     * informational responses FIRST is read only but can cancel events.
+     * informational responses.
      */
     FIRST,
 
     /**
      * The order point of EARLY handles standard actions that need to be done
-     * before other plugins EARLY is not read only and can cancel events.
+     * before other plugins.
      */
     EARLY,
 
     /**
      * The order point of DEFAULT handles just standard event handlings, you
-     * should use this unless you know you need otherwise DEFAULT is not read
-     * only and can cancel events.
+     * should use this unless you know you need otherwise.
      */
     DEFAULT,
 
     /**
      * The order point of LATE handles standard actions that need to be done
-     * after other plugins LATE is not read only and can cancel the event.
+     * after other plugins.
      */
     LATE,
 
     /**
      * The order point of LAST handles last minute cancellations by protection
-     * plugins LAST is read only but can cancel events.
+     * plugins.
      */
     LAST,
 
     /**
      * The order point of BEFORE_POST handles preparation for things needing
-     * to be done in post BEFORE_POST is read only and cannot cancel events.
+     * to be done in post.
      */
     BEFORE_POST,
 
     /**
      * The order point of POST handles last minute things and monitoring
-     * of events for rollback or logging POST is read only and
-     * cannot cancel events.
+     * of events for rollback or logging.
      */
     POST
 


### PR DESCRIPTION
As discussed on discord, read-only orders can't be enforced. This PR removes the concept from the jd.

I think there's value in `cancellation allowed` (prism-like plugins) in the sense of an event guaranteed not to be cancelled (`POST` is the last order, wheter the event has been cancelled or not. That's not gonna change after that) so I'm leaving the tab in the jd for discussion.

Close https://github.com/SpongePowered/SpongeCommon/issues/1213 (if we decide to remove both)

