### PR TITLE
Deprecate unused elements of the KickPlayerEvent

### DIFF
--- a/src/main/java/org/spongepowered/api/event/entity/living/humanoid/player/KickPlayerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/living/humanoid/player/KickPlayerEvent.java
@@ -26,10 +26,54 @@ package org.spongepowered.api.event.entity.living.humanoid.player;
 
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.message.MessageChannelEvent;
+import org.spongepowered.api.text.channel.MessageChannel;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
 
 /**
  * Fired when a {@link Player} is kicked.
  */
 public interface KickPlayerEvent extends TargetPlayerEvent, MessageChannelEvent {
+
+    /**
+     * Ignored.
+     *
+     * @return A {@link MessageChannel}
+     * @deprecated Not used in this event.
+     */
+    @Override
+    @Deprecated
+    MessageChannel getOriginalChannel();
+
+    /**
+     * Ignored.
+     *
+     * @return A {@link MessageChannel}
+     * @deprecated Not used in this event.
+     */
+    @Override
+    @Deprecated
+    Optional<MessageChannel> getChannel();
+
+    /**
+     * Ignored.
+     *
+     * @param channel A {@link MessageChannel} that is not used in this event.
+     * @deprecated Not used in this event.
+     */
+    @Override
+    @Deprecated
+    void setChannel(@Nullable MessageChannel channel);
+
+    /**
+     * Ignored.
+     *
+     * @param cancelled True if should not be sent
+     */
+    @Override
+    @Deprecated
+    void setMessageCancelled(boolean cancelled);
 
 }


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/3114) | [Original Issue](https://github.com/SpongePowered/SpongeAPI/issues/2178)

As it says. We don't use the message channel on the event.

We haven't added the ability to cancel the event as `Player#kick` returns a `void`, not a `boolean`, so there is no way to indicate to a plugin that a player wasn't kicked.

See #2178 