### PR TITLE
Set the default value for sharedRoot to false in ConfigDir and DefaultConfig

### DIFF
--- a/src/main/java/org/spongepowered/api/config/ConfigDir.java
+++ b/src/main/java/org/spongepowered/api/config/ConfigDir.java
@@ -55,6 +55,6 @@ public @interface ConfigDir {
      * @see ConfigRoot#getConfigPath() For information on what the
      *     shared root is
      */
-    boolean sharedRoot();
+    boolean sharedRoot() default false;
 
 }

--- a/src/main/java/org/spongepowered/api/config/DefaultConfig.java
+++ b/src/main/java/org/spongepowered/api/config/DefaultConfig.java
@@ -58,6 +58,6 @@ public @interface DefaultConfig {
      * @see ConfigRoot#getConfigPath() For information on what the
      *     shared root is
      */
-    boolean sharedRoot();
+    boolean sharedRoot() default false;
 
 }


### PR DESCRIPTION
The majority of plugins do not put their configuration in the shared root configuration directory. This PR makes this normal case less verbose but leaves the option to put a configuration in the root directory if needed.

There have been talks in the 1.14 updates channel of potentially removing the option to set sharedRoot at all. However, I believe that setting a default false value is a better alternative. It provides both the convenience of not having to specify it and keeps the option available for those who want it.