### PR TITLE
Genericize Palettes

### DIFF
--- a/src/main/java/org/spongepowered/api/state/State.java
+++ b/src/main/java/org/spongepowered/api/state/State.java
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-public interface State<S extends State<S>> extends SerializableDataHolder.Immutable<S>, CatalogType {
+public interface State<S extends State<S>> extends SerializableDataHolder.Immutable<S> {
 
     /**
      * Gets the {@link Comparable} value for the specific {@link StateProperty}

--- a/src/main/java/org/spongepowered/api/world/BlockChangeFlag.java
+++ b/src/main/java/org/spongepowered/api/world/BlockChangeFlag.java
@@ -93,6 +93,10 @@ public interface BlockChangeFlag {
      */
     BlockChangeFlag withNotifyObservers(boolean notifyObservers);
 
+    BlockChangeFlag withLightingUpdates(boolean lighting);
+
+    BlockChangeFlag withPathfindingUpdates(boolean pathfindingUpdates);
+
     /**
      * Gets the inverted {@link BlockChangeFlag} of this flag.
      * Normally, this may cancel out certain interactions, such

--- a/src/main/java/org/spongepowered/api/world/schematic/Palette.java
+++ b/src/main/java/org/spongepowered/api/world/schematic/Palette.java
@@ -27,8 +27,9 @@ package org.spongepowered.api.world.schematic;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
-import java.util.Collection;
 import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.stream.Stream;
 
 /**
  * Represents a mapping for types to a local identifier. Can be used for
@@ -39,7 +40,7 @@ import java.util.Optional;
  * @param <T> The type this palette will maintain
  */
 @CatalogedBy(PaletteTypes.class)
-public interface Palette<T extends CatalogType> {
+public interface Palette<T> {
 
     /**
      * Gets the type of this palette.
@@ -70,32 +71,54 @@ public interface Palette<T extends CatalogType> {
      * @param type The type
      * @return The identifier, if found
      */
-    Optional<Integer> get(T type);
+    OptionalInt get(T type);
 
-    /**
-     * Gets the identifier for the given {@code type T} from the mapping. If the
-     * {@code type T} is not yet registered in the mapping then it is registered and
-     * given the next available identifier.
-     *
-     * @param type The type
-     * @return The identifier
-     */
-    int getOrAssign(T type);
-
-    /**
-     * Removes the given {@code type T} from the mapping.
-     *
-     * <p>Note that if this palette is considered a global palette, removal is not supported.</p>
-     *
-     * @param type The type to remove
-     * @return If the type existed in the mapping
-     */
-    boolean remove(T type);
 
     /**
      * Gets all {@code type T}s contained in this palette.
      *
      * @return All contained types
      */
-    Collection<T> getEntries();
+    Stream<T> stream();
+
+    Mutable<T> asMutable();
+
+    Immutable<T> asImmutable();
+
+    interface Mutable<M> extends Palette<M> {
+
+        /**
+         * Gets the identifier for the given {@code type T} from the mapping. If the
+         * {@code type T} is not yet registered in the mapping then it is registered and
+         * given the next available identifier.
+         *
+         * @param type The type
+         * @return The identifier
+         */
+        int getOrAssign(M type);
+
+        /**
+         * Removes the given {@code type T} from the mapping.
+         *
+         * <p>Note that if this palette is considered a global palette, removal is not supported.</p>
+         *
+         * @param type The type to remove
+         * @return If the type existed in the mapping
+         */
+        boolean remove(M type);
+
+        @Override
+        default Mutable<M> asMutable() {
+            return this;
+        }
+    }
+
+    interface Immutable<I> extends Palette<I> {
+
+        @Override
+        default Immutable<I> asImmutable() {
+            return this;
+        }
+    }
+
 }

--- a/src/main/java/org/spongepowered/api/world/schematic/PaletteType.java
+++ b/src/main/java/org/spongepowered/api/world/schematic/PaletteType.java
@@ -25,11 +25,35 @@
 package org.spongepowered.api.world.schematic;
 
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.util.CatalogBuilder;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
+import java.util.Optional;
+import java.util.function.Function;
+
 @CatalogedBy(PaletteTypes.class)
-public interface PaletteType<T extends CatalogType> extends CatalogType {
+public interface PaletteType<T> extends CatalogType {
+
+    @SuppressWarnings("unchecked")
+    static <E> Builder<E> builder() {
+        return Sponge.getRegistry().getBuilderRegistry().provideBuilder(Builder.class);
+    }
 
     Palette<T> create();
+
+    Function<T, String> getEncoder();
+
+    Function<String, Optional<T>> getDecoder();
+
+    interface Builder<T> extends CatalogBuilder<PaletteType<T>, Builder<T>> {
+
+        Builder<T> encoder(Function<T, String> encoder);
+
+        Builder<T> decoder(Function<String, Optional<T>> decoder);
+
+        @Override
+        PaletteType<T> build() throws IllegalStateException;
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/world/schematic/PaletteTypes.java
+++ b/src/main/java/org/spongepowered/api/world/schematic/PaletteTypes.java
@@ -33,15 +33,41 @@ import java.util.function.Supplier;
 public final class PaletteTypes {
 
     // SORTFIELDS:ON
+    /**
+     * A type of {@link Palette} that refers to a simplified "global"
+     * {@link BiomeType} palette referring to each biome individually.
+     * <p>Note that while {@link PaletteType#create()} may allow a
+     * {@link Palette.Mutable mutable palette} to be created, all
+     * registered {@link BiomeType biomes} will have an assigned
+     * {@code integer id}.
+     */
+    public static Supplier<PaletteType<BiomeType>> GLOBAL_BIOME_PALETTE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(PaletteType.class, "global_biome_palette");
 
-    public static final Supplier<PaletteType<BiomeType>> GLOBAL_BIOMES = Sponge.getRegistry().getCatalogRegistry().provideSupplier(PaletteType.class, "global_biomes");
+    /**
+     * A type of {@link Palette} that refers to a simplified "global"
+     * {@link BlockState} palette referring to each state individually.
+     * <p>Note that while {@link PaletteType#create()} may allow a
+     * {@link Palette.Mutable mutable palette} to be created, all
+     * registered {@link BlockState block states} will have an assigned
+     * {@code integer id}.
+     */
+    public static Supplier<PaletteType<BlockState>> GLOBAL_BLOCK_PALETTE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(PaletteType.class, "global_block_palette");
 
-    public static final Supplier<PaletteType<BlockState>> GLOBAL_BLOCKS = Sponge.getRegistry().getCatalogRegistry().provideSupplier(PaletteType.class, "global_blocks");
+    /**
+     * A type of {@link PaletteType} that refers to a localized mapping of
+     * {@link BiomeType biomes} for individualized usage. Traditionally the
+     * palette will generate {@code integer ids} in the order in which a
+     * {@link BiomeType biome} is registered via {@link Palette.Mutable#getOrAssign(Object)}
+     */
+    public static Supplier<PaletteType<BiomeType>> BIOME_PALETTE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(PaletteType.class, "biome_palette");
 
-    public static final Supplier<PaletteType<BiomeType>> LOCAL_BIOMES = Sponge.getRegistry().getCatalogRegistry().provideSupplier(PaletteType.class, "local_biomnes");
-
-    public static final Supplier<PaletteType<BlockState>> LOCAL_BLOCKS = Sponge.getRegistry().getCatalogRegistry().provideSupplier(PaletteType.class, "local_blocks");
-
+    /**
+     * A type of {@link PaletteType} that refers to a localized mapping of
+     * {@link BlockState block states} for individualized usage. Traditionally the
+     * palette will generate {@code integer ids} in the order in which a
+     * {@link BlockState biome} is registered via {@link Palette.Mutable#getOrAssign(Object)}
+     */
+    public static Supplier<PaletteType<BlockState>> BLOCK_STATE_PALETTE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(PaletteType.class, "block_state_palette");
     // SORTFIELDS:OFF
 
     private PaletteTypes() {


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon]()

# Palettes and their evolution

Mostly as a request for WorldEdits' better handling, we seek to improve palettes to be more generic outside the purview of being indexing on `CatalogType`s alone. As Minecraft evolves, the handling of what a `BlockState` is allowed to contain increasingly becomes more and more data driven. As such, we need to less focus on a `ResourceKey` based object and more of a "here's a palette of object definitions that are defined by the `Palette`'s `PaletteType`.

## PaletteType and the encoder/decoder

Previously, we made `Palette` intrinsically serializable by building it up based on an index of `int`s to either `BlockState` or some other `CatalogType`. Now, we need to be able to serialize these `Palette`s  based on a predefinition from their `PaletteType` that already defines the *type* of object the `Palette` will support. As such, the `String` encoder/decoder will be maintained at the `PaletteType` level, and less so on the `Palette` itself.



