### PR TITLE
Create a SubjectProxy and separate CommandCause from CommandContext

### DIFF
--- a/src/main/java/org/spongepowered/api/command/CommandCause.java
+++ b/src/main/java/org/spongepowered/api/command/CommandCause.java
@@ -34,21 +34,14 @@ import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.EventContext;
 import org.spongepowered.api.event.cause.EventContextKeys;
-import org.spongepowered.api.service.context.Context;
 import org.spongepowered.api.service.permission.Subject;
-import org.spongepowered.api.service.permission.SubjectCollection;
-import org.spongepowered.api.service.permission.SubjectData;
-import org.spongepowered.api.service.permission.SubjectReference;
-import org.spongepowered.api.util.Tristate;
+import org.spongepowered.api.service.permission.SubjectProxy;
 import org.spongepowered.api.util.annotation.DoNotStore;
-import org.spongepowered.api.world.Locatable;
 import org.spongepowered.api.world.ServerLocation;
 import org.spongepowered.math.vector.Vector3d;
 import org.spongepowered.plugin.PluginContainer;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * The {@link CommandCause} represents the {@link Cause} of a command, and
@@ -111,7 +104,7 @@ import java.util.Set;
  * typically would be of interest to command API consumers.</p>
  */
 @DoNotStore
-public interface CommandCause extends Subject {
+public interface CommandCause extends SubjectProxy {
 
     /**
      * Creates a {@link CommandCause} from the current {@link Cause}.
@@ -151,11 +144,7 @@ public interface CommandCause extends Subject {
      *
      * @return The {@link Subject} responsible, if any.
      */
-    default Subject getSubject() {
-        return this.getCause().getContext()
-            .get(EventContextKeys.SUBJECT)
-            .orElseGet(() -> this.getCause().first(Subject.class).orElseGet(Sponge::getSystemSubject));
-    }
+    Subject getSubject();
 
     /**
      * Gets the {@link Audience} that should be the target for any
@@ -178,11 +167,7 @@ public interface CommandCause extends Subject {
      *
      * @return The {@link Audience} to send any messages to.
      */
-    default Audience getAudience() {
-        return this.getCause().getContext()
-            .get(EventContextKeys.AUDIENCE)
-            .orElseGet(() -> this.getCause().first(Audience.class).orElseGet(Sponge::getSystemSubject));
-    }
+    Audience getAudience();
 
     /**
      * Gets the {@link ServerLocation} that this command is associated with.
@@ -197,20 +182,7 @@ public interface CommandCause extends Subject {
      *
      * @return The {@link ServerLocation}, if it exists
      */
-    default Optional<ServerLocation> getLocation() {
-        final Cause cause = this.getCause();
-        final EventContext eventContext = cause.getContext();
-        if (eventContext.containsKey(EventContextKeys.LOCATION)) {
-            return eventContext.get(EventContextKeys.LOCATION);
-        }
-
-        final Optional<ServerLocation> optionalLocation = this.getTargetBlock().flatMap(BlockSnapshot::getLocation);
-        if (optionalLocation.isPresent()) {
-            return optionalLocation;
-        }
-
-        return cause.first(Locatable.class).map(Locatable::getServerLocation);
-    }
+    Optional<ServerLocation> getLocation();
 
     /**
      * Gets the {@link Vector3d} rotation that this command is associated with.
@@ -224,15 +196,7 @@ public interface CommandCause extends Subject {
      *
      * @return The {@link Vector3d} rotation, if it exists
      */
-    default Optional<Vector3d> getRotation() {
-        final Cause cause = this.getCause();
-        final EventContext eventContext = cause.getContext();
-        if (eventContext.containsKey(EventContextKeys.ROTATION)) {
-            return eventContext.get(EventContextKeys.ROTATION);
-        }
-
-        return cause.first(Entity.class).map(Entity::getRotation);
-    }
+    Optional<Vector3d> getRotation();
 
     /**
      * Returns the target block {@link ServerLocation}, if applicable.
@@ -246,95 +210,7 @@ public interface CommandCause extends Subject {
      *
      * @return The {@link BlockSnapshot} if applicable, or an empty optional.
      */
-    default Optional<BlockSnapshot> getTargetBlock() {
-        return Optional.ofNullable(this.getCause().getContext().get(EventContextKeys.BLOCK_TARGET)
-            .orElseGet(() -> this.getCause().first(BlockSnapshot.class).orElse(null)));
-    }
-
-    @Override
-    default SubjectCollection getContainingCollection() {
-        return this.getSubject().getContainingCollection();
-    }
-
-    @Override
-    default SubjectReference asSubjectReference() {
-        return this.getSubject().asSubjectReference();
-    }
-
-    @Override
-    default boolean isSubjectDataPersisted() {
-        return this.getSubject().isSubjectDataPersisted();
-    }
-
-    @Override
-    default SubjectData getSubjectData() {
-        return this.getSubject().getSubjectData();
-    }
-
-    @Override
-    default SubjectData getTransientSubjectData() {
-        return this.getSubject().getTransientSubjectData();
-    }
-
-    @Override
-    default Tristate getPermissionValue(final Set<Context> contexts, final String permission) {
-        return this.getSubject().getPermissionValue(contexts, permission);
-    }
-
-    @Override
-    default boolean isChildOf(final Set<Context> contexts, final SubjectReference parent) {
-        return this.getSubject().isChildOf(contexts, parent);
-    }
-
-    @Override
-    default List<SubjectReference> getParents(final Set<Context> contexts) {
-        return this.getSubject().getParents();
-    }
-
-    @Override
-    default Optional<String> getOption(final Set<Context> contexts, final String key) {
-        return this.getSubject().getOption(contexts, key);
-    }
-
-    @Override
-    default String getIdentifier() {
-        return this.getSubject().getIdentifier();
-    }
-
-    @Override
-    default Set<Context> getActiveContexts() {
-        return this.getSubject().getActiveContexts();
-    }
-
-    @Override
-    default boolean hasPermission(final Set<Context> contexts, final String permission) {
-        return this.getSubject().hasPermission(contexts, permission);
-    }
-
-    @Override
-    default boolean hasPermission(final String permission) {
-        return this.getSubject().hasPermission(permission);
-    }
-
-    @Override
-    default boolean isChildOf(final SubjectReference parent) {
-        return this.getSubject().isChildOf(parent);
-    }
-
-    @Override
-    default List<SubjectReference> getParents() {
-        return this.getSubject().getParents();
-    }
-
-    @Override
-    default Optional<String> getOption(final String key) {
-        return this.getSubject().getOption(key);
-    }
-
-    @Override
-    default Optional<String> getFriendlyIdentifier() {
-        return this.getSubject().getFriendlyIdentifier();
-    }
+    Optional<BlockSnapshot> getTargetBlock();
 
     /**
      * Sends a message to the {@link Audience} as given by
@@ -342,9 +218,7 @@ public interface CommandCause extends Subject {
      *
      * @param message The message to send.
      */
-    default void sendMessage(final Component message) {
-        this.getAudience().sendMessage(message);
-    }
+    void sendMessage(final Component message);
 
     /**
      * Creates instances of the {@link CommandCause}.

--- a/src/main/java/org/spongepowered/api/command/parameter/CommandContext.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/CommandContext.java
@@ -24,23 +24,45 @@
  */
 package org.spongepowered.api.command.parameter;
 
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
 import org.spongepowered.api.command.CommandCause;
 import org.spongepowered.api.command.parameter.managed.Flag;
 import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.service.permission.SubjectProxy;
 
 import java.util.Collection;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
 /**
- * The {@link CommandContext} contains the parsed arguments for a
- * command, and any other information that might be important when
- * executing a command.
+ * The {@link CommandContext} contains the parsed arguments for a command, and
+ * any other information that might be important when executing a command.
  *
- * <p>This context also contain methods that determine the
- * {@link Cause} of the command.</p>
+ * <p>For information about the cause of the command, the {@link CommandCause}
+ * is available (see {@link #getCommandCause()}. Some popular tasks that operate
+ * on the {@link CommandCause} are also directly available on this context,
+ * namely permission checks (via {@link SubjectProxy}) and sending a message to
+ * the {@link CommandCause}'s {@link Audience} (via
+ * {@link #sendMessage(Component)}).</p>
  */
-public interface CommandContext extends CommandCause {
+public interface CommandContext extends SubjectProxy {
+
+    /**
+     * Gets the {@link CommandCause} associated with this context.
+     *
+     * @return The {@link CommandCause}
+     */
+    CommandCause getCommandCause();
+
+    /**
+     * Gets the {@link Cause} of the command.
+     *
+     * @return The {@link Cause}
+     */
+    default Cause getCause() {
+        return this.getCommandCause().getCause();
+    }
 
     /**
      * Gets if a flag with given alias was specified at least once.
@@ -165,6 +187,13 @@ public interface CommandContext extends CommandCause {
      * @return the collection of all values
      */
     <T> Collection<? extends T> getAll(Parameter.Key<T> key);
+
+    /**
+     * Sends a message via {@link CommandCause#getAudience()}
+     *
+     * @param message The message to send.
+     */
+    void sendMessage(final Component message);
 
     /**
      * A builder for creating this context.

--- a/src/main/java/org/spongepowered/api/service/permission/SubjectProxy.java
+++ b/src/main/java/org/spongepowered/api/service/permission/SubjectProxy.java
@@ -1,0 +1,132 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.service.permission;
+
+import org.spongepowered.api.service.context.Context;
+import org.spongepowered.api.util.Tristate;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Enables an object to act as a proxy to a Subject, delegating all calls threw
+ * to the actual Subject.
+ */
+public interface SubjectProxy extends Subject {
+
+    /**
+     * Gets the {@link Subject} this interface is a proxy for.
+     *
+     * @return The {@link Subject}
+     */
+    Subject getSubject();
+
+    @Override
+    default SubjectCollection getContainingCollection() {
+        return this.getSubject().getContainingCollection();
+    }
+
+    @Override
+    default SubjectReference asSubjectReference() {
+        return this.getSubject().asSubjectReference();
+    }
+
+    @Override
+    default boolean isSubjectDataPersisted() {
+        return this.getSubject().isSubjectDataPersisted();
+    }
+
+    @Override
+    default SubjectData getSubjectData() {
+        return this.getSubject().getSubjectData();
+    }
+
+    @Override
+    default SubjectData getTransientSubjectData() {
+        return this.getSubject().getTransientSubjectData();
+    }
+
+    @Override
+    default Tristate getPermissionValue(final Set<Context> contexts, final String permission) {
+        return this.getSubject().getPermissionValue(contexts, permission);
+    }
+
+    @Override
+    default boolean isChildOf(final Set<Context> contexts, final SubjectReference parent) {
+        return this.getSubject().isChildOf(contexts, parent);
+    }
+
+    @Override
+    default List<SubjectReference> getParents(final Set<Context> contexts) {
+        return this.getSubject().getParents();
+    }
+
+    @Override
+    default Optional<String> getOption(final Set<Context> contexts, final String key) {
+        return this.getSubject().getOption(contexts, key);
+    }
+
+    @Override
+    default String getIdentifier() {
+        return this.getSubject().getIdentifier();
+    }
+
+    @Override
+    default Set<Context> getActiveContexts() {
+        return this.getSubject().getActiveContexts();
+    }
+
+    @Override
+    default boolean hasPermission(final Set<Context> contexts, final String permission) {
+        return this.getSubject().hasPermission(contexts, permission);
+    }
+
+    @Override
+    default boolean hasPermission(final String permission) {
+        return this.getSubject().hasPermission(permission);
+    }
+
+    @Override
+    default boolean isChildOf(final SubjectReference parent) {
+        return this.getSubject().isChildOf(parent);
+    }
+
+    @Override
+    default List<SubjectReference> getParents() {
+        return this.getSubject().getParents();
+    }
+
+    @Override
+    default Optional<String> getOption(final String key) {
+        return this.getSubject().getOption(key);
+    }
+
+    @Override
+    default Optional<String> getFriendlyIdentifier() {
+        return this.getSubject().getFriendlyIdentifier();
+    }
+
+}


### PR DESCRIPTION
Basic premise is that `CommandContext` and `CommandContext.Builder` no longer implement `CommandCause`.

I basically shouldn't have done this anyway, but the idea was that a `CommandContext` could functionally act as a `CommandCause` as a convenience to them. However, in implementation, there is an assumption that a `CommandSource` is a `CommandCause`, which is true. The opposite isn't necessarily true, however, and I've bumped up places where I've made this bad assupmption.

What I have opted to do is stop `CommandContext` and its builder from implementing `CommandCause`, but to continue helping plugin devs, it now implements the new `SubjectProxy` interface and continues to have the `sendMessage(Component)` method. So, if you need a `CommandCause` you have to explicity get it, but if you wanted to do a permission check and/or send a message (two very common things), this can be done via the context.

I do want to merge this soon because I'm working on Selectors and that does rely on this, but I'm using the PR as a sanity check for style and such.