### PR TITLE
Use gradle wrapper all

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Use the same wrapper used in common (https://github.com/SpongePowered/SpongeCommon/blob/f999ecc4a4e6269602cfb78108b28a168f54773a/gradle/wrapper/gradle-wrapper.properties#L3), this should avoid gradle downloading the wrapper twice.