### PR TITLE
Remove EconomyService#deleteAccount default implementation

### DIFF
--- a/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
+++ b/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
@@ -147,9 +147,7 @@ public interface EconomyService extends ContextualService<Account> {
      * @param uuid The {@link UUID} of the account to delete.
      * @return The result of the deletion.
      */
-    default AccountDeletionResultType deleteAccount(UUID uuid) {
-        return AccountDeletionResultTypes.UNSUPPORTED.get();
-    }
+    AccountDeletionResultType deleteAccount(UUID uuid);
 
     /**
      * Deletes the account with the specified identifier.
@@ -162,7 +160,5 @@ public interface EconomyService extends ContextualService<Account> {
      * @param identifier The identifier of the account to delete.
      * @return The result of the deletion.
      */
-    default AccountDeletionResultType deleteAccount(String identifier) {
-        return AccountDeletionResultTypes.UNSUPPORTED.get();
-    }
+    AccountDeletionResultType deleteAccount(String identifier);
 }

--- a/src/main/java/org/spongepowered/api/service/economy/account/AccountDeletionResultTypes.java
+++ b/src/main/java/org/spongepowered/api/service/economy/account/AccountDeletionResultTypes.java
@@ -53,12 +53,6 @@ public class AccountDeletionResultTypes {
             Sponge.getRegistry().getCatalogRegistry().provideSupplier(AccountDeletionResultType.class, "success");
 
     /**
-     * Represents an account deletion where the deletion feature is unsupported.
-     */
-    public static final Supplier<AccountDeletionResultType> UNSUPPORTED =
-            Sponge.getRegistry().getCatalogRegistry().provideSupplier(AccountDeletionResultType.class, "unsupported");
-
-    /**
      * Represents an account deletion where the account could not be deleted.
      */
     public static final Supplier<AccountDeletionResultType> UNDELETABLE =


### PR DESCRIPTION
`EconomyService#deleteAccount` was default implemented back in api 7 to avoid a breaking change. 
This PR removes the default implementation.
Input wanted on whether `AccountDeletionResultTypes#UNSUPPORTED` is worth keeping.