### PR TITLE
Add ability to get Command.Parameterized from CommandContext (#2217)

### DIFF
--- a/src/main/java/org/spongepowered/api/command/parameter/CommandContext.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/CommandContext.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.command.parameter;
 
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
+import org.spongepowered.api.command.Command;
 import org.spongepowered.api.command.CommandCause;
 import org.spongepowered.api.command.parameter.managed.Flag;
 import org.spongepowered.api.service.permission.SubjectProxy;
@@ -46,6 +47,14 @@ import java.util.Optional;
  * {@link #sendMessage(Component)}).</p>
  */
 public interface CommandContext extends SubjectProxy {
+
+    /**
+     * Gets the {@link Command.Parameterized} that is being executed, if it
+     * exists.
+     *
+     * @return The {@link Command.Parameterized}.
+     */
+    Optional<Command.Parameterized> getExecutedCommand();
 
     /**
      * Gets the {@link CommandCause} associated with this context.


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/3155) | [Original Issue]( https://github.com/SpongePowered/SpongeAPI/issues/2217)

See https://github.com/SpongePowered/SpongeAPI/issues/2217 - basically adds a way to get the `Command.Parameterized` being executed from the `CommandContext`.