### PR TITLE
Update errorprone to 2.3.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
         exclude(group = "com.google.j2objc", module = "j2objc-annotations")
         exclude(group = "org.codehaus.mojo", module = "animal-sniffer-annotations")
     }
-    api("com.google.errorprone:error_prone_annotations:2.1.3")
+    api("com.google.errorprone:error_prone_annotations:2.3.4")
     api("com.google.code.gson:gson:2.8.0")
     api("org.apache.commons:commons-lang3:3.5")
 


### PR DESCRIPTION
Part 1 of noideahowmanyprsthisisgoingtotake 

trying to solve the duplicate dependencies issue.

SpongeAPI uses errorprone 2.1.3:

https://github.com/SpongePowered/SpongeAPI/blob/585bb68da3b7536c232cc86a660a548b6aad46b7/build.gradle.kts#L43

SpongeAPI uses caffeine 2.8.4:

https://github.com/SpongePowered/SpongeAPI/blob/585bb68da3b7536c232cc86a660a548b6aad46b7/build.gradle.kts#L60

caffeine 2.8.4 uses errorprone 2.3.4:

https://github.com/ben-manes/caffeine/blob/7239bb0dda2af1e7301e8f66a5df28215b5173bc/gradle/dependencies.gradle#L38

Note: errorprone is not used AFAIK. I'm bumping them to solve the issue but I've no problem with removing the dep.