### PR TITLE
Refactor the GameProfileManager and make GameProfile immutable.

### DIFF
--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -858,9 +858,12 @@ public final class Keys {
     public static final Supplier<Key<Value<GameMode>>> GAME_MODE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "game_mode");
 
     /**
-     * The player represented by a
-     * {@link BlockTypes#PLAYER_HEAD} (and {@link BlockTypes#PLAYER_WALL_HEAD}) {@link BlockState}
-     * or a {@link ItemTypes#PLAYER_HEAD} {@link ItemStack}.
+     * The player represented by a {@link BlockTypes#PLAYER_HEAD} (and {@link BlockTypes#PLAYER_WALL_HEAD})
+     * {@link BlockState} or a {@link ItemTypes#PLAYER_HEAD} {@link ItemStack}.
+     *
+     * <p>The offered game profile will be set exactly, unlike in vanilla where the game profile will
+     * be resolved automatically for properties (including textures). You can obtain a game profile with
+     * properties using {@link org.spongepowered.api.profile.GameProfileManager#getProfile}.</p>
      */
     public static final Supplier<Key<Value<GameProfile>>> GAME_PROFILE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "game_profile");
 

--- a/src/main/java/org/spongepowered/api/profile/GameProfile.java
+++ b/src/main/java/org/spongepowered/api/profile/GameProfile.java
@@ -24,9 +24,6 @@
  */
 package org.spongepowered.api.profile;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.common.collect.Multimap;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.persistence.DataSerializable;
@@ -34,8 +31,10 @@ import org.spongepowered.api.profile.property.ProfileProperty;
 import org.spongepowered.api.user.UserManager;
 import org.spongepowered.api.util.Identifiable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Predicate;
 
 /**
  * Represents a profile of a user.
@@ -53,7 +52,7 @@ public interface GameProfile extends Identifiable, DataSerializable {
      * @param uniqueId The unique id
      * @return The created profile
      */
-    static GameProfile of(UUID uniqueId) {
+    static GameProfile of(final UUID uniqueId) {
         return of(uniqueId, null);
     }
 
@@ -64,8 +63,8 @@ public interface GameProfile extends Identifiable, DataSerializable {
      * @param name The name
      * @return The created profile
      */
-    static GameProfile of(UUID uniqueId, @Nullable String name) {
-        return Sponge.getServer().getGameProfileManager().createProfile(uniqueId, name);
+    static GameProfile of(final UUID uniqueId, final @Nullable String name) {
+        return Sponge.getRegistry().getFactoryRegistry().provideFactory(Factory.class).of(uniqueId, name);
     }
 
     /**
@@ -76,79 +75,94 @@ public interface GameProfile extends Identifiable, DataSerializable {
     Optional<String> getName();
 
     /**
-     * Gets the property map for this profile.
+     * Gets whether this game profile has a known name.
      *
-     * <p>This is a mutable map.</p>
-     *
-     * @return The property map
+     * @return Whether the name is known
      */
-    Multimap<String, ProfileProperty> getPropertyMap();
-
-    /**
-     * Adds a profile property to this game profile.
-     *
-     * <p>The {@link ProfileProperty#getName() name} of the property is used when
-     * adding the profile property to the {@link #getPropertyMap() property map}.</p>
-     *
-     * @param property The profile property
-     * @return The game profile
-     */
-    default GameProfile addProperty(ProfileProperty property) {
-        checkNotNull(property, "property");
-        return this.addProperty(property.getName(), property);
+    default boolean hasName() {
+        return this.getName().isPresent();
     }
 
     /**
-     * Adds a profile property to this game profile.
+     * Gets a new {@link GameProfile} with the given name.
      *
-     * @param name The name of the property
-     * @param property The profile property
-     * @return The game profile
+     * @param name The name
+     * @return The new game profile
      */
-    default GameProfile addProperty(String name, ProfileProperty property) {
-        checkNotNull(name, "name");
-        checkNotNull(property, "property");
-        this.getPropertyMap().put(name, property);
-        return this;
+    GameProfile withName(@Nullable String name);
+
+    /**
+     * Gets an immutable list of all the properties in this game profile.
+     *
+     * @return The properties
+     */
+    List<ProfileProperty> getProperties();
+
+    /**
+     * Gets a new {@link GameProfile} with the same name and unique id of this profile, but
+     * without any of the properties.
+     *
+     * @return The new game profile
+     */
+    GameProfile withoutProperties();
+
+    /**
+     * Gets a new {@link GameProfile} with the given properties added to its properties.
+     *
+     * @param properties The profile properties to add
+     * @return The new game profile
+     */
+    GameProfile withProperties(Iterable<ProfileProperty> properties);
+
+    /**
+     * Gets a new {@link GameProfile} with the given property added to its properties.
+     *
+     * @param property The profile property to add
+     * @return The new game profile
+     */
+    GameProfile withProperty(ProfileProperty property);
+
+    /**
+     * Gets a new {@link GameProfile} with the given property removed from to its properties.
+     *
+     * @param properties The profile properties to remove
+     * @return The new game profile
+     */
+    GameProfile withoutProperties(Iterable<ProfileProperty> properties);
+
+    /**
+     * Gets a new {@link GameProfile} where the properties which have the given name
+     * are removed from its properties.
+     *
+     * @param name The profile property name to remove
+     * @return The new game profile
+     */
+    default GameProfile withoutProperties(final String name) {
+        return this.withoutProperties(property -> property.getName().equals(name));
     }
 
     /**
-     * Removes a profile property to this game profile.
+     * Gets a new {@link GameProfile} with the given property removed from its properties.
      *
-     * <p>The {@link ProfileProperty#getName() name} of the property is used when
-     * removing the profile property from the {@link #getPropertyMap() property map}.</p>
-     *
-     * @param property The profile property
-     * @return {@code true} if the property map changed
+     * @param property The profile property to remove
+     * @return The new game profile
      */
-    default boolean removeProperty(ProfileProperty property) {
-        checkNotNull(property, "property");
-        return this.getPropertyMap().remove(property.getName(), property);
-    }
+    GameProfile withoutProperty(ProfileProperty property);
 
     /**
-     * Removes a profile property to this game profile.
+     * Gets a new {@link GameProfile} with where the properties that match the given
+     * filter are removed.
      *
-     * @param name The name of the property
-     * @param property The profile property
-     * @return {@code true} if the property map changed
+     * @param filter The profile property filter
+     * @return The new game profile
      */
-    default boolean removeProperty(String name, ProfileProperty property) {
-        checkNotNull(name, "name");
-        checkNotNull(property, "property");
-        return this.getPropertyMap().remove(name, property);
-    }
+    GameProfile withoutProperties(Predicate<ProfileProperty> filter);
 
     /**
-     * Checks if this profile is filled.
-     *
-     * <p>A filled profile contains both a unique id and name.</p>
-     *
-     * @return {@code true} if this profile is filled
-     * @see GameProfileManager#fill(GameProfile)
-     * @see GameProfileManager#fill(GameProfile, boolean)
-     * @see GameProfileManager#fill(GameProfile, boolean, boolean)
+     * A factory for {@link GameProfile}s.
      */
-    boolean isFilled();
+    interface Factory {
 
+        GameProfile of(UUID uniqueId, @Nullable String name);
+    }
 }

--- a/src/main/java/org/spongepowered/api/profile/GameProfileCache.java
+++ b/src/main/java/org/spongepowered/api/profile/GameProfileCache.java
@@ -24,63 +24,26 @@
  */
 package org.spongepowered.api.profile;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.user.UserManager;
 
-import java.time.Instant;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
- * Represents a cache of {@link GameProfile}s.
+ * Represents a cache of profile data.
  */
 public interface GameProfileCache {
 
     /**
-     * Add an entry to this cache.
-     *
-     * @param profile The profile to cache
-     * @return {@code true} if the profile was successfully cached,
-     *     otherwise {@code false}
-     */
-    default boolean add(GameProfile profile) {
-        return this.add(profile, (Instant) null);
-    }
-
-    /**
-     * Add an entry to this cache, with an optional expiration date.
-     *
-     * @param profile The profile to cache
-     * @param expiry The expiration date
-     * @return {@code true} if the profile was successfully cached,
-     *     otherwise {@code false}
-     */
-    default boolean add(GameProfile profile, @Nullable Instant expiry) {
-        return this.add(profile, false, expiry);
-    }
-
-    /**
-     * Add an entry to this cache, with an optional expiration date.
-     *
-     * @param profile The profile to cache
-     * @param overwrite If we should overwrite the cache entry for
-     *      the provided profile
-     * @param expiry The expiration date
-     * @return {@code true} if the profile was successfully cached,
-     *     otherwise {@code false}
-     */
-    boolean add(GameProfile profile, boolean overwrite, @Nullable Instant expiry);
-
-    /**
-     * Remove an entry from this cache.
+     * Remove entries from this cache in bulk.
      *
      * @param profile The profile to remove from the cache
-     * @return {@code true} if the profile was successfully removed,
-     *     otherwise {@code false}
+     * @return Whether the profile was successfully removed
      */
     boolean remove(GameProfile profile);
 
@@ -93,7 +56,15 @@ public interface GameProfileCache {
     Collection<GameProfile> remove(Iterable<GameProfile> profiles);
 
     /**
-     * Clear all entries from this cache.
+     * Remove entries from this cache in bulk.
+     *
+     * @param filter The filter which will be used to selected profiles to be removed
+     * @return A collection of profiles successfully removed
+     */
+    Collection<GameProfile> removeIf(Predicate<GameProfile> filter);
+
+    /**
+     * Clears all the entries from this cache.
      */
     void clear();
 
@@ -115,45 +86,6 @@ public interface GameProfileCache {
     Map<UUID, Optional<GameProfile>> getByIds(Iterable<UUID> uniqueIds);
 
     /**
-     * Looks a {@link GameProfile} up by its unique id and
-     * loads it into this cache.
-     *
-     * @param uniqueId The unique id of the profile
-     * @return The profile, if present, or {@link Optional#empty()} if
-     *     we couldn't find a profile with the provided id
-     */
-    Optional<GameProfile> lookupById(UUID uniqueId);
-
-    /**
-     * Looks up {@link GameProfile}s in bulk by their unique id and
-     * loads them into this cache.
-     *
-     * @param uniqueIds The unique ids
-     * @return A collection of successfully looked up profiles
-     */
-    Map<UUID, Optional<GameProfile>> lookupByIds(Iterable<UUID> uniqueIds);
-
-    /**
-     * Gets a {@link GameProfile} from this cache by its id if available,
-     * or lookups the profile by its unique id.
-     *
-     * @param uniqueId The unique id of the profile
-     * @return The profile, if present, or {@link Optional#empty()} if
-     *     the cache did not contain a profile with the provided id and
-     *     we couldn't lookup a profile with the provided id
-     */
-    Optional<GameProfile> getOrLookupById(UUID uniqueId);
-
-    /**
-     * Gets {@link GameProfile}s in bulk from this cache by when available,
-     * and lookups the profiles by their unique id when not cached.
-     *
-     * @param uniqueIds The unique ids of the profiles
-     * @return A collection of successfully found profiles
-     */
-    Map<UUID, Optional<GameProfile>> getOrLookupByIds(Iterable<UUID> uniqueIds);
-
-    /**
      * Gets a {@link GameProfile} from this cache by its name.
      *
      * @param name The name of the profile
@@ -171,95 +103,18 @@ public interface GameProfileCache {
     Map<String, Optional<GameProfile>> getByNames(Iterable<String> names);
 
     /**
-     * Looks a {@link GameProfile} up by its name and
-     * loads it into this cache.
+     * Gets a collection of all cached {@link GameProfile}s.
      *
-     * @param name The name of the profile
-     * @return The profile, if present, or {@link Optional#empty()} if
-     *     we couldn't find a profile with the provided name
+     * @return A {@link Collection} of cached {@link GameProfile}s
      */
-    Optional<GameProfile> lookupByName(String name);
-
-    /**
-     * Looks up {@link GameProfile}s in bulk by their name  and
-     * loads them into this cache.
-     *
-     * @param names The names
-     * @return A collection of successfully looked up profiles
-     */
-    Map<String, Optional<GameProfile>> lookupByNames(Iterable<String> names);
-
-    /**
-     * Gets a {@link GameProfile} from this cache by its if available,
-     * or lookups the profile by its name.
-     *
-     * @param name The name of the profile
-     * @return The profile, if present, or {@link Optional#empty()} if
-     *     the cache did not contain a profile with the provided name and
-     *     we couldn't lookup a profile with the provided name
-     */
-    Optional<GameProfile> getOrLookupByName(String name);
-
-    /**
-     * Gets {@link GameProfile}s in bulk from this cache by when available,
-     * and lookups the profiles by their unique id when not cached.
-     *
-     * @param names The names of the profiles
-     * @return A collection of successfully found profiles
-     */
-    Map<String, Optional<GameProfile>> getOrLookupByNames(Iterable<String> names);
-
-    /**
-     * Fills a {@link GameProfile} from cached values.
-     *
-     * @param profile The profile to fill
-     * @return The filled profile, if present, or {@link Optional#empty()} if
-     *     we were unable to fill the profile
-     */
-    default Optional<GameProfile> fillProfile(GameProfile profile) {
-        return this.fillProfile(profile, false);
-    }
-
-    /**
-     * Fills a {@link GameProfile} from cached values.
-     *
-     * @param profile The profile to fill
-     * @param signed true if we should request that the profile data be signed
-     * @return The filled profile, if present, or {@link Optional#empty()} if
-     *     we were unable to fill the profile
-     */
-    Optional<GameProfile> fillProfile(GameProfile profile, boolean signed);
+    Collection<GameProfile> all();
 
     /**
      * Gets a {@link Stream} of all cached {@link GameProfile}s.
      *
      * @return A {@link Stream} of cached {@link GameProfile}s
      */
-    Stream<GameProfile> streamProfiles();
-
-    /**
-     * Gets a collection of all cached {@link GameProfile}s.
-     *
-     * @return A {@link Collection} of cached {@link GameProfile}s
-     */
-    Collection<GameProfile> getProfiles();
-
-    /**
-     * Returns a stream of matching cached {@link GameProfile}s whose last
-     * known names start with the given string (case-insensitive).
-     *
-     * <p>This stream may also return profiles of players who never played
-     * on the server. If you would prefer only known profiles that also have
-     * {@link User} data, {@link UserManager#streamOfMatches(String)} should
-     * be used instead.</p>
-     *
-     * <p>This method only searches the local cache, so the data may not be up
-     * to date.</p>
-     *
-     * @param name The name
-     * @return A {@link Stream} of matching {@link GameProfile}s
-     */
-    Stream<GameProfile> streamOfMatches(String name);
+    Stream<GameProfile> stream();
 
     /**
      * Returns a collection of matching cached {@link GameProfile}s whose last
@@ -270,12 +125,22 @@ public interface GameProfileCache {
      * profiles that also have {@link User} data,
      * {@link UserManager#streamOfMatches(String)} should be used instead.</p>
      *
-     * <p>This method only searches the local cache, so the data may not be up
-     * to date.</p>
-     *
      * @param name The name
      * @return A {@link Collection} of matching {@link GameProfile}s
      */
-    Collection<GameProfile> match(String name);
+    Collection<GameProfile> allMatches(final String name);
 
+    /**
+     * Returns a stream of matching cached {@link GameProfile}s whose last
+     * known names start with the given string (case-insensitive).
+     *
+     * <p>This stream may also return profiles of players who never played
+     * on the server. If you would prefer only known profiles that also have
+     * {@link User} data, {@link UserManager#streamOfMatches(String)} should
+     * be used instead.</p>
+     *
+     * @param name The name
+     * @return A {@link Stream} of matching {@link GameProfile}s
+     */
+    Stream<GameProfile> streamOfMatches(String name);
 }

--- a/src/main/java/org/spongepowered/api/profile/GameProfileManager.java
+++ b/src/main/java/org/spongepowered/api/profile/GameProfileManager.java
@@ -36,7 +36,8 @@ public interface GameProfileManager extends GameProfileProvider {
      * Gets the {@link GameProfileCache} of this provider which will be
      * used to cache game profiles.
      *
-     * <p>In vanilla, properties do not persist between restarts.</p>
+     * <p>In vanilla, properties do not persist between restarts and profiles
+     * will expire after a month.</p>
      *
      * @return The cache
      */

--- a/src/main/java/org/spongepowered/api/profile/GameProfileManager.java
+++ b/src/main/java/org/spongepowered/api/profile/GameProfileManager.java
@@ -24,201 +24,29 @@
  */
 package org.spongepowered.api.profile;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.spongepowered.api.profile.property.ProfileProperty;
-
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-
 /**
  * Manages {@link GameProfile} creation and data population.
  *
  * <p>The manager may cache the data of a request for faster lookups. Note that
  * the cached data may not always be up to date.</p>
  */
-public interface GameProfileManager {
+public interface GameProfileManager extends GameProfileProvider {
 
     /**
-     * Creates a {@link GameProfile} from the provided ID and name.
+     * Gets the {@link GameProfileCache} of this provider which will be
+     * used to cache game profiles.
      *
-     * @param uniqueId The unique ID
-     * @param name The name
-     * @return The created profile
-     * @see GameProfile#of(UUID, String)
-     */
-    GameProfile createProfile(UUID uniqueId, @Nullable String name);
-
-    /**
-     * Creates a {@link ProfileProperty} from the provided name, value,
-     * and optional signature.
+     * <p>In vanilla, properties do not persist between restarts.</p>
      *
-     * @param name The name for the property
-     * @param value The value of the property
-     * @param signature The signature of the property
-     * @return The created profile property
-     * @see ProfileProperty#of(String, String)
-     * @see ProfileProperty#of(String, String, String)
-     */
-    ProfileProperty createProfileProperty(String name, String value, @Nullable String signature);
-
-    /**
-     * Looks up a {@link GameProfile} by its unique ID.
-     *
-     * <p>This method checks the local profile cache before contacting the
-     * profile servers. Use {@link #get(UUID, boolean)} to disable the cache
-     * lookup.</p>
-     *
-     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
-     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
-     * an {@link IOException} if a network error occurred.</p>
-     *
-     * @param uniqueId The unique ID
-     * @return The result of the request
-     */
-    default CompletableFuture<GameProfile> get(UUID uniqueId) {
-        return this.get(uniqueId, true);
-    }
-
-    /**
-     * Looks up a {@link GameProfile} by its user name (case-insensitive).
-     *
-     * <p>This method checks the local profile cache before contacting the
-     * profile servers. Use {@link #get(String, boolean)} to disable the cache
-     * lookup.</p>
-     *
-     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
-     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
-     * an {@link IOException} if a network error occurred.</p>
-     *
-     * @param name The username
-     * @return The result of the request
-     */
-    default CompletableFuture<GameProfile> get(String name) {
-        return this.get(name, true);
-    }
-
-    /**
-     * Looks up a {@link GameProfile} by its unique ID.
-     *
-     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
-     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
-     * an {@link IOException} if a network error occurred.</p>
-     *
-     * @param uniqueId The unique ID
-     * @param useCache true to perform a cache lookup first
-     * @return The result of the request
-     */
-    CompletableFuture<GameProfile> get(UUID uniqueId, boolean useCache);
-
-    /**
-     * Looks up a {@link GameProfile} by its user name (case-insensitive).
-     *
-     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
-     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
-     * an {@link IOException} if a network error occurred.</p>
-     *
-     * @param name The username
-     * @param useCache true to perform a cache lookup first
-     * @return The result of the request
-     */
-    CompletableFuture<GameProfile> get(String name, boolean useCache);
-
-    /**
-     * Gets a collection of {@link GameProfile}s by their unique IDs.
-     *
-     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
-     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
-     * an {@link IOException} if a network error occurred.</p>
-     *
-     * @param uniqueIds The UUIDs
-     * @param useCache true to perform a cache lookup first
-     * @return The result of the request
-     */
-    CompletableFuture<Map<UUID, Optional<GameProfile>>> getAllById(Iterable<UUID> uniqueIds, boolean useCache);
-
-    /**
-     * Gets a collection of {@link GameProfile}s by their user names
-     * (case-insensitive).
-     *
-     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
-     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
-     * an {@link IOException} if a network error occurred.</p>
-     *
-     * @param names The user names
-     * @param useCache true to perform a cache lookup first
-     * @return The result of the request
-     */
-    CompletableFuture<Map<String, Optional<GameProfile>>> getAllByName(Iterable<String> names, boolean useCache);
-
-    /**
-     * Fills a {@link GameProfile}.
-     *
-     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
-     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
-     * an {@link IOException} if a network error occurred.</p>
-     *
-     * @param profile The profile to fill
-     * @return The result of the request
-     */
-    default CompletableFuture<GameProfile> fill(GameProfile profile) {
-        return this.fill(profile, false);
-    }
-
-    /**
-     * Fills a {@link GameProfile}.
-     *
-     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
-     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
-     * an {@link IOException} if a network error occurred.</p>
-     *
-     * @param profile The profile to fill
-     * @param signed true if we should request that the profile data be signed
-     * @return The result of the request
-     */
-    default CompletableFuture<GameProfile> fill(GameProfile profile, boolean signed) {
-        return this.fill(profile, signed, true);
-    }
-
-    /**
-     * Fills a {@link GameProfile}.
-     *
-     * <p>The returned {@link CompletableFuture} throws an {@link ExecutionException}
-     * caused by a {@link ProfileNotFoundException} if the profile does not exist or
-     * an {@link IOException} if a network error occurred.</p>
-     *
-     * @param profile The profile to fill
-     * @param signed true if we should request that the profile data be signed
-     * @param useCache true to perform a cache lookup first
-     * @return The result of the request
-     */
-    CompletableFuture<GameProfile> fill(GameProfile profile, boolean signed, boolean useCache);
-
-    /**
-     * Gets the active {@link GameProfile} cache.
-     *
-     * @return The active cache
+     * @return The cache
      */
     GameProfileCache getCache();
 
     /**
-     * Sets the {@link GameProfile} cache.
+     * Gets a {@link GameProfileProvider} which bypasses the
+     * {@link GameProfileCache}.
      *
-     * <p>To restore the original cache, pass the result of {@link #getDefaultCache()}.</p>
-     *
-     * @param cache The new cache
+     * @return The uncached game profile provider
      */
-    void setCache(GameProfileCache cache);
-
-    /**
-     * Gets the default cache.
-     *
-     * @return The default cache.
-     */
-    GameProfileCache getDefaultCache();
-
+    GameProfileProvider uncached();
 }

--- a/src/main/java/org/spongepowered/api/profile/GameProfileProvider.java
+++ b/src/main/java/org/spongepowered/api/profile/GameProfileProvider.java
@@ -1,0 +1,201 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.profile;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A service which handles how game profile data is requested.
+ */
+public interface GameProfileProvider {
+
+    /**
+     * Attempts to get a basic {@link GameProfile} for the given unique id.
+     *
+     * <p>Basic game profiles don't include any profile properties.</p>
+     *
+     * <p>The {@link CompletableFuture} can fail with a
+     * {@link ProfileNotFoundException} if no profile was found with the
+     * given unique id.</p>
+     *
+     * @param uniqueId The unique id
+     * @return The profile found for the given unique id
+     */
+    CompletableFuture<GameProfile> getBasicProfile(UUID uniqueId);
+
+    /**
+     * Attempts to get a basic {@link GameProfile} for the given name.
+     *
+     * <p>Basic game profiles don't include any profile properties.</p>
+     *
+     * <p>The {@link CompletableFuture} can fail with a
+     * {@link ProfileNotFoundException} if no profile was found with the
+     * given name.</p>
+     *
+     * <p>The requested name is matched case insensitively, the corrected
+     * name will be present in the {@link GameProfile}.</p>
+     *
+     * @param name The name
+     * @return The profile found for the given name
+     */
+    default CompletableFuture<GameProfile> getBasicProfile(final String name) {
+        return this.getBasicProfile(name, null);
+    }
+
+    /**
+     * Attempts to get a basic {@link GameProfile} for the given name.
+     *
+     * <p>Basic game profiles don't include any profile properties.</p>
+     *
+     * <p>The {@link CompletableFuture} can fail with a
+     * {@link ProfileNotFoundException} if no profile was found with the
+     * given name.</p>
+     *
+     * <p>The requested name is matched case insensitively, the corrected
+     * name will be present in the {@link GameProfile}.</p>
+     *
+     * @param name The name
+     * @param time The time at which the name was assigned to a specific profile, or null if current
+     * @return The profile found for the given name
+     */
+    CompletableFuture<GameProfile> getBasicProfile(String name, @Nullable Instant time);
+
+    /**
+     * Attempts to get a basic {@link GameProfile}s for the given names.
+     *
+     * <p>Basic game profiles don't include any profile properties.</p>
+     *
+     * <p>The requested names are matched case insensitively, the corrected
+     * names will be present in the {@link GameProfile}s.</p>
+     *
+     * @param names The names
+     * @return The profiles found for the given names
+     */
+    default CompletableFuture<Map<String, GameProfile>> getBasicProfiles(final Iterable<String> names) {
+        return this.getBasicProfiles(names, null);
+    }
+
+    /**
+     * Attempts to get a basic {@link GameProfile}s for the given names.
+     *
+     * <p>Basic game profiles don't include any profile properties.</p>
+     *
+     * <p>The requested names are matched case insensitively, the corrected
+     * names will be present in the {@link GameProfile}s.</p>
+     *
+     * @param names The names
+     * @param time The time at which the names were assigned to specific profiles, or null if current
+     * @return The profiles found for the given names
+     */
+    CompletableFuture<Map<String, GameProfile>> getBasicProfiles(Iterable<String> names, @Nullable Instant time);
+
+    /**
+     * Attempts to get a full {@link GameProfile} for the given profile.
+     *
+     * <p>The {@link CompletableFuture} can fail with a
+     * {@link ProfileNotFoundException} if no profile was found with the
+     * unique id of the given profile.</p>
+     *
+     * @param profile The profile
+     * @return The profile found for the given unique id
+     */
+    default CompletableFuture<GameProfile> getProfile(final GameProfile profile) {
+        return this.getProfile(profile.getUniqueId(), true);
+    }
+
+    /**
+     * Attempts to get a full {@link GameProfile} for the given profile.
+     *
+     * <p>The {@link CompletableFuture} can fail with a
+     * {@link ProfileNotFoundException} if no profile was found with the
+     * unique id of the given profile.</p>
+     *
+     * @param profile The profile
+     * @param signed Whether property values should be signed
+     * @return The profile found for the given unique id
+     */
+    default CompletableFuture<GameProfile> getProfile(final GameProfile profile, boolean signed) {
+        return this.getProfile(profile.getUniqueId(), signed);
+    }
+
+    /**
+     * Attempts to get a full {@link GameProfile} for the given name.
+     *
+     * <p>The {@link CompletableFuture} can fail with a
+     * {@link ProfileNotFoundException} if no profile was found with the
+     * given name.</p>
+     *
+     * @param name The name
+     * @return The profile found for the given name
+     */
+    default CompletableFuture<GameProfile> getProfile(final String name) {
+        return this.getProfile(name, true);
+    }
+
+    /**
+     * Attempts to get a full {@link GameProfile} for the given unique id.
+     *
+     * <p>The {@link CompletableFuture} can fail with a
+     * {@link ProfileNotFoundException} if no profile was found with the
+     * given unique id.</p>
+     *
+     * @param uniqueId The unique id
+     * @return The profile found for the given unique id
+     */
+    default CompletableFuture<GameProfile> getProfile(final UUID uniqueId) {
+        return this.getProfile(uniqueId, true);
+    }
+
+    /**
+     * Attempts to get a full {@link GameProfile} for the given name.
+     *
+     * <p>The {@link CompletableFuture} can fail with a
+     * {@link ProfileNotFoundException} if no profile was found with the
+     * given name.</p>
+     *
+     * @param name The name
+     * @param signed Whether property values should be signed
+     * @return The profile found for the given name
+     */
+    CompletableFuture<GameProfile> getProfile(final String name, boolean signed);
+
+    /**
+     * Attempts to get a full {@link GameProfile} for the given unique id.
+     *
+     * <p>The {@link CompletableFuture} can fail with a
+     * {@link ProfileNotFoundException} if no profile was found with the
+     * given unique id.</p>
+     *
+     * @param uniqueId The unique id
+     * @param signed Whether property values should be signed
+     * @return The profile found for the given unique id
+     */
+    CompletableFuture<GameProfile> getProfile(UUID uniqueId, boolean signed);
+}

--- a/src/main/java/org/spongepowered/api/profile/GameProfileProvider.java
+++ b/src/main/java/org/spongepowered/api/profile/GameProfileProvider.java
@@ -32,7 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * A service which handles how game profile data is requested.
+ * A provider which can be used to lookup {@link GameProfile}s.
  */
 public interface GameProfileProvider {
 

--- a/src/main/java/org/spongepowered/api/profile/GameProfileProvider.java
+++ b/src/main/java/org/spongepowered/api/profile/GameProfileProvider.java
@@ -184,7 +184,7 @@ public interface GameProfileProvider {
      * @param signed Whether property values should be signed
      * @return The profile found for the given name
      */
-    CompletableFuture<GameProfile> getProfile(final String name, boolean signed);
+    CompletableFuture<GameProfile> getProfile(String name, boolean signed);
 
     /**
      * Attempts to get a full {@link GameProfile} for the given unique id.

--- a/src/main/java/org/spongepowered/api/profile/ProfileNotFoundException.java
+++ b/src/main/java/org/spongepowered/api/profile/ProfileNotFoundException.java
@@ -27,7 +27,7 @@ package org.spongepowered.api.profile;
 /**
  * Thrown by a profile lookup service if a profile does not exist.
  */
-public class ProfileNotFoundException extends Exception {
+public class ProfileNotFoundException extends RuntimeException {
 
     private static final long serialVersionUID = -6165011303382043479L;
 

--- a/src/main/java/org/spongepowered/api/profile/property/ProfileProperty.java
+++ b/src/main/java/org/spongepowered/api/profile/property/ProfileProperty.java
@@ -57,7 +57,7 @@ public interface ProfileProperty extends DataSerializable {
      * @param value The value of the property
      * @return The new property
      */
-    static ProfileProperty of(String name, String value) {
+    static ProfileProperty of(final String name, final String value) {
         return of(name, value, null);
     }
 
@@ -72,8 +72,8 @@ public interface ProfileProperty extends DataSerializable {
      * @param signature The signature of the property
      * @return The new property
      */
-    static ProfileProperty of(String name, String value, @Nullable String signature) {
-        return Sponge.getServer().getGameProfileManager().createProfileProperty(name, value, signature);
+    static ProfileProperty of(final String name, final String value, final @Nullable String signature) {
+        return Sponge.getRegistry().getFactoryRegistry().provideFactory(Factory.class).of(name, value, signature);
     }
 
     /**
@@ -109,4 +109,11 @@ public interface ProfileProperty extends DataSerializable {
         return this.getSignature().isPresent();
     }
 
+    /**
+     * A factory for {@link ProfileProperty}s.
+     */
+    interface Factory {
+
+        ProfileProperty of(String name, String value, @Nullable String signature);
+    }
 }

--- a/src/main/java/org/spongepowered/api/user/UserManager.java
+++ b/src/main/java/org/spongepowered/api/user/UserManager.java
@@ -27,7 +27,6 @@ package org.spongepowered.api.user;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.profile.GameProfile;
-import org.spongepowered.api.profile.GameProfileCache;
 import org.spongepowered.api.profile.GameProfileManager;
 
 import java.util.Collection;


### PR DESCRIPTION
**API** | [Common](https://github.com/SpongePowered/SpongeCommon/pull/3153)

This PR refactors the `GameProfile`, `GameProfileManager` and `GameProfileCache`. 

- It's no longer possible to add entries to the `GameProfileCache`, only remove them to invalidate.
- `GameProfileCache` is now just a cache, it was previously also a lookup service.
- `GameProfileCache` is no longer replaceable.
- `GameProfile` is now immutable, but has transformation methods.
- "filled" profiles are now just "profile", and non filled ones are "basic profile", e.g. `getProfile` and `getBasicProfile`.
- "filled" was previously a bit confusing, because `isFilled` meant that the profile has a name, although filling a profile through `GameProfileManager` also added properties. This is now renamed to `hasName`.