### PR TITLE
API additions + changes for Configurate 4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,7 +81,7 @@ dependencies {
     api("org.spongepowered:plugin-spi:0.1.3-SNAPSHOT")
 
     // Configurate
-    api(platform("org.spongepowered:configurate-bom:4.0.0-SNAPSHOT"))
+    api(platform("org.spongepowered:configurate-bom:4.0.0"))
     api("org.spongepowered:configurate-core") {
         exclude(group = "org.checkerframework", module = "checker-qual") // We use our own version
     }
@@ -171,8 +171,7 @@ tasks {
                                 "http://www.slf4j.org/apidocs/",
                                 "https://google.github.io/guava/releases/21.0/api/docs/",
                                 "https://google.github.io/guice/api-docs/4.1/javadoc/",
-                                "https://zml2008.github.io/configurate/configurate-core/apidocs/",
-                                "https://zml2008.github.io/configurate/configurate-hocon/apidocs/",
+                                "https://configurate.aoeu.xyz/4.0.0/apidocs/",
                                 "https://docs.oracle.com/javase/8/docs/api/"
                         )
                 )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,24 +81,26 @@ dependencies {
     api("org.spongepowered:plugin-spi:0.1.3-SNAPSHOT")
 
     // Configurate
-    api("org.spongepowered:configurate-core:3.7.1") {
-        exclude(group = "com.google.guava", module = "guava")
-        exclude(group = "com.google.inject", module = "guice")
+    api(platform("org.spongepowered:configurate-bom:4.0.0-SNAPSHOT"))
+    api("org.spongepowered:configurate-core") {
         exclude(group = "org.checkerframework", module = "checker-qual") // We use our own version
     }
-    api("org.spongepowered:configurate-hocon:3.7.1") {
+    api("org.spongepowered:configurate-hocon") {
         exclude(group = "org.spongepowered", module = "configurate-core")
         exclude(group= "org.checkerframework", module = "checker-qual")
 
     }
-    api("org.spongepowered:configurate-gson:3.7.1") {
+    api("org.spongepowered:configurate-gson") {
         exclude(group = "org.spongepowered", module = "configurate-core")
         exclude(group = "com.google.code.gson", module = "gson") // We have the same version technically, but use the gson we provide.
         exclude(group= "org.checkerframework", module = "checker-qual")
     }
-    api("org.spongepowered:configurate-yaml:3.7.1") {
+    api("org.spongepowered:configurate-yaml") {
         exclude(group = "org.spongepowered", module = "configurate-core")
         exclude(group= "org.checkerframework", module = "checker-qual")
+    }
+    api("org.spongepowered:configurate-extra-guice") {
+        exclude(group = "com.google.inject", module = "guice")
     }
 
     // Math and noise for world gen

--- a/src/main/java/org/spongepowered/api/ResourceKey.java
+++ b/src/main/java/org/spongepowered/api/ResourceKey.java
@@ -25,7 +25,7 @@
 package org.spongepowered.api;
 
 import net.kyori.adventure.key.Key;
-import ninja.leaping.configurate.ConfigurationNode;
+import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.api.data.DataRegistration;
 import org.spongepowered.api.data.persistence.DataSerializable;
 import org.spongepowered.api.data.persistence.DataTranslator;

--- a/src/main/java/org/spongepowered/api/advancement/criteria/trigger/Trigger.java
+++ b/src/main/java/org/spongepowered/api/advancement/criteria/trigger/Trigger.java
@@ -25,6 +25,9 @@
 package org.spongepowered.api.advancement.criteria.trigger;
 
 import com.google.gson.Gson;
+import io.leangen.geantyref.TypeToken;
+import org.spongepowered.api.config.ConfigManager;
+import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.serialize.TypeSerializer;
 import org.spongepowered.configurate.serialize.TypeSerializerCollection;
 import org.spongepowered.api.CatalogType;
@@ -39,7 +42,9 @@ import org.spongepowered.api.scoreboard.criteria.Criterion;
 import org.spongepowered.api.util.CopyableBuilder;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
+import java.lang.reflect.Type;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 
 /**
  * Represents a source that can trigger a {@link AdvancementCriterion}.
@@ -63,9 +68,11 @@ public interface Trigger<C extends FilteredTriggerConfiguration> extends Catalog
     /**
      * Gets the type of the used {@link FilteredTriggerConfiguration}.
      *
+     * <p>This type represents the {@code C} type parameter of this instance.</p>
+     *
      * @return The configuration type
      */
-    Class<C> getConfigurationType();
+    Type getConfigurationType();
 
     /**
      * Triggers the {@link Trigger} for all the online
@@ -113,6 +120,55 @@ public interface Trigger<C extends FilteredTriggerConfiguration> extends Catalog
          * a config serializable. This configuration will be constructed
          * using Configurate (with {@link TypeSerializer}s).
          *
+         * <p>By default, the configuration will be loaded with
+         * Sponge-default options, with serializers as defined in
+         * {@link ConfigManager#getSerializers()}.</p>
+         *
+         * @param configClass The configuration class
+         * @param <T> The configuration type
+         * @return This builder, for chaining
+         */
+        <T extends FilteredTriggerConfiguration> Builder<T> typeSerializableConfig(TypeToken<T> configClass);
+
+        /**
+         * Sets the class for the {@link FilteredTriggerConfiguration} as
+         * a config serializable. This configuration will be constructed using
+         * Configurate (with {@link TypeSerializer}s) with a
+         * specific {@link TypeSerializerCollection} instead of the global one.
+         *
+         * @param configClass The configuration class
+         * @param options The configuration options that control loading of data
+         * @param <T> The configuration type
+         * @return This builder, for chaining
+         */
+        <T extends FilteredTriggerConfiguration> Builder<T> typeSerializableConfig(TypeToken<T> configClass, ConfigurationOptions options);
+
+        /**
+         * Sets the class for the {@link FilteredTriggerConfiguration} as
+         * a config serializable. This configuration will be constructed using
+         * Configurate with specific options.
+         *
+         * <p>The configuration will be loaded with the returned
+         * derivation of Sponge-default options, with serializers as defined in
+         * {@link ConfigManager#getSerializers()}.</p>
+         *
+         * @param configClass The configuration class
+         * @param options A callback that will receive options to modify
+         * @param <T> The configuration type
+         * @return This builder, for chaining
+         */
+        <T extends FilteredTriggerConfiguration> Builder<T> typeSerializableConfig(TypeToken<T> configClass,
+                UnaryOperator<ConfigurationOptions> options);
+
+        /**
+         * Sets the class for the {@link FilteredTriggerConfiguration} as
+         * a config serializable. This configuration will be constructed
+         * using Configurate (with {@link TypeSerializer}s).
+         *
+         * <p>By default, the configuration will be loaded with
+         * Sponge-default options, with serializers as defined in
+         * {@link ConfigManager#getSerializers()}.</p>
+         *
          * @param configClass The configuration class
          * @param <T> The configuration type
          * @return This builder, for chaining
@@ -126,12 +182,28 @@ public interface Trigger<C extends FilteredTriggerConfiguration> extends Catalog
          * specific {@link TypeSerializerCollection} instead of the global one.
          *
          * @param configClass The configuration class
-         * @param typeSerializerCollection The type serializer collection
+         * @param options The configuration options that control loading of data
          * @param <T> The configuration type
          * @return This builder, for chaining
          */
-        <T extends FilteredTriggerConfiguration> Builder<T> typeSerializableConfig(Class<T> configClass,
-                TypeSerializerCollection typeSerializerCollection);
+        <T extends FilteredTriggerConfiguration> Builder<T> typeSerializableConfig(Class<T> configClass, ConfigurationOptions options);
+
+        /**
+         * Sets the class for the {@link FilteredTriggerConfiguration} as
+         * a config serializable. This configuration will be constructed using
+         * Configurate with customized options based off of the Sponge-default
+         * options.
+         *
+         * <p>The configuration will be loaded with the returned
+         * derivation of Sponge-default options, with serializers as defined in
+         * {@link ConfigManager#getSerializers()}.</p>
+         *
+         * @param configClass The configuration class
+         * @param options A callback that will receive options to modify
+         * @param <T> The configuration type
+         * @return This builder, for chaining
+         */
+        <T extends FilteredTriggerConfiguration> Builder<T> typeSerializableConfig(Class<T> configClass, UnaryOperator<ConfigurationOptions> options);
 
         /**
          * Sets the class for the {@link FilteredTriggerConfiguration} as

--- a/src/main/java/org/spongepowered/api/advancement/criteria/trigger/Trigger.java
+++ b/src/main/java/org/spongepowered/api/advancement/criteria/trigger/Trigger.java
@@ -25,8 +25,8 @@
 package org.spongepowered.api.advancement.criteria.trigger;
 
 import com.google.gson.Gson;
-import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
-import ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection;
+import org.spongepowered.configurate.serialize.TypeSerializer;
+import org.spongepowered.configurate.serialize.TypeSerializerCollection;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.advancement.criteria.AdvancementCriterion;

--- a/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.command.parameter;
 
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.TypeToken;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -125,7 +125,7 @@ public interface Parameter {
      * @return The {@link Value.Builder}
      */
     static <T> Value.Builder<T> builder(@NonNull final Class<T> valueClass) {
-        return builder(TypeToken.of(valueClass));
+        return builder(TypeToken.get(valueClass));
     }
 
     /**
@@ -151,7 +151,7 @@ public interface Parameter {
      * @return The {@link Value.Builder}
      */
     static <T> Value.Builder<T> builder(@NonNull final Class<T> valueClass, @NonNull final ValueParameter<T> parameter) {
-        return builder(TypeToken.of(valueClass), parameter);
+        return builder(TypeToken.get(valueClass), parameter);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/command/registrar/CommandRegistrar.java
+++ b/src/main/java/org/spongepowered/api/command/registrar/CommandRegistrar.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.command.registrar;
 
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.TypeToken;
 import net.kyori.adventure.text.Component;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.command.CommandCause;

--- a/src/main/java/org/spongepowered/api/config/ConfigManager.java
+++ b/src/main/java/org/spongepowered/api/config/ConfigManager.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.config;
 
+import org.spongepowered.configurate.reference.WatchServiceListener;
 import org.spongepowered.configurate.serialize.TypeSerializerCollection;
 import org.spongepowered.plugin.PluginContainer;
 
@@ -91,7 +92,18 @@ public interface ConfigManager {
      *         {@link org.spongepowered.api.data.persistence.DataTranslators})</li>
      * </ul>
      *
-     * @return a type serializer collection aware of Sponge serializers
+     * @return A type serializer collection aware of Sponge serializers
      */
     TypeSerializerCollection getSerializers();
+
+    /**
+     * Get a file watch listener using the game executor.
+     *
+     * <p>This can be used to get {@link org.spongepowered.configurate.reference.ConfigurationReference auto-reloading references}
+     * to configuration files.</p>
+     *
+     * @return The game watch service listener
+     */
+    WatchServiceListener getWatchServiceListener();
+
 }

--- a/src/main/java/org/spongepowered/api/config/ConfigManager.java
+++ b/src/main/java/org/spongepowered/api/config/ConfigManager.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.config;
 
+import org.spongepowered.configurate.serialize.TypeSerializerCollection;
 import org.spongepowered.plugin.PluginContainer;
 
 /**
@@ -75,4 +76,22 @@ public interface ConfigManager {
      * @return A plugin-specific configuration root
      */
     ConfigRoot getPluginConfig(PluginContainer plugin);
+
+    /**
+     * Get a type serializer collection supporting Sponge types.
+     *
+     * <p>This collection is expected to handle:</p>
+     * <ul>
+     *     <li>Every type built-in to Configurate</li>
+     *     <li>Registered subtypes of {@link org.spongepowered.api.CatalogType}</li>
+     *     <li>{@link org.spongepowered.api.ResourceKey}s</li>
+     *     <li>Registered implementations of {@link org.spongepowered.api.data.persistence.DataSerializable}</li>
+     *     <li>All Adventure types including {@link net.kyori.adventure.text.Component}</li>
+     *     <li>Any type with a {@link org.spongepowered.api.data.persistence.DataTranslator} (see
+     *         {@link org.spongepowered.api.data.persistence.DataTranslators})</li>
+     * </ul>
+     *
+     * @return a type serializer collection aware of Sponge serializers
+     */
+    TypeSerializerCollection getSerializers();
 }

--- a/src/main/java/org/spongepowered/api/config/ConfigRoot.java
+++ b/src/main/java/org/spongepowered/api/config/ConfigRoot.java
@@ -24,8 +24,8 @@
  */
 package org.spongepowered.api.config;
 
-import ninja.leaping.configurate.commented.CommentedConfigurationNode;
-import ninja.leaping.configurate.loader.ConfigurationLoader;
+import org.spongepowered.configurate.CommentedConfigurationNode;
+import org.spongepowered.configurate.loader.ConfigurationLoader;
 
 import java.nio.file.Path;
 

--- a/src/main/java/org/spongepowered/api/config/ConfigRoot.java
+++ b/src/main/java/org/spongepowered/api/config/ConfigRoot.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.config;
 
 import org.spongepowered.configurate.CommentedConfigurationNode;
 import org.spongepowered.configurate.loader.ConfigurationLoader;
+import org.spongepowered.configurate.serialize.TypeSerializerCollection;
 
 import java.nio.file.Path;
 
@@ -73,6 +74,18 @@ public interface ConfigRoot {
      * @see #getConfigPath()
      */
     ConfigurationLoader<CommentedConfigurationNode> getConfig();
+
+    /**
+     * Get the serializers applicable to this root.
+     *
+     * <p>The returned serializers will be for Sponge and Adventure types, as
+     * well as an object mapper that can use any applicable
+     * Guice {@link com.google.inject.Injector} to create instances.</p>
+     *
+     * @return applicable serializers
+     * @see ConfigManager#getSerializers() for globally available serializers
+     */
+    TypeSerializerCollection getSerializers();
 
     /**
      * Gets the directory that this configuration root refers to.

--- a/src/main/java/org/spongepowered/api/config/ConfigRoot.java
+++ b/src/main/java/org/spongepowered/api/config/ConfigRoot.java
@@ -25,8 +25,8 @@
 package org.spongepowered.api.config;
 
 import org.spongepowered.configurate.CommentedConfigurationNode;
+import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.loader.ConfigurationLoader;
-import org.spongepowered.configurate.serialize.TypeSerializerCollection;
 
 import java.nio.file.Path;
 
@@ -70,22 +70,31 @@ public interface ConfigRoot {
      * Gets the configuration file that utilizes the default configuration
      * pathname.
      *
+     * <p>The returned loader will default to using options that:</p>
+     * <ul>
+     *     <li>Copy default values to the configuration</li>
+     *     <li>Implicitly initialize values (so will provide an empty value if
+     *     no default is provided)</li>
+     *     <li>Use the Sponge default {@link org.spongepowered.configurate.serialize.TypeSerializer TypeSerializers},
+     *     as described in {@link ConfigManager#getSerializers()}.</li>
+     * </ul>
+     *
      * @return A configuration object
      * @see #getConfigPath()
      */
     ConfigurationLoader<CommentedConfigurationNode> getConfig();
 
     /**
-     * Get the serializers applicable to this root.
+     * Gets the configuration file that utilizes the default configuration
+     * pathname.
      *
-     * <p>The returned serializers will be for Sponge and Adventure types, as
-     * well as an object mapper that can use any applicable
-     * Guice {@link com.google.inject.Injector} to create instances.</p>
+     * <p>The returned loader will default to using the provided options.</p>
      *
-     * @return applicable serializers
-     * @see ConfigManager#getSerializers() for globally available serializers
+     * @param options Default options to be used when loading
+     * @return A configuration object
+     * @see #getConfigPath()
      */
-    TypeSerializerCollection getSerializers();
+    ConfigurationLoader<CommentedConfigurationNode> getConfig(final ConfigurationOptions options);
 
     /**
      * Gets the directory that this configuration root refers to.

--- a/src/main/java/org/spongepowered/api/config/DefaultConfig.java
+++ b/src/main/java/org/spongepowered/api/config/DefaultConfig.java
@@ -26,7 +26,7 @@ package org.spongepowered.api.config;
 
 import com.google.inject.BindingAnnotation;
 import com.google.inject.Inject;
-import ninja.leaping.configurate.loader.ConfigurationLoader;
+import org.spongepowered.configurate.loader.ConfigurationLoader;
 
 import java.io.File;
 import java.lang.annotation.ElementType;

--- a/src/main/java/org/spongepowered/api/data/DataProvider.java
+++ b/src/main/java/org/spongepowered/api/data/DataProvider.java
@@ -24,13 +24,14 @@
  */
 package org.spongepowered.api.data;
 
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.TypeToken;
 import org.spongepowered.api.Server;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.event.data.ChangeDataHolderEvent;
 
+import java.lang.reflect.Type;
 import java.util.Optional;
 
 @SuppressWarnings("unchecked")
@@ -123,7 +124,11 @@ public interface DataProvider<V extends Value<E>, E> {
      */
     boolean isSupported(DataHolder dataHolder);
 
-    boolean isSupported(TypeToken<? extends DataHolder> dataHolder);
+    default boolean isSupported(final TypeToken<? extends DataHolder> dataHolder) {
+        return isSupported(dataHolder.getType());
+    }
+
+    boolean isSupported(Type dataHolder);
 
     DataTransactionResult offer(DataHolder.Mutable dataHolder, E element);
 

--- a/src/main/java/org/spongepowered/api/data/DataRegistration.java
+++ b/src/main/java/org/spongepowered/api/data/DataRegistration.java
@@ -143,6 +143,7 @@ public interface DataRegistration extends CatalogType {
      *
      * @return The built data registration
      */
+    @SafeVarargs
     static <T> DataRegistration of(Key<Value<T>> key, Class<? extends DataHolder> dataHolder, Class<? extends DataHolder>... dataHolders) {
         final DataStore dataStore = DataStore.of(key, DataQuery.of(key.getKey().getNamespace(), key.getKey().getValue()), dataHolder, dataHolders);
         return DataRegistration.builder().dataKey(key).store(dataStore).key(key.getKey()).build();

--- a/src/main/java/org/spongepowered/api/data/DataRegistration.java
+++ b/src/main/java/org/spongepowered/api/data/DataRegistration.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.data;
 
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.TypeToken;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.persistence.DataQuery;

--- a/src/main/java/org/spongepowered/api/data/DataRegistration.java
+++ b/src/main/java/org/spongepowered/api/data/DataRegistration.java
@@ -102,6 +102,19 @@ public interface DataRegistration extends CatalogType {
     Optional<DataStore> getDataStore(TypeToken<? extends DataHolder> token);
 
     /**
+     * Gets the appropriate {@link DataStore} for the context of the
+     * {@link TypeToken} that is being serialized/deserialized. It is always
+     * possible that there may be a {@link DataStore} that does not support
+     * the provided {@link Class}, while a {@link DataProvider} may be
+     * provided for a particular {@link Key}.
+     *
+     * @param token The class of the desired ValueContainer. Cannot be a raw type
+     * @return The relevant DataStore for the desired type token of the target
+     *     type.
+     */
+    Optional<DataStore> getDataStore(Class<? extends DataHolder> token);
+
+    /**
      * Gets the registered {@link Key Keys} this controls. Note that each
      * {@link Key} can only be registered/owned by a single
      * {@link PluginContainer}. It is possible for there to be only a single

--- a/src/main/java/org/spongepowered/api/data/ImmutableDataProviderBuilder.java
+++ b/src/main/java/org/spongepowered/api/data/ImmutableDataProviderBuilder.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.data;
 
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.TypeToken;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.util.ResettableBuilder;
 
@@ -35,6 +35,7 @@ public interface ImmutableDataProviderBuilder<H extends DataHolder, V extends Va
 
     <NV extends Value<NE>, NE> ImmutableDataProviderBuilder<H, NV, NE> key(Key<NV> key);
     <NH extends H> ImmutableDataProviderBuilder<NH, V, E> dataHolder(TypeToken<NH> holder);
+    <NH extends H> ImmutableDataProviderBuilder<NH, V, E> dataHolder(Class<NH> holder);
 
     ImmutableDataProviderBuilder<H, V, E> get(Function<H, E> get);
     ImmutableDataProviderBuilder<H, V, E> set(BiFunction<H, E, H> set);

--- a/src/main/java/org/spongepowered/api/data/Key.java
+++ b/src/main/java/org/spongepowered/api/data/Key.java
@@ -37,6 +37,7 @@ import org.spongepowered.api.util.TypeTokens;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 import org.spongepowered.plugin.PluginContainer;
 
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Comparator;
@@ -62,7 +63,6 @@ import java.util.function.BiPredicate;
  *
  * @param <V> The type of {@link Value}
  */
-@SuppressWarnings("UnstableApiUsage")
 @CatalogedBy(Keys.class)
 public interface Key<V extends Value<?>> extends CatalogType {
 
@@ -88,23 +88,22 @@ public interface Key<V extends Value<?>> extends CatalogType {
     }
 
     /**
-     * Gets the class of the {@link Value} this {@link Key} is representing.
+     * Gets the type of the {@link Value} this {@link Key} is representing.
      *
-     * @return The value class
+     * @return The value generic type
      */
-    TypeToken<V> getValueToken();
+    Type getValueType();
 
     /**
-     * Gets the class of the element of the {@link Value} this {@link Key}
+     * Gets the type of the element of the {@link Value} this {@link Key}
      * is representing. On occasion, if the element is a {@link Collection} type,
-     * one can occasionally use {@link TypeToken#resolveType(Type)} with
-     * {@link Class#getTypeParameters()} as the type parameter of a collection
-     * is retrievable, such as the element type parameter for {@link List} or
-     * {@link Map}.
+     * one can use {@link ParameterizedType#getActualTypeArguments()} to access
+     * type parameters, such as the element type parameter for {@link List} or
+     * {@link Map} values.
      *
-     * @return The element class
+     * @return The element generic type
      */
-    TypeToken<?> getElementToken();
+    Type getElementType();
 
     /**
      * Gets the {@link Comparator} to
@@ -151,16 +150,30 @@ public interface Key<V extends Value<?>> extends CatalogType {
          * <p>Common {@link TypeToken TypeTokens} can be found in
          * {@link TypeTokens}. If a new TypeToken is to be created, it is
          * recommended to create an anonymous class instance of a token,
-         * as recommended by Guava's wiki found
-         * <a href="https://github.com/google/guava/wiki/ReflectionExplained#introduction">here</a>.
+         * as described in <a hrep="https://github.com/leangen/geantyref#creating-type-literals-using-typetoken">the GeAnTyRef documentation</a>
          * </p>
          *
-         * @param token The type token, preferably an anonymous
+         * @param token The type token
          * @param <T> The element type of the Key
          * @param <B> The base value type of the key
          * @return This builder, generified
          */
         <T, B extends Value<T>> Builder<T, B> type(TypeToken<B> token);
+
+
+        /**
+         * Starter method for the builder, to be used immediately after
+         * {@link Key#builder()} is called. This defines the generics for the
+         * builder itself to provide the properly generified {@link Key}.
+         *
+         * <p>This overload is provided for simple cases where a plain
+         * {@link Value} is used.</p>
+         *
+         * @param type The element type
+         * @param <T> The element type of the Key
+         * @return This builder, generified
+         */
+        <T> Builder<T, Value<T>> elementType(Class<T> type);
 
         /**
          * Sets the {@link Comparator} that can be used to compare

--- a/src/main/java/org/spongepowered/api/data/Key.java
+++ b/src/main/java/org/spongepowered/api/data/Key.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.data;
 
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.TypeToken;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;

--- a/src/main/java/org/spongepowered/api/data/MutableDataProviderBuilder.java
+++ b/src/main/java/org/spongepowered/api/data/MutableDataProviderBuilder.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.data;
 
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.TypeToken;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.util.ResettableBuilder;
 
@@ -38,6 +38,7 @@ public interface MutableDataProviderBuilder<H extends DataHolder.Mutable, V exte
 
     <NV extends Value<NE>, NE> MutableDataProviderBuilder<H, NV, NE> key(Key<NV> key);
     <NH extends H> MutableDataProviderBuilder<NH, V, E> dataHolder(TypeToken<NH> holder);
+    <NH extends H> MutableDataProviderBuilder<NH, V, E> dataHolder(Class<NH> holder);
 
     MutableDataProviderBuilder<H, V, E> get(Function<H, E> get);
     MutableDataProviderBuilder<H, V, E> set(BiConsumer<H, E> set);

--- a/src/main/java/org/spongepowered/api/data/persistence/DataQuery.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/DataQuery.java
@@ -25,17 +25,21 @@
 package org.spongepowered.api.data.persistence;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 /**
  * Represents a query that can be done on views. Queries do not depend on
  * their separator, it is just a way to construct them.
  */
-public final class DataQuery {
+public final class DataQuery implements Iterable<String> {
 
     private static final DataQuery EMPTY = new DataQuery();
 
@@ -44,7 +48,7 @@ public final class DataQuery {
      */
     private final ImmutableList<String> parts;
 
-    private ImmutableList<DataQuery> queryParts; //lazy loaded
+    private @MonotonicNonNull ImmutableList<DataQuery> queryParts; //lazy loaded
 
     /**
      * Constructs a query using the given separator character and path.
@@ -56,7 +60,7 @@ public final class DataQuery {
      * @param separator The separator
      * @param path The path
      */
-    private DataQuery(char separator, String path) {
+    private DataQuery(final char separator, final String path) {
         this(path.split(Pattern.quote(String.valueOf(separator))));
     }
 
@@ -65,7 +69,7 @@ public final class DataQuery {
      *
      * @param parts The parts
      */
-    private DataQuery(String... parts) {
+    private DataQuery(final String... parts) {
         this.parts = ImmutableList.copyOf(parts);
     }
 
@@ -74,7 +78,7 @@ public final class DataQuery {
      *
      * @param parts The parts
      */
-    private DataQuery(List<String> parts) {
+    private DataQuery(final List<String> parts) {
         this.parts = ImmutableList.copyOf(parts);
     }
 
@@ -100,7 +104,7 @@ public final class DataQuery {
      * @param path The path
      * @return The newly constructed {@link DataQuery}
      */
-    public static DataQuery of(char separator, String path) {
+    public static DataQuery of(final char separator, final String path) {
         return new DataQuery(separator, path);
     }
 
@@ -110,7 +114,7 @@ public final class DataQuery {
      * @param parts The parts
      * @return The newly constructed {@link DataQuery}
      */
-    public static DataQuery of(String... parts) {
+    public static DataQuery of(final String... parts) {
         if (parts.length == 0) {
             return DataQuery.EMPTY;
         }
@@ -123,7 +127,7 @@ public final class DataQuery {
      * @param parts The parts
      * @return The newly constructed {@link DataQuery}
      */
-    public static DataQuery of(List<String> parts) {
+    public static DataQuery of(final List<String> parts) {
         if (parts.isEmpty()) {
             return DataQuery.EMPTY;
         }
@@ -146,9 +150,8 @@ public final class DataQuery {
      * @param that The given query to follow this one
      * @return The constructed query
      */
-    public DataQuery then(DataQuery that) {
-        ImmutableList.Builder<String> builder =
-            new ImmutableList.Builder<>();
+    public DataQuery then(final DataQuery that) {
+        final ImmutableList.Builder<String> builder = new ImmutableList.Builder<>();
 
         builder.addAll(this.parts);
         builder.addAll(that.parts);
@@ -163,8 +166,8 @@ public final class DataQuery {
      * @param that The given query to follow this one
      * @return The constructed query
      */
-    public DataQuery then(String that) {
-        ImmutableList.Builder<String> builder =
+    public DataQuery then(final String that) {
+        final ImmutableList.Builder<String> builder =
             new ImmutableList.Builder<>();
 
         builder.addAll(this.parts);
@@ -181,8 +184,8 @@ public final class DataQuery {
      */
     public List<DataQuery> getQueryParts() {
         if (this.queryParts == null) {
-            ImmutableList.Builder<DataQuery> builder = ImmutableList.builder();
-            for (String part : getParts()) {
+            final ImmutableList.Builder<DataQuery> builder = ImmutableList.builder();
+            for (final String part : getParts()) {
                 builder.add(new DataQuery(part));
             }
             this.queryParts = builder.build();
@@ -201,7 +204,7 @@ public final class DataQuery {
         if (this.parts.size() <= 1) {
             return of();
         }
-        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        final ImmutableList.Builder<String> builder = ImmutableList.builder();
         for (int i = 0; i < this.parts.size() - 1; i++) {
             builder.add(this.parts.get(i));
         }
@@ -219,7 +222,7 @@ public final class DataQuery {
         if (this.parts.size() <= 1) {
             return of();
         }
-        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        final ImmutableList.Builder<String> builder = ImmutableList.builder();
         for (int i = 1; i < this.parts.size(); i++) {
             builder.add(this.parts.get(i));
         }
@@ -245,7 +248,7 @@ public final class DataQuery {
      * @param separator The separator
      * @return This query as a string
      */
-    public String asString(String separator) {
+    public String asString(final String separator) {
         return Joiner.on(separator).join(this.parts);
     }
 
@@ -255,7 +258,7 @@ public final class DataQuery {
      * @param separator The separator
      * @return This query as a string
      */
-    public String asString(char separator) {
+    public String asString(final char separator) {
         return asString(String.valueOf(separator));
     }
 
@@ -266,11 +269,11 @@ public final class DataQuery {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.parts);
+        return Objects.hash(this.parts);
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(final Object obj) {
         if (this == obj) {
             return true;
         }
@@ -278,6 +281,22 @@ public final class DataQuery {
             return false;
         }
         final DataQuery other = (DataQuery) obj;
-        return Objects.equal(this.parts, other.parts);
+        return Objects.equals(this.parts, other.parts);
     }
+
+    @Override
+    public Iterator<String> iterator() {
+        return this.parts.iterator();
+    }
+
+    @Override
+    public void forEach(final Consumer<? super String> action) {
+        this.parts.forEach(action);
+    }
+
+    @Override
+    public Spliterator<String> spliterator() {
+        return this.parts.spliterator();
+    }
+
 }

--- a/src/main/java/org/spongepowered/api/data/persistence/DataStore.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/DataStore.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.data.persistence;
 
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.TypeToken;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.DataHolder;
@@ -33,7 +33,6 @@ import org.spongepowered.api.data.Key;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.util.ResettableBuilder;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/org/spongepowered/api/data/persistence/DataStore.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/DataStore.java
@@ -130,6 +130,7 @@ public interface DataStore {
      * @return The new data store
      */
     @SafeVarargs
+    @SuppressWarnings("unchecked")
     static <T> DataStore of(Key<Value<T>> key, DataQuery dataQuery, TypeToken<? extends DataHolder> typeToken, TypeToken<? extends DataHolder>... typeTokens) {
         return DataStore.builder().pluginData(key.getKey()).holder(typeToken).holder(typeTokens).key(key, dataQuery).build();
     }
@@ -148,6 +149,7 @@ public interface DataStore {
      * @return The new data store
      */
     @SafeVarargs
+    @SuppressWarnings("unchecked")
     static <T> DataStore of(Key<Value<T>> key, DataQuery dataQuery, Class<?extends DataHolder> type, Class<? extends DataHolder>... types) {
         return DataStore.builder().pluginData(key.getKey()).holder(type).holder(types).key(key, dataQuery).build();
     }
@@ -258,14 +260,6 @@ public interface DataStore {
              */
             DataStore build();
         }
-=======
-
-        /**
-         * Builds a dataStore for given dataHolder type.
-         *
-         * @return The new data store
-         */
-        DataStore build();
     }
 
 }

--- a/src/main/java/org/spongepowered/api/data/persistence/DataStore.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/DataStore.java
@@ -33,6 +33,7 @@ import org.spongepowered.api.data.Key;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.util.ResettableBuilder;
 
+import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -42,11 +43,14 @@ import java.util.function.Function;
 public interface DataStore {
 
     /**
-     * Gets the supported {@link DataHolder} type.
+     * Gets the supported {@link DataHolder} types.
+     *
+     * <p>Every returned {@link java.lang.reflect.Type} will be a subtype
+     * of {@link DataHolder}.</p>
      *
      * @return The supported dataHolder type.
      */
-    Collection<TypeToken<? extends DataHolder>> getSupportedTokens();
+    Collection<Type> getSupportedTypes();
 
     /**
      * Serializes the values of the {@link DataManipulator}
@@ -193,6 +197,8 @@ public interface DataStore {
             /**
              * Adds one or more allowed dataHolder types
              *
+             * <p>These must not be parameterized types.</p>
+             *
              * @param types the dataHolder types
              *
              * @return this builder for chaining
@@ -252,6 +258,14 @@ public interface DataStore {
              */
             DataStore build();
         }
+=======
+
+        /**
+         * Builds a dataStore for given dataHolder type.
+         *
+         * @return The new data store
+         */
+        DataStore build();
     }
 
 }

--- a/src/main/java/org/spongepowered/api/data/persistence/DataTranslator.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/DataTranslator.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.data.persistence;
 
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.TypeToken;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 

--- a/src/main/java/org/spongepowered/api/data/persistence/DataTranslators.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/DataTranslators.java
@@ -25,7 +25,7 @@
 package org.spongepowered.api.data.persistence;
 
 import net.kyori.adventure.text.Component;
-import ninja.leaping.configurate.ConfigurationNode;
+import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.world.schematic.Schematic;
 import org.spongepowered.math.imaginary.Complexd;

--- a/src/main/java/org/spongepowered/api/event/EventContextKey.java
+++ b/src/main/java/org/spongepowered/api/event/EventContextKey.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.event;
 
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.TypeToken;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.util.CatalogBuilder;
@@ -58,7 +58,7 @@ public interface EventContextKey<T> extends CatalogType {
     interface Builder<T> extends CatalogBuilder<EventContextKey<T>, Builder<T>> {
 
         default <N> Builder<N> type(Class<N> allowedType) {
-            return type(TypeToken.of(allowedType));
+            return type(TypeToken.get(allowedType));
         }
 
         <N> Builder<N> type(TypeToken<N> allowedType);

--- a/src/main/java/org/spongepowered/api/event/EventContextKey.java
+++ b/src/main/java/org/spongepowered/api/event/EventContextKey.java
@@ -30,6 +30,8 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.util.CatalogBuilder;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
+import java.lang.reflect.Type;
+
 /**
  * A key for values in the {@link EventContext}.
  *
@@ -51,15 +53,32 @@ public interface EventContextKey<T> extends CatalogType {
     /**
      * Gets the allowed type for the value of this key.
      *
+     * <p>This is a concrete type equal to the parameter {@code T}</p>
+     *
      * @return The allowed type
      */
-    TypeToken<T> getAllowedType();
+    Type getAllowedType();
+
+    /**
+     * Return whether the value is an instance of this key's value type.
+     *
+     * @param value value to check
+     * @return if instance
+     */
+    boolean isInstance(Object value);
+
+    /**
+     * Cast the provided value to the value type.
+     *
+     * @param value value
+     * @return the casted value
+     * @throws ClassCastException if {@code value} is not of the correct type
+     */
+    T cast(Object value);
 
     interface Builder<T> extends CatalogBuilder<EventContextKey<T>, Builder<T>> {
 
-        default <N> Builder<N> type(Class<N> allowedType) {
-            return type(TypeToken.get(allowedType));
-        }
+        <N> Builder<N> type(Class<N> allowedType);
 
         <N> Builder<N> type(TypeToken<N> allowedType);
     }

--- a/src/main/java/org/spongepowered/api/event/EventManager.java
+++ b/src/main/java/org/spongepowered/api/event/EventManager.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.event;
 
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.TypeToken;
 import org.spongepowered.plugin.PluginContainer;
 
 /**

--- a/src/main/java/org/spongepowered/api/event/GenericEvent.java
+++ b/src/main/java/org/spongepowered/api/event/GenericEvent.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.event;
 
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.TypeToken;
 
 /**
  * All {@link Event}s that require a generic type should implement this

--- a/src/main/java/org/spongepowered/api/event/lifecycle/StartingEngineEvent.java
+++ b/src/main/java/org/spongepowered/api/event/lifecycle/StartingEngineEvent.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.event.lifecycle;
 
 import org.spongepowered.api.Engine;
-import org.spongepowered.api.event.GenericEvent;
 
 public interface StartingEngineEvent<E extends Engine> extends EngineLifecycleEvent<E> {
 }

--- a/src/main/java/org/spongepowered/api/statistic/StatisticCategory.java
+++ b/src/main/java/org/spongepowered/api/statistic/StatisticCategory.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.statistic;
 
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.TypeToken;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 

--- a/src/main/java/org/spongepowered/api/util/TypeTokens.java
+++ b/src/main/java/org/spongepowered/api/util/TypeTokens.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.util;
 
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.TypeToken;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
@@ -142,477 +142,477 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 
-@SuppressWarnings({"unused", "UnstableApiUsage"})
+@SuppressWarnings({"unused"})
 public final class TypeTokens {
 
     // SORTFIELDS:ON
     // @formatter:off
 
-    public static final TypeToken<Audience> AUDIENCE = new TypeToken<Audience>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Audience> AUDIENCE = new TypeToken<Audience>() {};
 
-    public static final TypeToken<ArmorMaterial> ARMOR_MATERIAL_TOKEN = new TypeToken<ArmorMaterial>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ArmorMaterial> ARMOR_MATERIAL_TOKEN = new TypeToken<ArmorMaterial>() {};
 
-    public static final TypeToken<Value<ArmorMaterial>> ARMOR_MATERIAL_VALUE_TOKEN = new TypeToken<Value<ArmorMaterial>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<ArmorMaterial>> ARMOR_MATERIAL_VALUE_TOKEN = new TypeToken<Value<ArmorMaterial>>() {};
 
-    public static final TypeToken<AttributeOperation> ATTRIBUTE_OPERATION_TOKEN = new TypeToken<AttributeOperation>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<AttributeOperation> ATTRIBUTE_OPERATION_TOKEN = new TypeToken<AttributeOperation>() {};
 
-    public static final TypeToken<Value<AttributeOperation>> ATTRIBUTE_OPERATION_VALUE_TOKEN = new TypeToken<Value<AttributeOperation>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<AttributeOperation>> ATTRIBUTE_OPERATION_VALUE_TOKEN = new TypeToken<Value<AttributeOperation>>() {};
 
-    public static final TypeToken<AttributeType> ATTRIBUTE_TYPE_TOKEN = new TypeToken<AttributeType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<AttributeType> ATTRIBUTE_TYPE_TOKEN = new TypeToken<AttributeType>() {};
 
-    public static final TypeToken<Value<AttributeType>> ATTRIBUTE_TYPE_VALUE_TOKEN = new TypeToken<Value<AttributeType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<AttributeType>> ATTRIBUTE_TYPE_VALUE_TOKEN = new TypeToken<Value<AttributeType>>() {};
 
-    public static final TypeToken<ArtType> ART_TYPE_TOKEN = new TypeToken<ArtType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ArtType> ART_TYPE_TOKEN = new TypeToken<ArtType>() {};
 
-    public static final TypeToken<Value<ArtType>> ART_TYPE_VALUE_TOKEN = new TypeToken<Value<ArtType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<ArtType>> ART_TYPE_VALUE_TOKEN = new TypeToken<Value<ArtType>>() {};
 
-    public static final TypeToken<AttachmentSurface> ATTACHMENT_SURFACE_TOKEN = new TypeToken<AttachmentSurface>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<AttachmentSurface> ATTACHMENT_SURFACE_TOKEN = new TypeToken<AttachmentSurface>() {};
 
-    public static final TypeToken<Value<AttachmentSurface>> ATTACHMENT_SURFACE_VALUE_TOKEN = new TypeToken<Value<AttachmentSurface>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<AttachmentSurface>> ATTACHMENT_SURFACE_VALUE_TOKEN = new TypeToken<Value<AttachmentSurface>>() {};
 
-    public static final TypeToken<Axis> AXIS_TOKEN = new TypeToken<Axis>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Axis> AXIS_TOKEN = new TypeToken<Axis>() {};
 
-    public static final TypeToken<Value<Axis>> AXIS_VALUE_TOKEN = new TypeToken<Value<Axis>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Axis>> AXIS_VALUE_TOKEN = new TypeToken<Value<Axis>>() {};
 
-    public static final TypeToken<BlockEntityArchetype> BLOCK_ENTITY_ARCHETYPE_TOKEN = new TypeToken<BlockEntityArchetype>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<BlockEntityArchetype> BLOCK_ENTITY_ARCHETYPE_TOKEN = new TypeToken<BlockEntityArchetype>() {};
 
-    public static final TypeToken<BlockEntity> BLOCK_ENTITY_TOKEN = new TypeToken<BlockEntity>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<BlockEntity> BLOCK_ENTITY_TOKEN = new TypeToken<BlockEntity>() {};
 
-    public static final TypeToken<BlockSnapshot> BLOCK_SNAPSHOT_TOKEN = new TypeToken<BlockSnapshot>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<BlockSnapshot> BLOCK_SNAPSHOT_TOKEN = new TypeToken<BlockSnapshot>() {};
 
-    public static final TypeToken<BlockState> BLOCK_STATE_TOKEN = new TypeToken<BlockState>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<BlockState> BLOCK_STATE_TOKEN = new TypeToken<BlockState>() {};
 
-    public static final TypeToken<Value<BlockState>> BLOCK_STATE_VALUE_TOKEN = new TypeToken<Value<BlockState>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<BlockState>> BLOCK_STATE_VALUE_TOKEN = new TypeToken<Value<BlockState>>() {};
 
-    public static final TypeToken<BoatType> BOAT_TYPE_TOKEN = new TypeToken<BoatType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<BoatType> BOAT_TYPE_TOKEN = new TypeToken<BoatType>() {};
 
-    public static final TypeToken<Value<BoatType>> BOAT_TYPE_VALUE_TOKEN = new TypeToken<Value<BoatType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<BoatType>> BOAT_TYPE_VALUE_TOKEN = new TypeToken<Value<BoatType>>() {};
 
-    public static final TypeToken<Boolean> BOOLEAN_TOKEN = new TypeToken<Boolean>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Boolean> BOOLEAN_TOKEN = new TypeToken<Boolean>() {};
 
-    public static final TypeToken<Value<Boolean>> BOOLEAN_VALUE_TOKEN = new TypeToken<Value<Boolean>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Boolean>> BOOLEAN_VALUE_TOKEN = new TypeToken<Value<Boolean>>() {};
 
-    public static final TypeToken<BossBar> BOSS_BAR_TOKEN = new TypeToken<BossBar>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<BossBar> BOSS_BAR_TOKEN = new TypeToken<BossBar>() {};
 
-    public static final TypeToken<Value<BossBar>> BOSS_BAR_VALUE_TOKEN = new TypeToken<Value<BossBar>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<BossBar>> BOSS_BAR_VALUE_TOKEN = new TypeToken<Value<BossBar>>() {};
 
-    public static final TypeToken<CatType> CAT_TYPE_TOKEN = new TypeToken<CatType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<CatType> CAT_TYPE_TOKEN = new TypeToken<CatType>() {};
 
-    public static final TypeToken<Value<CatType>> CAT_TYPE_VALUE_TOKEN = new TypeToken<Value<CatType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<CatType>> CAT_TYPE_VALUE_TOKEN = new TypeToken<Value<CatType>>() {};
 
-    public static final TypeToken<ChestAttachmentType> CHEST_ATTACHMENT_TYPE_TOKEN = new TypeToken<ChestAttachmentType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ChestAttachmentType> CHEST_ATTACHMENT_TYPE_TOKEN = new TypeToken<ChestAttachmentType>() {};
 
-    public static final TypeToken<Value<ChestAttachmentType>> CHEST_ATTACHMENT_TYPE_VALUE_TOKEN = new TypeToken<Value<ChestAttachmentType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<ChestAttachmentType>> CHEST_ATTACHMENT_TYPE_VALUE_TOKEN = new TypeToken<Value<ChestAttachmentType>>() {};
 
-    public static final TypeToken<Color> COLOR_TOKEN = new TypeToken<Color>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Color> COLOR_TOKEN = new TypeToken<Color>() {};
 
-    public static final TypeToken<Value<Color>> COLOR_VALUE_TOKEN = new TypeToken<Value<Color>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Color>> COLOR_VALUE_TOKEN = new TypeToken<Value<Color>>() {};
 
-    public static final TypeToken<Consumer<CommandCause>> COMMAND_CAUSE_CONSUMER = new TypeToken<Consumer<CommandCause>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Consumer<CommandCause>> COMMAND_CAUSE_CONSUMER = new TypeToken<Consumer<CommandCause>>() {};
 
-    public static final TypeToken<CommandExecutor> COMMAND_EXECUTOR = new TypeToken<CommandExecutor>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<CommandExecutor> COMMAND_EXECUTOR = new TypeToken<CommandExecutor>() {};
 
-    public static final TypeToken<CommandMapping> COMMAND_MAPPING = new TypeToken<CommandMapping>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<CommandMapping> COMMAND_MAPPING = new TypeToken<CommandMapping>() {};
 
-    public static final TypeToken<ComparatorMode> COMPARATOR_MODE_TOKEN = new TypeToken<ComparatorMode>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ComparatorMode> COMPARATOR_MODE_TOKEN = new TypeToken<ComparatorMode>() {};
 
-    public static final TypeToken<Value<ComparatorMode>> COMPARATOR_MODE_VALUE_TOKEN = new TypeToken<Value<ComparatorMode>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<ComparatorMode>> COMPARATOR_MODE_VALUE_TOKEN = new TypeToken<Value<ComparatorMode>>() {};
 
-    public static final TypeToken<Component> COMPONENT_TOKEN = new TypeToken<Component>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Component> COMPONENT_TOKEN = new TypeToken<Component>() {};
 
-    public static final TypeToken<Value<Component>> COMPONENT_VALUE_TOKEN = new TypeToken<Value<Component>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Component>> COMPONENT_VALUE_TOKEN = new TypeToken<Value<Component>>() {};
 
-    public static final TypeToken<Direction> DIRECTION_TOKEN = new TypeToken<Direction>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Direction> DIRECTION_TOKEN = new TypeToken<Direction>() {};
 
-    public static final TypeToken<Value<Direction>> DIRECTION_VALUE_TOKEN = new TypeToken<Value<Direction>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Direction>> DIRECTION_VALUE_TOKEN = new TypeToken<Value<Direction>>() {};
 
-    public static final TypeToken<DoorHinge> DOOR_HINGE_TOKEN = new TypeToken<DoorHinge>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<DoorHinge> DOOR_HINGE_TOKEN = new TypeToken<DoorHinge>() {};
 
-    public static final TypeToken<Value<DoorHinge>> DOOR_HINGE_VALUE_TOKEN = new TypeToken<Value<DoorHinge>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<DoorHinge>> DOOR_HINGE_VALUE_TOKEN = new TypeToken<Value<DoorHinge>>() {};
 
-    public static final TypeToken<Double> DOUBLE_TOKEN = new TypeToken<Double>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Double> DOUBLE_TOKEN = new TypeToken<Double>() {};
 
-    public static final TypeToken<Value<Double>> DOUBLE_VALUE_TOKEN = new TypeToken<Value<Double>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Double>> DOUBLE_VALUE_TOKEN = new TypeToken<Value<Double>>() {};
 
-    public static final TypeToken<DyeColor> DYE_COLOR_TOKEN = new TypeToken<DyeColor>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<DyeColor> DYE_COLOR_TOKEN = new TypeToken<DyeColor>() {};
 
-    public static final TypeToken<Value<DyeColor>> DYE_COLOR_VALUE_TOKEN = new TypeToken<Value<DyeColor>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<DyeColor>> DYE_COLOR_VALUE_TOKEN = new TypeToken<Value<DyeColor>>() {};
 
-    public static final TypeToken<EnderCrystal> ENDER_CRYSTAL_TOKEN = new TypeToken<EnderCrystal>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<EnderCrystal> ENDER_CRYSTAL_TOKEN = new TypeToken<EnderCrystal>() {};
 
-    public static final TypeToken<Value<EnderCrystal>> ENDER_CRYSTAL_VALUE_TOKEN = new TypeToken<Value<EnderCrystal>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<EnderCrystal>> ENDER_CRYSTAL_VALUE_TOKEN = new TypeToken<Value<EnderCrystal>>() {};
 
-    public static final TypeToken<EntityArchetype> ENTITY_ARCHETYPE_TOKEN = new TypeToken<EntityArchetype>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<EntityArchetype> ENTITY_ARCHETYPE_TOKEN = new TypeToken<EntityArchetype>() {};
 
-    public static final TypeToken<EntitySnapshot> ENTITY_SNAPSHOT_TOKEN = new TypeToken<EntitySnapshot>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<EntitySnapshot> ENTITY_SNAPSHOT_TOKEN = new TypeToken<EntitySnapshot>() {};
 
-    public static final TypeToken<Value<EntitySnapshot>> ENTITY_SNAPSHOT_VALUE_TOKEN = new TypeToken<Value<EntitySnapshot>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<EntitySnapshot>> ENTITY_SNAPSHOT_VALUE_TOKEN = new TypeToken<Value<EntitySnapshot>>() {};
 
-    public static final TypeToken<Entity> ENTITY_TOKEN = new TypeToken<Entity>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Entity> ENTITY_TOKEN = new TypeToken<Entity>() {};
 
-    public static final TypeToken<Value<Entity>> ENTITY_VALUE_TOKEN = new TypeToken<Value<Entity>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Entity>> ENTITY_VALUE_TOKEN = new TypeToken<Value<Entity>>() {};
 
-    public static final TypeToken<Map<EntityType<?>, Double>> MAP_ENTITY_TYPE_DOUBLE_TOKEN = new TypeToken<Map<EntityType<?>, Double>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Map<EntityType<?>, Double>> MAP_ENTITY_TYPE_DOUBLE_TOKEN = new TypeToken<Map<EntityType<?>, Double>>() {};
 
-    public static final TypeToken<MapValue<EntityType<?>, Double>> MAP_ENTITY_TYPE_DOUBLE_VALUE_TOKEN = new TypeToken<MapValue<EntityType<?>, Double>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<MapValue<EntityType<?>, Double>> MAP_ENTITY_TYPE_DOUBLE_VALUE_TOKEN = new TypeToken<MapValue<EntityType<?>, Double>>() {};
 
-    public static final TypeToken<EntityType<?>> ENTITY_TYPE_TOKEN = new TypeToken<EntityType<?>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<EntityType<?>> ENTITY_TYPE_TOKEN = new TypeToken<EntityType<?>>() {};
 
-    public static final TypeToken<Value<EntityType<?>>> ENTITY_TYPE_VALUE_TOKEN = new TypeToken<Value<EntityType<?>>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<EntityType<?>>> ENTITY_TYPE_VALUE_TOKEN = new TypeToken<Value<EntityType<?>>>() {};
 
-    public static final TypeToken<EquipmentType> EQUIPMENT_TYPE_TOKEN = new TypeToken<EquipmentType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<EquipmentType> EQUIPMENT_TYPE_TOKEN = new TypeToken<EquipmentType>() {};
 
-    public static final TypeToken<Value<EquipmentType>> EQUIPMENT_TYPE_VALUE_TOKEN = new TypeToken<Value<EquipmentType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<EquipmentType>> EQUIPMENT_TYPE_VALUE_TOKEN = new TypeToken<Value<EquipmentType>>() {};
 
-    public static final TypeToken<Value<FireworkShape>> FIREWORK_SHAPE_VALUE_TOKEN = new TypeToken<Value<FireworkShape>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<FireworkShape>> FIREWORK_SHAPE_VALUE_TOKEN = new TypeToken<Value<FireworkShape>>() {};
 
-    public static final TypeToken<Float> FLOAT_TOKEN = new TypeToken<Float>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Float> FLOAT_TOKEN = new TypeToken<Float>() {};
 
-    public static final TypeToken<FluidStack> FLUID_STACK_TOKEN = new TypeToken<FluidStack>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<FluidStack> FLUID_STACK_TOKEN = new TypeToken<FluidStack>() {};
 
-    public static final TypeToken<FluidState> FLUID_STATE_TOKEN = new TypeToken<FluidState>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<FluidState> FLUID_STATE_TOKEN = new TypeToken<FluidState>() {};
 
-    public static final TypeToken<FluidStackSnapshot> FLUID_STACK_SNAPSHOT_TOKEN = new TypeToken<FluidStackSnapshot>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<FluidStackSnapshot> FLUID_STACK_SNAPSHOT_TOKEN = new TypeToken<FluidStackSnapshot>() {};
 
-    public static final TypeToken<Value<FluidStackSnapshot>> FLUID_STACK_SNAPSHOT_VALUE_TOKEN = new TypeToken<Value<FluidStackSnapshot>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<FluidStackSnapshot>> FLUID_STACK_SNAPSHOT_VALUE_TOKEN = new TypeToken<Value<FluidStackSnapshot>>() {};
 
-    public static final TypeToken<FoxType> FOX_TYPE_TOKEN = new TypeToken<FoxType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<FoxType> FOX_TYPE_TOKEN = new TypeToken<FoxType>() {};
 
-    public static final TypeToken<Value<FoxType>> FOX_TYPE_VALUE_TOKEN = new TypeToken<Value<FoxType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<FoxType>> FOX_TYPE_VALUE_TOKEN = new TypeToken<Value<FoxType>>() {};
 
-    public static final TypeToken<GameMode> GAME_MODE_TOKEN = new TypeToken<GameMode>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<GameMode> GAME_MODE_TOKEN = new TypeToken<GameMode>() {};
 
-    public static final TypeToken<Value<GameMode>> GAME_MODE_VALUE_TOKEN = new TypeToken<Value<GameMode>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<GameMode>> GAME_MODE_VALUE_TOKEN = new TypeToken<Value<GameMode>>() {};
 
-    public static final TypeToken<GameProfile> GAME_PROFILE_TOKEN = new TypeToken<GameProfile>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<GameProfile> GAME_PROFILE_TOKEN = new TypeToken<GameProfile>() {};
 
-    public static final TypeToken<Value<GameProfile>> GAME_PROFILE_VALUE_TOKEN = new TypeToken<Value<GameProfile>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<GameProfile>> GAME_PROFILE_VALUE_TOKEN = new TypeToken<Value<GameProfile>>() {};
 
-    public static final TypeToken<HandPreference> HAND_PREFERENCE_TOKEN = new TypeToken<HandPreference>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<HandPreference> HAND_PREFERENCE_TOKEN = new TypeToken<HandPreference>() {};
 
-    public static final TypeToken<Value<HandPreference>> HAND_PREFERENCE_VALUE_TOKEN = new TypeToken<Value<HandPreference>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<HandPreference>> HAND_PREFERENCE_VALUE_TOKEN = new TypeToken<Value<HandPreference>>() {};
 
-    public static final TypeToken<HorseColor> HORSE_COLOR_TOKEN = new TypeToken<HorseColor>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<HorseColor> HORSE_COLOR_TOKEN = new TypeToken<HorseColor>() {};
 
-    public static final TypeToken<Value<HorseColor>> HORSE_COLOR_VALUE_TOKEN = new TypeToken<Value<HorseColor>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<HorseColor>> HORSE_COLOR_VALUE_TOKEN = new TypeToken<Value<HorseColor>>() {};
 
-    public static final TypeToken<HorseStyle> HORSE_STYLE_TOKEN = new TypeToken<HorseStyle>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<HorseStyle> HORSE_STYLE_TOKEN = new TypeToken<HorseStyle>() {};
 
-    public static final TypeToken<Value<HorseStyle>> HORSE_STYLE_VALUE_TOKEN = new TypeToken<Value<HorseStyle>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<HorseStyle>> HORSE_STYLE_VALUE_TOKEN = new TypeToken<Value<HorseStyle>>() {};
 
-    public static final TypeToken<Instant> INSTANT_TOKEN = new TypeToken<Instant>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Instant> INSTANT_TOKEN = new TypeToken<Instant>() {};
 
-    public static final TypeToken<Value<Instant>> INSTANT_VALUE_TOKEN = new TypeToken<Value<Instant>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Instant>> INSTANT_VALUE_TOKEN = new TypeToken<Value<Instant>>() {};
 
-    public static final TypeToken<InstrumentType> INSTRUMENT_TYPE_TOKEN = new TypeToken<InstrumentType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<InstrumentType> INSTRUMENT_TYPE_TOKEN = new TypeToken<InstrumentType>() {};
 
-    public static final TypeToken<Value<InstrumentType>> INSTRUMENT_TYPE_VALUE_TOKEN = new TypeToken<Value<InstrumentType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<InstrumentType>> INSTRUMENT_TYPE_VALUE_TOKEN = new TypeToken<Value<InstrumentType>>() {};
 
-    public static final TypeToken<Integer> INTEGER_TOKEN = new TypeToken<Integer>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Integer> INTEGER_TOKEN = new TypeToken<Integer>() {};
 
-    public static final TypeToken<Value<Integer>> INTEGER_VALUE_TOKEN = new TypeToken<Value<Integer>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Integer>> INTEGER_VALUE_TOKEN = new TypeToken<Value<Integer>>() {};
 
-    public static final TypeToken<ItemType> ITEM_TYPE_TOKEN = new TypeToken<ItemType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ItemType> ITEM_TYPE_TOKEN = new TypeToken<ItemType>() {};
 
-    public static final TypeToken<Value<ItemType>> ITEM_TYPE_VALUE_TOKEN = new TypeToken<Value<ItemType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<ItemType>> ITEM_TYPE_VALUE_TOKEN = new TypeToken<Value<ItemType>>() {};
 
-    public static final TypeToken<ItemStackSnapshot> ITEM_STACK_SNAPSHOT_TOKEN = new TypeToken<ItemStackSnapshot>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ItemStackSnapshot> ITEM_STACK_SNAPSHOT_TOKEN = new TypeToken<ItemStackSnapshot>() {};
 
-    public static final TypeToken<Value<ItemStackSnapshot>> ITEM_STACK_SNAPSHOT_VALUE_TOKEN = new TypeToken<Value<ItemStackSnapshot>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<ItemStackSnapshot>> ITEM_STACK_SNAPSHOT_VALUE_TOKEN = new TypeToken<Value<ItemStackSnapshot>>() {};
 
-    public static final TypeToken<ItemStack> ITEM_STACK_TOKEN = new TypeToken<ItemStack>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ItemStack> ITEM_STACK_TOKEN = new TypeToken<ItemStack>() {};
 
-    public static final TypeToken<List<BannerPatternLayer>> LIST_BANNER_PATTERN_LAYER_TOKEN = new TypeToken<List<BannerPatternLayer>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<List<BannerPatternLayer>> LIST_BANNER_PATTERN_LAYER_TOKEN = new TypeToken<List<BannerPatternLayer>>() {};
 
-    public static final TypeToken<ListValue<BannerPatternLayer>> LIST_BANNER_PATTERN_LAYER_VALUE_TOKEN = new TypeToken<ListValue<BannerPatternLayer>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ListValue<BannerPatternLayer>> LIST_BANNER_PATTERN_LAYER_VALUE_TOKEN = new TypeToken<ListValue<BannerPatternLayer>>() {};
 
-    public static final TypeToken<List<Component>> LIST_COMPONENT_TOKEN = new TypeToken<List<Component>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<List<Component>> LIST_COMPONENT_TOKEN = new TypeToken<List<Component>>() {};
 
-    public static final TypeToken<ListValue<Component>> LIST_COMPONENT_VALUE_TOKEN = new TypeToken<ListValue<Component>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ListValue<Component>> LIST_COMPONENT_VALUE_TOKEN = new TypeToken<ListValue<Component>>() {};
 
-    public static final TypeToken<List<? extends DataSerializable>> LIST_DATA_SERIALIZABLE_TOKEN = new TypeToken<List<? extends DataSerializable>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<List<? extends DataSerializable>> LIST_DATA_SERIALIZABLE_TOKEN = new TypeToken<List<? extends DataSerializable>>() {};
 
-    public static final TypeToken<List<DyeColor>> LIST_DYE_COLOR_TOKEN = new TypeToken<List<DyeColor>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<List<DyeColor>> LIST_DYE_COLOR_TOKEN = new TypeToken<List<DyeColor>>() {};
 
-    public static final TypeToken<ListValue<DyeColor>> LIST_DYE_COLOR_VALUE_TOKEN = new TypeToken<ListValue<DyeColor>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ListValue<DyeColor>> LIST_DYE_COLOR_VALUE_TOKEN = new TypeToken<ListValue<DyeColor>>() {};
 
-    public static final TypeToken<List<Enchantment>> LIST_ENCHANTMENT_TOKEN = new TypeToken<List<Enchantment>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<List<Enchantment>> LIST_ENCHANTMENT_TOKEN = new TypeToken<List<Enchantment>>() {};
 
-    public static final TypeToken<ListValue<Enchantment>> LIST_ENCHANTMENT_VALUE_TOKEN = new TypeToken<ListValue<Enchantment>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ListValue<Enchantment>> LIST_ENCHANTMENT_VALUE_TOKEN = new TypeToken<ListValue<Enchantment>>() {};
 
-    public static final TypeToken<List<Entity>> LIST_ENTITY_TOKEN = new TypeToken<List<Entity>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<List<Entity>> LIST_ENTITY_TOKEN = new TypeToken<List<Entity>>() {};
 
-    public static final TypeToken<ListValue<Entity>> LIST_ENTITY_VALUE_TOKEN = new TypeToken<ListValue<Entity>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ListValue<Entity>> LIST_ENTITY_VALUE_TOKEN = new TypeToken<ListValue<Entity>>() {};
 
-    public static final TypeToken<List<FireworkEffect>> LIST_FIREWORK_EFFECT_TOKEN = new TypeToken<List<FireworkEffect>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<List<FireworkEffect>> LIST_FIREWORK_EFFECT_TOKEN = new TypeToken<List<FireworkEffect>>() {};
 
-    public static final TypeToken<ListValue<FireworkEffect>> LIST_FIREWORK_EFFECT_VALUE_TOKEN = new TypeToken<ListValue<FireworkEffect>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ListValue<FireworkEffect>> LIST_FIREWORK_EFFECT_VALUE_TOKEN = new TypeToken<ListValue<FireworkEffect>>() {};
 
-    public static final TypeToken<List<PotionEffect>> LIST_POTION_EFFECT_TOKEN = new TypeToken<List<PotionEffect>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<List<PotionEffect>> LIST_POTION_EFFECT_TOKEN = new TypeToken<List<PotionEffect>>() {};
 
-    public static final TypeToken<ListValue<PotionEffect>> LIST_POTION_EFFECT_VALUE_TOKEN = new TypeToken<ListValue<PotionEffect>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ListValue<PotionEffect>> LIST_POTION_EFFECT_VALUE_TOKEN = new TypeToken<ListValue<PotionEffect>>() {};
 
-    public static final TypeToken<ListValue<String>> LIST_STRING_VALUE_TOKEN = new TypeToken<ListValue<String>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ListValue<String>> LIST_STRING_VALUE_TOKEN = new TypeToken<ListValue<String>>() {};
 
-    public static final TypeToken<List<TradeOffer>> LIST_TRADE_OFFER_TOKEN = new TypeToken<List<TradeOffer>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<List<TradeOffer>> LIST_TRADE_OFFER_TOKEN = new TypeToken<List<TradeOffer>>() {};
 
-    public static final TypeToken<ListValue<TradeOffer>> LIST_TRADE_OFFER_VALUE_TOKEN = new TypeToken<ListValue<TradeOffer>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ListValue<TradeOffer>> LIST_TRADE_OFFER_VALUE_TOKEN = new TypeToken<ListValue<TradeOffer>>() {};
 
-    public static final TypeToken<Living> LIVING_TOKEN = new TypeToken<Living>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Living> LIVING_TOKEN = new TypeToken<Living>() {};
 
-    public static final TypeToken<Value<Living>> LIVING_VALUE_TOKEN = new TypeToken<Value<Living>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Living>> LIVING_VALUE_TOKEN = new TypeToken<Value<Living>>() {};
 
-    public static final TypeToken<LlamaType> LLAMA_TYPE_TOKEN = new TypeToken<LlamaType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<LlamaType> LLAMA_TYPE_TOKEN = new TypeToken<LlamaType>() {};
 
-    public static final TypeToken<Value<LlamaType>> LLAMA_TYPE_VALUE_TOKEN = new TypeToken<Value<LlamaType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<LlamaType>> LLAMA_TYPE_VALUE_TOKEN = new TypeToken<Value<LlamaType>>() {};
 
-    public static final TypeToken<Long> LONG_TOKEN = new TypeToken<Long>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Long> LONG_TOKEN = new TypeToken<Long>() {};
 
-    public static final TypeToken<Value<Long>> LONG_VALUE_TOKEN = new TypeToken<Value<Long>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Long>> LONG_VALUE_TOKEN = new TypeToken<Value<Long>>() {};
 
-    public static final TypeToken<Map<EquipmentType, Boolean>> MAP_EQUIPMENT_TYPE_BOOLEAN_TOKEN = new TypeToken<Map<EquipmentType, Boolean>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Map<EquipmentType, Boolean>> MAP_EQUIPMENT_TYPE_BOOLEAN_TOKEN = new TypeToken<Map<EquipmentType, Boolean>>() {};
 
-    public static final TypeToken<MapValue<EquipmentType, Boolean>> MAP_EQUIPMENT_TYPE_BOOLEAN_VALUE_TOKEN = new TypeToken<MapValue<EquipmentType, Boolean>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<MapValue<EquipmentType, Boolean>> MAP_EQUIPMENT_TYPE_BOOLEAN_VALUE_TOKEN = new TypeToken<MapValue<EquipmentType, Boolean>>() {};
 
-    public static final TypeToken<Map<BodyPart, Vector3d>> MAP_BODY_VECTOR3D_TOKEN = new TypeToken<Map<BodyPart, Vector3d>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Map<BodyPart, Vector3d>> MAP_BODY_VECTOR3D_TOKEN = new TypeToken<Map<BodyPart, Vector3d>>() {};
 
-    public static final TypeToken<MapValue<BodyPart, Vector3d>> MAP_BODY_VECTOR3D_VALUE_TOKEN = new TypeToken<MapValue<BodyPart, Vector3d>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<MapValue<BodyPart, Vector3d>> MAP_BODY_VECTOR3D_VALUE_TOKEN = new TypeToken<MapValue<BodyPart, Vector3d>>() {};
 
-    public static final TypeToken<Map<Direction, List<FluidStackSnapshot>>> MAP_DIRECTION_FLUID_STACK_SNAPSHOT_TOKEN = new TypeToken<Map<Direction, List<FluidStackSnapshot>>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Map<Direction, List<FluidStackSnapshot>>> MAP_DIRECTION_FLUID_STACK_SNAPSHOT_TOKEN = new TypeToken<Map<Direction, List<FluidStackSnapshot>>>() {};
 
-    public static final TypeToken<MapValue<Direction, List<FluidStackSnapshot>>> MAP_DIRECTION_FLUID_STACK_SNAPSHOT_VALUE_TOKEN = new TypeToken<MapValue<Direction, List<FluidStackSnapshot>>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<MapValue<Direction, List<FluidStackSnapshot>>> MAP_DIRECTION_FLUID_STACK_SNAPSHOT_VALUE_TOKEN = new TypeToken<MapValue<Direction, List<FluidStackSnapshot>>>() {};
 
-    public static final TypeToken<Map<UUID, RespawnLocation>> MAP_UUID_RESPAWN_LOCATION_TOKEN = new TypeToken<Map<UUID, RespawnLocation>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Map<UUID, RespawnLocation>> MAP_UUID_RESPAWN_LOCATION_TOKEN = new TypeToken<Map<UUID, RespawnLocation>>() {};
 
-    public static final TypeToken<MapValue<UUID, RespawnLocation>> MAP_UUID_RESPAWN_LOCATION_VALUE_TOKEN = new TypeToken<MapValue<UUID, RespawnLocation>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<MapValue<UUID, RespawnLocation>> MAP_UUID_RESPAWN_LOCATION_VALUE_TOKEN = new TypeToken<MapValue<UUID, RespawnLocation>>() {};
 
-    public static final TypeToken<Map<UUID, Vector3d>> MAP_UUID_VECTOR3D_TOKEN = new TypeToken<Map<UUID, Vector3d>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Map<UUID, Vector3d>> MAP_UUID_VECTOR3D_TOKEN = new TypeToken<Map<UUID, Vector3d>>() {};
 
-    public static final TypeToken<MapValue<UUID, Vector3d>> MAP_UUID_VECTOR3D_VALUE_TOKEN = new TypeToken<MapValue<UUID, Vector3d>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<MapValue<UUID, Vector3d>> MAP_UUID_VECTOR3D_VALUE_TOKEN = new TypeToken<MapValue<UUID, Vector3d>>() {};
 
-    public static final TypeToken<MatterState> MATTER_STATE_TOKEN = new TypeToken<MatterState>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<MatterState> MATTER_STATE_TOKEN = new TypeToken<MatterState>() {};
 
-    public static final TypeToken<Value<MatterState>> MATTER_STATE_VALUE_TOKEN = new TypeToken<Value<MatterState>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<MatterState>> MATTER_STATE_VALUE_TOKEN = new TypeToken<Value<MatterState>>() {};
 
-    public static final TypeToken<MooshroomType> MOOSHROOM_TYPE_TOKEN = new TypeToken<MooshroomType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<MooshroomType> MOOSHROOM_TYPE_TOKEN = new TypeToken<MooshroomType>() {};
 
-    public static final TypeToken<Value<MooshroomType>> MOOSHROOM_TYPE_VALUE_TOKEN = new TypeToken<Value<MooshroomType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<MooshroomType>> MOOSHROOM_TYPE_VALUE_TOKEN = new TypeToken<Value<MooshroomType>>() {};
 
-    public static final TypeToken<MusicDisc> MUSIC_DISC_TOKEN = new TypeToken<MusicDisc>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<MusicDisc> MUSIC_DISC_TOKEN = new TypeToken<MusicDisc>() {};
 
-    public static final TypeToken<Value<MusicDisc>> MUSIC_DISC_VALUE_TOKEN = new TypeToken<Value<MusicDisc>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<MusicDisc>> MUSIC_DISC_VALUE_TOKEN = new TypeToken<Value<MusicDisc>>() {};
 
-    public static final TypeToken<NotePitch> NOTE_PITCH_TOKEN = new TypeToken<NotePitch>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<NotePitch> NOTE_PITCH_TOKEN = new TypeToken<NotePitch>() {};
 
-    public static final TypeToken<Value<NotePitch>> NOTE_PITCH_VALUE_TOKEN = new TypeToken<Value<NotePitch>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<NotePitch>> NOTE_PITCH_VALUE_TOKEN = new TypeToken<Value<NotePitch>>() {};
 
-    public static final TypeToken<Object> OBJECT = TypeToken.of(Object.class);
+    public static final TypeToken<Object> OBJECT = TypeToken.get(Object.class);
 
-    public static final TypeToken<Orientation> ORIENTATION_TOKEN = new TypeToken<Orientation>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Orientation> ORIENTATION_TOKEN = new TypeToken<Orientation>() {};
 
-    public static final TypeToken<Value<Orientation>> ORIENTATION_VALUE_TOKEN = new TypeToken<Value<Orientation>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Orientation>> ORIENTATION_VALUE_TOKEN = new TypeToken<Value<Orientation>>() {};
 
-    public static final TypeToken<PandaGene> PANDA_GENE_TOKEN = new TypeToken<PandaGene>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<PandaGene> PANDA_GENE_TOKEN = new TypeToken<PandaGene>() {};
 
-    public static final TypeToken<Value<PandaGene>> PANDA_GENE_VALUE_TOKEN = new TypeToken<Value<PandaGene>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<PandaGene>> PANDA_GENE_VALUE_TOKEN = new TypeToken<Value<PandaGene>>() {};
 
-    public static final TypeToken<ParrotType> PARROT_TYPE_TOKEN = new TypeToken<ParrotType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ParrotType> PARROT_TYPE_TOKEN = new TypeToken<ParrotType>() {};
 
-    public static final TypeToken<Value<ParrotType>> PARROT_TYPE_VALUE_TOKEN = new TypeToken<Value<ParrotType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<ParrotType>> PARROT_TYPE_VALUE_TOKEN = new TypeToken<Value<ParrotType>>() {};
 
-    public static final TypeToken<ParticleEffect> PARTICLE_EFFECT_TOKEN = new TypeToken<ParticleEffect>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ParticleEffect> PARTICLE_EFFECT_TOKEN = new TypeToken<ParticleEffect>() {};
 
-    public static final TypeToken<Value<ParticleEffect>> PARTICLE_EFFECT_VALUE_TOKEN = new TypeToken<Value<ParticleEffect>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<ParticleEffect>> PARTICLE_EFFECT_VALUE_TOKEN = new TypeToken<Value<ParticleEffect>>() {};
 
-    public static final TypeToken<ParticleType> PARTICLE_TYPE_TOKEN = new TypeToken<ParticleType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ParticleType> PARTICLE_TYPE_TOKEN = new TypeToken<ParticleType>() {};
 
-    public static final TypeToken<Value<ParticleType>> PARTICLE_TYPE_VALUE_TOKEN = new TypeToken<Value<ParticleType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<ParticleType>> PARTICLE_TYPE_VALUE_TOKEN = new TypeToken<Value<ParticleType>>() {};
 
-    public static final TypeToken<PhantomPhase> PHANTOM_PHASE_TOKEN = new TypeToken<PhantomPhase>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<PhantomPhase> PHANTOM_PHASE_TOKEN = new TypeToken<PhantomPhase>() {};
 
-    public static final TypeToken<Value<PhantomPhase>> PHANTOM_PHASE_VALUE_TOKEN = new TypeToken<Value<PhantomPhase>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<PhantomPhase>> PHANTOM_PHASE_VALUE_TOKEN = new TypeToken<Value<PhantomPhase>>() {};
 
-    public static final TypeToken<PickupRule> PICKUP_RULE_TOKEN = new TypeToken<PickupRule>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<PickupRule> PICKUP_RULE_TOKEN = new TypeToken<PickupRule>() {};
 
-    public static final TypeToken<Value<PickupRule>> PICKUP_RULE_VALUE_TOKEN = new TypeToken<Value<PickupRule>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<PickupRule>> PICKUP_RULE_VALUE_TOKEN = new TypeToken<Value<PickupRule>>() {};
 
-    public static final TypeToken<PistonType> PISTON_TYPE_TOKEN = new TypeToken<PistonType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<PistonType> PISTON_TYPE_TOKEN = new TypeToken<PistonType>() {};
 
-    public static final TypeToken<Value<PistonType>> PISTON_TYPE_VALUE_TOKEN = new TypeToken<Value<PistonType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<PistonType>> PISTON_TYPE_VALUE_TOKEN = new TypeToken<Value<PistonType>>() {};
 
-    public static final TypeToken<PluginContainer> PLUGIN_CONTAINER_TOKEN = new TypeToken<PluginContainer>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<PluginContainer> PLUGIN_CONTAINER_TOKEN = new TypeToken<PluginContainer>() {};
 
-    public static final TypeToken<Value<PluginContainer>> PLUGIN_CONTAINER_VALUE_TOKEN = new TypeToken<Value<PluginContainer>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<PluginContainer>> PLUGIN_CONTAINER_VALUE_TOKEN = new TypeToken<Value<PluginContainer>>() {};
 
-    public static final TypeToken<PortionType> PORTION_TYPE_TOKEN = new TypeToken<PortionType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<PortionType> PORTION_TYPE_TOKEN = new TypeToken<PortionType>() {};
 
-    public static final TypeToken<Value<PortionType>> PORTION_TYPE_VALUE_TOKEN = new TypeToken<Value<PortionType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<PortionType>> PORTION_TYPE_VALUE_TOKEN = new TypeToken<Value<PortionType>>() {};
 
-    public static final TypeToken<PotionEffectType> POTION_EFFECT_TYPE_TOKEN = new TypeToken<PotionEffectType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<PotionEffectType> POTION_EFFECT_TYPE_TOKEN = new TypeToken<PotionEffectType>() {};
 
-    public static final TypeToken<Value<PotionEffectType>> POTION_EFFECT_TYPE_VALUE_TOKEN = new TypeToken<Value<PotionEffectType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<PotionEffectType>> POTION_EFFECT_TYPE_VALUE_TOKEN = new TypeToken<Value<PotionEffectType>>() {};
 
-    public static final TypeToken<PotionType> POTION_TYPE_TOKEN = new TypeToken<PotionType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<PotionType> POTION_TYPE_TOKEN = new TypeToken<PotionType>() {};
 
-    public static final TypeToken<Value<PotionType>> POTION_TYPE_VALUE_TOKEN = new TypeToken<Value<PotionType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<PotionType>> POTION_TYPE_VALUE_TOKEN = new TypeToken<Value<PotionType>>() {};
 
-    public static final TypeToken<ProfessionType> PROFESSION_TOKEN = new TypeToken<ProfessionType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ProfessionType> PROFESSION_TOKEN = new TypeToken<ProfessionType>() {};
 
-    public static final TypeToken<Value<ProfessionType>> PROFESSION_VALUE_TOKEN = new TypeToken<Value<ProfessionType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<ProfessionType>> PROFESSION_VALUE_TOKEN = new TypeToken<Value<ProfessionType>>() {};
 
-    public static final TypeToken<ProfileProperty> PROFILE_PROPERTY_TOKEN = new TypeToken<ProfileProperty>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ProfileProperty> PROFILE_PROPERTY_TOKEN = new TypeToken<ProfileProperty>() {};
 
-    public static final TypeToken<Value<ProfileProperty>> PROFILE_PROPERTY_VALUE_TOKEN = new TypeToken<Value<ProfileProperty>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<ProfileProperty>> PROFILE_PROPERTY_VALUE_TOKEN = new TypeToken<Value<ProfileProperty>>() {};
 
-    public static final TypeToken<ProjectileSource> PROJECTILE_SOURCE_TOKEN = new TypeToken<ProjectileSource>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ProjectileSource> PROJECTILE_SOURCE_TOKEN = new TypeToken<ProjectileSource>() {};
 
-    public static final TypeToken<Value<ProjectileSource>> PROJECTILE_SOURCE_VALUE_TOKEN = new TypeToken<Value<ProjectileSource>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<ProjectileSource>> PROJECTILE_SOURCE_VALUE_TOKEN = new TypeToken<Value<ProjectileSource>>() {};
 
-    public static final TypeToken<RabbitType> RABBIT_TYPE_TOKEN = new TypeToken<RabbitType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<RabbitType> RABBIT_TYPE_TOKEN = new TypeToken<RabbitType>() {};
 
-    public static final TypeToken<Value<RabbitType>> RABBIT_TYPE_VALUE_TOKEN = new TypeToken<Value<RabbitType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<RabbitType>> RABBIT_TYPE_VALUE_TOKEN = new TypeToken<Value<RabbitType>>() {};
 
-    public static final TypeToken<RaidWave> RAID_WAVE_TOKEN = new TypeToken<RaidWave>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<RaidWave> RAID_WAVE_TOKEN = new TypeToken<RaidWave>() {};
 
-    public static final TypeToken<Value<RaidWave>> RAID_WAVE_VALUE_TOKEN = new TypeToken<Value<RaidWave>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<RaidWave>> RAID_WAVE_VALUE_TOKEN = new TypeToken<Value<RaidWave>>() {};
 
-    public static final TypeToken<RailDirection> RAIL_DIRECTION_TOKEN = new TypeToken<RailDirection>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<RailDirection> RAIL_DIRECTION_TOKEN = new TypeToken<RailDirection>() {};
 
-    public static final TypeToken<Value<RailDirection>> RAIL_DIRECTION_VALUE_TOKEN = new TypeToken<Value<RailDirection>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<RailDirection>> RAIL_DIRECTION_VALUE_TOKEN = new TypeToken<Value<RailDirection>>() {};
 
-    public static final TypeToken<Orientation> ROTATION_TOKEN = new TypeToken<Orientation>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Orientation> ROTATION_TOKEN = new TypeToken<Orientation>() {};
 
-    public static final TypeToken<Value<Orientation>> ROTATION_VALUE_TOKEN = new TypeToken<Value<Orientation>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Orientation>> ROTATION_VALUE_TOKEN = new TypeToken<Value<Orientation>>() {};
 
-    public static final TypeToken<Set<BlockType>> SET_BLOCK_TYPE_TOKEN = new TypeToken<Set<BlockType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Set<BlockType>> SET_BLOCK_TYPE_TOKEN = new TypeToken<Set<BlockType>>() {};
 
-    public static final TypeToken<SetValue<BlockType>> SET_BLOCK_TYPE_VALUE_TOKEN = new TypeToken<SetValue<BlockType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<SetValue<BlockType>> SET_BLOCK_TYPE_VALUE_TOKEN = new TypeToken<SetValue<BlockType>>() {};
 
-    public static final TypeToken<Set<Direction>> SET_DIRECTION_TOKEN = new TypeToken<Set<Direction>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Set<Direction>> SET_DIRECTION_TOKEN = new TypeToken<Set<Direction>>() {};
 
-    public static final TypeToken<SetValue<Direction>> SET_DIRECTION_VALUE_TOKEN = new TypeToken<SetValue<Direction>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<SetValue<Direction>> SET_DIRECTION_VALUE_TOKEN = new TypeToken<SetValue<Direction>>() {};
 
-    public static final TypeToken<Set<String>> SET_STRING_TOKEN = new TypeToken<Set<String>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Set<String>> SET_STRING_TOKEN = new TypeToken<Set<String>>() {};
 
-    public static final TypeToken<SetValue<String>> SET_STRING_VALUE_TOKEN = new TypeToken<SetValue<String>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<SetValue<String>> SET_STRING_VALUE_TOKEN = new TypeToken<SetValue<String>>() {};
 
-    public static final TypeToken<Sheep> SHEEP_TOKEN = new TypeToken<Sheep>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Sheep> SHEEP_TOKEN = new TypeToken<Sheep>() {};
 
-    public static final TypeToken<Value<Sheep>> SHEEP_VALUE_TOKEN = new TypeToken<Value<Sheep>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Sheep>> SHEEP_VALUE_TOKEN = new TypeToken<Value<Sheep>>() {};
 
-    public static final TypeToken<Short> SHORT_TOKEN = new TypeToken<Short>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Short> SHORT_TOKEN = new TypeToken<Short>() {};
 
-    public static final TypeToken<SlabPortion> SLAB_PORTION_TOKEN = new TypeToken<SlabPortion>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<SlabPortion> SLAB_PORTION_TOKEN = new TypeToken<SlabPortion>() {};
 
-    public static final TypeToken<Value<SlabPortion>> SLAB_PORTION_VALUE_TOKEN = new TypeToken<Value<SlabPortion>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<SlabPortion>> SLAB_PORTION_VALUE_TOKEN = new TypeToken<Value<SlabPortion>>() {};
 
-    public static final TypeToken<SpellType> SPELL_TYPE_TOKEN = new TypeToken<SpellType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<SpellType> SPELL_TYPE_TOKEN = new TypeToken<SpellType>() {};
 
-    public static final TypeToken<Value<SpellType>> SPELL_TYPE_VALUE_TOKEN = new TypeToken<Value<SpellType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<SpellType>> SPELL_TYPE_VALUE_TOKEN = new TypeToken<Value<SpellType>>() {};
 
-    public static final TypeToken<StairShape> STAIR_SHAPE_TOKEN = new TypeToken<StairShape>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<StairShape> STAIR_SHAPE_TOKEN = new TypeToken<StairShape>() {};
 
-    public static final TypeToken<Value<StairShape>> STAIR_SHAPE_VALUE_TOKEN = new TypeToken<Value<StairShape>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<StairShape>> STAIR_SHAPE_VALUE_TOKEN = new TypeToken<Value<StairShape>>() {};
 
-    public static final TypeToken<Map<Statistic, Long>> MAP_STATISTIC_LONG_TOKEN = new TypeToken<Map<Statistic, Long>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Map<Statistic, Long>> MAP_STATISTIC_LONG_TOKEN = new TypeToken<Map<Statistic, Long>>() {};
 
-    public static final TypeToken<MapValue<Statistic, Long>> MAP_STATISTIC_LONG_VALUE_TOKEN = new TypeToken<MapValue<Statistic, Long>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<MapValue<Statistic, Long>> MAP_STATISTIC_LONG_VALUE_TOKEN = new TypeToken<MapValue<Statistic, Long>>() {};
 
-    public static final TypeToken<String> STRING_TOKEN = new TypeToken<String>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<String> STRING_TOKEN = new TypeToken<String>() {};
 
-    public static final TypeToken<Value<String>> STRING_VALUE_TOKEN = new TypeToken<Value<String>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<String>> STRING_VALUE_TOKEN = new TypeToken<Value<String>>() {};
 
-    public static final TypeToken<StructureMode> STRUCTURE_MODE_TOKEN = new TypeToken<StructureMode>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<StructureMode> STRUCTURE_MODE_TOKEN = new TypeToken<StructureMode>() {};
 
-    public static final TypeToken<Value<StructureMode>> STRUCTURE_MODE_VALUE_TOKEN = new TypeToken<Value<StructureMode>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<StructureMode>> STRUCTURE_MODE_VALUE_TOKEN = new TypeToken<Value<StructureMode>>() {};
 
-    public static final TypeToken<ToolType> TOOL_TYPE_TOKEN = new TypeToken<ToolType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ToolType> TOOL_TYPE_TOKEN = new TypeToken<ToolType>() {};
 
-    public static final TypeToken<Value<ToolType>> TOOL_TYPE_VALUE_TOKEN = new TypeToken<Value<ToolType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<ToolType>> TOOL_TYPE_VALUE_TOKEN = new TypeToken<Value<ToolType>>() {};
 
-    public static final TypeToken<TropicalFishShape> TROPICAL_FISH_SHAPE_TOKEN = new TypeToken<TropicalFishShape>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<TropicalFishShape> TROPICAL_FISH_SHAPE_TOKEN = new TypeToken<TropicalFishShape>() {};
 
-    public static final TypeToken<Value<TropicalFishShape>> TROPICAL_FISH_SHAPE_VALUE_TOKEN = new TypeToken<Value<TropicalFishShape>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<TropicalFishShape>> TROPICAL_FISH_SHAPE_VALUE_TOKEN = new TypeToken<Value<TropicalFishShape>>() {};
 
-    public static final TypeToken<User> USER_TOKEN = new TypeToken<User>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<User> USER_TOKEN = new TypeToken<User>() {};
 
-    public static final TypeToken<UUID> UUID_TOKEN = new TypeToken<UUID>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<UUID> UUID_TOKEN = new TypeToken<UUID>() {};
 
-    public static final TypeToken<Value<UUID>> UUID_VALUE_TOKEN = new TypeToken<Value<UUID>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<UUID>> UUID_VALUE_TOKEN = new TypeToken<Value<UUID>>() {};
 
-    public static final TypeToken<Vector2i> VECTOR_2I_TOKEN = new TypeToken<Vector2i>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Vector2i> VECTOR_2I_TOKEN = new TypeToken<Vector2i>() {};
 
-    public static final TypeToken<Value<Vector2i>> VECTOR_2I_VALUE_TOKEN = new TypeToken<Value<Vector2i>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Vector2i>> VECTOR_2I_VALUE_TOKEN = new TypeToken<Value<Vector2i>>() {};
 
-    public static final TypeToken<Vector3d> VECTOR_3D_TOKEN = new TypeToken<Vector3d>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Vector3d> VECTOR_3D_TOKEN = new TypeToken<Vector3d>() {};
 
-    public static final TypeToken<Value<Vector3d>> VECTOR_3D_VALUE_TOKEN = new TypeToken<Value<Vector3d>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Vector3d>> VECTOR_3D_VALUE_TOKEN = new TypeToken<Value<Vector3d>>() {};
 
-    public static final TypeToken<Vector3i> VECTOR_3I_TOKEN = new TypeToken<Vector3i>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Vector3i> VECTOR_3I_TOKEN = new TypeToken<Vector3i>() {};
 
-    public static final TypeToken<Value<Vector3i>> VECTOR_3I_VALUE_TOKEN = new TypeToken<Value<Vector3i>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<Vector3i>> VECTOR_3I_VALUE_TOKEN = new TypeToken<Value<Vector3i>>() {};
 
-    public static final TypeToken<VillagerType> VILLAGER_TYPE_TOKEN = new TypeToken<VillagerType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<VillagerType> VILLAGER_TYPE_TOKEN = new TypeToken<VillagerType>() {};
 
-    public static final TypeToken<Value<VillagerType>> VILLAGER_TYPE_VALUE_TOKEN = new TypeToken<Value<VillagerType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<VillagerType>> VILLAGER_TYPE_VALUE_TOKEN = new TypeToken<Value<VillagerType>>() {};
 
-    public static final TypeToken<WeightedCollectionValue<PotionEffect>> WEIGHTED_POTION_EFFECT_COLLECTION_VALUE_TOKEN = new TypeToken<WeightedCollectionValue<PotionEffect>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<WeightedCollectionValue<PotionEffect>> WEIGHTED_POTION_EFFECT_COLLECTION_VALUE_TOKEN = new TypeToken<WeightedCollectionValue<PotionEffect>>() {};
 
-    public static final TypeToken<WeightedCollectionValue<EntityArchetype>> WEIGHTED_ENTITY_ARCHETYPE_COLLECTION_VALUE_TOKEN = new TypeToken<WeightedCollectionValue<EntityArchetype>> () {private static final long serialVersionUID = -1;};
+    public static final TypeToken<WeightedCollectionValue<EntityArchetype>> WEIGHTED_ENTITY_ARCHETYPE_COLLECTION_VALUE_TOKEN = new TypeToken<WeightedCollectionValue<EntityArchetype>> () {};
 
-    public static final TypeToken<WeightedTable<EntityArchetype>> WEIGHTED_ENTITY_ARCHETYPE_TABLE_TOKEN = new TypeToken<WeightedTable<EntityArchetype>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<WeightedTable<EntityArchetype>> WEIGHTED_ENTITY_ARCHETYPE_TABLE_TOKEN = new TypeToken<WeightedTable<EntityArchetype>>() {};
 
-    public static final TypeToken<WeightedSerializableObject<EntityArchetype>> WEIGHTED_ENTITY_ARCHETYPE_TOKEN = new TypeToken<WeightedSerializableObject<EntityArchetype>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<WeightedSerializableObject<EntityArchetype>> WEIGHTED_ENTITY_ARCHETYPE_TOKEN = new TypeToken<WeightedSerializableObject<EntityArchetype>>() {};
 
-    public static final TypeToken<Value<WeightedSerializableObject<EntityArchetype>>> WEIGHTED_ENTITY_ARCHETYPE_VALUE_TOKEN = new TypeToken<Value<WeightedSerializableObject<EntityArchetype>>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<WeightedSerializableObject<EntityArchetype>>> WEIGHTED_ENTITY_ARCHETYPE_VALUE_TOKEN = new TypeToken<Value<WeightedSerializableObject<EntityArchetype>>>() {};
 
-    public static final TypeToken<Map<Direction, WireAttachmentType>> MAP_DIRECTION_WIRE_ATTACHMENT_TOKEN = new TypeToken<Map<Direction, WireAttachmentType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Map<Direction, WireAttachmentType>> MAP_DIRECTION_WIRE_ATTACHMENT_TOKEN = new TypeToken<Map<Direction, WireAttachmentType>>() {};
 
-    public static final TypeToken<MapValue<Direction, WireAttachmentType>> MAP_DIRECTION_WIRE_ATTACHMENT_VALUE_TOKEN = new TypeToken<MapValue<Direction, WireAttachmentType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<MapValue<Direction, WireAttachmentType>> MAP_DIRECTION_WIRE_ATTACHMENT_VALUE_TOKEN = new TypeToken<MapValue<Direction, WireAttachmentType>>() {};
 
-    public static final TypeToken<WireAttachmentType> WIRE_ATTACHMENT_TYPE_TOKEN = new TypeToken<WireAttachmentType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<WireAttachmentType> WIRE_ATTACHMENT_TYPE_TOKEN = new TypeToken<WireAttachmentType>() {};
 
-    public static final TypeToken<Value<WireAttachmentType>> WIRE_ATTACHMENT_TYPE_VALUE_TOKEN = new TypeToken<Value<WireAttachmentType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<WireAttachmentType>> WIRE_ATTACHMENT_TYPE_VALUE_TOKEN = new TypeToken<Value<WireAttachmentType>>() {};
 
-    public static final TypeToken<WoodType> WOOD_TYPE_TOKEN = new TypeToken<WoodType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<WoodType> WOOD_TYPE_TOKEN = new TypeToken<WoodType>() {};
 
-    public static final TypeToken<Value<WoodType>> WOOD_TYPE_VALUE_TOKEN = new TypeToken<Value<WoodType>>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Value<WoodType>> WOOD_TYPE_VALUE_TOKEN = new TypeToken<Value<WoodType>>() {};
 
-    public static final TypeToken<WorldProperties> WORLD_PROPERTIES_TOKEN = new TypeToken<WorldProperties>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<WorldProperties> WORLD_PROPERTIES_TOKEN = new TypeToken<WorldProperties>() {};
 
-    public static final TypeToken<LocatableBlock> LOCATABLE_BLOCK_TOKEN = new TypeToken<LocatableBlock>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<LocatableBlock> LOCATABLE_BLOCK_TOKEN = new TypeToken<LocatableBlock>() {};
 
-    public static final TypeToken<ChangeBlockEvent.Break> CHANGE_BLOCK_EVENT_BREAK_TOKEN = new TypeToken<ChangeBlockEvent.Break>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ChangeBlockEvent.Break> CHANGE_BLOCK_EVENT_BREAK_TOKEN = new TypeToken<ChangeBlockEvent.Break>() {};
 
-    public static final TypeToken<DamageType> DAMAGE_TYPE_TOKEN = new TypeToken<DamageType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<DamageType> DAMAGE_TYPE_TOKEN = new TypeToken<DamageType>() {};
 
-    public static final TypeToken<ChangeBlockEvent.Decay> CHANGE_BLOCK_EVENT_DECAY_TOKEN = new TypeToken<ChangeBlockEvent.Decay>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ChangeBlockEvent.Decay> CHANGE_BLOCK_EVENT_DECAY_TOKEN = new TypeToken<ChangeBlockEvent.Decay>() {};
 
-    public static final TypeToken<DismountType> DISMOUNT_TYPE_TOKEN = new TypeToken<DismountType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<DismountType> DISMOUNT_TYPE_TOKEN = new TypeToken<DismountType>() {};
 
-    public static final TypeToken<Player> PLAYER_TOKEN = new TypeToken<Player>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Player> PLAYER_TOKEN = new TypeToken<Player>() {};
 
-    public static final TypeToken<ServerPlayer> SERVER_PLAYER_TOKEN = new TypeToken<ServerPlayer>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ServerPlayer> SERVER_PLAYER_TOKEN = new TypeToken<ServerPlayer>() {};
 
-    public static final TypeToken<ServerWorld> SERVER_WORLD_TOKEN = new TypeToken<ServerWorld>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ServerWorld> SERVER_WORLD_TOKEN = new TypeToken<ServerWorld>() {};
 
-    public static final TypeToken<ChangeBlockEvent.Grow> CHANGE_BLOCK_EVENT_GROW_TOKEN = new TypeToken<ChangeBlockEvent.Grow>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ChangeBlockEvent.Grow> CHANGE_BLOCK_EVENT_GROW_TOKEN = new TypeToken<ChangeBlockEvent.Grow>() {};
 
-    public static final TypeToken<ServerLocation> SERVER_LOCATION_TOKEN = new TypeToken<ServerLocation>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ServerLocation> SERVER_LOCATION_TOKEN = new TypeToken<ServerLocation>() {};
 
-    public static final TypeToken<DamageSource> DAMAGE_SOURCE_TOKEN = new TypeToken<DamageSource>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<DamageSource> DAMAGE_SOURCE_TOKEN = new TypeToken<DamageSource>() {};
 
-    public static final TypeToken<ChangeBlockEvent.Modify> CHANGE_BLOCK_EVENT_MODIFY_TOKEN = new TypeToken<ChangeBlockEvent.Modify>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ChangeBlockEvent.Modify> CHANGE_BLOCK_EVENT_MODIFY_TOKEN = new TypeToken<ChangeBlockEvent.Modify>() {};
 
-    public static final TypeToken<ChangeBlockEvent.Place> CHANGE_BLOCK_EVENT_PLACE_TOKEN = new TypeToken<ChangeBlockEvent.Place>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<ChangeBlockEvent.Place> CHANGE_BLOCK_EVENT_PLACE_TOKEN = new TypeToken<ChangeBlockEvent.Place>() {};
 
-    public static final TypeToken<SpawnType> SPAWN_TYPE_TOKEN = new TypeToken<SpawnType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<SpawnType> SPAWN_TYPE_TOKEN = new TypeToken<SpawnType>() {};
 
-    public static final TypeToken<Subject> SUBJECT_TOKEN = new TypeToken<Subject>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<Subject> SUBJECT_TOKEN = new TypeToken<Subject>() {};
 
-    public static final TypeToken<MovementType> MOVEMENT_TYPE_TOKEN = new TypeToken<MovementType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<MovementType> MOVEMENT_TYPE_TOKEN = new TypeToken<MovementType>() {};
 
-    public static final TypeToken<HandType> HAND_TYPE_TOKEN = new TypeToken<HandType>() {private static final long serialVersionUID = -1;};
+    public static final TypeToken<HandType> HAND_TYPE_TOKEN = new TypeToken<HandType>() {};
 
     // @formatter:on
     // SORTFIELDS:OFF

--- a/src/main/java/org/spongepowered/api/util/TypeTokens.java
+++ b/src/main/java/org/spongepowered/api/util/TypeTokens.java
@@ -25,17 +25,11 @@
 package org.spongepowered.api.util;
 
 import io.leangen.geantyref.TypeToken;
-import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
-import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
-import org.spongepowered.api.block.entity.BlockEntity;
-import org.spongepowered.api.block.entity.BlockEntityArchetype;
 import org.spongepowered.api.command.CommandCause;
-import org.spongepowered.api.command.CommandExecutor;
-import org.spongepowered.api.command.manager.CommandMapping;
 import org.spongepowered.api.data.meta.BannerPatternLayer;
 import org.spongepowered.api.data.persistence.DataSerializable;
 import org.spongepowered.api.data.type.ArmorMaterial;
@@ -50,7 +44,6 @@ import org.spongepowered.api.data.type.DoorHinge;
 import org.spongepowered.api.data.type.DyeColor;
 import org.spongepowered.api.data.type.FoxType;
 import org.spongepowered.api.data.type.HandPreference;
-import org.spongepowered.api.data.type.HandType;
 import org.spongepowered.api.data.type.HorseColor;
 import org.spongepowered.api.data.type.HorseStyle;
 import org.spongepowered.api.data.type.InstrumentType;
@@ -95,24 +88,12 @@ import org.spongepowered.api.entity.attribute.type.AttributeType;
 import org.spongepowered.api.entity.explosive.EnderCrystal;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.living.animal.Sheep;
-import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
-import org.spongepowered.api.entity.living.player.server.ServerPlayer;
-import org.spongepowered.api.event.block.ChangeBlockEvent;
-import org.spongepowered.api.event.cause.entity.DismountType;
-import org.spongepowered.api.event.cause.entity.MovementType;
-import org.spongepowered.api.event.cause.entity.SpawnType;
-import org.spongepowered.api.event.cause.entity.damage.DamageType;
-import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
-import org.spongepowered.api.fluid.FluidStack;
 import org.spongepowered.api.fluid.FluidStackSnapshot;
-import org.spongepowered.api.fluid.FluidState;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.FireworkShape;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.enchantment.Enchantment;
-import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.equipment.EquipmentType;
 import org.spongepowered.api.item.merchant.TradeOffer;
@@ -121,15 +102,10 @@ import org.spongepowered.api.profile.GameProfile;
 import org.spongepowered.api.profile.property.ProfileProperty;
 import org.spongepowered.api.projectile.source.ProjectileSource;
 import org.spongepowered.api.raid.RaidWave;
-import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.statistic.Statistic;
 import org.spongepowered.api.util.orientation.Orientation;
 import org.spongepowered.api.util.weighted.WeightedSerializableObject;
 import org.spongepowered.api.util.weighted.WeightedTable;
-import org.spongepowered.api.world.LocatableBlock;
-import org.spongepowered.api.world.ServerLocation;
-import org.spongepowered.api.world.server.ServerWorld;
-import org.spongepowered.api.world.storage.WorldProperties;
 import org.spongepowered.math.vector.Vector2i;
 import org.spongepowered.math.vector.Vector3d;
 import org.spongepowered.math.vector.Vector3i;
@@ -148,107 +124,49 @@ public final class TypeTokens {
     // SORTFIELDS:ON
     // @formatter:off
 
-    public static final TypeToken<Audience> AUDIENCE = new TypeToken<Audience>() {};
-
-    public static final TypeToken<ArmorMaterial> ARMOR_MATERIAL_TOKEN = new TypeToken<ArmorMaterial>() {};
-
     public static final TypeToken<Value<ArmorMaterial>> ARMOR_MATERIAL_VALUE_TOKEN = new TypeToken<Value<ArmorMaterial>>() {};
-
-    public static final TypeToken<AttributeOperation> ATTRIBUTE_OPERATION_TOKEN = new TypeToken<AttributeOperation>() {};
 
     public static final TypeToken<Value<AttributeOperation>> ATTRIBUTE_OPERATION_VALUE_TOKEN = new TypeToken<Value<AttributeOperation>>() {};
 
-    public static final TypeToken<AttributeType> ATTRIBUTE_TYPE_TOKEN = new TypeToken<AttributeType>() {};
-
     public static final TypeToken<Value<AttributeType>> ATTRIBUTE_TYPE_VALUE_TOKEN = new TypeToken<Value<AttributeType>>() {};
-
-    public static final TypeToken<ArtType> ART_TYPE_TOKEN = new TypeToken<ArtType>() {};
 
     public static final TypeToken<Value<ArtType>> ART_TYPE_VALUE_TOKEN = new TypeToken<Value<ArtType>>() {};
 
-    public static final TypeToken<AttachmentSurface> ATTACHMENT_SURFACE_TOKEN = new TypeToken<AttachmentSurface>() {};
-
     public static final TypeToken<Value<AttachmentSurface>> ATTACHMENT_SURFACE_VALUE_TOKEN = new TypeToken<Value<AttachmentSurface>>() {};
-
-    public static final TypeToken<Axis> AXIS_TOKEN = new TypeToken<Axis>() {};
 
     public static final TypeToken<Value<Axis>> AXIS_VALUE_TOKEN = new TypeToken<Value<Axis>>() {};
 
-    public static final TypeToken<BlockEntityArchetype> BLOCK_ENTITY_ARCHETYPE_TOKEN = new TypeToken<BlockEntityArchetype>() {};
-
-    public static final TypeToken<BlockEntity> BLOCK_ENTITY_TOKEN = new TypeToken<BlockEntity>() {};
-
-    public static final TypeToken<BlockSnapshot> BLOCK_SNAPSHOT_TOKEN = new TypeToken<BlockSnapshot>() {};
-
-    public static final TypeToken<BlockState> BLOCK_STATE_TOKEN = new TypeToken<BlockState>() {};
-
     public static final TypeToken<Value<BlockState>> BLOCK_STATE_VALUE_TOKEN = new TypeToken<Value<BlockState>>() {};
-
-    public static final TypeToken<BoatType> BOAT_TYPE_TOKEN = new TypeToken<BoatType>() {};
 
     public static final TypeToken<Value<BoatType>> BOAT_TYPE_VALUE_TOKEN = new TypeToken<Value<BoatType>>() {};
 
-    public static final TypeToken<Boolean> BOOLEAN_TOKEN = new TypeToken<Boolean>() {};
-
     public static final TypeToken<Value<Boolean>> BOOLEAN_VALUE_TOKEN = new TypeToken<Value<Boolean>>() {};
-
-    public static final TypeToken<BossBar> BOSS_BAR_TOKEN = new TypeToken<BossBar>() {};
 
     public static final TypeToken<Value<BossBar>> BOSS_BAR_VALUE_TOKEN = new TypeToken<Value<BossBar>>() {};
 
-    public static final TypeToken<CatType> CAT_TYPE_TOKEN = new TypeToken<CatType>() {};
-
     public static final TypeToken<Value<CatType>> CAT_TYPE_VALUE_TOKEN = new TypeToken<Value<CatType>>() {};
 
-    public static final TypeToken<ChestAttachmentType> CHEST_ATTACHMENT_TYPE_TOKEN = new TypeToken<ChestAttachmentType>() {};
-
     public static final TypeToken<Value<ChestAttachmentType>> CHEST_ATTACHMENT_TYPE_VALUE_TOKEN = new TypeToken<Value<ChestAttachmentType>>() {};
-
-    public static final TypeToken<Color> COLOR_TOKEN = new TypeToken<Color>() {};
 
     public static final TypeToken<Value<Color>> COLOR_VALUE_TOKEN = new TypeToken<Value<Color>>() {};
 
     public static final TypeToken<Consumer<CommandCause>> COMMAND_CAUSE_CONSUMER = new TypeToken<Consumer<CommandCause>>() {};
 
-    public static final TypeToken<CommandExecutor> COMMAND_EXECUTOR = new TypeToken<CommandExecutor>() {};
-
-    public static final TypeToken<CommandMapping> COMMAND_MAPPING = new TypeToken<CommandMapping>() {};
-
-    public static final TypeToken<ComparatorMode> COMPARATOR_MODE_TOKEN = new TypeToken<ComparatorMode>() {};
-
     public static final TypeToken<Value<ComparatorMode>> COMPARATOR_MODE_VALUE_TOKEN = new TypeToken<Value<ComparatorMode>>() {};
-
-    public static final TypeToken<Component> COMPONENT_TOKEN = new TypeToken<Component>() {};
 
     public static final TypeToken<Value<Component>> COMPONENT_VALUE_TOKEN = new TypeToken<Value<Component>>() {};
 
-    public static final TypeToken<Direction> DIRECTION_TOKEN = new TypeToken<Direction>() {};
-
     public static final TypeToken<Value<Direction>> DIRECTION_VALUE_TOKEN = new TypeToken<Value<Direction>>() {};
-
-    public static final TypeToken<DoorHinge> DOOR_HINGE_TOKEN = new TypeToken<DoorHinge>() {};
 
     public static final TypeToken<Value<DoorHinge>> DOOR_HINGE_VALUE_TOKEN = new TypeToken<Value<DoorHinge>>() {};
 
-    public static final TypeToken<Double> DOUBLE_TOKEN = new TypeToken<Double>() {};
-
     public static final TypeToken<Value<Double>> DOUBLE_VALUE_TOKEN = new TypeToken<Value<Double>>() {};
-
-    public static final TypeToken<DyeColor> DYE_COLOR_TOKEN = new TypeToken<DyeColor>() {};
 
     public static final TypeToken<Value<DyeColor>> DYE_COLOR_VALUE_TOKEN = new TypeToken<Value<DyeColor>>() {};
 
-    public static final TypeToken<EnderCrystal> ENDER_CRYSTAL_TOKEN = new TypeToken<EnderCrystal>() {};
-
     public static final TypeToken<Value<EnderCrystal>> ENDER_CRYSTAL_VALUE_TOKEN = new TypeToken<Value<EnderCrystal>>() {};
 
-    public static final TypeToken<EntityArchetype> ENTITY_ARCHETYPE_TOKEN = new TypeToken<EntityArchetype>() {};
-
-    public static final TypeToken<EntitySnapshot> ENTITY_SNAPSHOT_TOKEN = new TypeToken<EntitySnapshot>() {};
-
     public static final TypeToken<Value<EntitySnapshot>> ENTITY_SNAPSHOT_VALUE_TOKEN = new TypeToken<Value<EntitySnapshot>>() {};
-
-    public static final TypeToken<Entity> ENTITY_TOKEN = new TypeToken<Entity>() {};
 
     public static final TypeToken<Value<Entity>> ENTITY_VALUE_TOKEN = new TypeToken<Value<Entity>>() {};
 
@@ -256,71 +174,35 @@ public final class TypeTokens {
 
     public static final TypeToken<MapValue<EntityType<?>, Double>> MAP_ENTITY_TYPE_DOUBLE_VALUE_TOKEN = new TypeToken<MapValue<EntityType<?>, Double>>() {};
 
-    public static final TypeToken<EntityType<?>> ENTITY_TYPE_TOKEN = new TypeToken<EntityType<?>>() {};
-
     public static final TypeToken<Value<EntityType<?>>> ENTITY_TYPE_VALUE_TOKEN = new TypeToken<Value<EntityType<?>>>() {};
-
-    public static final TypeToken<EquipmentType> EQUIPMENT_TYPE_TOKEN = new TypeToken<EquipmentType>() {};
 
     public static final TypeToken<Value<EquipmentType>> EQUIPMENT_TYPE_VALUE_TOKEN = new TypeToken<Value<EquipmentType>>() {};
 
     public static final TypeToken<Value<FireworkShape>> FIREWORK_SHAPE_VALUE_TOKEN = new TypeToken<Value<FireworkShape>>() {};
 
-    public static final TypeToken<Float> FLOAT_TOKEN = new TypeToken<Float>() {};
-
-    public static final TypeToken<FluidStack> FLUID_STACK_TOKEN = new TypeToken<FluidStack>() {};
-
-    public static final TypeToken<FluidState> FLUID_STATE_TOKEN = new TypeToken<FluidState>() {};
-
-    public static final TypeToken<FluidStackSnapshot> FLUID_STACK_SNAPSHOT_TOKEN = new TypeToken<FluidStackSnapshot>() {};
-
     public static final TypeToken<Value<FluidStackSnapshot>> FLUID_STACK_SNAPSHOT_VALUE_TOKEN = new TypeToken<Value<FluidStackSnapshot>>() {};
-
-    public static final TypeToken<FoxType> FOX_TYPE_TOKEN = new TypeToken<FoxType>() {};
 
     public static final TypeToken<Value<FoxType>> FOX_TYPE_VALUE_TOKEN = new TypeToken<Value<FoxType>>() {};
 
-    public static final TypeToken<GameMode> GAME_MODE_TOKEN = new TypeToken<GameMode>() {};
-
     public static final TypeToken<Value<GameMode>> GAME_MODE_VALUE_TOKEN = new TypeToken<Value<GameMode>>() {};
-
-    public static final TypeToken<GameProfile> GAME_PROFILE_TOKEN = new TypeToken<GameProfile>() {};
 
     public static final TypeToken<Value<GameProfile>> GAME_PROFILE_VALUE_TOKEN = new TypeToken<Value<GameProfile>>() {};
 
-    public static final TypeToken<HandPreference> HAND_PREFERENCE_TOKEN = new TypeToken<HandPreference>() {};
-
     public static final TypeToken<Value<HandPreference>> HAND_PREFERENCE_VALUE_TOKEN = new TypeToken<Value<HandPreference>>() {};
-
-    public static final TypeToken<HorseColor> HORSE_COLOR_TOKEN = new TypeToken<HorseColor>() {};
 
     public static final TypeToken<Value<HorseColor>> HORSE_COLOR_VALUE_TOKEN = new TypeToken<Value<HorseColor>>() {};
 
-    public static final TypeToken<HorseStyle> HORSE_STYLE_TOKEN = new TypeToken<HorseStyle>() {};
-
     public static final TypeToken<Value<HorseStyle>> HORSE_STYLE_VALUE_TOKEN = new TypeToken<Value<HorseStyle>>() {};
-
-    public static final TypeToken<Instant> INSTANT_TOKEN = new TypeToken<Instant>() {};
 
     public static final TypeToken<Value<Instant>> INSTANT_VALUE_TOKEN = new TypeToken<Value<Instant>>() {};
 
-    public static final TypeToken<InstrumentType> INSTRUMENT_TYPE_TOKEN = new TypeToken<InstrumentType>() {};
-
     public static final TypeToken<Value<InstrumentType>> INSTRUMENT_TYPE_VALUE_TOKEN = new TypeToken<Value<InstrumentType>>() {};
-
-    public static final TypeToken<Integer> INTEGER_TOKEN = new TypeToken<Integer>() {};
 
     public static final TypeToken<Value<Integer>> INTEGER_VALUE_TOKEN = new TypeToken<Value<Integer>>() {};
 
-    public static final TypeToken<ItemType> ITEM_TYPE_TOKEN = new TypeToken<ItemType>() {};
-
     public static final TypeToken<Value<ItemType>> ITEM_TYPE_VALUE_TOKEN = new TypeToken<Value<ItemType>>() {};
 
-    public static final TypeToken<ItemStackSnapshot> ITEM_STACK_SNAPSHOT_TOKEN = new TypeToken<ItemStackSnapshot>() {};
-
     public static final TypeToken<Value<ItemStackSnapshot>> ITEM_STACK_SNAPSHOT_VALUE_TOKEN = new TypeToken<Value<ItemStackSnapshot>>() {};
-
-    public static final TypeToken<ItemStack> ITEM_STACK_TOKEN = new TypeToken<ItemStack>() {};
 
     public static final TypeToken<List<BannerPatternLayer>> LIST_BANNER_PATTERN_LAYER_TOKEN = new TypeToken<List<BannerPatternLayer>>() {};
 
@@ -358,15 +240,9 @@ public final class TypeTokens {
 
     public static final TypeToken<ListValue<TradeOffer>> LIST_TRADE_OFFER_VALUE_TOKEN = new TypeToken<ListValue<TradeOffer>>() {};
 
-    public static final TypeToken<Living> LIVING_TOKEN = new TypeToken<Living>() {};
-
     public static final TypeToken<Value<Living>> LIVING_VALUE_TOKEN = new TypeToken<Value<Living>>() {};
 
-    public static final TypeToken<LlamaType> LLAMA_TYPE_TOKEN = new TypeToken<LlamaType>() {};
-
     public static final TypeToken<Value<LlamaType>> LLAMA_TYPE_VALUE_TOKEN = new TypeToken<Value<LlamaType>>() {};
-
-    public static final TypeToken<Long> LONG_TOKEN = new TypeToken<Long>() {};
 
     public static final TypeToken<Value<Long>> LONG_VALUE_TOKEN = new TypeToken<Value<Long>>() {};
 
@@ -390,97 +266,49 @@ public final class TypeTokens {
 
     public static final TypeToken<MapValue<UUID, Vector3d>> MAP_UUID_VECTOR3D_VALUE_TOKEN = new TypeToken<MapValue<UUID, Vector3d>>() {};
 
-    public static final TypeToken<MatterState> MATTER_STATE_TOKEN = new TypeToken<MatterState>() {};
-
     public static final TypeToken<Value<MatterState>> MATTER_STATE_VALUE_TOKEN = new TypeToken<Value<MatterState>>() {};
-
-    public static final TypeToken<MooshroomType> MOOSHROOM_TYPE_TOKEN = new TypeToken<MooshroomType>() {};
 
     public static final TypeToken<Value<MooshroomType>> MOOSHROOM_TYPE_VALUE_TOKEN = new TypeToken<Value<MooshroomType>>() {};
 
-    public static final TypeToken<MusicDisc> MUSIC_DISC_TOKEN = new TypeToken<MusicDisc>() {};
-
     public static final TypeToken<Value<MusicDisc>> MUSIC_DISC_VALUE_TOKEN = new TypeToken<Value<MusicDisc>>() {};
-
-    public static final TypeToken<NotePitch> NOTE_PITCH_TOKEN = new TypeToken<NotePitch>() {};
 
     public static final TypeToken<Value<NotePitch>> NOTE_PITCH_VALUE_TOKEN = new TypeToken<Value<NotePitch>>() {};
 
-    public static final TypeToken<Object> OBJECT = TypeToken.get(Object.class);
-
-    public static final TypeToken<Orientation> ORIENTATION_TOKEN = new TypeToken<Orientation>() {};
-
     public static final TypeToken<Value<Orientation>> ORIENTATION_VALUE_TOKEN = new TypeToken<Value<Orientation>>() {};
-
-    public static final TypeToken<PandaGene> PANDA_GENE_TOKEN = new TypeToken<PandaGene>() {};
 
     public static final TypeToken<Value<PandaGene>> PANDA_GENE_VALUE_TOKEN = new TypeToken<Value<PandaGene>>() {};
 
-    public static final TypeToken<ParrotType> PARROT_TYPE_TOKEN = new TypeToken<ParrotType>() {};
-
     public static final TypeToken<Value<ParrotType>> PARROT_TYPE_VALUE_TOKEN = new TypeToken<Value<ParrotType>>() {};
-
-    public static final TypeToken<ParticleEffect> PARTICLE_EFFECT_TOKEN = new TypeToken<ParticleEffect>() {};
 
     public static final TypeToken<Value<ParticleEffect>> PARTICLE_EFFECT_VALUE_TOKEN = new TypeToken<Value<ParticleEffect>>() {};
 
-    public static final TypeToken<ParticleType> PARTICLE_TYPE_TOKEN = new TypeToken<ParticleType>() {};
-
     public static final TypeToken<Value<ParticleType>> PARTICLE_TYPE_VALUE_TOKEN = new TypeToken<Value<ParticleType>>() {};
-
-    public static final TypeToken<PhantomPhase> PHANTOM_PHASE_TOKEN = new TypeToken<PhantomPhase>() {};
 
     public static final TypeToken<Value<PhantomPhase>> PHANTOM_PHASE_VALUE_TOKEN = new TypeToken<Value<PhantomPhase>>() {};
 
-    public static final TypeToken<PickupRule> PICKUP_RULE_TOKEN = new TypeToken<PickupRule>() {};
-
     public static final TypeToken<Value<PickupRule>> PICKUP_RULE_VALUE_TOKEN = new TypeToken<Value<PickupRule>>() {};
-
-    public static final TypeToken<PistonType> PISTON_TYPE_TOKEN = new TypeToken<PistonType>() {};
 
     public static final TypeToken<Value<PistonType>> PISTON_TYPE_VALUE_TOKEN = new TypeToken<Value<PistonType>>() {};
 
-    public static final TypeToken<PluginContainer> PLUGIN_CONTAINER_TOKEN = new TypeToken<PluginContainer>() {};
-
     public static final TypeToken<Value<PluginContainer>> PLUGIN_CONTAINER_VALUE_TOKEN = new TypeToken<Value<PluginContainer>>() {};
-
-    public static final TypeToken<PortionType> PORTION_TYPE_TOKEN = new TypeToken<PortionType>() {};
 
     public static final TypeToken<Value<PortionType>> PORTION_TYPE_VALUE_TOKEN = new TypeToken<Value<PortionType>>() {};
 
-    public static final TypeToken<PotionEffectType> POTION_EFFECT_TYPE_TOKEN = new TypeToken<PotionEffectType>() {};
-
     public static final TypeToken<Value<PotionEffectType>> POTION_EFFECT_TYPE_VALUE_TOKEN = new TypeToken<Value<PotionEffectType>>() {};
-
-    public static final TypeToken<PotionType> POTION_TYPE_TOKEN = new TypeToken<PotionType>() {};
 
     public static final TypeToken<Value<PotionType>> POTION_TYPE_VALUE_TOKEN = new TypeToken<Value<PotionType>>() {};
 
-    public static final TypeToken<ProfessionType> PROFESSION_TOKEN = new TypeToken<ProfessionType>() {};
-
     public static final TypeToken<Value<ProfessionType>> PROFESSION_VALUE_TOKEN = new TypeToken<Value<ProfessionType>>() {};
-
-    public static final TypeToken<ProfileProperty> PROFILE_PROPERTY_TOKEN = new TypeToken<ProfileProperty>() {};
 
     public static final TypeToken<Value<ProfileProperty>> PROFILE_PROPERTY_VALUE_TOKEN = new TypeToken<Value<ProfileProperty>>() {};
 
-    public static final TypeToken<ProjectileSource> PROJECTILE_SOURCE_TOKEN = new TypeToken<ProjectileSource>() {};
-
     public static final TypeToken<Value<ProjectileSource>> PROJECTILE_SOURCE_VALUE_TOKEN = new TypeToken<Value<ProjectileSource>>() {};
-
-    public static final TypeToken<RabbitType> RABBIT_TYPE_TOKEN = new TypeToken<RabbitType>() {};
 
     public static final TypeToken<Value<RabbitType>> RABBIT_TYPE_VALUE_TOKEN = new TypeToken<Value<RabbitType>>() {};
 
-    public static final TypeToken<RaidWave> RAID_WAVE_TOKEN = new TypeToken<RaidWave>() {};
-
     public static final TypeToken<Value<RaidWave>> RAID_WAVE_VALUE_TOKEN = new TypeToken<Value<RaidWave>>() {};
 
-    public static final TypeToken<RailDirection> RAIL_DIRECTION_TOKEN = new TypeToken<RailDirection>() {};
-
     public static final TypeToken<Value<RailDirection>> RAIL_DIRECTION_VALUE_TOKEN = new TypeToken<Value<RailDirection>>() {};
-
-    public static final TypeToken<Orientation> ROTATION_TOKEN = new TypeToken<Orientation>() {};
 
     public static final TypeToken<Value<Orientation>> ROTATION_VALUE_TOKEN = new TypeToken<Value<Orientation>>() {};
 
@@ -496,21 +324,11 @@ public final class TypeTokens {
 
     public static final TypeToken<SetValue<String>> SET_STRING_VALUE_TOKEN = new TypeToken<SetValue<String>>() {};
 
-    public static final TypeToken<Sheep> SHEEP_TOKEN = new TypeToken<Sheep>() {};
-
     public static final TypeToken<Value<Sheep>> SHEEP_VALUE_TOKEN = new TypeToken<Value<Sheep>>() {};
-
-    public static final TypeToken<Short> SHORT_TOKEN = new TypeToken<Short>() {};
-
-    public static final TypeToken<SlabPortion> SLAB_PORTION_TOKEN = new TypeToken<SlabPortion>() {};
 
     public static final TypeToken<Value<SlabPortion>> SLAB_PORTION_VALUE_TOKEN = new TypeToken<Value<SlabPortion>>() {};
 
-    public static final TypeToken<SpellType> SPELL_TYPE_TOKEN = new TypeToken<SpellType>() {};
-
     public static final TypeToken<Value<SpellType>> SPELL_TYPE_VALUE_TOKEN = new TypeToken<Value<SpellType>>() {};
-
-    public static final TypeToken<StairShape> STAIR_SHAPE_TOKEN = new TypeToken<StairShape>() {};
 
     public static final TypeToken<Value<StairShape>> STAIR_SHAPE_VALUE_TOKEN = new TypeToken<Value<StairShape>>() {};
 
@@ -518,41 +336,21 @@ public final class TypeTokens {
 
     public static final TypeToken<MapValue<Statistic, Long>> MAP_STATISTIC_LONG_VALUE_TOKEN = new TypeToken<MapValue<Statistic, Long>>() {};
 
-    public static final TypeToken<String> STRING_TOKEN = new TypeToken<String>() {};
-
     public static final TypeToken<Value<String>> STRING_VALUE_TOKEN = new TypeToken<Value<String>>() {};
-
-    public static final TypeToken<StructureMode> STRUCTURE_MODE_TOKEN = new TypeToken<StructureMode>() {};
 
     public static final TypeToken<Value<StructureMode>> STRUCTURE_MODE_VALUE_TOKEN = new TypeToken<Value<StructureMode>>() {};
 
-    public static final TypeToken<ToolType> TOOL_TYPE_TOKEN = new TypeToken<ToolType>() {};
-
     public static final TypeToken<Value<ToolType>> TOOL_TYPE_VALUE_TOKEN = new TypeToken<Value<ToolType>>() {};
-
-    public static final TypeToken<TropicalFishShape> TROPICAL_FISH_SHAPE_TOKEN = new TypeToken<TropicalFishShape>() {};
 
     public static final TypeToken<Value<TropicalFishShape>> TROPICAL_FISH_SHAPE_VALUE_TOKEN = new TypeToken<Value<TropicalFishShape>>() {};
 
-    public static final TypeToken<User> USER_TOKEN = new TypeToken<User>() {};
-
-    public static final TypeToken<UUID> UUID_TOKEN = new TypeToken<UUID>() {};
-
     public static final TypeToken<Value<UUID>> UUID_VALUE_TOKEN = new TypeToken<Value<UUID>>() {};
-
-    public static final TypeToken<Vector2i> VECTOR_2I_TOKEN = new TypeToken<Vector2i>() {};
 
     public static final TypeToken<Value<Vector2i>> VECTOR_2I_VALUE_TOKEN = new TypeToken<Value<Vector2i>>() {};
 
-    public static final TypeToken<Vector3d> VECTOR_3D_TOKEN = new TypeToken<Vector3d>() {};
-
     public static final TypeToken<Value<Vector3d>> VECTOR_3D_VALUE_TOKEN = new TypeToken<Value<Vector3d>>() {};
 
-    public static final TypeToken<Vector3i> VECTOR_3I_TOKEN = new TypeToken<Vector3i>() {};
-
     public static final TypeToken<Value<Vector3i>> VECTOR_3I_VALUE_TOKEN = new TypeToken<Value<Vector3i>>() {};
-
-    public static final TypeToken<VillagerType> VILLAGER_TYPE_TOKEN = new TypeToken<VillagerType>() {};
 
     public static final TypeToken<Value<VillagerType>> VILLAGER_TYPE_VALUE_TOKEN = new TypeToken<Value<VillagerType>>() {};
 
@@ -570,49 +368,9 @@ public final class TypeTokens {
 
     public static final TypeToken<MapValue<Direction, WireAttachmentType>> MAP_DIRECTION_WIRE_ATTACHMENT_VALUE_TOKEN = new TypeToken<MapValue<Direction, WireAttachmentType>>() {};
 
-    public static final TypeToken<WireAttachmentType> WIRE_ATTACHMENT_TYPE_TOKEN = new TypeToken<WireAttachmentType>() {};
-
     public static final TypeToken<Value<WireAttachmentType>> WIRE_ATTACHMENT_TYPE_VALUE_TOKEN = new TypeToken<Value<WireAttachmentType>>() {};
 
-    public static final TypeToken<WoodType> WOOD_TYPE_TOKEN = new TypeToken<WoodType>() {};
-
     public static final TypeToken<Value<WoodType>> WOOD_TYPE_VALUE_TOKEN = new TypeToken<Value<WoodType>>() {};
-
-    public static final TypeToken<WorldProperties> WORLD_PROPERTIES_TOKEN = new TypeToken<WorldProperties>() {};
-
-    public static final TypeToken<LocatableBlock> LOCATABLE_BLOCK_TOKEN = new TypeToken<LocatableBlock>() {};
-
-    public static final TypeToken<ChangeBlockEvent.Break> CHANGE_BLOCK_EVENT_BREAK_TOKEN = new TypeToken<ChangeBlockEvent.Break>() {};
-
-    public static final TypeToken<DamageType> DAMAGE_TYPE_TOKEN = new TypeToken<DamageType>() {};
-
-    public static final TypeToken<ChangeBlockEvent.Decay> CHANGE_BLOCK_EVENT_DECAY_TOKEN = new TypeToken<ChangeBlockEvent.Decay>() {};
-
-    public static final TypeToken<DismountType> DISMOUNT_TYPE_TOKEN = new TypeToken<DismountType>() {};
-
-    public static final TypeToken<Player> PLAYER_TOKEN = new TypeToken<Player>() {};
-
-    public static final TypeToken<ServerPlayer> SERVER_PLAYER_TOKEN = new TypeToken<ServerPlayer>() {};
-
-    public static final TypeToken<ServerWorld> SERVER_WORLD_TOKEN = new TypeToken<ServerWorld>() {};
-
-    public static final TypeToken<ChangeBlockEvent.Grow> CHANGE_BLOCK_EVENT_GROW_TOKEN = new TypeToken<ChangeBlockEvent.Grow>() {};
-
-    public static final TypeToken<ServerLocation> SERVER_LOCATION_TOKEN = new TypeToken<ServerLocation>() {};
-
-    public static final TypeToken<DamageSource> DAMAGE_SOURCE_TOKEN = new TypeToken<DamageSource>() {};
-
-    public static final TypeToken<ChangeBlockEvent.Modify> CHANGE_BLOCK_EVENT_MODIFY_TOKEN = new TypeToken<ChangeBlockEvent.Modify>() {};
-
-    public static final TypeToken<ChangeBlockEvent.Place> CHANGE_BLOCK_EVENT_PLACE_TOKEN = new TypeToken<ChangeBlockEvent.Place>() {};
-
-    public static final TypeToken<SpawnType> SPAWN_TYPE_TOKEN = new TypeToken<SpawnType>() {};
-
-    public static final TypeToken<Subject> SUBJECT_TOKEN = new TypeToken<Subject>() {};
-
-    public static final TypeToken<MovementType> MOVEMENT_TYPE_TOKEN = new TypeToken<MovementType>() {};
-
-    public static final TypeToken<HandType> HAND_TYPE_TOKEN = new TypeToken<HandType>() {};
 
     // @formatter:on
     // SORTFIELDS:OFF

--- a/src/main/java/org/spongepowered/api/world/gamerule/GameRule.java
+++ b/src/main/java/org/spongepowered/api/world/gamerule/GameRule.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.world.gamerule;
 
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.TypeToken;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.NamedCatalogType;
@@ -82,7 +82,7 @@ public interface GameRule<V> extends NamedCatalogType {
          * @return This builder, for chaining
          */
         default <NV> Builder<NV> valueType(Class<NV> valueType) {
-            return valueType(TypeToken.of(valueType));
+            return valueType(TypeToken.get(valueType));
         }
 
         /**

--- a/src/main/java/org/spongepowered/api/world/gamerule/GameRule.java
+++ b/src/main/java/org/spongepowered/api/world/gamerule/GameRule.java
@@ -81,7 +81,7 @@ public interface GameRule<V> extends NamedCatalogType {
          * @param <NV> The value type
          * @return This builder, for chaining
          */
-        default <NV> Builder<NV> valueType(Class<NV> valueType) {
+        default <NV> Builder<NV> valueType(final Class<NV> valueType) {
             return valueType(TypeToken.get(valueType));
         }
 

--- a/src/main/java/org/spongepowered/api/world/gamerule/GameRule.java
+++ b/src/main/java/org/spongepowered/api/world/gamerule/GameRule.java
@@ -31,6 +31,8 @@ import org.spongepowered.api.NamedCatalogType;
 import org.spongepowered.api.util.NamedCatalogBuilder;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
+import java.lang.reflect.Type;
+
 /**
  * Represents a game rule.
  *
@@ -44,7 +46,7 @@ public interface GameRule<V> extends NamedCatalogType {
      *
      * @return The value type
      */
-    TypeToken<V> getValueType();
+    Type getValueType();
 
     /**
      * Gets the default value.
@@ -77,13 +79,13 @@ public interface GameRule<V> extends NamedCatalogType {
         /**
          * Sets the value type.
          *
+         * <p>This must not be a raw parameterized type.</p>
+         *
          * @param valueType The value type
          * @param <NV> The value type
          * @return This builder, for chaining
          */
-        default <NV> Builder<NV> valueType(final Class<NV> valueType) {
-            return valueType(TypeToken.get(valueType));
-        }
+        <NV> Builder<NV> valueType(final Class<NV> valueType);
 
         /**
          * Sets the value {@link TypeToken type}.

--- a/src/test/java/org/spongepowered/api/event/SpongeEventFactoryTest.java
+++ b/src/test/java/org/spongepowered/api/event/SpongeEventFactoryTest.java
@@ -33,8 +33,6 @@ import com.google.common.collect.ImmutableSet;
 import io.leangen.geantyref.GenericTypeReflector;
 import io.leangen.geantyref.TypeToken;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
@@ -50,7 +48,7 @@ import org.spongepowered.api.util.Transform;
 import org.spongepowered.api.world.ServerLocation;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.server.ServerWorld;
-import org.spongepowered.configurate.util.Typing;
+import org.spongepowered.configurate.util.Types;
 import org.spongepowered.math.vector.Vector3d;
 
 import java.lang.reflect.Array;
@@ -212,7 +210,7 @@ public class SpongeEventFactoryTest {
             return false;
         } else if (paramType == void.class || paramType == Void.class) {
             return null;
-        } else if (Typing.isArray(paramType)) {
+        } else if (Types.isArray(paramType)) {
             final Type componentType = GenericTypeReflector.getArrayComponentType(paramType);
             Object array = Array.newInstance(GenericTypeReflector.erase(componentType), 1);
             Array.set(array, 0, mockParam(componentType));

--- a/src/test/java/org/spongepowered/api/event/SpongeEventFactoryTest.java
+++ b/src/test/java/org/spongepowered/api/event/SpongeEventFactoryTest.java
@@ -30,8 +30,11 @@ import static org.mockito.Mockito.withSettings;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.reflect.TypeToken;
+import io.leangen.geantyref.GenericTypeReflector;
+import io.leangen.geantyref.TypeToken;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
@@ -47,6 +50,7 @@ import org.spongepowered.api.util.Transform;
 import org.spongepowered.api.world.ServerLocation;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.server.ServerWorld;
+import org.spongepowered.configurate.util.Typing;
 import org.spongepowered.math.vector.Vector3d;
 
 import java.lang.reflect.Array;
@@ -77,8 +81,6 @@ public class SpongeEventFactoryTest {
     private static List<World> worlds = new ArrayList<>();
 
     private static final Answer<Object> EVENT_MOCKING_ANSWER = (invoc -> {
-        Class<?> clazz = invoc.getMethod().getReturnType();
-
         // We use the original mock type to try to get more information about
         // the return type. For example, imagine that SignData#asImmutable is called
         // on a mocked SignData instance. The return type given to use by
@@ -87,25 +89,10 @@ public class SpongeEventFactoryTest {
         // the 'generic' return type of SignData#asImmutable, which is ImmutableSignData.
         // Guava's TypeToken takes generic parameters into account, allowing us to mock
         // the most specific known return type.
-        Type returnType = TypeToken.of(
+        Type returnType = GenericTypeReflector.getExactReturnType(invoc.getMethod(),
                 Mockito.mockingDetails(invoc.getMock()).getMockCreationSettings().getTypeToMock()
-        )
-                .method(invoc.getMethod())
-                .getReturnType().getType();
-
-        if (returnType instanceof Class<?> && clazz != returnType) {
-            clazz = (Class<?>) returnType;
-        }
-
-        // We pass along a TypeToken built from the generic return type.
-        // This allows 'mockParam' to take into account generic parameters when
-        // resolving the return type of future method invocations.
-        // For example, imagine that we're mocking MutableBoundedValue<Integer>.
-        // For 'mockParam' to know that the mocked 'get()' method should return
-        // Integer, and not Object, it needs the TypeToken to provide the information
-        // not present in the base class.
-        TypeToken<?> token = TypeToken.of(invoc.getMethod().getGenericReturnType());
-        return mockParam(clazz, token);
+        );
+        return mockParam(returnType);
     });
 
     @Parameterized.Parameters(name = "{0}")
@@ -132,10 +119,10 @@ public class SpongeEventFactoryTest {
             // of this particular event.
             worlds.clear();
 
-            Class<?>[] paramTypes = this.method.getParameterTypes();
+            Type[] paramTypes = this.method.getGenericParameterTypes();
             Object[] params = new Object[paramTypes.length];
             for (int i = 0; i < paramTypes.length; i++) {
-                params[i] = mockParam(paramTypes[i], null);
+                params[i] = mockParam(paramTypes[i]);
             }
             Object testEvent = this.method.invoke(null, params);
             for (Method eventMethod : testEvent.getClass().getMethods()) {
@@ -145,7 +132,7 @@ public class SpongeEventFactoryTest {
                 }
 
                 try {
-                    paramTypes = eventMethod.getParameterTypes();
+                    paramTypes = eventMethod.getGenericParameterTypes();
                     params = new Object[paramTypes.length];
                     for (int i = 0; i < paramTypes.length; i++) {
                         params[i] = mockParam(paramTypes[i]);
@@ -202,14 +189,9 @@ public class SpongeEventFactoryTest {
         }
     }
 
-    @Nullable
-    public static Object mockParam(final Class<?> paramType) {
-        return mockParam(paramType, null);
-    }
-
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Nullable
-    public static Object mockParam(final Class<?> paramType, @Nullable TypeToken<?> token) {
+    public static Object mockParam(final Type paramType) {
         if (paramType == Class.class) {
             return PEBKACException.class;
         } else if (paramType == byte.class || paramType == Byte.class) {
@@ -230,9 +212,10 @@ public class SpongeEventFactoryTest {
             return false;
         } else if (paramType == void.class || paramType == Void.class) {
             return null;
-        } else if (paramType.isArray()) {
-            Object array = Array.newInstance(paramType.getComponentType(), 1);
-            Array.set(array, 0, mockParam(paramType.getComponentType()));
+        } else if (Typing.isArray(paramType)) {
+            final Type componentType = GenericTypeReflector.getArrayComponentType(paramType);
+            Object array = Array.newInstance(GenericTypeReflector.erase(componentType), 1);
+            Array.set(array, 0, mockParam(componentType));
             return array;
         } else if (paramType == String.class) {
             return "Cupcakes";
@@ -240,9 +223,9 @@ public class SpongeEventFactoryTest {
             return Optional.empty();
         } else if (paramType == OptionalInt.class) {
             return OptionalInt.empty();
-        } else if (Enum.class.isAssignableFrom(paramType)) {
-            return paramType.getEnumConstants()[0];
-        } else if (ServerLocation.class.isAssignableFrom(paramType)) {
+        } else if (GenericTypeReflector.isSuperType(Enum.class, paramType)) {
+            return GenericTypeReflector.erase(paramType).getEnumConstants()[0];
+        } else if (GenericTypeReflector.isSuperType(ServerLocation.class, paramType)) {
             ServerWorld world = (ServerWorld) mockParam(ServerWorld.class);
             // Make sure we keep a reference to the World,
             // as Location stores a weak reference
@@ -252,7 +235,7 @@ public class SpongeEventFactoryTest {
             return mock;
         } else if (paramType == Transform.class) {
             return mock(Transform.class);
-        } else if (InetSocketAddress.class.isAssignableFrom(paramType)) {
+        } else if (GenericTypeReflector.isSuperType(InetSocketAddress.class, paramType)) {
             return new InetSocketAddress(12345);
         } else if (paramType == UUID.class) {
             return UUID.randomUUID();
@@ -269,26 +252,25 @@ public class SpongeEventFactoryTest {
         } else if (paramType == Instant.class) {
             return Instant.now();
         } else if (paramType == TypeToken.class) {
-            return TypeToken.of(Object.class);
+            return TypeToken.get(Object.class);
         } else if (paramType == Color.class) {
             return Color.BLACK;
-        } else if (DataHolder.class.isAssignableFrom(paramType)) {
-            DataHolder mock = (DataHolder) mock(paramType,
+        } else if (GenericTypeReflector.isSuperType(DataHolder.class, paramType)) {
+            DataHolder mock = (DataHolder) mock(GenericTypeReflector.erase(paramType),
                     withSettings().defaultAnswer(EVENT_MOCKING_ANSWER));
             return mock;
 
         } else {
-            if (token != null) {
-                // If we hsve a TypeToken available, we use to try to resolve a more specific
-                // return type on any of the methods that we mock. This allows us to correctly
-                // return an Integer from MutableBoundedValue<Integer>#get(), instead of accidentally
-                // returning an Object mock.
-                return mock(paramType, withSettings().defaultAnswer(invoc -> {
-                    Class<?> realReturnType = token.method(invoc.getMethod()).getReturnType().getRawType();
-                    return mockParam(realReturnType, null);
-                }));
+            if (paramType instanceof Class<?>) {
+                return mock((Class<?>) paramType, withSettings().defaultAnswer(EVENT_MOCKING_ANSWER));
             }
-            return mock(paramType, withSettings().defaultAnswer(EVENT_MOCKING_ANSWER));
+            // If we have a TypeToken available, we use to try to resolve a more specific
+            // return type on any of the methods that we mock. This allows us to correctly
+            // return an Integer from MutableBoundedValue<Integer>#get(), instead of accidentally
+            // returning an Object mock.
+            return mock(GenericTypeReflector.erase(paramType), withSettings().defaultAnswer(invoc -> {
+                return mockParam(GenericTypeReflector.getExactReturnType(invoc.getMethod(), paramType));
+            }));
         }
     }
 }


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/3188)

This updates the API for changes in Configurate, and to move away from the Guava `TypeToken`.

## API spec changes

The biggest non-obvious changes are to injection -- since these are defined in the implementation they aren't captured super well. I've added in a few new injectable types:

- `ConfigurationReference<CommentedConfigurationNode>`: both shared and private roots, provides an auto-reloading configuration
- `TypeSerializerCollection`: Exposes the Sponge-defined serializers

and set up some customized default options for configurations:

- implicit initialization is enabled for object-mapped values
- defaults are automatically copied