### PR TITLE
Allow ValueCompleters to filter based on input string

### DIFF
--- a/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
@@ -1043,27 +1043,6 @@ public interface Parameter {
             }
 
             /**
-             * Provides a function that provides tab completions.
-             *
-             * <p>Optional. If this is <code>null</code> (or never set),
-             * completions will either be done via the supplied
-             * {@link Builder#parser(ValueParser)} or will just return an empty
-             * list. If this is supplied, no modifiers will run on completion.</p>
-             *
-             * <p>This method only exists to allow developers to provide a one
-             * argument lambda should they wish to use the default filtering
-             * provided in {@link ValueCompleter.All}. Developers wishing to
-             * control the completions that appear for a given string should use
-             * {@link #setSuggestions(ValueCompleter)} instead.</p>
-             *
-             * @param completer The {@link ValueCompleter.All}
-             * @return This builder, for chaining
-             */
-            default Builder<T> setSuggestions(final ValueCompleter.@Nullable All completer) {
-                return this.setSuggestions((ValueCompleter) completer);
-            }
-
-            /**
              * Provides a function that provides tab completions
              *
              * <p>Optional. If this is <code>null</code> (or never set),

--- a/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
@@ -962,7 +962,8 @@ public interface Parameter {
         void parse(ArgumentReader.@NonNull Mutable reader, CommandContext.@NonNull Builder context) throws ArgumentParseException;
 
         /**
-         * Returns potential completions of the current tokenized argument.
+         * Returns potential completions of the current tokenized argument. The
+         * completion will be based on {@link ArgumentReader#getRemaining()}.
          *
          * @param reader The {@link ArgumentReader} containing the strings that need
          *               to be parsed
@@ -1039,6 +1040,27 @@ public interface Parameter {
              */
             default <V extends ValueParser<? extends T>> Builder<T> parser(@NonNull final Supplier<V> parser) {
                 return this.parser(parser.get());
+            }
+
+            /**
+             * Provides a function that provides tab completions.
+             *
+             * <p>Optional. If this is <code>null</code> (or never set),
+             * completions will either be done via the supplied
+             * {@link Builder#parser(ValueParser)} or will just return an empty
+             * list. If this is supplied, no modifiers will run on completion.</p>
+             *
+             * <p>This method only exists to allow developers to provide a one
+             * argument lambda should they wish to use the default filtering
+             * provided in {@link ValueCompleter.All}. Developers wishing to
+             * control the completions that appear for a given string should use
+             * {@link #setSuggestions(ValueCompleter)} instead.</p>
+             *
+             * @param completer The {@link ValueCompleter.All}
+             * @return This builder, for chaining
+             */
+            default Builder<T> setSuggestions(final ValueCompleter.@Nullable All completer) {
+                return this.setSuggestions((ValueCompleter) completer);
             }
 
             /**

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/ValueCompleter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/ValueCompleter.java
@@ -46,27 +46,4 @@ public interface ValueCompleter {
      */
     List<String> complete(CommandContext context, String currentInput);
 
-    /**
-     * Define all completions for a parameter, with a default implementation for
-     * {@link ValueCompleter#complete(CommandContext, String)} to filter entries
-     * upon completion based on whether an option starts with the input string.
-     */
-    @FunctionalInterface
-    interface All extends ValueCompleter {
-
-        /**
-         * Gets all valid completions for this element, regardless of input.
-         *
-         * @param context The {@link CommandContext} that contains the parsed
-         *  arguments
-         * @return The list of values
-         */
-        List<String> complete(CommandContext context);
-
-        default List<String> complete(final CommandContext context, final String currentInput) {
-            return this.complete(context).stream().filter(x -> x.startsWith(currentInput)).collect(Collectors.toList());
-        }
-
-    }
-
 }

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/ValueCompleter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/ValueCompleter.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.command.parameter.managed;
 import org.spongepowered.api.command.parameter.CommandContext;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Defines the completions for a parameter.
@@ -35,11 +36,37 @@ import java.util.List;
 public interface ValueCompleter {
 
     /**
-     * Gets valid completions for this element.
+     * Gets valid completions for this element, given the supplied
+     * {@link CommandContext} and current input for this element.
      *
-     * @param context The {@link CommandContext} that contains the parsed arguments
+     * @param context The {@link CommandContext} that contains the parsed
+     *  arguments
+     * @param currentInput The current input for this argument
      * @return The list of values
      */
-    List<String> complete(CommandContext context);
+    List<String> complete(CommandContext context, String currentInput);
+
+    /**
+     * Define all completions for a parameter, with a default implementation for
+     * {@link ValueCompleter#complete(CommandContext, String)} to filter entries
+     * upon completion based on whether an option starts with the input string.
+     */
+    @FunctionalInterface
+    interface All extends ValueCompleter {
+
+        /**
+         * Gets all valid completions for this element, regardless of input.
+         *
+         * @param context The {@link CommandContext} that contains the parsed
+         *  arguments
+         * @return The list of values
+         */
+        List<String> complete(CommandContext context);
+
+        default List<String> complete(final CommandContext context, final String currentInput) {
+            return this.complete(context).stream().filter(x -> x.startsWith(currentInput)).collect(Collectors.toList());
+        }
+
+    }
 
 }


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/3165)

Originally, I'd written Commands in mind with the idea that developers would only need to provide all the completions that their command would want to supply, and that we would do the filtering. However, as I've been updating my own plugin, as well as thinking about the `User` parameter (I don't want to get every user to tab complete an nearly complete name, for example), I've realised this was not a good way to think about it.

This PR adds a `String` parameter to `ValueCompleter#complete` to give developers control on how they filter, meaning that they can potentially reduce the load on calculating completions. ~~I've also added `ValueCompleter.All` for the previous behaviour, but I'm open to dropping that idea.~~ - opted to drop this idea.