### PR TITLE
API8 Recipes

### DIFF
--- a/src/main/java/org/spongepowered/api/data/persistence/DataStore.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/DataStore.java
@@ -121,9 +121,10 @@ public interface DataStore {
      * @param key The data key
      * @param dataQuery The dataQuery to serialize this key under
      * @param typeToken The dataHolder type
-
+     *
      * @return The new data store
      */
+    @SafeVarargs
     static <T> DataStore of(Key<Value<T>> key, DataQuery dataQuery, TypeToken<? extends DataHolder>... typeToken) {
         return builder().key(key, dataQuery).holder(typeToken).build();
     }
@@ -187,6 +188,7 @@ public interface DataStore {
          *
          * @return this builder for chaining
          */
+        @SuppressWarnings("unchecked")
         Builder holder(TypeToken<? extends DataHolder>... typeTokens);
 
         /**

--- a/src/main/java/org/spongepowered/api/event/block/entity/SmeltEvent.java
+++ b/src/main/java/org/spongepowered/api/event/block/entity/SmeltEvent.java
@@ -28,7 +28,7 @@ import org.spongepowered.api.block.entity.carrier.furnace.FurnaceBlockEntity;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.item.inventory.AffectItemStackEvent;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
-import org.spongepowered.api.item.recipe.smelting.SmeltingRecipe;
+import org.spongepowered.api.item.recipe.cooking.CookingRecipe;
 
 import java.util.List;
 import java.util.Optional;
@@ -55,7 +55,7 @@ public interface SmeltEvent extends Event {
      *
      * @return The recipe
      */
-    Optional<SmeltingRecipe> getRecipe();
+    Optional<CookingRecipe> getRecipe();
 
     /**
      * The first tick of an item smelting.

--- a/src/main/java/org/spongepowered/api/item/ItemType.java
+++ b/src/main/java/org/spongepowered/api/item/ItemType.java
@@ -31,7 +31,9 @@ import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
+import java.util.Arrays;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * A type of item.
@@ -61,4 +63,23 @@ public interface ItemType extends CatalogType, ComponentLike, DataHolder.Immutab
      * @return Max stack quantity
      */
     int getMaxStackQuantity();
+
+    /**
+     * Returns true if this type is any of the given item types
+     *
+     * @param types the item types to check
+     *
+     * @return true if this type is any of the given item types
+     */
+    @SuppressWarnings("unchecked")
+    boolean isAnyOf(Supplier<ItemType>... types);
+
+    /**
+     * Returns true if this type is any of the given item types
+     *
+     * @param types the item types to check
+     *
+     * @return true if this type is any of the given item types
+     */
+    boolean isAnyOf(ItemType... types);
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/Inventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Inventory.java
@@ -343,6 +343,19 @@ public interface Inventory extends ValueContainer {
     }
 
     /**
+     * Query this inventory with given {@link QueryType.OneParam} and one parameter.
+     *
+     * @param queryType The queryType
+     * @param param The parameter
+     * @param <P> The parameter type
+     *
+     * @return The queried inventory
+     */
+    default <P> Inventory query(Supplier<QueryType.OneParam<P>> queryType, Supplier<P> param) {
+        return this.query(queryType.get().of(param.get()));
+    }
+
+    /**
      * Query this inventory with given {@link QueryType.TwoParam} and two parameters.
      *
      * @param queryType The queryType

--- a/src/main/java/org/spongepowered/api/item/recipe/Recipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/Recipe.java
@@ -41,8 +41,7 @@ import org.spongepowered.api.item.recipe.crafting.ShapedCraftingRecipe;
 import org.spongepowered.api.item.recipe.crafting.ShapelessCraftingRecipe;
 import org.spongepowered.api.item.recipe.crafting.SpecialCraftingRecipe;
 import org.spongepowered.api.item.recipe.single.StoneCutterRecipe;
-import org.spongepowered.api.item.recipe.smelting.SmeltingRecipe;
-import org.spongepowered.api.world.World;
+import org.spongepowered.api.item.recipe.cooking.CookingRecipe;
 import org.spongepowered.api.world.server.ServerWorld;
 
 import java.util.List;
@@ -54,7 +53,7 @@ import java.util.Optional;
  * <p>{@link ShapelessCraftingRecipe} for recipes with simple ingredients/result without pattern in a {@link CraftingInventory}</p>
  * <p>{@link ShapedCraftingRecipe} for recipes with simple ingredients/result in a pattern in a {@link CraftingInventory}</p>
  * <p>{@link SpecialCraftingRecipe} for recipes with complex ingredients and result in a {@link CraftingInventory}</p>
- * <p>{@link SmeltingRecipe} for recipes in {@link Furnace}, {@link BlastFurnace}, {@link Smoker} and {@link Campfire}</p>
+ * <p>{@link CookingRecipe} for recipes in {@link Furnace}, {@link BlastFurnace}, {@link Smoker} and {@link Campfire}</p>
  * <p>{@link StoneCutterRecipe} for recipes in a {@link BlockTypes#STONECUTTER} block</p>
  */
 public interface Recipe extends CatalogType {
@@ -70,37 +69,33 @@ public interface Recipe extends CatalogType {
     boolean isValid(Inventory inventory, ServerWorld world);
 
     /**
-     * This method should only be called if {@link #isValid(Inventory, ServerWorld)} returns {@code true}.
+     * The result of this recipe. This method should only be called if
+     * {@link #isValid(Inventory, ServerWorld)} returns {@code true}.
      *
-     * <p>This method is preferred over the
-     * {@link CraftingRecipe#getExemplaryResult()} method, as it customizes
-     * the result further depending on the context.</p>
-     *
-     * <p>Implementing classes are advised to use the output of
-     * {@link CraftingRecipe#getExemplaryResult()}, modify it accordingly,
-     * and {@code return} it.</p>
+     * <p>This method is preferred over the {@link CraftingRecipe#getExemplaryResult()} method,
+     * as it may customize the result further depending on the context.</p>
      *
      * @param inventory The input inventory
      *
-     * @return An {@link ItemStackSnapshot}
+     * @return The result of this recipe
      */
     ItemStackSnapshot getResult(Inventory inventory);
 
     /**
-     * A general result of this recipe. This result may be customized depending
-     * on the context.
+     * A general result of this recipe. This result may be customized depending on the context.
+     * See {@link #getResult(Inventory)}
      *
      * @return The exemplary result of this recipe
      */
     ItemStackSnapshot getExemplaryResult();
 
     /**
+     * The remaining items result of this recipe.
      * This method should only be called if {@link #isValid(Inventory, ServerWorld)} returns {@code true}.
      *
-     * <p>A list of items to be added to the inventory of the player when they
-     * craft the result. For example, if a player crafts a
-     * {@link ItemTypes#CAKE}, the empty buckets are returned to their
-     * inventory.</p>
+     * <p>A list of items to be added to the inventory of the player when they craft the result.
+     * For example, if a player crafts a {@link ItemTypes#CAKE}, the empty buckets are returned to
+     * their inventory.</p>
      *
      * @param inventory The input inventory
      * @return The list of items to be added to the inventory of the player
@@ -111,8 +106,7 @@ public interface Recipe extends CatalogType {
     /**
      * Returns the {@link RecipeResult} for the given inventory and world.
      *
-     * <p>Returns
-     * {@link Optional#empty()} if the arguments do not satisfy
+     * <p>Returns {@link Optional#empty()} if the arguments do not satisfy
      * {@link #isValid(Inventory, ServerWorld)}.</p>
      *
      * @param inventory The input inventory
@@ -145,7 +139,7 @@ public interface Recipe extends CatalogType {
     boolean isDynamic();
 
     /**
-     * Gets the type of recipe
+     * Gets the {@link RecipeType} of this recipe.
      *
      * @return The recipe type.
      */

--- a/src/main/java/org/spongepowered/api/item/recipe/RecipeRegistration.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/RecipeRegistration.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.item.recipe;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.data.persistence.DataSerializable;
+
+/**
+ * A Sponge plugin recipe registration use {@link org.spongepowered.api.event.lifecycle.RegisterCatalogEvent<RecipeRegistration>} to register the recipe.
+ * <p>Recipes are registered as a data-pack.</p>
+ */
+public interface RecipeRegistration extends CatalogType, DataSerializable {
+
+}

--- a/src/main/java/org/spongepowered/api/item/recipe/RecipeRegistry.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/RecipeRegistry.java
@@ -29,7 +29,7 @@ import org.spongepowered.api.event.lifecycle.RegisterCatalogEvent;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.crafting.RecipeResult;
-import org.spongepowered.api.item.recipe.smelting.SmeltingRecipe;
+import org.spongepowered.api.item.recipe.cooking.CookingRecipe;
 import org.spongepowered.api.world.server.ServerWorld;
 
 import java.util.Collection;
@@ -134,25 +134,25 @@ public interface RecipeRegistry {
     }
 
     /**
-     * Finds a matching smelting recipe for given type and ingredient
+     * Finds a matching cooking recipe for given type and ingredient
      *
      * @param type The recipe type
      * @param ingredient The ingredient
      *
      * @return The matching recipe.
      */
-    <T extends SmeltingRecipe> Optional<T> findSmeltingRecipe(RecipeType<T> type, ItemStackSnapshot ingredient);
+    <T extends CookingRecipe> Optional<T> findCookingRecipe(RecipeType<T> type, ItemStackSnapshot ingredient);
 
     /**
-     * Finds a matching smelting recipe for given type and ingredient
+     * Finds a matching cooking recipe for given type and ingredient
      *
      * @param supplier The recipe type
      * @param ingredient The ingredient
      *
      * @return The matching recipe.
      */
-    default <T extends SmeltingRecipe> Optional<T> findSmeltingRecipe(Supplier<? extends RecipeType<T>> supplier, ItemStackSnapshot ingredient) {
-        return this.findSmeltingRecipe(supplier.get(), ingredient);
+    default <T extends CookingRecipe> Optional<T> findCookingRecipe(Supplier<? extends RecipeType<T>> supplier, ItemStackSnapshot ingredient) {
+        return this.findCookingRecipe(supplier.get(), ingredient);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/item/recipe/RecipeTypes.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/RecipeTypes.java
@@ -27,7 +27,7 @@ package org.spongepowered.api.item.recipe;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.item.recipe.crafting.CraftingRecipe;
 import org.spongepowered.api.item.recipe.single.StoneCutterRecipe;
-import org.spongepowered.api.item.recipe.smelting.SmeltingRecipe;
+import org.spongepowered.api.item.recipe.cooking.CookingRecipe;
 
 import java.util.function.Supplier;
 
@@ -39,10 +39,10 @@ public class RecipeTypes {
 
     // CRAFTING_SHAPED - CRAFTING_SHAPELESS
     public static final Supplier<RecipeType<CraftingRecipe>> CRAFTING = Sponge.getRegistry().getCatalogRegistry().provideSupplier(RecipeType.class, "crafting");
-    public static final Supplier<RecipeType<SmeltingRecipe>> SMELTING = Sponge.getRegistry().getCatalogRegistry().provideSupplier(RecipeType.class, "smelting");
-    public static final Supplier<RecipeType<SmeltingRecipe>> BLASTING = Sponge.getRegistry().getCatalogRegistry().provideSupplier(RecipeType.class, "blasting");
-    public static final Supplier<RecipeType<SmeltingRecipe>> SMOKING = Sponge.getRegistry().getCatalogRegistry().provideSupplier(RecipeType.class, "smoking");
-    public static final Supplier<RecipeType<SmeltingRecipe>> CAMPFIRE_COOKING = Sponge.getRegistry().getCatalogRegistry().provideSupplier(RecipeType.class, "campfire_cooking");
+    public static final Supplier<RecipeType<CookingRecipe>> SMELTING = Sponge.getRegistry().getCatalogRegistry().provideSupplier(RecipeType.class, "smelting");
+    public static final Supplier<RecipeType<CookingRecipe>> BLASTING = Sponge.getRegistry().getCatalogRegistry().provideSupplier(RecipeType.class, "blasting");
+    public static final Supplier<RecipeType<CookingRecipe>> SMOKING = Sponge.getRegistry().getCatalogRegistry().provideSupplier(RecipeType.class, "smoking");
+    public static final Supplier<RecipeType<CookingRecipe>> CAMPFIRE_COOKING = Sponge.getRegistry().getCatalogRegistry().provideSupplier(RecipeType.class, "campfire_cooking");
     public static final Supplier<RecipeType<StoneCutterRecipe>> STONECUTTING = Sponge.getRegistry().getCatalogRegistry().provideSupplier(RecipeType.class, "stonecutting");
 
     // SORTFIELDS:OFF

--- a/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingRecipe.java
@@ -22,68 +22,70 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.item.recipe.smelting;
+package org.spongepowered.api.item.recipe.cooking;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.Recipe;
+import org.spongepowered.api.item.recipe.RecipeRegistration;
 import org.spongepowered.api.item.recipe.RecipeType;
 import org.spongepowered.api.item.recipe.crafting.Ingredient;
 import org.spongepowered.api.util.CatalogBuilder;
-import org.spongepowered.api.util.ResettableBuilder;
 
 import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
- * A general interface for furnace-type recipes.
+ * A general interface for cooking-type/furnace recipes.
  */
-public interface SmeltingRecipe extends Recipe {
+public interface CookingRecipe extends Recipe {
 
     /**
-     * Builds a simple furnace recipe. Note, that you can implement the
-     * {@link SmeltingRecipe} manually, too.
+     * Builds a cooking recipe.
      *
-     * @return A {@link SmeltingRecipe} builder
+     * @return A {@link CookingRecipe} builder
      */
     static Builder builder() {
         return Sponge.getRegistry().getBuilderRegistry().provideBuilder(Builder.class);
     }
 
     /**
-     * Returns the {@link Ingredient} for this {@link SmeltingRecipe}.
+     * Returns the {@link Ingredient} for this {@link CookingRecipe}.
      *
-     * @return The {@link Ingredient} for this {@link SmeltingRecipe}.
+     * @return The {@link Ingredient} for this {@link CookingRecipe}.
      */
     Ingredient getIngredient();
 
     /**
      * Checks if the given {@link ItemStackSnapshot} fits the required
-     * constraints to craft this {@link SmeltingRecipe}.
+     * constraints to craft this {@link CookingRecipe}.
      *
      * @param ingredient The ingredient to check against
+     *
      * @return Whether this ingredient can be used to craft the result
      */
     boolean isValid(ItemStackSnapshot ingredient);
 
     /**
-     * <p>Returns the {@link SmeltingResult} containing the resulting
+     * <p>Returns the {@link CookingResult} containing the resulting
      * {@link ItemStackSnapshot} and the amount of experience released.</p>
      *
-     * @param ingredient The {@link ItemStackSnapshot} currently being smelted
-     * @return The {@link SmeltingResult}, or {@link Optional#empty()}
+     * @param ingredient The {@link ItemStackSnapshot} currently being cooked
+     * @return The {@link CookingResult}, or {@link Optional#empty()}
      *         if the recipe is not valid according to
      *         {@link #isValid(ItemStackSnapshot)}.
      */
-    Optional<SmeltingResult> getResult(ItemStackSnapshot ingredient);
+    Optional<CookingResult> getResult(ItemStackSnapshot ingredient);
 
     /**
-     * Returns the smelting time in ticks.
+     * Returns the cooking time in ticks.
      *
-     * @return The smelting time in ticks.
+     * @return The cooking time in ticks.
      */
-    int getSmeltTime();
+    int getCookingTime();
 
     /**
      * Returns the experience of this recipe.
@@ -95,7 +97,7 @@ public interface SmeltingRecipe extends Recipe {
     /**
      * Builds a simple furnace recipe.
      */
-    interface Builder extends ResettableBuilder<SmeltingRecipe, Builder> {
+    interface Builder extends CatalogBuilder<RecipeRegistration, Builder> {
 
         /**
          * Sets the type of recipe
@@ -104,7 +106,18 @@ public interface SmeltingRecipe extends Recipe {
          *
          * @return This builder, for chaining
          */
-        IngredientStep type(RecipeType<SmeltingRecipe> type);
+        IngredientStep type(RecipeType<CookingRecipe> type);
+
+        /**
+         * Sets the type of recipe
+         *
+         * @param type the type of recipe
+         *
+         * @return This builder, for chaining
+         */
+        default IngredientStep type(Supplier<RecipeType<CookingRecipe>> type) {
+            return this.type(type.get());
+        }
 
         interface IngredientStep extends Builder {
 
@@ -164,31 +177,56 @@ public interface SmeltingRecipe extends Recipe {
             default EndStep result(Supplier<ItemType> result) {
                 return this.result(result.get());
             }
-        }
-
-        interface EndStep extends Builder, CatalogBuilder<SmeltingRecipe, Builder> {
 
             /**
-             * Changes the experience and returns this builder. It is the
-             * required amount of experience the user must possess in order to
-             * be able to fulfill the recipe.
+             * Changes the result and returns this builder. The result is the
+             * {@link ItemStack} created when the recipe is fulfilled.
              *
-             * @param experience The amount of experience released when this
-             *     recipe is completed
+             * @param result The output of this recipe
+             *
+             * @return This builder, for chaining
+             */
+            EndStep result(ItemStack result);
+
+            /**
+             * Changes the result and returns this builder. The result is the
+             * {@link ItemStack} created when the recipe is fulfilled.
+             *
+             * @param result The output of this recipe
+             *
+             * @return This builder, for chaining
+             */
+            EndStep result(ItemStackSnapshot result);
+        }
+
+        interface EndStep extends Builder, CatalogBuilder<RecipeRegistration, Builder> {
+
+            /**
+             * Sets the group of the recipe.
+             *
+             * @param name the group
+             * @return This builder, for chaining
+             */
+            EndStep group(@Nullable String name);
+
+            /**
+             * Changes the experience and returns this builder.
+             *
+             * @param experience The amount of experience released when this recipe is completed
+             *
              * @return This builder, for chaining
              */
             EndStep experience(double experience);
 
             /**
-             * Sets the smeltTime for this recipe in ticks.
+             * Sets the cookingTime for this recipe in ticks.
              *
-             * @param ticks the smeltTime
+             * @param ticks the cookingTime
              *
              * @return This builder, for chaining
              */
-            EndStep smeltTime(int ticks);
+            EndStep cookingTime(int ticks);
 
-            // TODO possible?  EndStep group(String group);
         }
     }
 }

--- a/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingResult.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingResult.java
@@ -22,7 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.item.recipe.smelting;
+package org.spongepowered.api.item.recipe.cooking;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -33,25 +33,23 @@ import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import java.util.Objects;
 
 /**
- * The result of fulfilling a {@link SmeltingRecipe}.
+ * The result of fulfilling a {@link CookingRecipe}.
  */
-public final class SmeltingResult {
+public final class CookingResult {
 
     private final ItemStackSnapshot result;
     private final double experience;
 
     /**
-     * Creates a new {@link SmeltingResult}.
+     * Creates a new {@link CookingResult}.
      *
-     * <p>Note that this may be replaced with a static of method in the
-     * future.</p>
+     * <p>Note that this may be replaced with a static of method in the future.</p>
      *
-     * @param result The result of the smelting recipe
-     * @param experience The experience that should be created from this
-     *     smelting result
+     * @param result The result of the cooking recipe
+     * @param experience The experience that should be created from this result
      */
     @SuppressWarnings("ConstantConditions")
-    public SmeltingResult(ItemStackSnapshot result, double experience) {
+    public CookingResult(ItemStackSnapshot result, double experience) {
         checkNotNull(result, "result");
         checkArgument(!result.isEmpty(), "The result must not be empty.");
         checkArgument(experience >= 0, "The experience must be non-negative.");
@@ -62,14 +60,14 @@ public final class SmeltingResult {
 
     /**
      * This method should be used instead of the
-     * {@link SmeltingRecipe#getExemplaryResult()} method, as it customizes the
+     * {@link CookingRecipe#getExemplaryResult()} method, as it customizes the
      * result further depending on the specified ingredient
      * {@link ItemStackSnapshot}. It is advised to use the output of
-     * {@link SmeltingRecipe#getExemplaryResult()}, modify it accordingly, and
+     * {@link CookingRecipe#getExemplaryResult()}, modify it accordingly, and
      * {@code return} it.
      *
      * @return The result of fulfilling the requirements of a
-     *         {@link SmeltingRecipe}
+     *         {@link CookingRecipe}
      */
     public ItemStackSnapshot getResult() {
         return this.result;
@@ -79,7 +77,7 @@ public final class SmeltingResult {
      * Returns the amount of experience released after completing a recipe.
      *
      * @return The amount of experience released after fulfilling the
-     *         requirements of a {@link SmeltingRecipe}
+     *         requirements of a {@link CookingRecipe}
      */
     public double getExperience() {
         return this.experience;
@@ -90,10 +88,10 @@ public final class SmeltingResult {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof SmeltingResult)) {
+        if (!(o instanceof CookingResult)) {
             return false;
         }
-        SmeltingResult that = (SmeltingResult) o;
+        CookingResult that = (CookingResult) o;
         return Double.compare(that.experience, this.experience) == 0 && Objects.equals(this.result, that.result);
     }
 

--- a/src/main/java/org/spongepowered/api/item/recipe/cooking/package-info.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/cooking/package-info.java
@@ -23,4 +23,4 @@
  * THE SOFTWARE.
  */
 @org.checkerframework.framework.qual.DefaultQualifier(org.checkerframework.checker.nullness.qual.NonNull.class)
-package org.spongepowered.api.item.recipe.smelting;
+package org.spongepowered.api.item.recipe.cooking;

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/CraftingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/CraftingRecipe.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.item.recipe.crafting;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.crafting.CraftingGridInventory;
+import org.spongepowered.api.item.inventory.crafting.CraftingInventory;
 import org.spongepowered.api.item.recipe.Recipe;
 import org.spongepowered.api.item.recipe.RecipeType;
 
@@ -34,16 +35,10 @@ import java.util.Optional;
 
 /**
  * A CraftingRecipe represents some craftable recipe in the game.
- *
- * <p>It is essentially a Predicate that checks for if a recipe is valid as well
- * as a function from a crafting matrix to a list of {@link ItemStack} (the
- * crafting result), therefore making it an immutable interface.</p>
- *
- * <p>The passed in {@link CraftingGridInventory} is usually a crafting
- * inventory, e.g. a 2x2 or 3x3 crafting matrix.</p>
- *
- * <p>The requirements of a CraftingRecipe can be general, they just have to
- * eventually return a boolean given an crafting grid.</p>
+ * <p>Currently supported crafting recipe types are:</p>
+ * <p>{@link ShapelessCraftingRecipe} for recipes with simple ingredients/result without pattern in a {@link CraftingInventory}</p>
+ * <p>{@link ShapedCraftingRecipe} for recipes with simple ingredients/result in a pattern in a {@link CraftingInventory}</p>
+ * <p>{@link SpecialCraftingRecipe} for recipes with complex ingredients and result in a {@link CraftingInventory}</p>
  */
 public interface CraftingRecipe extends Recipe {
 

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/Ingredient.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/Ingredient.java
@@ -34,6 +34,7 @@ import org.spongepowered.api.util.ResettableBuilder;
 
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * An Ingredient for a crafting recipe.
@@ -41,9 +42,6 @@ import java.util.function.Predicate;
  * <p>Crafting recipes can only be crafted when all of the ingredients match
  * the items in the input grid.</p>
  */
-// TODO Ingredients for normal (recipe book supporting) crafting recipes MUST be a stream of mc Ingredient.IItemList
-// which is either based on ItemStacks/IItemProvider actually serialized to ItemType only (Ingredient.SingleItemList)
-// or one Tag<Item> (Ingredient.TagList) see ItemTags
 public interface Ingredient extends Predicate<ItemStack> {
 
     /**
@@ -87,6 +85,63 @@ public interface Ingredient extends Predicate<ItemStack> {
     }
 
     /**
+     * Creates a new {@link Ingredient} for the provided {@link ItemStack}s.
+     *
+     * @param items The items
+     * @return The new ingredient
+     */
+    static Ingredient of(@Nullable ItemStack... items) {
+        if (items == null || items.length == 0) {
+            return empty();
+        }
+        return builder().with(items).build();
+    }
+
+    /**
+     * Creates a new {@link Ingredient} for the provided {@link ItemStackSnapshot}s.
+     *
+     * @param items The item
+     * @return The new ingredient
+     */
+    static Ingredient of(@Nullable ItemStackSnapshot... items) {
+        if (items == null) {
+            return empty();
+        }
+        return builder().with(items).build();
+    }
+
+    /**
+     * Creates a new {@link Ingredient} for the provided {@link ItemType}s.
+     *
+     * @param itemTypes The items
+     * @return The new ingredient
+     */
+    @SafeVarargs
+    static Ingredient of(@Nullable Supplier<ItemType>... itemTypes) {
+        if (itemTypes == null || itemTypes.length == 0) {
+            return empty();
+        }
+        return builder().with(itemTypes).build();
+    }
+
+    /**
+     * Creates a new {@link Ingredient} for the provided {@link Predicate} and exemplary {@link ItemStack}s.
+     * <p>Note: Predicate ingredients may not be fully supported for all recipe types</p>
+     *
+     * @param key A unique resource key
+     * @param predicate The predicate
+     * @param exemplaryStacks The exemplary items
+     *
+     * @return The new ingredient
+     */
+    static Ingredient of(ResourceKey key, Predicate<ItemStack> predicate, ItemStack... exemplaryStacks) {
+        if (exemplaryStacks.length == 0) {
+            throw new IllegalArgumentException("At least exemplary stack is required");
+        }
+        return builder().with(key, predicate, exemplaryStacks).build();
+    }
+
+    /**
      * Creates a new {@link Ingredient} for the provided {@link ResourceKey key} which
      * should match an {@link ItemType item}.
      *
@@ -110,6 +165,42 @@ public interface Ingredient extends Predicate<ItemStack> {
          * @return This Builder, for chaining
          */
         Builder with(ItemType... types);
+
+        /**
+         * Sets one or more ItemTypes for matching the ingredient.
+         *
+         * @param types The items
+         * @return This Builder, for chaining
+         */
+        @SuppressWarnings("unchecked")
+        Builder with(Supplier<ItemType>... types);
+
+        /**
+         * Sets one ore more ItemStack for matching the ingredient.
+         *
+         * @param types The items
+         * @return This Builder, for chaining
+         */
+        Builder with(ItemStack... types);
+
+        /**
+         * Sets a Predicate for matching the ingredient.
+         * <p>Exemplary types are used for the vanilla recipe book.</p>
+         * <p>Note: Predicate ingredients may not be fully supported for all recipe types</p>
+         *
+         * @param predicate The predicate
+         * @param exemplaryTypes The items
+         * @return This Builder, for chaining
+         */
+        Builder with(ResourceKey resourceKey, Predicate<ItemStack> predicate, ItemStack... exemplaryTypes);
+
+        /**
+         * Sets one ItemStack for matching the ingredient.
+         *
+         * @param types The items
+         * @return This Builder, for chaining
+         */
+        Builder with(ItemStackSnapshot... types);
 
         /**
          * Sets the item tag for matching the ingredient.

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapedCraftingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapedCraftingRecipe.java
@@ -24,21 +24,22 @@
  */
 package org.spongepowered.api.item.recipe.crafting;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.item.inventory.crafting.CraftingGridInventory;
+import org.spongepowered.api.item.recipe.RecipeRegistration;
 import org.spongepowered.api.util.CatalogBuilder;
 import org.spongepowered.api.util.ResettableBuilder;
 
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
- * A ShapedCraftingRecipe is a CraftingRecipe that has shape and fits into
- * a grid.
+ * A ShapedCraftingRecipe is a CraftingRecipe that has shape and fits into a grid.
  */
 public interface ShapedCraftingRecipe extends CraftingRecipe {
 
@@ -52,11 +53,11 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
     }
 
     /**
-     * Returns the ingredient predicate at the specified location in this
-     * recipe.
+     * Returns the ingredient at the specified location in this recipe.
      *
      * @param x The x coordinate counted from the left side
      * @param y The y coordinate counted from the top
+     *
      * @return The ingredient predicate at this position defined by the aisle
      * @throws IndexOutOfBoundsException if the location is invalid
      */
@@ -77,17 +78,11 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
     int getHeight();
 
     /**
-     * The builder which you create {@link ShapedCraftingRecipe}s through.
+     * The Builder for {@link ShapedCraftingRecipe}s.
      *
-     * <p>First decide how you want to build your recipe. Either by defining
-     * the pattern with {@link #aisle} and then setting {@link AisleStep#where}
-     * the ingredients are, or by defining the pattern using {@link #rows}
-     * adding each {@link RowsStep#row} of ingredients after the other. When the
-     * ingredients are set define the {@link ResultStep#result} of the recipe.
-     * Next you can define its {@link EndStep#group}. And
-     * finally {@link EndStep#build} your recipe.</p>
-     *
-     * <p>Here is an example, where the two resulting recipes are identical:</p>
+     * <p>The shaped recipe pattern can be built one of two ways:</p>
+     * <p>Either by defining the pattern with {@link #aisle} and then setting {@link AisleStep#where} the ingredients are.</p>
+     * <p>Or by defining the pattern using {@link #rows} adding each {@link RowsStep#row} of ingredients after the other.</p>
 
      * <pre>
      * {@code
@@ -96,17 +91,19 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
      *         .aisle("sss")
      *         .where('s', log)
      *         .result(ItemStack.of(WOODEN_PRESSURE_PLATE, 1))
-     *         .build("mypressureplate", plugin);
+     *         .key(RessourceKey.of(plugin, "my_pressure_plate))
+     *         .build();
      *
      *     ShapedCraftingRecipe.builder()
      *         .rows()
      *         .row(log, log, log)
      *         .result(ItemStack.of(WOODEN_PRESSURE_PLATE, 1))
-     *         .build("mypressureplate", plugin);
+     *         .key(RessourceKey.of(plugin, "my_pressure_plate))
+     *         .build();
      * }
      * </pre>
      */
-    interface Builder extends ResettableBuilder<ShapedCraftingRecipe, Builder> {
+    interface Builder extends CatalogBuilder<RecipeRegistration, Builder> {
 
         /**
          * Start building a new recipe based on the aisle pattern.
@@ -114,13 +111,13 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
          * <p>Use {@link AisleStep#where} to assign ingredients to characters
          * of the aisles.</p>
          *
-         * <p>The space character will be defaulted to {@link Ingredient#empty()}
-         * if not specified.</p>
+         * <p>Use the space character for {@link Ingredient#empty()}</p>
          *
          * <p>Any other not assigned characters will cause an Exception
          * when {@link EndStep#build}ing the Recipe.</p>
          *
          * @param aisle A string array of ingredients
+         *
          * @return The builder
          */
         AisleStep aisle(String... aisle);
@@ -144,6 +141,7 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
              *
              * @param symbol The ingredient symbol
              * @param ingredient The ingredient to set
+             *
              * @return The builder
              * @throws IllegalArgumentException If the aisle does not contain
              *     the specified character symbol
@@ -154,6 +152,7 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
              * Sets multiple ingredients based on the aisle pattern.
              *
              * @param ingredientMap The ingredients to set
+             *
              * @return The builder
              * @throws IllegalArgumentException If the aisle does not contain
              *     the specified character symbol
@@ -185,6 +184,7 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
              * Adds a row of ingredients.
              *
              * @param ingredients The row of ingredients.
+             *
              * @return This builder
              */
             default RowsStep.ResultStep row(Ingredient... ingredients) {
@@ -197,6 +197,7 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
              *
              * @param skip The amount of columns to skip.
              * @param ingredients The row of ingredients.
+             *
              * @return This builder
              */
             RowsStep.ResultStep row(int skip, Ingredient... ingredients);
@@ -204,57 +205,64 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
         }
 
         /**
-         * Copies the ingredients and shape from given recipe.
-         * <p>Registering this recipe will override the original recipe</p>TODO does it?
-         *
-         * @param recipe the original recipe
-         *
-         * @return This builder
-         */
-        ResultStep shapedLike(ShapedCraftingRecipe recipe);
-
-        /**
          * In this Step set the result of the recipe.
          */
         interface ResultStep extends Builder {
+
+            /**
+             * Sets the remainingItems function. The function must return a list of the same size as the input CraftingGridInventory.
+             *
+             * @param remainingItemsFunction the remaining items function
+             *
+             * @return This builder, for chaining
+             */
+            ResultStep remainingItems(Function<CraftingGridInventory, List<ItemStack>> remainingItemsFunction);
 
             /**
              * Sets the resultant {@link ItemStackSnapshot} for when this shaped
              * recipe is correctly crafted.
              *
              * @param result The resultant snapshot
+             *
              * @return The builder
              */
-            default EndStep result(ItemStackSnapshot result) {
-                checkNotNull(result, "result");
-                return this.result(result.createStack());
-            }
+            EndStep result(ItemStackSnapshot result);
 
             /**
              * Sets the resultant {@link ItemStack} for when this shaped recipe
              * is correctly crafted.
              *
              * @param result The resultant stack
+             *
              * @return The builder
              */
             EndStep result(ItemStack result);
+
+            /**
+             * Sets the result function and an exemplary result.
+             * <p>Use {@link ItemStack#empty()} as exemplary result if the function returns different items.</p>
+             *
+             * @param resultFunction The result function
+             * @param exemplaryResult The exemplary result stack
+             *
+             * @return The builder
+             */
+            EndStep result(Function<CraftingGridInventory, ItemStack> resultFunction, ItemStack exemplaryResult);
         }
 
         /**
          * In this Step set the group of the Recipe and/or build it.
          */
-        interface EndStep extends Builder, CatalogBuilder<ShapedCraftingRecipe, Builder> {
+        interface EndStep extends Builder, CatalogBuilder<RecipeRegistration, Builder> {
 
             /**
              * Sets the group of the recipe.
              *
              * @param name the group
+             *
              * @return This builder, for chaining
              */
             EndStep group(@Nullable String name);
-
-            @Override
-            EndStep key(ResourceKey key);
 
             /**
              * Builds the {@link ShapedCraftingRecipe}.
@@ -264,7 +272,7 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
              *                               or the {@link #key(ResourceKey)} isn't set.
              */
             @Override
-            ShapedCraftingRecipe build() throws IllegalStateException;
+            RecipeRegistration build() throws IllegalStateException;
         }
     }
 

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapelessCraftingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapelessCraftingRecipe.java
@@ -24,16 +24,20 @@
  */
 package org.spongepowered.api.item.recipe.crafting;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.item.inventory.crafting.CraftingGridInventory;
+import org.spongepowered.api.item.recipe.RecipeRegistration;
 import org.spongepowered.api.util.CatalogBuilder;
 import org.spongepowered.api.util.ResettableBuilder;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * A ShapelessCraftingRecipe is a CraftingRecipe that does not have shape and
@@ -51,9 +55,9 @@ public interface ShapelessCraftingRecipe extends CraftingRecipe {
     }
 
     /**
-     * Builder for {@link ShapelessCraftingRecipe}s.
+     * The Builder for {@link ShapelessCraftingRecipe}s.
      */
-    interface Builder extends ResettableBuilder<ShapelessCraftingRecipe, Builder> {
+    interface Builder extends CatalogBuilder<RecipeRegistration, Builder> {
 
         /**
          * Adds ingredients for this recipe.
@@ -65,48 +69,84 @@ public interface ShapelessCraftingRecipe extends CraftingRecipe {
         ResultStep addIngredients(ItemType... ingredients);
 
         /**
+         * Adds ingredients for this recipe.
+         *
+         * @param ingredients The ingredients to add
+         *
+         * @return This builder, for chaining
+         */
+        @SuppressWarnings("unchecked")
+        ResultStep addIngredients(Supplier<ItemType>... ingredients);
+
+        /**
+         * Adds ingredients for this recipe.
+         *
+         * @param ingredients The ingredients to add
+         *
+         * @return This builder, for chaining
+         */
+        ResultStep addIngredients(Ingredient... ingredients);
+
+        /**
          * In this Step set the result of the Recipe.
          */
         interface ResultStep extends Builder {
 
             /**
-             * Changes the result and returns this builder. The result is the
+             * Sets the remainingItems function. The function must return a list of the same size as the input CraftingGridInventory.
+             *
+             * @param remainingItemsFunction the remaining items function
+             *
+             * @return This builder, for chaining
+             */
+            ResultStep remainingItems(Function<CraftingGridInventory, List<ItemStack>> remainingItemsFunction);
+
+            /**
+             * Sets the result and returns this builder. The result is the
              * {@link ItemStack} created when the recipe is fulfilled.
              *
              * @param result The result
+             *
              * @return This builder, for chaining
              */
             EndStep result(ItemStackSnapshot result);
 
             /**
-             * Changes the result and returns this builder. The result is the
+             * Sets the result and returns this builder. The result is the
              * {@link ItemStack} created when the recipe is fulfilled.
              *
              * @param result The result
+             *
              * @return This builder, for chaining
              */
-            default EndStep result(ItemStack result) {
-                checkNotNull(result, "result");
+            EndStep result(ItemStack result);
 
-                return this.result(result.createSnapshot());
-            }
+            /**
+             * Sets the result function and an exemplary result.
+             * <p>The exemplary result is used for the recipe book.</p>
+             *
+             * @param resultFunction The result function
+             * @param exemplaryResult The exemplary result stack
+             *
+             * @return This builder, for chaining
+             */
+            EndStep result(Function<CraftingGridInventory, ItemStack> resultFunction, ItemStack exemplaryResult);
+
         }
 
         /**
          * In this Step set the group of the Recipe and/or build it.
          */
-        interface EndStep extends Builder, CatalogBuilder<ShapelessCraftingRecipe, Builder> {
+        interface EndStep extends Builder, CatalogBuilder<RecipeRegistration, Builder> {
 
             /**
              * Sets the group of the recipe.
              *
              * @param name the group
+             *
              * @return This builder, for chaining
              */
             EndStep group(@Nullable String name);
-
-            @Override
-            EndStep key(ResourceKey key);
 
             /**
              * Builds the {@link ShapelessCraftingRecipe}.
@@ -116,7 +156,7 @@ public interface ShapelessCraftingRecipe extends CraftingRecipe {
              *                               or the {@link #key(ResourceKey)} isn't set.
              */
             @Override
-            ShapelessCraftingRecipe build() throws IllegalStateException;
+            RecipeRegistration build() throws IllegalStateException;
         }
 
     }

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/SpecialCraftingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/SpecialCraftingRecipe.java
@@ -27,7 +27,8 @@ package org.spongepowered.api.item.recipe.crafting;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.item.inventory.ItemStack;
-import org.spongepowered.api.item.inventory.crafting.CraftingInventory;
+import org.spongepowered.api.item.inventory.crafting.CraftingGridInventory;
+import org.spongepowered.api.item.recipe.RecipeRegistration;
 import org.spongepowered.api.util.CatalogBuilder;
 import org.spongepowered.api.util.ResettableBuilder;
 import org.spongepowered.api.world.server.ServerWorld;
@@ -38,12 +39,7 @@ import java.util.function.Function;
 
 /**
  * Recipes with custom matching/result logic.
- * <p>By default special recipes cannot be displayed in a recipe book.</p>
- * <p>But providing both a fixed/exemplary shaped or shapeless recipe shape
- * ({@link Builder#matching(CraftingRecipe)}/{@link Builder#matching(BiPredicate, CraftingRecipe)})
- * and a fixed/exemplary result
- * ({@link Builder.ResultStep#result(ItemStack)}/{@link Builder.ResultStep#result(Function, ItemStack)})
- * Sponge can provide a recipe book entry anyways.</p>
+ * <p>Special recipes cannot be displayed in a recipe book.</p>
  */
 public interface SpecialCraftingRecipe extends CraftingRecipe {
 
@@ -56,7 +52,7 @@ public interface SpecialCraftingRecipe extends CraftingRecipe {
         return Sponge.getRegistry().getBuilderRegistry().provideBuilder(SpecialCraftingRecipe.Builder.class);
     }
 
-    interface Builder extends ResettableBuilder<SpecialCraftingRecipe, SpecialCraftingRecipe.Builder> {
+    interface Builder extends ResettableBuilder<RecipeRegistration, SpecialCraftingRecipe.Builder> {
 
         /**
          * Sets the recipe matcher.
@@ -65,27 +61,7 @@ public interface SpecialCraftingRecipe extends CraftingRecipe {
          *
          * @return This builder, for chaining
          */
-        SpecialCraftingRecipe.Builder.ResultStep matching(BiPredicate<CraftingInventory, ServerWorld> biPredicate);
-
-        /**
-         * Sets the recipe matcher and an exemplary shape from another CraftingRecipe.
-         * <p>The example should match one of the allowed shapes, as it will be used for the recipe book.</p>
-         *
-         * @param biPredicate The matching predicate.
-         * @param exemplaryShape The recipe used for the exemplary shape.
-         *
-         * @return This builder, for chaining
-         */
-        SpecialCraftingRecipe.Builder.ResultStep matching(BiPredicate<CraftingInventory, ServerWorld> biPredicate, CraftingRecipe exemplaryShape);
-
-        /**
-         * Sets the recipe matcher from another CraftingRecipe
-         *
-         * @param shape The recipe used for the shape.
-         *
-         * @return This builder, for chaining
-         */
-        SpecialCraftingRecipe.Builder.ResultStep matching(CraftingRecipe shape);
+        SpecialCraftingRecipe.Builder.ResultStep matching(BiPredicate<CraftingGridInventory, ServerWorld> biPredicate);
 
         /**
          * In this Step set the result of the Recipe.
@@ -94,13 +70,13 @@ public interface SpecialCraftingRecipe extends CraftingRecipe {
         interface ResultStep extends SpecialCraftingRecipe.Builder {
 
             /**
-             * Sets the remainingItems function. The function must return a list of the same size as the input CraftingInventory.
+             * Sets the remainingItems function. The function must return a list of the same size as the input CraftingGridInventory.
              *
              * @param remainingItemsFunction the remaining items function
              *
              * @return This builder, for chaining
              */
-            ResultStep remainingItems(Function<CraftingInventory, List<ItemStack>> remainingItemsFunction);
+            ResultStep remainingItems(Function<CraftingGridInventory, List<ItemStack>> remainingItemsFunction);
 
             /**
              * Sets the result function.
@@ -109,18 +85,7 @@ public interface SpecialCraftingRecipe extends CraftingRecipe {
              *
              * @return This builder, for chaining
              */
-            EndStep result(Function<CraftingInventory, ItemStack> resultFunction);
-
-            /**
-             * Sets the result function and an exemplary result.
-             * <p>The example should match one of the possible crafting results, as it will be used for the recipe book.</p>
-             *
-             * @param resultFunction The result function
-             * @param exemplaryResult The exemplary result
-             *
-             * @return This builder, for chaining
-             */
-            EndStep result(Function<CraftingInventory, ItemStack> resultFunction, ItemStack exemplaryResult);
+            EndStep result(Function<CraftingGridInventory, ItemStack> resultFunction);
 
             /**
              * Sets the result
@@ -132,7 +97,7 @@ public interface SpecialCraftingRecipe extends CraftingRecipe {
             EndStep result(ItemStack result);
         }
 
-        interface EndStep extends SpecialCraftingRecipe.Builder, CatalogBuilder<SpecialCraftingRecipe, SpecialCraftingRecipe.Builder> {
+        interface EndStep extends SpecialCraftingRecipe.Builder, CatalogBuilder<RecipeRegistration, SpecialCraftingRecipe.Builder> {
 
             @Override
             EndStep key(ResourceKey key);
@@ -145,7 +110,7 @@ public interface SpecialCraftingRecipe extends CraftingRecipe {
              *                               or the {@link #key(ResourceKey)} isn't set.
              */
             @Override
-            SpecialCraftingRecipe build() throws IllegalStateException;
+            RecipeRegistration build() throws IllegalStateException;
         }
 
     }

--- a/src/main/java/org/spongepowered/api/item/recipe/single/StoneCutterRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/single/StoneCutterRecipe.java
@@ -24,17 +24,23 @@
  */
 package org.spongepowered.api.item.recipe.single;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.Recipe;
+import org.spongepowered.api.item.recipe.RecipeRegistration;
 import org.spongepowered.api.item.recipe.RecipeType;
+import org.spongepowered.api.item.recipe.crafting.Ingredient;
+import org.spongepowered.api.item.recipe.crafting.ShapedCraftingRecipe;
 import org.spongepowered.api.util.CatalogBuilder;
 import org.spongepowered.api.util.ResettableBuilder;
 
-import java.util.function.Predicate;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * A StoneCutter Recipe.
@@ -49,9 +55,9 @@ public interface StoneCutterRecipe extends Recipe {
     RecipeType<? extends StoneCutterRecipe> getType();
 
     /**
-     * Builds a simple furnace recipe.
+     * Builds a simple stonecutter recipe
      */
-    interface Builder extends ResettableBuilder<StoneCutterRecipe, StoneCutterRecipe.Builder> {
+    interface Builder extends CatalogBuilder<RecipeRegistration, StoneCutterRecipe.Builder> {
 
         /**
          * Sets the ingredient and returns this builder.
@@ -63,14 +69,24 @@ public interface StoneCutterRecipe extends Recipe {
         ResultStep ingredient(ItemType ingredient);
 
         /**
-         * Sets the ingredient and exemplary ingredient.
+         * Sets the ingredient and returns this builder.
          *
-         * @param predicate The ingredient predicate
-         * @param exemplaryIngredient The exemplary ingredient for the recipe book
+         * @param ingredient The ingredient
          *
          * @return This builder, for chaining
          */
-        ResultStep ingredient(Predicate<ItemStackSnapshot> predicate, ItemType exemplaryIngredient);
+        default ResultStep ingredient(Supplier<ItemType> ingredient) {
+            return this.ingredient(ingredient.get());
+        }
+
+        /**
+         * Sets the ingredient and returns this builder.
+         *
+         * @param ingredient The ingredient
+         *
+         * @return This builder, for chaining
+         */
+        ResultStep ingredient(Ingredient ingredient);
 
         interface ResultStep extends StoneCutterRecipe.Builder {
 
@@ -79,6 +95,7 @@ public interface StoneCutterRecipe extends Recipe {
              * {@link ItemStack} created when the recipe is fulfilled.
              *
              * @param result The output of this recipe
+             *
              * @return This builder, for chaining
              */
             EndStep result(ItemStackSnapshot result);
@@ -88,18 +105,34 @@ public interface StoneCutterRecipe extends Recipe {
              * {@link ItemStack} created when the recipe is fulfilled.
              *
              * @param result The output of this recipe
+             *
              * @return This builder, for chaining
              */
-            default EndStep result(ItemStack result) {
-                return this.result(result.createSnapshot());
-            }
+            EndStep result(ItemStack result);
+
+            /**
+             * Changes the result and returns this builder. The result is the
+             * {@link ItemStack} created when the recipe is fulfilled.
+             *
+             * @param resultFunction The result function
+             * @param exemplaryResult The exemplary output of this recipe
+             *
+             * @return This builder, for chaining
+             */
+            EndStep result(Function<Inventory, ItemStack> resultFunction, ItemStack exemplaryResult);
 
         }
 
-        interface EndStep extends StoneCutterRecipe.Builder, CatalogBuilder<StoneCutterRecipe, Builder> {
+        interface EndStep extends StoneCutterRecipe.Builder, CatalogBuilder<RecipeRegistration, Builder> {
 
-            @Override
-            EndStep key(ResourceKey key);
+            /**
+             * Sets the group of the recipe.
+             *
+             * @param name the group
+             *
+             * @return This builder, for chaining
+             */
+            EndStep group(@Nullable String name);
 
             /**
              * Builds the {@link StoneCutterRecipe}.
@@ -109,7 +142,7 @@ public interface StoneCutterRecipe extends Recipe {
              *                               or the {@link #key(ResourceKey)} isn't set.
              */
             @Override
-            StoneCutterRecipe build() throws IllegalStateException;
+            RecipeRegistration build() throws IllegalStateException;
         }
     }
 }


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/3168)

RecipeRegistrations are saved as a datapack under:
`<serverlocation>/world/datapacks/plugin-recipes/data/<pluginid>/recipes/<name>.json`

When possible the recipes use vanilla syntax but sponge allows for more complex recipes too.
Vanilla Recipe Example:

```json
{
    "type": "minecraft:crafting_shaped",
    "pattern": [
        "AAA",
        "ADA",
        "AAA"
    ],
    "key": {
        "A": {
            "item": "minecraft:polished_diorite"
        },
        "D": {
            "item": "minecraft:white_bed"
        }
    },
    "result": {
        "item": "minecraft:bedrock"
    }
}
```
Sponge Recipe Example:

```json
{
    "type": "sponge:crafting_shaped",
    "pattern": [
        "ggg",
        "gbg",
        "ggg"
    ],
    "key": {
        "b": {
            "item": "minecraft:red_bed"
        },
        "g": {
            "item": "minecraft:polished_granite"
        }
    },
    "result": {
        "item": "minecraft:bedrock"
    },
    "sponge:result": {
        "ContentVersion": 1,
        "ItemType": "minecraft:bedrock",
        "Count": 1,
        "UnsafeDamage": 0,
        "UnsafeData": {
            "display": {
                "Name": "{\"color\":\"red\",\"text\":\"Bedrock\"}"
            }
        }
    }
}
```

