### PR TITLE
Removing Guava usage

### DIFF
--- a/src/main/java/co/aikar/timings/Timings.java
+++ b/src/main/java/co/aikar/timings/Timings.java
@@ -24,11 +24,11 @@
  */
 package co.aikar.timings;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import net.kyori.adventure.audience.Audience;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.plugin.PluginContainer;
+
+import java.util.Objects;
 
 /**
  * Utility class for creating and configuring timings.
@@ -45,8 +45,10 @@ public final class Timings {
      * @param name Name of the timing
      * @return A {@link Timing} instance
      */
-    public static Timing of(PluginContainer plugin, String name) {
-        return Sponge.getRegistry().getFactoryRegistry().provideFactory(TimingsFactory.class).of(checkNotNull(plugin, "plugin"), checkNotNull(name, "name"), null);
+    public static Timing of(final PluginContainer plugin, final String name) {
+        Objects.requireNonNull(plugin, "PluginContainer cannot be null!");
+        Objects.requireNonNull(name, "Timing name cannot be null!");
+        return Sponge.getRegistry().getFactoryRegistry().provideFactory(TimingsFactory.class).of(plugin, name, null);
     }
 
     /**
@@ -62,8 +64,11 @@ public final class Timings {
      * @param groupHandler Parent handler to mirror .start/stop calls to
      * @return A {@link Timing} instance
      */
-    public static Timing of(PluginContainer plugin, String name, Timing groupHandler) {
-        return Sponge.getRegistry().getFactoryRegistry().provideFactory(TimingsFactory.class).of(checkNotNull(plugin, "plugin"), checkNotNull(name, "name"), checkNotNull(groupHandler, "groupHandler"));
+    public static Timing of(final PluginContainer plugin, final String name, final Timing groupHandler) {
+        Objects.requireNonNull(plugin, "PluginContainer cannot be null!");
+        Objects.requireNonNull(name, "Timing name cannot be null!");
+        Objects.requireNonNull(groupHandler, "Group Handler cannot be null!");
+        return Sponge.getRegistry().getFactoryRegistry().provideFactory(TimingsFactory.class).of(plugin, name, groupHandler);
     }
 
     /**
@@ -80,8 +85,8 @@ public final class Timings {
      * @param name Name of timing
      * @return A {@link Timing} instance
      */
-    public static Timing ofStart(PluginContainer plugin, String name) {
-        Timing timing = of(plugin, name);
+    public static Timing ofStart(final PluginContainer plugin, final String name) {
+        final Timing timing = Timings.of(plugin, name);
         timing.startTimingIfSync();
         return timing;
     }
@@ -102,8 +107,11 @@ public final class Timings {
      * @param groupHandler Parent handler to mirror start/stop calls to
      * @return A {@link Timing} instance
      */
-    public static Timing ofStart(PluginContainer plugin, String name, Timing groupHandler) {
-        Timing timing = of(plugin, name, groupHandler);
+    public static Timing ofStart(final PluginContainer plugin, final String name, final Timing groupHandler) {
+        Objects.requireNonNull(plugin, "PluginContainer cannot be null!");
+        Objects.requireNonNull(name, "Timing name cannot be null!");
+        Objects.requireNonNull(groupHandler, "Group Handler cannot be null!");
+        final Timing timing = Timings.of(plugin, name, groupHandler);
         timing.startTimingIfSync();
         return timing;
     }
@@ -123,7 +131,7 @@ public final class Timings {
      *
      * @param enabled Should timings be reported
      */
-    public static void setTimingsEnabled(boolean enabled) {
+    public static void setTimingsEnabled(final boolean enabled) {
         Sponge.getRegistry().getFactoryRegistry().provideFactory(TimingsFactory.class).setTimingsEnabled(enabled);
     }
 
@@ -144,7 +152,7 @@ public final class Timings {
      *
      * @param enabled Should high-frequency timings be reported
      */
-    public static void setVerboseTimingsEnabled(boolean enabled) {
+    public static void setVerboseTimingsEnabled(final boolean enabled) {
         Sponge.getRegistry().getFactoryRegistry().provideFactory(TimingsFactory.class).setVerboseTimingsEnabled(enabled);
     }
 
@@ -165,7 +173,7 @@ public final class Timings {
      *
      * @param interval Interval in ticks
      */
-    public static void setHistoryInterval(int interval) {
+    public static void setHistoryInterval(final int interval) {
         Sponge.getRegistry().getFactoryRegistry().provideFactory(TimingsFactory.class).setHistoryInterval(interval);
     }
 
@@ -189,7 +197,7 @@ public final class Timings {
      *
      * @param length Duration in ticks
      */
-    public static void setHistoryLength(int length) {
+    public static void setHistoryLength(final int length) {
         Sponge.getRegistry().getFactoryRegistry().provideFactory(TimingsFactory.class).setHistoryLength(length);
     }
 
@@ -206,7 +214,7 @@ public final class Timings {
      *
      * @param channel The channel to send report to
      */
-    public static void generateReport(Audience channel) {
+    public static void generateReport(final Audience channel) {
         Sponge.getRegistry().getFactoryRegistry().provideFactory(TimingsFactory.class).generateReport(channel);
     }
 

--- a/src/main/java/org/spongepowered/api/Sponge.java
+++ b/src/main/java/org/spongepowered/api/Sponge.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import com.google.inject.Inject;
 import org.spongepowered.api.asset.AssetManager;
 import org.spongepowered.api.command.manager.CommandManager;
@@ -56,7 +54,9 @@ public final class Sponge {
      * @return The game instance
      */
     public static Game getGame() {
-        checkState(Sponge.game != null, "Sponge has not been initialized!");
+        if (Sponge.game == null) {
+            throw new IllegalStateException("Sponge has not been initialized!");
+        }
         return Sponge.game;
     }
 

--- a/src/main/java/org/spongepowered/api/asset/Asset.java
+++ b/src/main/java/org/spongepowered/api/asset/Asset.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.asset;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.io.Resources;
 import org.spongepowered.plugin.PluginContainer;
 import org.spongepowered.plugin.jvm.Plugin;
@@ -38,6 +36,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Represents an {@link Asset} within Sponge that belongs to a {@link Plugin}.
@@ -93,7 +92,7 @@ public interface Asset {
      * @throws IOException File exception
      */
     default void copyToFile(Path output, boolean overwrite, boolean onlyIfAbsent) throws IOException {
-        checkNotNull(output, "output");
+        Objects.requireNonNull(output, "output");
         if (Files.exists(output)) {
             if (overwrite) {
                 Files.delete(output);
@@ -136,7 +135,7 @@ public interface Asset {
      * @throws IOException File exception
      */
     default void copyToDirectory(Path outputDirectory, boolean overwrite, boolean onlyIfAbsent) throws IOException {
-        checkNotNull(outputDirectory, "outputDirectory");
+        Objects.requireNonNull(outputDirectory, "outputDirectory");
         Files.createDirectories(outputDirectory);
         this.copyToFile(outputDirectory.resolve(this.getFileName()), overwrite, onlyIfAbsent);
     }
@@ -177,7 +176,7 @@ public interface Asset {
      * @throws IOException If any file exception is thrown
      */
     default String readString(Charset charset) throws IOException {
-        checkNotNull(charset, "charset");
+        Objects.requireNonNull(charset, "charset");
         return Resources.toString(getUrl(), charset);
     }
 
@@ -199,7 +198,7 @@ public interface Asset {
      * @throws IOException If any file exception is thrown
      */
     default List<String> readLines(Charset charset) throws IOException {
-        checkNotNull(charset, "charset");
+        Objects.requireNonNull(charset, "charset");
         return Resources.asCharSource(getUrl(), charset).readLines();
     }
 

--- a/src/main/java/org/spongepowered/api/command/CommandCause.java
+++ b/src/main/java/org/spongepowered/api/command/CommandCause.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.command;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.identity.Identity;
@@ -34,8 +32,8 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.SystemSubject;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.event.Cause;
+import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.event.EventContext;
 import org.spongepowered.api.event.EventContextKeys;
 import org.spongepowered.api.service.permission.Subject;

--- a/src/main/java/org/spongepowered/api/command/exception/CommandNotFoundException.java
+++ b/src/main/java/org/spongepowered/api/command/exception/CommandNotFoundException.java
@@ -24,8 +24,9 @@
  */
 package org.spongepowered.api.command.exception;
 
-import com.google.common.base.Preconditions;
 import net.kyori.adventure.text.Component;
+
+import java.util.Objects;
 
 /**
  * This exception is thrown when a sender tries to execute a command that does
@@ -45,7 +46,7 @@ public class CommandNotFoundException extends CommandException {
      */
     public CommandNotFoundException(Component message, String command) {
         super(message);
-        this.command = Preconditions.checkNotNull(command, "command");
+        this.command = Objects.requireNonNull(command, "command");
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/data/DataManipulator.java
+++ b/src/main/java/org/spongepowered/api/data/DataManipulator.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.data;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.value.CopyableValueContainer;
@@ -527,7 +525,9 @@ public interface DataManipulator extends CopyableValueContainer {
          * @return This manipulator, for chaining
          */
         default <E> Mutable transform(Key<? extends Value<E>> key, Function<E, E> function) {
-            checkArgument(supports(key), "The provided key is not supported!" + key.toString());
+            if (!this.supports(key)) {
+                throw new IllegalArgumentException("The provided key is not supported: " + key.toString());
+            }
             return set(key, Objects.requireNonNull(function.apply(get(key).get()), "The function can not be returning null!"));
         }
 

--- a/src/main/java/org/spongepowered/api/data/DataManipulator.java
+++ b/src/main/java/org/spongepowered/api/data/DataManipulator.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.data;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.Sponge;
@@ -37,6 +36,7 @@ import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.util.annotation.eventgen.TransformWith;
 import org.spongepowered.api.world.World;
 
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -242,8 +242,8 @@ public interface DataManipulator extends CopyableValueContainer {
          * @return This manipulator, for chaining
          */
         default <E> Immutable transform(Key<? extends Value<E>> key, Function<E, E> function) {
-            checkNotNull(function, "function");
-            return get(key).map(element -> with(key, checkNotNull(function.apply(element)))).orElse(this);
+            Objects.requireNonNull(function, "function");
+            return get(key).map(element -> with(key, Objects.requireNonNull(function.apply(element)))).orElse(this);
         }
 
         /**
@@ -485,9 +485,9 @@ public interface DataManipulator extends CopyableValueContainer {
          * @return This manipulator, for chaining
          */
         default Mutable set(Value<?>... values) {
-            for (Value<?> value : checkNotNull(values)) {
+            for (Value<?> value : Objects.requireNonNull(values)) {
                 try {
-                    set(checkNotNull(value, "A null value was provided!"));
+                    set(Objects.requireNonNull(value, "A null value was provided!"));
                 } catch (IllegalArgumentException e) {
                     e.printStackTrace();
                 }
@@ -507,9 +507,9 @@ public interface DataManipulator extends CopyableValueContainer {
          * @return This manipulator, for chaining
          */
         default Mutable set(Iterable<? extends Value<?>> values) {
-            for (Value<?> value : checkNotNull(values)) {
+            for (Value<?> value : Objects.requireNonNull(values)) {
                 try {
-                    set(checkNotNull(value, "A null value was provided!"));
+                    set(Objects.requireNonNull(value, "A null value was provided!"));
                 } catch (IllegalArgumentException e) {
                     e.printStackTrace();
                 }
@@ -528,7 +528,7 @@ public interface DataManipulator extends CopyableValueContainer {
          */
         default <E> Mutable transform(Key<? extends Value<E>> key, Function<E, E> function) {
             checkArgument(supports(key), "The provided key is not supported!" + key.toString());
-            return set(key, checkNotNull(function.apply(get(key).get()), "The function can not be returning null!"));
+            return set(key, Objects.requireNonNull(function.apply(get(key).get()), "The function can not be returning null!"));
         }
 
         Mutable remove(Key<?> key);

--- a/src/main/java/org/spongepowered/api/data/DataTransactionResult.java
+++ b/src/main/java/org/spongepowered/api/data/DataTransactionResult.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.data;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
@@ -698,7 +696,9 @@ public final class DataTransactionResult {
          * @return The newly created transaction result
          */
         public DataTransactionResult build() {
-            checkState(this.resultType != null);
+            if (this.resultType == null) {
+                throw new IllegalStateException("ResultType must be set!");
+            }
             return new DataTransactionResult(this);
         }
 

--- a/src/main/java/org/spongepowered/api/data/DataTransactionResult.java
+++ b/src/main/java/org/spongepowered/api/data/DataTransactionResult.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.data;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.base.MoreObjects;
@@ -434,7 +433,7 @@ public final class DataTransactionResult {
          * @return This builder, for chaining
          */
         public Builder result(final Type type) {
-            this.resultType = checkNotNull(type);
+            this.resultType = java.util.Objects.requireNonNull(type);
             return this;
         }
 
@@ -450,7 +449,7 @@ public final class DataTransactionResult {
             if (this.replaced == null) {
                 this.replaced = Lists.newArrayList();
             }
-            this.replaced.add(checkNotNull(value));
+            this.replaced.add(java.util.Objects.requireNonNull(value));
             return this;
         }
 
@@ -464,7 +463,7 @@ public final class DataTransactionResult {
          */
         public Builder replace(final Iterable<Value.Immutable<?>> values) {
             for (Value.Immutable<?> value : values) {
-                replace(checkNotNull(value));
+                replace(java.util.Objects.requireNonNull(value));
             }
             return this;
         }
@@ -481,7 +480,7 @@ public final class DataTransactionResult {
             if (this.rejected == null) {
                 this.rejected = Lists.newArrayList();
             }
-            this.rejected.add(checkNotNull(value));
+            this.rejected.add(java.util.Objects.requireNonNull(value));
             return this;
         }
 
@@ -495,7 +494,7 @@ public final class DataTransactionResult {
          */
         public Builder reject(final Iterable<Value.Immutable<?>> values) {
             for (Value.Immutable<?> value : values) {
-                reject(checkNotNull(value));
+                reject(java.util.Objects.requireNonNull(value));
             }
             return this;
         }
@@ -512,7 +511,7 @@ public final class DataTransactionResult {
             if (this.successful == null) {
                 this.successful = Lists.newArrayList();
             }
-            this.successful.add(checkNotNull(value));
+            this.successful.add(java.util.Objects.requireNonNull(value));
             return this;
         }
 
@@ -526,7 +525,7 @@ public final class DataTransactionResult {
          */
         public Builder success(final Iterable<Value.Immutable<?>> values) {
             for (Value.Immutable<?> value : values) {
-                success(checkNotNull(value));
+                success(java.util.Objects.requireNonNull(value));
             }
             return this;
         }

--- a/src/main/java/org/spongepowered/api/data/DataTransactionResult.java
+++ b/src/main/java/org/spongepowered/api/data/DataTransactionResult.java
@@ -24,18 +24,19 @@
  */
 package org.spongepowered.api.data;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.util.CopyableBuilder;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
@@ -49,8 +50,8 @@ import java.util.stream.Collector;
  */
 public final class DataTransactionResult {
 
-    private static final DataTransactionResult SUCCESS_NODATA = builder().result(Type.SUCCESS).build();
-    private static final DataTransactionResult FAIL_NODATA = builder().result(Type.FAILURE).build();
+    private static final DataTransactionResult SUCCESS_NODATA = DataTransactionResult.builder().result(Type.SUCCESS).build();
+    private static final DataTransactionResult FAIL_NODATA = DataTransactionResult.builder().result(Type.FAILURE).build();
     private static final Collector<DataTransactionResult, DataTransactionResult.Builder, DataTransactionResult> COLLECTOR = new Collector<DataTransactionResult, Builder, DataTransactionResult>() {
         @Override
         public Supplier<Builder> supplier() {
@@ -79,7 +80,7 @@ public final class DataTransactionResult {
     };
 
     public static Collector<DataTransactionResult, DataTransactionResult.Builder, DataTransactionResult> toTransaction() {
-        return COLLECTOR;
+        return DataTransactionResult.COLLECTOR;
     }
 
     /**
@@ -102,113 +103,113 @@ public final class DataTransactionResult {
      * @return A clean and empty data transaction
      */
     public static DataTransactionResult successNoData() {
-        return SUCCESS_NODATA;
+        return DataTransactionResult.SUCCESS_NODATA;
     }
 
     /**
      * Creates a new {@link DataTransactionResult} with the provided
-     * {@link org.spongepowered.api.data.value.Value.Immutable} being the successful addition. The result type is
-     * still {@link Type#SUCCESS}. If a {@link org.spongepowered.api.data.value.Value.Mutable} is
-     * necessary, use {@link org.spongepowered.api.data.value.Value.Mutable}#asImmutable()} to use this method. A
+     * {@link Value.Immutable} being the successful addition. The result type is
+     * still {@link Type#SUCCESS}. If a {@link Value.Mutable} is
+     * necessary, use {@link Value.Mutable}#asImmutable()} to use this method. A
      * {@link DataTransactionResult} is always immutable once created, and any
-     * {@link Value}s should be provided as {@link org.spongepowered.api.data.value.Value.Immutable}s or
-     * transformed into {@link org.spongepowered.api.data.value.Value.Immutable}s.
+     * {@link Value}s should be provided as {@link Value.Immutable}s or
+     * transformed into {@link Value.Immutable}s.
      *
      * @param value The successfully added immutable value
      * @return The new data transaction result
      */
     public static DataTransactionResult successResult(final Value.Immutable<?> value) {
-        return builder().success(value).result(Type.SUCCESS).build();
+        return DataTransactionResult.builder().success(value).result(Type.SUCCESS).build();
     }
 
     /**
      * Creates a new {@link DataTransactionResult} with the provided
-     * {@link org.spongepowered.api.data.value.Value.Immutable} being the successful addition. The result type is
-     * still {@link Type#SUCCESS}. If a {@link org.spongepowered.api.data.value.Value.Mutable} is
-     * necessary, use {@link org.spongepowered.api.data.value.Value.Mutable}#asImmutable()} to use this method. A
+     * {@link Value.Immutable} being the successful addition. The result type is
+     * still {@link Type#SUCCESS}. If a {@link Value.Mutable} is
+     * necessary, use {@link Value.Mutable}#asImmutable()} to use this method. A
      * {@link DataTransactionResult} is always immutable once created, and any
-     * {@link Value}s should be provided as {@link org.spongepowered.api.data.value.Value.Immutable}s or
-     * transformed into {@link org.spongepowered.api.data.value.Value.Immutable}s.
+     * {@link Value}s should be provided as {@link Value.Immutable}s or
+     * transformed into {@link Value.Immutable}s.
      *
      * @param successful The successfully added immutable value
      * @param replaced The replaced value
      * @return The new data transaction result
      */
     public static DataTransactionResult successReplaceResult(final Value.Immutable<?> successful, final Value.Immutable<?> replaced) {
-        return builder().result(Type.SUCCESS).success(successful).replace(replaced).build();
+        return DataTransactionResult.builder().result(Type.SUCCESS).success(successful).replace(replaced).build();
     }
 
     /**
      * Creates a new {@link DataTransactionResult} with the provided
-     * {@link org.spongepowered.api.data.value.Value.Immutable}s being the successful additions and
-     * the provided {@link org.spongepowered.api.data.value.Value.Immutable}s that were replaced. The result type
-     * is still {@link Type#SUCCESS}. If a {@link org.spongepowered.api.data.value.Value.Mutable}
-     * is necessary, use {@link org.spongepowered.api.data.value.Value.Mutable}#asImmutable()} to use this method. A
+     * {@link Value.Immutable}s being the successful additions and
+     * the provided {@link Value.Immutable}s that were replaced. The result type
+     * is still {@link Type#SUCCESS}. If a {@link Value.Mutable}
+     * is necessary, use {@link Value.Mutable}#asImmutable()} to use this method. A
      * {@link DataTransactionResult} is always immutable once created, and any
-     * {@link Value}s should be provided as {@link org.spongepowered.api.data.value.Value.Immutable}s or
-     * transformed into {@link org.spongepowered.api.data.value.Value.Immutable}s.
+     * {@link Value}s should be provided as {@link Value.Immutable}s or
+     * transformed into {@link Value.Immutable}s.
      *
      * @param successful The successfully added immutable values
      * @param replaced The successfully replaced immutable values
      * @return The new data transaction result
      */
-    public static DataTransactionResult successReplaceResult(Collection<Value.Immutable<?>> successful, Collection<Value.Immutable<?>> replaced) {
-        return builder().success(successful).replace(replaced).result(Type.SUCCESS).build();
+    public static DataTransactionResult successReplaceResult(final Collection<Value.Immutable<?>> successful, final Collection<Value.Immutable<?>> replaced) {
+        return DataTransactionResult.builder().success(successful).replace(replaced).result(Type.SUCCESS).build();
     }
 
     /**
      * Creates a {@link DataTransactionResult} with the provided
-     * {@link org.spongepowered.api.data.value.Value.Immutable}s being successfully removed. The result type is
-     * still {@link Type#SUCCESS}. If a {@link org.spongepowered.api.data.value.Value.Mutable} is necessary, use
-     * {@link org.spongepowered.api.data.value.Value.Mutable}#asImmutable()} to use this method. A {@link DataTransactionResult}
+     * {@link Value.Immutable}s being successfully removed. The result type is
+     * still {@link Type#SUCCESS}. If a {@link Value.Mutable} is necessary, use
+     * {@link Value.Mutable}#asImmutable()} to use this method. A {@link DataTransactionResult}
      * is always immutable once created, and any {@link Value}s should be provided
-     * as {@link org.spongepowered.api.data.value.Value.Immutable}s or transformed into {@link org.spongepowered.api.data.value.Value.Immutable}s.
+     * as {@link Value.Immutable}s or transformed into {@link Value.Immutable}s.
      *
      * @param removed The successfully removed values
      * @return The new data transaction result
      */
-    public static DataTransactionResult successRemove(Collection<Value.Immutable<?>> removed) {
-        return builder().replace(removed).result(Type.SUCCESS).build();
+    public static DataTransactionResult successRemove(final Collection<Value.Immutable<?>> removed) {
+        return DataTransactionResult.builder().replace(removed).result(Type.SUCCESS).build();
     }
 
     /**
      * Creates a {@link DataTransactionResult} with the provided
-     * {@link org.spongepowered.api.data.value.Value.Immutable} being successfully removed. The result type is
-     * still {@link Type#SUCCESS}. If a {@link org.spongepowered.api.data.value.Value.Mutable} is necessary, use
-     * {@link org.spongepowered.api.data.value.Value.Mutable}#asImmutable()} to use this method. A
+     * {@link Value.Immutable} being successfully removed. The result type is
+     * still {@link Type#SUCCESS}. If a {@link Value.Mutable} is necessary, use
+     * {@link Value.Mutable}#asImmutable()} to use this method. A
      * {@link DataTransactionResult} is always immutable once created, and a
-     * {@link Value} should be provided as an {@link org.spongepowered.api.data.value.Value.Immutable} or
-     * transformed into an {@link org.spongepowered.api.data.value.Value.Immutable}.
+     * {@link Value} should be provided as an {@link Value.Immutable} or
+     * transformed into an {@link Value.Immutable}.
      *
      * @param removed The successfully removed value
      * @return The new data transaction result
      */
-    public static DataTransactionResult successRemove(Value.Immutable<?> removed) {
-        return builder().replace(removed).result(Type.SUCCESS).build();
+    public static DataTransactionResult successRemove(final Value.Immutable<?> removed) {
+        return DataTransactionResult.builder().replace(removed).result(Type.SUCCESS).build();
     }
 
     /**
      * Creates a new {@link DataTransactionResult} that ends in failure. The
-     * provided {@link org.spongepowered.api.data.value.Value.Immutable} is considered "rejected" and was not
+     * provided {@link Value.Immutable} is considered "rejected" and was not
      * successfully added.
      *
      * @param value The value that was rejected
      * @return The new data transaction result
      */
     public static DataTransactionResult failResult(final Value.Immutable<?> value) {
-        return builder().reject(value).result(Type.FAILURE).build();
+        return DataTransactionResult.builder().reject(value).result(Type.FAILURE).build();
     }
 
     /**
      * Creates a new {@link DataTransactionResult} that ends in failure. The
-     * provided {@link org.spongepowered.api.data.value.Value.Immutable}s are considered "rejected" and were not
+     * provided {@link Value.Immutable}s are considered "rejected" and were not
      * successfully added.
      *
      * @param values The values that were rejected
      * @return The new data transaction result
      */
     public static DataTransactionResult failResult(final Iterable<Value.Immutable<?>> values) {
-        return builder().reject(values).result(Type.FAILURE).build();
+        return DataTransactionResult.builder().reject(values).result(Type.FAILURE).build();
     }
 
     /**
@@ -218,19 +219,19 @@ public final class DataTransactionResult {
      * @return The new data transaction result
      */
     public static DataTransactionResult failNoData() {
-        return FAIL_NODATA;
+        return DataTransactionResult.FAIL_NODATA;
     }
 
     /**
      * Creates a new {@link DataTransactionResult} that ends in failure. The
-     * provided {@link org.spongepowered.api.data.value.Value.Immutable} is considered "incompatible" and was not
+     * provided {@link Value.Immutable} is considered "incompatible" and was not
      * successfully added.
      *
      * @param value The value that was incompatible or errored
      * @return The new data transaction result
      */
     public static DataTransactionResult errorResult(final Value.Immutable<?> value) {
-        return builder().result(Type.ERROR).reject(value).build();
+        return DataTransactionResult.builder().result(Type.ERROR).reject(value).build();
     }
 
     /**
@@ -315,7 +316,7 @@ public final class DataTransactionResult {
      * @return True if this result was successful
      */
     public boolean isSuccessful() {
-        return getType() == Type.SUCCESS;
+        return this.getType() == Type.SUCCESS;
     }
 
     /**
@@ -329,8 +330,8 @@ public final class DataTransactionResult {
     }
 
     /**
-     * If {@link org.spongepowered.api.data.value.Value.Mutable}s were supplied to the operation, this
-     * collection will return any {@link org.spongepowered.api.data.value.Value.Immutable}s which were rejected
+     * If {@link Value.Mutable}s were supplied to the operation, this
+     * collection will return any {@link Value.Immutable}s which were rejected
      * by the target {@link DataHolder}.
      *
      * @return Any data that was rejected from the operation
@@ -340,8 +341,8 @@ public final class DataTransactionResult {
     }
 
     /**
-     * If the operation replaced any {@link org.spongepowered.api.data.value.Value.Mutable}s, this returns a collection
-     * of the replaced {@link org.spongepowered.api.data.value.Value.Immutable}s.
+     * If the operation replaced any {@link Value.Mutable}s, this returns a collection
+     * of the replaced {@link Value.Immutable}s.
      *
      * @return Any data that was replaced
      */
@@ -356,8 +357,8 @@ public final class DataTransactionResult {
      *
      * @param consumer The consumer to call
      */
-    public void ifSuccessful(Consumer<List<Value.Immutable<?>>> consumer) {
-        if (isSuccessful()) {
+    public void ifSuccessful(final Consumer<List<Value.Immutable<?>>> consumer) {
+        if (this.isSuccessful()) {
             consumer.accept(this.success);
         }
     }
@@ -371,40 +372,40 @@ public final class DataTransactionResult {
      * @param <E> The type of exception
      * @throws E The exception to throw if this transaction is not successful
      */
-    public <E extends Exception> void ifNotSuccessful(Supplier<E> supplier) throws E {
-        if (!isSuccessful()) {
+    public <E extends Exception> void ifNotSuccessful(final Supplier<E> supplier) throws E {
+        if (!this.isSuccessful()) {
             throw supplier.get();
         }
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("resultType", this.type)
-                .add("rejectedData", this.rejected)
-                .add("replacedData", this.replaced)
-                .add("successfulData", this.success)
-                .toString();
+        return new StringJoiner(", ", DataTransactionResult.class.getSimpleName() + "[", "]")
+            .add("type=" + this.type)
+            .add("rejected=" + this.rejected)
+            .add("replaced=" + this.replaced)
+            .add("success=" + this.success)
+            .toString();
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final @Nullable Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (o == null || this.getClass() != o.getClass()) {
             return false;
         }
-        DataTransactionResult that = (DataTransactionResult) o;
+        final DataTransactionResult that = (DataTransactionResult) o;
         return this.type == that.type
-               && Objects.equal(this.rejected, that.rejected)
-               && Objects.equal(this.replaced, that.replaced)
-               && Objects.equal(this.success, that.success);
+            && Objects.equals(this.rejected, that.rejected)
+            && Objects.equals(this.replaced, that.replaced)
+            && Objects.equals(this.success, that.success);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.type, this.rejected, this.replaced, this.success);
+        return Objects.hash(this.type, this.rejected, this.replaced, this.success);
     }
 
     /**
@@ -414,10 +415,10 @@ public final class DataTransactionResult {
      */
     public static final class Builder implements CopyableBuilder<DataTransactionResult, Builder> {
 
-        List<Value.Immutable<?>> rejected;
-        List<Value.Immutable<?>> replaced;
-        List<Value.Immutable<?>> successful;
-        Type resultType;
+        @MonotonicNonNull List<Value.Immutable<?>> rejected;
+        @MonotonicNonNull List<Value.Immutable<?>> replaced;
+        @MonotonicNonNull List<Value.Immutable<?>> successful;
+        @MonotonicNonNull Type resultType;
 
         Builder() {
         }
@@ -431,13 +432,13 @@ public final class DataTransactionResult {
          * @return This builder, for chaining
          */
         public Builder result(final Type type) {
-            this.resultType = java.util.Objects.requireNonNull(type);
+            this.resultType = Objects.requireNonNull(type);
             return this;
         }
 
         /**
-         * Adds the provided {@link org.spongepowered.api.data.value.Value.Immutable} to the {@link List} of
-         * "replaced" {@link org.spongepowered.api.data.value.Value.Immutable}s. The replaced values are always
+         * Adds the provided {@link Value.Immutable} to the {@link List} of
+         * "replaced" {@link Value.Immutable}s. The replaced values are always
          * copied for every {@link DataTransactionResult} for referencing.
          *
          * @param value The value to replace
@@ -445,30 +446,30 @@ public final class DataTransactionResult {
          */
         public Builder replace(final Value.Immutable<?> value) {
             if (this.replaced == null) {
-                this.replaced = Lists.newArrayList();
+                this.replaced = new ArrayList<>();
             }
-            this.replaced.add(java.util.Objects.requireNonNull(value));
+            this.replaced.add(Objects.requireNonNull(value));
             return this;
         }
 
         /**
-         * Adds the provided {@link org.spongepowered.api.data.value.Value.Immutable}s to the {@link List} of
-         * "replaced" {@link org.spongepowered.api.data.value.Value.Immutable}s. The replaced values are always
+         * Adds the provided {@link Value.Immutable}s to the {@link List} of
+         * "replaced" {@link Value.Immutable}s. The replaced values are always
          * copied for every {@link DataTransactionResult} for referencing.
          *
          * @param values The values to replace
          * @return This builder, for chaining
          */
         public Builder replace(final Iterable<Value.Immutable<?>> values) {
-            for (Value.Immutable<?> value : values) {
-                replace(java.util.Objects.requireNonNull(value));
+            for (final Value.Immutable<?> value : values) {
+                this.replace(Objects.requireNonNull(value));
             }
             return this;
         }
 
         /**
-         * Adds the provided {@link org.spongepowered.api.data.value.Value.Immutable} to the {@link List} of
-         * "rejected" {@link org.spongepowered.api.data.value.Value.Immutable}s. The rejected values are always
+         * Adds the provided {@link Value.Immutable} to the {@link List} of
+         * "rejected" {@link Value.Immutable}s. The rejected values are always
          * copied for every {@link DataTransactionResult} for referencing.
          *
          * @param value The values to reject
@@ -476,30 +477,30 @@ public final class DataTransactionResult {
          */
         public Builder reject(final Value.Immutable<?> value) {
             if (this.rejected == null) {
-                this.rejected = Lists.newArrayList();
+                this.rejected = new ArrayList<>();
             }
-            this.rejected.add(java.util.Objects.requireNonNull(value));
+            this.rejected.add(Objects.requireNonNull(value));
             return this;
         }
 
         /**
-         * Adds the provided {@link org.spongepowered.api.data.value.Value.Immutable}s to the {@link List} of
-         * "rejected" {@link org.spongepowered.api.data.value.Value.Immutable}s. The rejected values are always
+         * Adds the provided {@link Value.Immutable}s to the {@link List} of
+         * "rejected" {@link Value.Immutable}s. The rejected values are always
          * copied for every {@link DataTransactionResult} for referencing.
          *
          * @param values The values to reject
          * @return This builder, for chaining
          */
         public Builder reject(final Iterable<Value.Immutable<?>> values) {
-            for (Value.Immutable<?> value : values) {
-                reject(java.util.Objects.requireNonNull(value));
+            for (final Value.Immutable<?> value : values) {
+                this.reject(Objects.requireNonNull(value));
             }
             return this;
         }
 
         /**
-         * Adds the provided {@link org.spongepowered.api.data.value.Value.Immutable} to the {@link List} of
-         * "successful" {@link org.spongepowered.api.data.value.Value.Immutable}s. The successful values are always
+         * Adds the provided {@link Value.Immutable} to the {@link List} of
+         * "successful" {@link Value.Immutable}s. The successful values are always
          * copied for every {@link DataTransactionResult} for referencing.
          *
          * @param value The value that was successfully provided
@@ -507,23 +508,23 @@ public final class DataTransactionResult {
          */
         public Builder success(final Value.Immutable<?> value) {
             if (this.successful == null) {
-                this.successful = Lists.newArrayList();
+                this.successful = new ArrayList<>();
             }
-            this.successful.add(java.util.Objects.requireNonNull(value));
+            this.successful.add(Objects.requireNonNull(value));
             return this;
         }
 
         /**
-         * Adds the provided {@link org.spongepowered.api.data.value.Value.Immutable}s to the {@link List} of
-         * "successful" {@link org.spongepowered.api.data.value.Value.Immutable}s. The rejected values are always
+         * Adds the provided {@link Value.Immutable}s to the {@link List} of
+         * "successful" {@link Value.Immutable}s. The rejected values are always
          * copied for every {@link DataTransactionResult} for referencing.
          *
          * @param values The values that were successfully provided
          * @return This builder, for chaining
          */
         public Builder success(final Iterable<Value.Immutable<?>> values) {
-            for (Value.Immutable<?> value : values) {
-                success(java.util.Objects.requireNonNull(value));
+            for (final Value.Immutable<?> value : values) {
+                this.success(Objects.requireNonNull(value));
             }
             return this;
         }
@@ -531,10 +532,10 @@ public final class DataTransactionResult {
         /**
          * Combines the currently building {@link DataTransactionResult} with the
          * one provided. Usually, this means that there is some merging of the
-         * {@link org.spongepowered.api.data.value.Value.Immutable}s based on {@link Key}. If this builder already
-         * has an {@link org.spongepowered.api.data.value.Value.Immutable} as being successfully offered, and the
+         * {@link Value.Immutable}s based on {@link Key}. If this builder already
+         * has an {@link Value.Immutable} as being successfully offered, and the
          * provided result shows the same key as being rejected, the rejected
-         * {@link org.spongepowered.api.data.value.Value.Immutable} will remain in the final result.
+         * {@link Value.Immutable} will remain in the final result.
          *
          * @param result The result to merge
          * @return This builder, for chaining
@@ -548,9 +549,9 @@ public final class DataTransactionResult {
                     this.resultType = result.getType();
                 }
             }
-            final List<Value.Immutable<?>> newSuccessful = Lists.newArrayList();
-            final List<Value.Immutable<?>> newReplaced = Lists.newArrayList();
-            final List<Value.Immutable<?>> newRejected = Lists.newArrayList();
+            final List<Value.Immutable<?>> newSuccessful = new ArrayList<>();
+            final List<Value.Immutable<?>> newReplaced = new ArrayList<>();
+            final List<Value.Immutable<?>> newRejected = new ArrayList<>();
             // Now let's handle the successful data
             if (this.successful != null) {
                 dance:
@@ -689,9 +690,9 @@ public final class DataTransactionResult {
 
         /**
          * Builds a new {@link DataTransactionResult} with the providing
-         * {@link List}s of {@link org.spongepowered.api.data.value.Value.Immutable}s that are successfully
-         * offered, {@link org.spongepowered.api.data.value.Value.Immutable}s that were replaced, and
-         * {@link org.spongepowered.api.data.value.Value.Immutable}s that were rejected.
+         * {@link List}s of {@link Value.Immutable}s that are successfully
+         * offered, {@link Value.Immutable}s that were replaced, and
+         * {@link Value.Immutable}s that were rejected.
          *
          * @return The newly created transaction result
          */
@@ -703,7 +704,7 @@ public final class DataTransactionResult {
         }
 
         @Override
-        public Builder from(DataTransactionResult value) {
+        public Builder from(final DataTransactionResult value) {
             this.resultType = value.type;
             this.rejected = new ArrayList<>(value.getRejectedData());
             this.replaced = new ArrayList<>(value.getReplacedData());

--- a/src/main/java/org/spongepowered/api/data/Transaction.java
+++ b/src/main/java/org/spongepowered/api/data/Transaction.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.data;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.data.persistence.DataContainer;
 import org.spongepowered.api.data.persistence.DataSerializable;
@@ -51,8 +49,8 @@ public class Transaction<T extends DataSerializable> implements DataSerializable
      * @param defaultReplacement The default replacement
      */
     public Transaction(T original, T defaultReplacement) {
-        this.original = checkNotNull(original);
-        this.defaultReplacement = checkNotNull(defaultReplacement);
+        this.original = Objects.requireNonNull(original);
+        this.defaultReplacement = Objects.requireNonNull(defaultReplacement);
         this.intermediary = null;
     }
 
@@ -73,8 +71,8 @@ public class Transaction<T extends DataSerializable> implements DataSerializable
      * @param intermediary The intermediary results
      */
     public Transaction(T original, T defaultReplacement, @Nullable List<? extends T> intermediary) {
-        this.original = checkNotNull(original, "Original cannot be null");
-        this.defaultReplacement = checkNotNull(defaultReplacement, "Default replacement cannot be null");
+        this.original = Objects.requireNonNull(original, "Original cannot be null");
+        this.defaultReplacement = Objects.requireNonNull(defaultReplacement, "Default replacement cannot be null");
         this.intermediary = intermediary == null ? null : Collections.unmodifiableList(intermediary);
     }
 

--- a/src/main/java/org/spongepowered/api/data/persistence/AbstractDataBuilder.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/AbstractDataBuilder.java
@@ -24,10 +24,9 @@
  */
 package org.spongepowered.api.data.persistence;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.spongepowered.api.Sponge;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -47,7 +46,7 @@ public abstract class AbstractDataBuilder<T extends DataSerializable> implements
     private final Class<T> requiredClass;
 
     protected AbstractDataBuilder(Class<T> requiredClass, int supportedVersion) {
-        this.requiredClass = checkNotNull(requiredClass, "Required class");
+        this.requiredClass = Objects.requireNonNull(requiredClass, "Required class");
         this.supportedVersion = supportedVersion;
     }
 

--- a/src/main/java/org/spongepowered/api/data/persistence/DataQuery.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/DataQuery.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.data.persistence;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
@@ -32,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Spliterator;
+import java.util.StringJoiner;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
@@ -185,7 +185,7 @@ public final class DataQuery implements Iterable<String> {
     public List<DataQuery> getQueryParts() {
         if (this.queryParts == null) {
             final ImmutableList.Builder<DataQuery> builder = ImmutableList.builder();
-            for (final String part : getParts()) {
+            for (final String part : this.getParts()) {
                 builder.add(new DataQuery(part));
             }
             this.queryParts = builder.build();
@@ -202,7 +202,7 @@ public final class DataQuery implements Iterable<String> {
      */
     public DataQuery pop() {
         if (this.parts.size() <= 1) {
-            return of();
+            return DataQuery.of();
         }
         final ImmutableList.Builder<String> builder = ImmutableList.builder();
         for (int i = 0; i < this.parts.size() - 1; i++) {
@@ -220,7 +220,7 @@ public final class DataQuery implements Iterable<String> {
      */
     public DataQuery popFirst() {
         if (this.parts.size() <= 1) {
-            return of();
+            return DataQuery.of();
         }
         final ImmutableList.Builder<String> builder = ImmutableList.builder();
         for (int i = 1; i < this.parts.size(); i++) {
@@ -249,7 +249,9 @@ public final class DataQuery implements Iterable<String> {
      * @return This query as a string
      */
     public String asString(final String separator) {
-        return Joiner.on(separator).join(this.parts);
+        final StringJoiner stringJoiner = new StringJoiner(separator);
+        this.parts.forEach(stringJoiner::add);
+        return stringJoiner.toString();
     }
 
     /**
@@ -259,12 +261,12 @@ public final class DataQuery implements Iterable<String> {
      * @return This query as a string
      */
     public String asString(final char separator) {
-        return asString(String.valueOf(separator));
+        return this.asString(String.valueOf(separator));
     }
 
     @Override
     public String toString() {
-        return asString('.');
+        return this.asString('.');
     }
 
     @Override
@@ -277,7 +279,7 @@ public final class DataQuery implements Iterable<String> {
         if (this == obj) {
             return true;
         }
-        if (obj == null || getClass() != obj.getClass()) {
+        if (obj == null || this.getClass() != obj.getClass()) {
             return false;
         }
         final DataQuery other = (DataQuery) obj;

--- a/src/main/java/org/spongepowered/api/data/value/MergeFunction.java
+++ b/src/main/java/org/spongepowered/api/data/value/MergeFunction.java
@@ -24,10 +24,9 @@
  */
 package org.spongepowered.api.data.value;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -92,7 +91,7 @@ public interface MergeFunction {
     MergeFunction REPLACEMENT_PREFERRED = new MergeFunction() {
         @Override
         public <V extends Value<E>, E> V merge(@Nullable V original, @Nullable V replacement) {
-            return replacement == null ? checkNotNull(original, "Original and replacement cannot be null!") : replacement;
+            return replacement == null ? Objects.requireNonNull(original, "Original and replacement cannot be null!") : replacement;
         }
     };
 
@@ -103,7 +102,7 @@ public interface MergeFunction {
     MergeFunction ORIGINAL_PREFERRED = new MergeFunction() {
         @Override
         public <V extends Value<E>, E> V merge(@Nullable V original, @Nullable V replacement) {
-            return original == null ? checkNotNull(replacement, "Replacement and original cannot be null!") : original;
+            return original == null ? Objects.requireNonNull(replacement, "Replacement and original cannot be null!") : original;
         }
     };
 

--- a/src/main/java/org/spongepowered/api/data/value/ValueContainer.java
+++ b/src/main/java/org/spongepowered/api/data/value/ValueContainer.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.data.value;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.collect.ImmutableSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.data.DataHolder;
@@ -33,6 +31,7 @@ import org.spongepowered.api.data.DataManipulator;
 import org.spongepowered.api.data.Key;
 
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
@@ -244,7 +243,7 @@ public interface ValueContainer {
      * @return The value, or default if not set
      */
     default <E> E getOrElse(Key<? extends Value<E>> key, E defaultValue) {
-        return this.get(key).orElse(checkNotNull(defaultValue, "defaultValue"));
+        return this.get(key).orElse(Objects.requireNonNull(defaultValue, "defaultValue"));
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/effect/Viewer.java
+++ b/src/main/java/org/spongepowered/api/effect/Viewer.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.effect;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.sound.Sound;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -39,6 +37,7 @@ import org.spongepowered.api.world.dimension.DimensionTypes;
 import org.spongepowered.math.vector.Vector3d;
 import org.spongepowered.math.vector.Vector3i;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
@@ -131,7 +130,7 @@ public interface Viewer extends Audience {
      * @param state The block state
      */
     default void sendBlockChange(Vector3i vec, BlockState state) {
-        checkNotNull(vec, "vec");
+        Objects.requireNonNull(vec, "vec");
         this.sendBlockChange(vec.getX(), vec.getY(), vec.getZ(), state);
     }
 
@@ -157,7 +156,7 @@ public interface Viewer extends Audience {
      * @param vec The position
      */
     default void resetBlockChange(Vector3i vec) {
-        checkNotNull(vec, "vec");
+        Objects.requireNonNull(vec, "vec");
         this.resetBlockChange(vec.getX(), vec.getY(), vec.getZ());
     }
 

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.entity;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
@@ -296,7 +294,9 @@ public interface Entity extends Identifiable, HoverEventSource<HoverEvent.ShowEn
      * @return The collection of nearby entities
      */
     default Collection<? extends Entity> getNearbyEntities(final double distance) {
-        checkState(distance > 0, "Distance must be greater than 0!");
+        if (distance <= 0) {
+            throw new IllegalArgumentException("Distance must be greater than 0!");
+        }
         return this.getWorld().getNearbyEntities(this.getLocation().getPosition(), distance);
     }
 

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.entity;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import net.kyori.adventure.text.Component;
@@ -225,7 +224,7 @@ public interface Entity extends Identifiable, HoverEventSource<HoverEvent.ShowEn
      *      removed)
      */
     default boolean transferToWorld(final ServerWorld world) {
-        Objects.requireNonNull(world);
+        Objects.requireNonNull(world, "World cannot be null");
         return this.transferToWorld(world, world.getProperties().getSpawnPosition().toDouble());
     }
 
@@ -310,7 +309,7 @@ public interface Entity extends Identifiable, HoverEventSource<HoverEvent.ShowEn
      * @return The collection of entities
      */
     default Collection<? extends Entity> getNearbyEntities(final double distance, final Predicate<? super Entity> predicate) {
-        checkNotNull(predicate);
+        Objects.requireNonNull(predicate, "Predicate cannot be null");
         return this.getWorld().getEntities(this.getBoundingBox().get().expand(distance, distance, distance), predicate);
     }
 
@@ -321,7 +320,7 @@ public interface Entity extends Identifiable, HoverEventSource<HoverEvent.ShowEn
      * @return {@code true} if this entity can see the provided entity
      */
     default boolean canSee(final Entity entity) {
-        checkNotNull(entity);
+        Objects.requireNonNull(entity, "Entity cannot be null");
         final Optional<Boolean> optional = entity.get(Keys.VANISH);
         return !optional.isPresent() || !optional.get();
     }

--- a/src/main/java/org/spongepowered/api/entity/ai/goal/AbstractGoal.java
+++ b/src/main/java/org/spongepowered/api/entity/ai/goal/AbstractGoal.java
@@ -24,10 +24,10 @@
  */
 package org.spongepowered.api.entity.ai.goal;
 
-import com.google.common.base.Preconditions;
-import org.spongepowered.api.registry.BuilderRegistry;
 import org.spongepowered.api.entity.living.Agent;
+import org.spongepowered.api.registry.BuilderRegistry;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -70,7 +70,7 @@ public abstract class AbstractGoal<O extends Agent> implements Goal<O> {
      * @param type The type
      */
     public AbstractGoal(GoalType type) {
-        Preconditions.checkNotNull(type);
+        Objects.requireNonNull(type);
         this.type = type;
     }
 

--- a/src/main/java/org/spongepowered/api/event/Cause.java
+++ b/src/main/java/org/spongepowered/api/event/Cause.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.event;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.base.Objects;
@@ -78,8 +77,8 @@ public final class Cause implements Iterable<Object> {
      * @return The constructed cause
      */
     public static Cause of(EventContext ctx, Object cause) {
-        checkNotNull(ctx, "Context");
-        checkNotNull(cause, "Cause cannot be null!");
+        java.util.Objects.requireNonNull(ctx, "Context");
+        java.util.Objects.requireNonNull(cause, "Cause cannot be null!");
         return new Cause(ctx, new Object[] {cause});
     }
 
@@ -92,7 +91,7 @@ public final class Cause implements Iterable<Object> {
      * @return The built cause
      */
     public static Cause of(EventContext ctx, Object cause, Object... causes) {
-        checkNotNull(ctx, "Context");
+        java.util.Objects.requireNonNull(ctx, "Context");
         Builder builder = builder();
         builder.append(cause);
         for (Object namedCause : causes) {
@@ -109,7 +108,7 @@ public final class Cause implements Iterable<Object> {
      * @return The built cause
      */
     public static Cause of(EventContext ctx, Iterable<Object> iterable) {
-        checkNotNull(ctx, "Context");
+        java.util.Objects.requireNonNull(ctx, "Context");
         Builder builder = builder();
         for (Object cause : iterable) {
             builder.append(cause);
@@ -130,10 +129,10 @@ public final class Cause implements Iterable<Object> {
      * @param causes The causes
      */
     Cause(EventContext ctx, Object[] causes) {
-        checkNotNull(ctx, "Context");
+        java.util.Objects.requireNonNull(ctx, "Context");
         final Object[] objects = new Object[causes.length];
         for (int index = 0; index < causes.length; index++) {
-            objects[index] = checkNotNull(causes[index], "Null cause element!");
+            objects[index] = java.util.Objects.requireNonNull(causes[index], "Null cause element!");
         }
         this.cause = objects;
         this.context = ctx;
@@ -146,11 +145,11 @@ public final class Cause implements Iterable<Object> {
      * @param causes The causes
      */
     Cause(EventContext ctx, Collection<Object> causes) {
-        checkNotNull(ctx, "Context");
+        java.util.Objects.requireNonNull(ctx, "Context");
         final Object[] objects = new Object[causes.size()];
         int index = 0;
         for (Object cause: causes) {
-            objects[index++] = checkNotNull(cause, "Null cause element!");
+            objects[index++] = java.util.Objects.requireNonNull(cause, "Null cause element!");
         }
         this.cause = objects;
         this.context = ctx;
@@ -337,7 +336,7 @@ public final class Cause implements Iterable<Object> {
      * @return The new cause
      */
     public Cause with(Object additional) {
-        checkNotNull(additional, "No null arguments allowed!");
+        java.util.Objects.requireNonNull(additional, "No null arguments allowed!");
         List<Object> list = new ArrayList<>();
         list.add(additional);
         return with(list);
@@ -352,11 +351,11 @@ public final class Cause implements Iterable<Object> {
      * @return The new cause
      */
     public Cause with(Object additional, Object... additionals) {
-        checkNotNull(additional, "No null arguments allowed!");
+        java.util.Objects.requireNonNull(additional, "No null arguments allowed!");
         List<Object> list = new ArrayList<>();
         list.add(additional);
         for (Object object : additionals) {
-            checkNotNull(object, "Cannot add null objects!");
+            java.util.Objects.requireNonNull(object, "Cannot add null objects!");
             list.add(object);
         }
         return with(list);
@@ -372,7 +371,7 @@ public final class Cause implements Iterable<Object> {
     public Cause with(Iterable<Object> iterable) {
         Cause.Builder builder = new Builder().from(this);
         for (Object o : iterable) {
-            checkNotNull(o, "Cannot add null causes");
+            java.util.Objects.requireNonNull(o, "Cannot add null causes");
             builder.append(o);
         }
         return builder.build(this.context);
@@ -457,7 +456,7 @@ public final class Cause implements Iterable<Object> {
          * @return The modified builder, for chaining
          */
         public Builder append(Object cause) {
-            checkNotNull(cause, "Cause cannot be null!");
+            java.util.Objects.requireNonNull(cause, "Cause cannot be null!");
             if (!this.causes.isEmpty() && this.causes.get(this.causes.size() - 1) == cause) {
                 return this;
             }
@@ -473,7 +472,7 @@ public final class Cause implements Iterable<Object> {
          * @return The modified builder, for chaining
          */
         public Builder insert(int position, Object cause) {
-            checkNotNull(cause, "Cause cannot be null!");
+            java.util.Objects.requireNonNull(cause, "Cause cannot be null!");
             this.causes.add(position, cause);
             return this;
         }
@@ -485,7 +484,7 @@ public final class Cause implements Iterable<Object> {
          * @return The modified builder, for chaining
          */
         public Builder appendAll(Collection<Object> causes) {
-            checkNotNull(causes, "Causes cannot be null!");
+            java.util.Objects.requireNonNull(causes, "Causes cannot be null!");
             causes.forEach(this::append);
             return this;
         }

--- a/src/main/java/org/spongepowered/api/event/Cause.java
+++ b/src/main/java/org/spongepowered/api/event/Cause.java
@@ -24,9 +24,6 @@
  */
 package org.spongepowered.api.event;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
-
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -214,7 +211,9 @@ public final class Cause implements Iterable<Object> {
      * @return The object
      */
     public Optional<?> before(Class<?> clazz) {
-        checkArgument(clazz != null, "The provided class cannot be null!");
+        if (clazz == null) {
+            throw new IllegalArgumentException("The provided class cannot be null!");
+        }
         if (this.cause.length == 1) {
             return Optional.empty();
         }
@@ -234,7 +233,9 @@ public final class Cause implements Iterable<Object> {
      * @return The object after, if available
      */
     public Optional<?> after(Class<?> clazz) {
-        checkArgument(clazz != null, "The provided class cannot be null!");
+        if (clazz == null) {
+            throw new IllegalArgumentException("The provided class cannot be null!");
+        }
         if (this.cause.length == 1) {
             return Optional.empty();
         }
@@ -254,7 +255,7 @@ public final class Cause implements Iterable<Object> {
      * @return True if found, false otherwise
      */
     public boolean containsType(Class<?> target) {
-        checkArgument(target != null, "The provided class cannot be null!");
+        java.util.Objects.requireNonNull(target, "The provided class cannot be null!");
         for (Object aCause : this.cause) {
             if (target.isInstance(aCause)) {
                 return true;
@@ -496,7 +497,9 @@ public final class Cause implements Iterable<Object> {
          * @return The built cause
          */
         public Cause build(EventContext ctx) {
-            checkState(!this.causes.isEmpty(), "Cannot create an empty Cause!");
+            if (this.causes.isEmpty()) {
+                throw new IllegalStateException("Cannot create an empty Cause!");
+            }
             return new Cause(ctx, this.causes);
         }
 

--- a/src/main/java/org/spongepowered/api/event/Cause.java
+++ b/src/main/java/org/spongepowered/api/event/Cause.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.event;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.util.CopyableBuilder;
@@ -36,6 +35,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 
@@ -73,7 +73,7 @@ public final class Cause implements Iterable<Object> {
      * @param cause The direct object cause
      * @return The constructed cause
      */
-    public static Cause of(EventContext ctx, Object cause) {
+    public static Cause of(final EventContext ctx, final Object cause) {
         java.util.Objects.requireNonNull(ctx, "Context");
         java.util.Objects.requireNonNull(cause, "Cause cannot be null!");
         return new Cause(ctx, new Object[] {cause});
@@ -87,11 +87,11 @@ public final class Cause implements Iterable<Object> {
      * @param causes Other associated causes
      * @return The built cause
      */
-    public static Cause of(EventContext ctx, Object cause, Object... causes) {
+    public static Cause of(final EventContext ctx, final Object cause, final Object... causes) {
         java.util.Objects.requireNonNull(ctx, "Context");
-        Builder builder = builder();
+        final Builder builder = Cause.builder();
         builder.append(cause);
-        for (Object namedCause : causes) {
+        for (final Object namedCause : causes) {
             builder.append(namedCause);
         }
         return builder.build(ctx);
@@ -104,10 +104,10 @@ public final class Cause implements Iterable<Object> {
      * @param iterable The associated causes
      * @return The built cause
      */
-    public static Cause of(EventContext ctx, Iterable<Object> iterable) {
+    public static Cause of(final EventContext ctx, final Iterable<Object> iterable) {
         java.util.Objects.requireNonNull(ctx, "Context");
-        Builder builder = builder();
-        for (Object cause : iterable) {
+        final Builder builder = Cause.builder();
+        for (final Object cause : iterable) {
             builder.append(cause);
         }
         return builder.build(ctx);
@@ -125,7 +125,7 @@ public final class Cause implements Iterable<Object> {
      * @param ctx The event context
      * @param causes The causes
      */
-    Cause(EventContext ctx, Object[] causes) {
+    Cause(final EventContext ctx, final Object[] causes) {
         java.util.Objects.requireNonNull(ctx, "Context");
         final Object[] objects = new Object[causes.length];
         for (int index = 0; index < causes.length; index++) {
@@ -141,11 +141,11 @@ public final class Cause implements Iterable<Object> {
      * @param ctx The event context
      * @param causes The causes
      */
-    Cause(EventContext ctx, Collection<Object> causes) {
+    Cause(final EventContext ctx, final Collection<Object> causes) {
         java.util.Objects.requireNonNull(ctx, "Context");
         final Object[] objects = new Object[causes.size()];
         int index = 0;
-        for (Object cause: causes) {
+        for (final Object cause: causes) {
             objects[index++] = java.util.Objects.requireNonNull(cause, "Null cause element!");
         }
         this.cause = objects;
@@ -177,8 +177,8 @@ public final class Cause implements Iterable<Object> {
      * @param <T> The type of object being queried for
      * @return The first element of the type, if available
      */
-    public <T> Optional<T> first(Class<T> target) {
-        for (Object aCause : this.cause) {
+    public <T> Optional<T> first(final Class<T> target) {
+        for (final Object aCause : this.cause) {
             if (target.isInstance(aCause)) {
                 return Optional.of((T) aCause);
             }
@@ -194,7 +194,7 @@ public final class Cause implements Iterable<Object> {
      * @param <T> The type of object being queried for
      * @return The last element of the type, if available
      */
-    public <T> Optional<T> last(Class<T> target) {
+    public <T> Optional<T> last(final Class<T> target) {
         for (int i = this.cause.length - 1; i >= 0; i--) {
             if (target.isInstance(this.cause[i])) {
                 return Optional.of((T) this.cause[i]);
@@ -210,7 +210,7 @@ public final class Cause implements Iterable<Object> {
      * @param clazz The class of the object
      * @return The object
      */
-    public Optional<?> before(Class<?> clazz) {
+    public Optional<?> before(final Class<?> clazz) {
         if (clazz == null) {
             throw new IllegalArgumentException("The provided class cannot be null!");
         }
@@ -232,7 +232,7 @@ public final class Cause implements Iterable<Object> {
      * @param clazz The class to type check
      * @return The object after, if available
      */
-    public Optional<?> after(Class<?> clazz) {
+    public Optional<?> after(final Class<?> clazz) {
         if (clazz == null) {
             throw new IllegalArgumentException("The provided class cannot be null!");
         }
@@ -254,9 +254,9 @@ public final class Cause implements Iterable<Object> {
      * @param target The class of the target type
      * @return True if found, false otherwise
      */
-    public boolean containsType(Class<?> target) {
+    public boolean containsType(final Class<?> target) {
         java.util.Objects.requireNonNull(target, "The provided class cannot be null!");
-        for (Object aCause : this.cause) {
+        for (final Object aCause : this.cause) {
             if (target.isInstance(aCause)) {
                 return true;
             }
@@ -273,8 +273,8 @@ public final class Cause implements Iterable<Object> {
      * @param object The object to check if it is contained
      * @return True if the object is contained within this cause
      */
-    public boolean contains(Object object) {
-        for (Object aCause : this.cause) {
+    public boolean contains(final Object object) {
+        for (final Object aCause : this.cause) {
             if (aCause.equals(object)) {
                 return true;
             }
@@ -290,9 +290,9 @@ public final class Cause implements Iterable<Object> {
      * @param target The class of the target type
      * @return An immutable list of the objects queried
      */
-    public <T> List<T> allOf(Class<T> target) {
-        ImmutableList.Builder<T> builder = ImmutableList.builder();
-        for (Object aCause : this.cause) {
+    public <T> List<T> allOf(final Class<T> target) {
+        final ImmutableList.Builder<T> builder = ImmutableList.builder();
+        for (final Object aCause : this.cause) {
             if (target.isInstance(aCause)) {
                 builder.add((T) aCause);
             }
@@ -307,9 +307,9 @@ public final class Cause implements Iterable<Object> {
      * @param ignoredClass The class of object types to ignore
      * @return The list of objects not an instance of the provided class
      */
-    public List<Object> noneOf(Class<?> ignoredClass) {
-        ImmutableList.Builder<Object> builder = ImmutableList.builder();
-        for (Object cause : this.cause) {
+    public List<Object> noneOf(final Class<?> ignoredClass) {
+        final ImmutableList.Builder<Object> builder = ImmutableList.builder();
+        for (final Object cause : this.cause) {
             if (!ignoredClass.isInstance(cause)) {
                 builder.add(cause);
             }
@@ -336,11 +336,11 @@ public final class Cause implements Iterable<Object> {
      * @param additional The additional object to add
      * @return The new cause
      */
-    public Cause with(Object additional) {
+    public Cause with(final Object additional) {
         java.util.Objects.requireNonNull(additional, "No null arguments allowed!");
-        List<Object> list = new ArrayList<>();
+        final List<Object> list = new ArrayList<>();
         list.add(additional);
-        return with(list);
+        return this.with(list);
     }
 
     /**
@@ -351,15 +351,15 @@ public final class Cause implements Iterable<Object> {
      * @param additionals The remaining objects to add
      * @return The new cause
      */
-    public Cause with(Object additional, Object... additionals) {
+    public Cause with(final Object additional, final Object... additionals) {
         java.util.Objects.requireNonNull(additional, "No null arguments allowed!");
-        List<Object> list = new ArrayList<>();
+        final List<Object> list = new ArrayList<>();
         list.add(additional);
-        for (Object object : additionals) {
+        for (final Object object : additionals) {
             java.util.Objects.requireNonNull(object, "Cannot add null objects!");
             list.add(object);
         }
-        return with(list);
+        return this.with(list);
     }
 
     /**
@@ -369,9 +369,9 @@ public final class Cause implements Iterable<Object> {
      * @param iterable The additional objects
      * @return The new cause
      */
-    public Cause with(Iterable<Object> iterable) {
-        Cause.Builder builder = new Builder().from(this);
-        for (Object o : iterable) {
+    public Cause with(final Iterable<Object> iterable) {
+        final Cause.Builder builder = new Builder().from(this);
+        for (final Object o : iterable) {
             java.util.Objects.requireNonNull(o, "Cannot add null causes");
             builder.append(o);
         }
@@ -384,8 +384,8 @@ public final class Cause implements Iterable<Object> {
      * @param cause The cause to merge with this
      * @return The new merged cause
      */
-    public Cause with(Cause cause) {
-        Cause.Builder builder = builder().from(this);
+    public Cause with(final Cause cause) {
+        final Cause.Builder builder = Cause.builder().from(this);
         for (int i = 0; i < cause.cause.length; i++) {
             builder.append(cause.cause[i]);
         }
@@ -398,9 +398,9 @@ public final class Cause implements Iterable<Object> {
     }
 
     @Override
-    public boolean equals(@Nullable Object object) {
+    public boolean equals(@Nullable final Object object) {
         if (object instanceof Cause) {
-            Cause cause = ((Cause) object);
+            final Cause cause = ((Cause) object);
             return Arrays.equals(this.cause, cause.cause);
         }
         return false;
@@ -413,8 +413,8 @@ public final class Cause implements Iterable<Object> {
 
     @Override
     public String toString() {
-        String causeString = "Cause[Context=" + this.context.toString() + ", Stack={";
-        StringJoiner joiner = new StringJoiner(", ");
+        final String causeString = "Cause[Context=" + this.context.toString() + ", Stack={";
+        final StringJoiner joiner = new StringJoiner(", ");
         for (int i = 0; i < this.cause.length; i++) {
             joiner.add(this.cause[i].toString());
         }
@@ -456,7 +456,7 @@ public final class Cause implements Iterable<Object> {
          * @param cause The object to append to the cause.
          * @return The modified builder, for chaining
          */
-        public Builder append(Object cause) {
+        public Builder append(final Object cause) {
             java.util.Objects.requireNonNull(cause, "Cause cannot be null!");
             if (!this.causes.isEmpty() && this.causes.get(this.causes.size() - 1) == cause) {
                 return this;
@@ -472,7 +472,7 @@ public final class Cause implements Iterable<Object> {
          * @param cause The object to insert into the cause
          * @return The modified builder, for chaining
          */
-        public Builder insert(int position, Object cause) {
+        public Builder insert(final int position, final Object cause) {
             java.util.Objects.requireNonNull(cause, "Cause cannot be null!");
             this.causes.add(position, cause);
             return this;
@@ -484,7 +484,7 @@ public final class Cause implements Iterable<Object> {
          * @param causes The objects to add onto the cause
          * @return The modified builder, for chaining
          */
-        public Builder appendAll(Collection<Object> causes) {
+        public Builder appendAll(final Collection<Object> causes) {
             java.util.Objects.requireNonNull(causes, "Causes cannot be null!");
             causes.forEach(this::append);
             return this;
@@ -496,7 +496,7 @@ public final class Cause implements Iterable<Object> {
          * @param ctx The context to build the cause with
          * @return The built cause
          */
-        public Cause build(EventContext ctx) {
+        public Cause build(final EventContext ctx) {
             if (this.causes.isEmpty()) {
                 throw new IllegalStateException("Cannot create an empty Cause!");
             }
@@ -504,7 +504,7 @@ public final class Cause implements Iterable<Object> {
         }
 
         @Override
-        public Builder from(Cause value) {
+        public Builder from(final Cause value) {
             for (int i = 0; i < value.cause.length; i++) {
                 this.causes.add(value.cause[i]);
             }

--- a/src/main/java/org/spongepowered/api/event/EventContext.java
+++ b/src/main/java/org/spongepowered/api/event/EventContext.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.event;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -35,6 +34,7 @@ import org.spongepowered.api.util.annotation.DoNotStore;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -65,9 +65,9 @@ public final class EventContext {
      * @return The new EventContext
      */
     public static EventContext of(Map<EventContextKey<?>, Object> entries) {
-        checkNotNull(entries, "Context entries cannot be null");
+        Objects.requireNonNull(entries, "Context entries cannot be null");
         for (Map.Entry<EventContextKey<?>, Object> entry : entries.entrySet()) {
-            checkNotNull(entry.getValue(), "Entries cannot contain null values");
+            Objects.requireNonNull(entry.getValue(), "Entries cannot contain null values");
         }
         return new EventContext(entries);
     }
@@ -96,7 +96,7 @@ public final class EventContext {
      */
     @SuppressWarnings("unchecked")
     public <T> Optional<T> get(EventContextKey<T> key) {
-        checkNotNull(key, "EventContextKey cannot be null");
+        Objects.requireNonNull(key, "EventContextKey cannot be null");
         return Optional.ofNullable((T) this.entries.get(key));
     }
 
@@ -109,7 +109,7 @@ public final class EventContext {
      */
     @SuppressWarnings("unchecked")
     public <T> Optional<T> get(Supplier<? extends EventContextKey<T>> key) {
-        checkNotNull(key, "EventContextKey cannot be null");
+        Objects.requireNonNull(key, "EventContextKey cannot be null");
         return Optional.ofNullable((T) this.entries.get(key.get()));
     }
 
@@ -241,7 +241,7 @@ public final class EventContext {
          * @return This builder, for chaining
          */
         public <T> Builder add(EventContextKey<T> key, T value) {
-            checkNotNull(value, "Context object cannot be null");
+            Objects.requireNonNull(value, "Context object cannot be null");
             checkArgument(!this.entries.containsKey(key), "Duplicate context keys");
             this.entries.put(key, value);
             return this;
@@ -257,9 +257,9 @@ public final class EventContext {
          * @return This builder, for chaining
          */
         public <T> Builder add(Supplier<? extends EventContextKey<T>> key, T value) {
-            checkNotNull(value, "Context object cannot be null");
+            Objects.requireNonNull(value, "Context object cannot be null");
             final EventContextKey<T> suppliedKey = key.get();
-            checkNotNull(suppliedKey, "Supplied key cannot be null!");
+            Objects.requireNonNull(suppliedKey, "Supplied key cannot be null!");
             checkArgument(!this.entries.containsKey(suppliedKey), "Duplicate context keys");
             this.entries.put(suppliedKey, value);
             return this;

--- a/src/main/java/org/spongepowered/api/event/EventContext.java
+++ b/src/main/java/org/spongepowered/api/event/EventContext.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.event;
 
-import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -242,7 +241,9 @@ public final class EventContext {
          */
         public <T> Builder add(EventContextKey<T> key, T value) {
             Objects.requireNonNull(value, "Context object cannot be null");
-            checkArgument(!this.entries.containsKey(key), "Duplicate context keys");
+            if (this.entries.containsKey(key)) {
+                throw new IllegalArgumentException("Duplicate context keys: " + key.toString());
+            }
             this.entries.put(key, value);
             return this;
         }
@@ -260,7 +261,9 @@ public final class EventContext {
             Objects.requireNonNull(value, "Context object cannot be null");
             final EventContextKey<T> suppliedKey = key.get();
             Objects.requireNonNull(suppliedKey, "Supplied key cannot be null!");
-            checkArgument(!this.entries.containsKey(suppliedKey), "Duplicate context keys");
+            if (this.entries.containsKey(suppliedKey)) {
+                throw new IllegalArgumentException("Duplicate context keys!");
+            }
             this.entries.put(suppliedKey, value);
             return this;
         }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageFunction.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageFunction.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.event.cause.entity.damage;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
@@ -69,8 +67,8 @@ public class DamageFunction implements ModifierFunction<DamageModifier> {
      * @param function The function
      */
     public DamageFunction(DamageModifier modifier, DoubleUnaryOperator function) {
-        this.modifier = checkNotNull(modifier, "modifier");
-        this.function = checkNotNull(function, "function");
+        this.modifier = java.util.Objects.requireNonNull(modifier, "modifier");
+        this.function = java.util.Objects.requireNonNull(function, "function");
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageFunction.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageFunction.java
@@ -24,9 +24,10 @@
  */
 package org.spongepowered.api.event.cause.entity.damage;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.Objects;
+import java.util.StringJoiner;
 import java.util.function.DoubleUnaryOperator;
 
 public class DamageFunction implements ModifierFunction<DamageModifier> {
@@ -40,7 +41,7 @@ public class DamageFunction implements ModifierFunction<DamageModifier> {
      * @param second The unary operator to use
      * @return The resulting damage function
      */
-    public static DamageFunction of(DamageModifier first, DoubleUnaryOperator second) {
+    public static DamageFunction of(final DamageModifier first, final DoubleUnaryOperator second) {
         return new DamageFunction(first, second);
     }
 
@@ -55,8 +56,8 @@ public class DamageFunction implements ModifierFunction<DamageModifier> {
      *
      * @param modifier The damage modifier
      */
-    public DamageFunction(DamageModifier modifier) {
-        this(modifier, ZERO_DAMAGE);
+    public DamageFunction(final DamageModifier modifier) {
+        this(modifier, DamageFunction.ZERO_DAMAGE);
     }
 
     /**
@@ -66,7 +67,7 @@ public class DamageFunction implements ModifierFunction<DamageModifier> {
      * @param modifier The modifier
      * @param function The function
      */
-    public DamageFunction(DamageModifier modifier, DoubleUnaryOperator function) {
+    public DamageFunction(final DamageModifier modifier, final DoubleUnaryOperator function) {
         this.modifier = java.util.Objects.requireNonNull(modifier, "modifier");
         this.function = java.util.Objects.requireNonNull(function, "function");
     }
@@ -93,27 +94,27 @@ public class DamageFunction implements ModifierFunction<DamageModifier> {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("modifier", getModifier())
-                .add("function", getFunction())
+        return new StringJoiner(",", DamageFunction.class.getSimpleName() + "[", "]")
+                .add("modifier=" +this.getModifier())
+                .add("function=" + this.getFunction())
                 .toString();
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final @Nullable Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (o == null || this.getClass() != o.getClass()) {
             return false;
         }
-        DamageFunction that = (DamageFunction) o;
-        return Objects.equal(this.modifier, that.modifier)
-            && Objects.equal(this.function, that.function);
+        final DamageFunction that = (DamageFunction) o;
+        return Objects.equals(this.modifier, that.modifier)
+            && Objects.equals(this.function, that.function);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.modifier, this.function);
+        return Objects.hash(this.modifier, this.function);
     }
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.event.cause.entity.damage;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -151,8 +149,12 @@ public interface DamageModifier {
          * @return The newly created damage modifier
          */
         public DamageModifier build() {
-            checkState(this.type != null, "The DamageModifierType must not be null!");
-            checkState(this.cause != null, "The cause for the DamageModifier must not be null!");
+            if (this.type == null) {
+                throw new IllegalStateException("The DamageModifierType must not be null!");
+            }
+            if (this.cause == null) {
+                throw new IllegalStateException("The cause for the DamageModifier must not be null!");
+            }
             return new ImplementedDamageModifier(this);
         }
 

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.event.cause.entity.damage;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.base.MoreObjects;
@@ -120,17 +119,17 @@ public interface DamageModifier {
          * @return This builder, for chaining
          */
         public Builder type(DamageModifierType damageModifierType) {
-            this.type = checkNotNull(damageModifierType);
+            this.type = java.util.Objects.requireNonNull(damageModifierType);
             return this;
         }
 
         public Builder item(ItemStack itemStack) {
-            item(checkNotNull(itemStack, "ItemStack").createSnapshot());
+            item(java.util.Objects.requireNonNull(itemStack, "ItemStack").createSnapshot());
             return this;
         }
 
         public Builder item(ItemStackSnapshot snapshot) {
-            this.snapshot = checkNotNull(snapshot, "ItemStackSnapshot");
+            this.snapshot = java.util.Objects.requireNonNull(snapshot, "ItemStackSnapshot");
             return this;
         }
 
@@ -141,7 +140,7 @@ public interface DamageModifier {
          * @return This builder, for chaining
          */
         public Builder cause(Cause cause) {
-            this.cause = checkNotNull(cause);
+            this.cause = java.util.Objects.requireNonNull(cause);
             return this;
         }
 
@@ -179,8 +178,8 @@ public interface DamageModifier {
             @Nullable private final ItemStackSnapshot snapshot;
 
             ImplementedDamageModifier(Builder builder) {
-                this.type = checkNotNull(builder.type, "DamageType is null!");
-                this.cause = checkNotNull(builder.cause, "Cause is null!");
+                this.type = java.util.Objects.requireNonNull(builder.type, "DamageType is null!");
+                this.cause = java.util.Objects.requireNonNull(builder.cause, "Cause is null!");
                 this.snapshot = builder.snapshot;
             }
 

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.event.cause.entity.damage;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.Cause;
@@ -35,7 +33,9 @@ import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.util.CopyableBuilder;
 
+import java.util.Objects;
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.function.DoubleUnaryOperator;
 import java.util.function.Supplier;
 
@@ -105,7 +105,7 @@ public interface DamageModifier {
          * @param damageModifierType The damage modifier type
          * @return This builder, for chaining
          */
-        public Builder type(Supplier<? extends DamageModifierType> damageModifierType) {
+        public Builder type(final Supplier<? extends DamageModifierType> damageModifierType) {
             return this.type(damageModifierType.get());
         }
 
@@ -116,17 +116,17 @@ public interface DamageModifier {
          * @param damageModifierType The damage modifier type
          * @return This builder, for chaining
          */
-        public Builder type(DamageModifierType damageModifierType) {
+        public Builder type(final DamageModifierType damageModifierType) {
             this.type = java.util.Objects.requireNonNull(damageModifierType);
             return this;
         }
 
-        public Builder item(ItemStack itemStack) {
-            item(java.util.Objects.requireNonNull(itemStack, "ItemStack").createSnapshot());
+        public Builder item(final ItemStack itemStack) {
+            this.item(java.util.Objects.requireNonNull(itemStack, "ItemStack").createSnapshot());
             return this;
         }
 
-        public Builder item(ItemStackSnapshot snapshot) {
+        public Builder item(final ItemStackSnapshot snapshot) {
             this.snapshot = java.util.Objects.requireNonNull(snapshot, "ItemStackSnapshot");
             return this;
         }
@@ -137,7 +137,7 @@ public interface DamageModifier {
          * @param cause The cause for the damage modifier
          * @return This builder, for chaining
          */
-        public Builder cause(Cause cause) {
+        public Builder cause(final Cause cause) {
             this.cause = java.util.Objects.requireNonNull(cause);
             return this;
         }
@@ -159,7 +159,7 @@ public interface DamageModifier {
         }
 
         @Override
-        public Builder from(DamageModifier value) {
+        public Builder from(final DamageModifier value) {
             this.type = value.getType();
             this.cause = value.getCause();
             this.snapshot = value.getContributingItem().orElse(null);
@@ -179,7 +179,7 @@ public interface DamageModifier {
             private final Cause cause;
             @Nullable private final ItemStackSnapshot snapshot;
 
-            ImplementedDamageModifier(Builder builder) {
+            ImplementedDamageModifier(final Builder builder) {
                 this.type = java.util.Objects.requireNonNull(builder.type, "DamageType is null!");
                 this.cause = java.util.Objects.requireNonNull(builder.cause, "Cause is null!");
                 this.snapshot = builder.snapshot;
@@ -202,30 +202,30 @@ public interface DamageModifier {
 
             @Override
             public int hashCode() {
-                return Objects.hashCode(this.type, this.cause);
+                return Objects.hash(this.type, this.cause);
             }
 
             @Override
-            public boolean equals(Object obj) {
+            public boolean equals(final Object obj) {
                 if (this == obj) {
                     return true;
                 }
-                if (obj == null || getClass() != obj.getClass()) {
+                if (obj == null || this.getClass() != obj.getClass()) {
                     return false;
                 }
                 final ImplementedDamageModifier other = (ImplementedDamageModifier) obj;
-                return Objects.equal(this.type, other.type)
-                       && Objects.equal(this.cause, other.cause)
-                       && Objects.equal(this.snapshot, other.snapshot);
+                return Objects.equals(this.type, other.type)
+                       && Objects.equals(this.cause, other.cause)
+                       && Objects.equals(this.snapshot, other.snapshot);
             }
 
             @Override
             public String toString() {
-                return MoreObjects.toStringHelper("DamageModifier")
-                        .add("type", this.type)
-                        .add("cause", this.cause)
-                        .add("contributing", this.snapshot)
-                        .toString();
+                return new StringJoiner(", ", "DamageModifier[", "]")
+                    .add("type=" + this.type)
+                    .add("cause=" + this.cause)
+                    .add("snapshot=" + this.snapshot)
+                    .toString();
             }
         }
 

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSource.java
@@ -24,10 +24,10 @@
  */
 package org.spongepowered.api.event.cause.entity.damage.source.common;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.spongepowered.api.event.cause.entity.damage.DamageType;
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
+
+import java.util.Objects;
 
 /**
  * An abstract implementation of {@link DamageSource} to allow plugins to create
@@ -49,7 +49,7 @@ public abstract class AbstractDamageSource implements DamageSource {
     private final double exhaustion;
 
     protected AbstractDamageSource(AbstractDamageSourceBuilder<?, ?> builder) {
-        this.apiDamageType = checkNotNull(builder.damageType, "DamageType cannot be null!");
+        this.apiDamageType = Objects.requireNonNull(builder.damageType, "DamageType cannot be null!");
         this.absolute = builder.absolute;
         this.bypassesArmor = builder.bypasses;
         this.scales = builder.scales;

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSourceBuilder.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSourceBuilder.java
@@ -24,11 +24,11 @@
  */
 package org.spongepowered.api.event.cause.entity.damage.source.common;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.event.cause.entity.damage.DamageType;
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
+
+import java.util.Objects;
 
 @SuppressWarnings("unchecked")
 public abstract class AbstractDamageSourceBuilder<T extends DamageSource, B extends DamageSource.DamageSourceBuilder<T, B>>
@@ -94,7 +94,7 @@ public abstract class AbstractDamageSourceBuilder<T extends DamageSource, B exte
 
     @Override
     public B type(final DamageType damageType) {
-        this.damageType = checkNotNull(damageType, "DamageType cannot be null!");
+        this.damageType = Objects.requireNonNull(damageType, "DamageType cannot be null!");
         return (B) this;
     }
 

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractEntityDamageSource.java
@@ -24,11 +24,11 @@
  */
 package org.spongepowered.api.event.cause.entity.damage.source.common;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.cause.entity.damage.DamageType;
 import org.spongepowered.api.event.cause.entity.damage.source.EntityDamageSource;
+
+import java.util.Objects;
 
 public abstract class AbstractEntityDamageSource implements EntityDamageSource {
 
@@ -43,7 +43,7 @@ public abstract class AbstractEntityDamageSource implements EntityDamageSource {
     private final Entity source;
 
     protected AbstractEntityDamageSource(AbstractEntityDamageSourceBuilder<?, ?> builder) {
-        this.apiDamageType = checkNotNull(builder.damageType, "DamageType cannot be null!");
+        this.apiDamageType = Objects.requireNonNull(builder.damageType, "DamageType cannot be null!");
         this.absolute = builder.absolute;
         this.bypassesArmor = builder.bypasses;
         this.scales = builder.scales;
@@ -57,7 +57,7 @@ public abstract class AbstractEntityDamageSource implements EntityDamageSource {
         } else {
             this.exhaustion = 0.1;
         }
-        this.source = checkNotNull(builder.source, "Entity source cannot be null!");
+        this.source = Objects.requireNonNull(builder.source, "Entity source cannot be null!");
     }
 
     @Override
@@ -115,7 +115,7 @@ public abstract class AbstractEntityDamageSource implements EntityDamageSource {
 
         @Override
         public B entity(Entity entity) {
-            this.source = checkNotNull(entity, "Entity source cannot be null!");
+            this.source = Objects.requireNonNull(entity, "Entity source cannot be null!");
             return (B) this;
         }
 

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSource.java
@@ -24,11 +24,11 @@
  */
 package org.spongepowered.api.event.cause.entity.damage.source.common;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.cause.entity.damage.DamageType;
 import org.spongepowered.api.event.cause.entity.damage.source.IndirectEntityDamageSource;
+
+import java.util.Objects;
 
 public abstract class AbstractIndirectEntityDamageSource implements IndirectEntityDamageSource {
 
@@ -44,7 +44,7 @@ public abstract class AbstractIndirectEntityDamageSource implements IndirectEnti
     private final Entity indirect;
 
     protected AbstractIndirectEntityDamageSource(AbstractIndirectEntityDamageSourceBuilder<?, ?> builder) {
-        this.apiDamageType = checkNotNull(builder.damageType, "DamageType cannot be null!");
+        this.apiDamageType = Objects.requireNonNull(builder.damageType, "DamageType cannot be null!");
         this.absolute = builder.absolute;
         this.bypassesArmor = builder.bypasses;
         this.scales = builder.scales;
@@ -58,8 +58,8 @@ public abstract class AbstractIndirectEntityDamageSource implements IndirectEnti
         } else {
             this.exhaustion = 0.1;
         }
-        this.source = checkNotNull(builder.sourceEntity, "Entity source cannot be null!");
-        this.indirect = checkNotNull(builder.indirect, "Indirect source cannot be null!");
+        this.source = Objects.requireNonNull(builder.sourceEntity, "Entity source cannot be null!");
+        this.indirect = Objects.requireNonNull(builder.indirect, "Indirect source cannot be null!");
     }
 
     @Override
@@ -123,14 +123,14 @@ public abstract class AbstractIndirectEntityDamageSource implements IndirectEnti
 
         @Override
         public B entity(Entity entity) {
-            this.sourceEntity = checkNotNull(entity, "Entity source cannot be null!");
+            this.sourceEntity = Objects.requireNonNull(entity, "Entity source cannot be null!");
             return (B) this;
         }
 
 
         @Override
         public B proxySource(Entity projectile) {
-            this.indirect = checkNotNull(projectile);
+            this.indirect = Objects.requireNonNull(projectile);
             return (B) this;
         }
 

--- a/src/main/java/org/spongepowered/api/event/impl/entity/AbstractAttackEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/entity/AbstractAttackEntityEvent.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.event.impl.entity;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.event.cause.entity.damage.DamageFunction;
@@ -39,6 +38,7 @@ import org.spongepowered.api.util.annotation.eventgen.UseField;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.DoubleUnaryOperator;
 
@@ -84,20 +84,20 @@ public abstract class AbstractAttackEntityEvent extends AbstractModifierEvent<Da
 
     @Override
     public final boolean isModifierApplicable(final DamageModifier damageModifier) {
-        return this.modifiers.containsKey(checkNotNull(damageModifier));
+        return this.modifiers.containsKey(Objects.requireNonNull(damageModifier));
     }
 
     @Override
     public final double getOutputDamage(final DamageModifier damageModifier) {
-        checkArgument(this.modifiers.containsKey(checkNotNull(damageModifier)), "The provided damage modifier is not applicable : "
+        checkArgument(this.modifiers.containsKey(Objects.requireNonNull(damageModifier)), "The provided damage modifier is not applicable : "
                                                                                 + damageModifier.toString());
-        return this.modifiers.get(checkNotNull(damageModifier));
+        return this.modifiers.get(Objects.requireNonNull(damageModifier));
     }
 
     @Override
     public final void setOutputDamage(final DamageModifier damageModifier, final DoubleUnaryOperator function) {
-        checkNotNull(damageModifier, "Damage modifier was null!");
-        checkNotNull(function, "Function was null!");
+        Objects.requireNonNull(damageModifier, "Damage modifier was null!");
+        Objects.requireNonNull(function, "Function was null!");
         int indexToAddTo = 0;
         boolean addAtEnd = true;
         for (final Iterator<DamageFunction> iterator = this.modifierFunctions.iterator(); iterator.hasNext(); ) {
@@ -119,8 +119,8 @@ public abstract class AbstractAttackEntityEvent extends AbstractModifierEvent<Da
 
     @Override
     public void addDamageModifierBefore(final DamageModifier damageModifier, final DoubleUnaryOperator function, final Set<DamageModifierType> before) {
-        checkNotNull(damageModifier, "Damage modifier was null!");
-        checkNotNull(function, "Function was null!");
+        Objects.requireNonNull(damageModifier, "Damage modifier was null!");
+        Objects.requireNonNull(function, "Function was null!");
         int indexToAddBefore = -1;
         int index = 0;
         for (final ModifierFunction<DamageModifier> tuple : this.modifierFunctions) {
@@ -141,8 +141,8 @@ public abstract class AbstractAttackEntityEvent extends AbstractModifierEvent<Da
 
     @Override
     public void addDamageModifierAfter(final DamageModifier damageModifier, final DoubleUnaryOperator function, final Set<DamageModifierType> after) {
-        checkNotNull(damageModifier, "Damage modifier was null!");
-        checkNotNull(function, "Function was null!");
+        Objects.requireNonNull(damageModifier, "Damage modifier was null!");
+        Objects.requireNonNull(function, "Function was null!");
         int indexToAddAfter = -1;
         int index = 0;
         for (final ModifierFunction<DamageModifier> tuple : this.modifierFunctions) {

--- a/src/main/java/org/spongepowered/api/event/impl/entity/AbstractAttackEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/entity/AbstractAttackEntityEvent.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.event.impl.entity;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.event.cause.entity.damage.DamageFunction;
 import org.spongepowered.api.event.cause.entity.damage.DamageModifier;
@@ -57,7 +55,7 @@ public abstract class AbstractAttackEntityEvent extends AbstractModifierEvent<Da
 
     @Override
     public final double getOriginalModifierDamage(final DamageModifier damageModifier) {
-        checkArgument(damageModifier != null, "The damage modifier cannot be null!");
+        Objects.requireNonNull(damageModifier, "Damage modifier cannot be null!");
         for (final Tuple<DamageModifier, Double> tuple : this.originalModifiers) {
             if (tuple.getFirst().equals(damageModifier)) {
                 return tuple.getSecond();
@@ -89,8 +87,9 @@ public abstract class AbstractAttackEntityEvent extends AbstractModifierEvent<Da
 
     @Override
     public final double getOutputDamage(final DamageModifier damageModifier) {
-        checkArgument(this.modifiers.containsKey(Objects.requireNonNull(damageModifier)), "The provided damage modifier is not applicable : "
-                                                                                + damageModifier.toString());
+        if (!this.modifiers.containsKey(Objects.requireNonNull(damageModifier, "Damage Modifier cannot be null!"))) {
+            throw new IllegalArgumentException("The provided damage modifier is not applicable: " + damageModifier.toString());
+        }
         return this.modifiers.get(Objects.requireNonNull(damageModifier));
     }
 
@@ -124,7 +123,9 @@ public abstract class AbstractAttackEntityEvent extends AbstractModifierEvent<Da
         int indexToAddBefore = -1;
         int index = 0;
         for (final ModifierFunction<DamageModifier> tuple : this.modifierFunctions) {
-            checkArgument(!tuple.getModifier().equals(damageModifier), "Cannot add a duplicate modifier!");
+            if (tuple.getModifier().equals(damageModifier)) {
+                throw new IllegalArgumentException("Cannot add a duplicate modifier");
+            }
             if (before.contains(tuple.getModifier().getType())) {
                 indexToAddBefore = index;
             }
@@ -146,7 +147,9 @@ public abstract class AbstractAttackEntityEvent extends AbstractModifierEvent<Da
         int indexToAddAfter = -1;
         int index = 0;
         for (final ModifierFunction<DamageModifier> tuple : this.modifierFunctions) {
-            checkArgument(!tuple.getModifier().equals(damageModifier), "Cannot add a duplicate modifier!");
+            if (tuple.getModifier().equals(damageModifier)) {
+                throw new IllegalArgumentException("Cannot add a duplicate modifier");
+            }
             if (after.contains(tuple.getModifier().getType())) {
                 indexToAddAfter = index;
             }

--- a/src/main/java/org/spongepowered/api/event/impl/entity/AbstractDamageEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/entity/AbstractDamageEntityEvent.java
@@ -25,14 +25,13 @@
 package org.spongepowered.api.event.impl.entity;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.data.Keys;
-import org.spongepowered.api.event.cause.entity.damage.ModifierFunction;
 import org.spongepowered.api.event.cause.entity.damage.DamageFunction;
 import org.spongepowered.api.event.cause.entity.damage.DamageModifier;
 import org.spongepowered.api.event.cause.entity.damage.DamageModifierType;
+import org.spongepowered.api.event.cause.entity.damage.ModifierFunction;
 import org.spongepowered.api.event.entity.DamageEntityEvent;
 import org.spongepowered.api.util.Tuple;
 import org.spongepowered.api.util.annotation.eventgen.UseField;
@@ -40,6 +39,7 @@ import org.spongepowered.api.util.annotation.eventgen.UseField;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.DoubleUnaryOperator;
@@ -85,20 +85,20 @@ public abstract class AbstractDamageEntityEvent extends AbstractModifierEvent<Da
 
     @Override
     public final boolean isModifierApplicable(DamageModifier damageModifier) {
-        return this.modifiers.containsKey(checkNotNull(damageModifier));
+        return this.modifiers.containsKey(Objects.requireNonNull(damageModifier));
     }
 
     @Override
     public final double getDamage(DamageModifier damageModifier) {
-        checkArgument(this.modifiers.containsKey(checkNotNull(damageModifier)), "The provided damage modifier is not applicable : "
+        checkArgument(this.modifiers.containsKey(Objects.requireNonNull(damageModifier)), "The provided damage modifier is not applicable : "
                                                                                 + damageModifier.toString());
-        return this.modifiers.get(checkNotNull(damageModifier));
+        return this.modifiers.get(Objects.requireNonNull(damageModifier));
     }
 
     @Override
     public final void setDamage(DamageModifier damageModifier, DoubleUnaryOperator function) {
-        checkNotNull(damageModifier, "Damage modifier was null!");
-        checkNotNull(function, "Function was null!");
+        Objects.requireNonNull(damageModifier, "Damage modifier was null!");
+        Objects.requireNonNull(function, "Function was null!");
         int indexToAddTo = 0;
         boolean addAtEnd = true;
         for (Iterator<DamageFunction> iterator = this.modifierFunctions.iterator(); iterator.hasNext(); ) {
@@ -120,8 +120,8 @@ public abstract class AbstractDamageEntityEvent extends AbstractModifierEvent<Da
 
     @Override
     public void addDamageModifierBefore(DamageModifier damageModifier, DoubleUnaryOperator function, Set<DamageModifierType> before) {
-        checkNotNull(damageModifier, "Damage modifier was null!");
-        checkNotNull(function, "Function was null!");
+        Objects.requireNonNull(damageModifier, "Damage modifier was null!");
+        Objects.requireNonNull(function, "Function was null!");
         int indexToAddBefore = -1;
         int index = 0;
         for (ModifierFunction<DamageModifier> tuple : this.modifierFunctions) {
@@ -142,8 +142,8 @@ public abstract class AbstractDamageEntityEvent extends AbstractModifierEvent<Da
 
     @Override
     public void addModifierAfter(DamageModifier damageModifier, DoubleUnaryOperator function, Set<DamageModifierType> after) {
-        checkNotNull(damageModifier, "Damage modifier was null!");
-        checkNotNull(function, "Function was null!");
+        Objects.requireNonNull(damageModifier, "Damage modifier was null!");
+        Objects.requireNonNull(function, "Function was null!");
         int indexToAddAfter = -1;
         int index = 0;
         for (ModifierFunction<DamageModifier> tuple : this.modifierFunctions) {

--- a/src/main/java/org/spongepowered/api/event/impl/entity/AbstractDamageEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/entity/AbstractDamageEntityEvent.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.event.impl.entity;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.data.Keys;
 import org.spongepowered.api.event.cause.entity.damage.DamageFunction;
@@ -58,7 +56,7 @@ public abstract class AbstractDamageEntityEvent extends AbstractModifierEvent<Da
 
     @Override
     public final double getOriginalModifierDamage(DamageModifier damageModifier) {
-        checkArgument(damageModifier != null, "The damage modifier cannot be null!");
+        Objects.requireNonNull(damageModifier, "The damage modifier cannot be null!");
         for (Tuple<DamageModifier, Double> tuple : this.originalModifiers) {
             if (tuple.getFirst().equals(damageModifier)) {
                 return tuple.getSecond();
@@ -90,8 +88,9 @@ public abstract class AbstractDamageEntityEvent extends AbstractModifierEvent<Da
 
     @Override
     public final double getDamage(DamageModifier damageModifier) {
-        checkArgument(this.modifiers.containsKey(Objects.requireNonNull(damageModifier)), "The provided damage modifier is not applicable : "
-                                                                                + damageModifier.toString());
+        if (!this.modifiers.containsKey(Objects.requireNonNull(damageModifier, "Damage Modifier cannot be null!"))) {
+            throw new IllegalArgumentException("The provided damage modifier is not applicable: " + damageModifier.toString());
+        }
         return this.modifiers.get(Objects.requireNonNull(damageModifier));
     }
 
@@ -125,7 +124,9 @@ public abstract class AbstractDamageEntityEvent extends AbstractModifierEvent<Da
         int indexToAddBefore = -1;
         int index = 0;
         for (ModifierFunction<DamageModifier> tuple : this.modifierFunctions) {
-            checkArgument(!tuple.getModifier().equals(damageModifier), "Cannot add a duplicate modifier!");
+            if (tuple.getModifier().equals(damageModifier)) {
+                throw new IllegalArgumentException("Cannot add a duplicate modifier");
+            }
             if (before.contains(tuple.getModifier().getType())) {
                 indexToAddBefore = index;
             }
@@ -147,7 +148,9 @@ public abstract class AbstractDamageEntityEvent extends AbstractModifierEvent<Da
         int indexToAddAfter = -1;
         int index = 0;
         for (ModifierFunction<DamageModifier> tuple : this.modifierFunctions) {
-            checkArgument(!tuple.getModifier().equals(damageModifier), "Cannot add a duplicate modifier!");
+            if (tuple.getModifier().equals(damageModifier)) {
+                throw new IllegalArgumentException("Cannot add a duplicate modifier");
+            }
             if (after.contains(tuple.getModifier().getType())) {
                 indexToAddAfter = index;
             }

--- a/src/main/java/org/spongepowered/api/event/impl/entity/AbstractModifierEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/entity/AbstractModifierEvent.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.event.impl.entity;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -38,6 +36,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.DoubleUnaryOperator;
 
 /**
@@ -60,7 +59,7 @@ public abstract class AbstractModifierEvent<T extends ModifierFunction<M>, M> ex
         double finalDamage = originalValue;
         for (T tuple : originalFunctions) {
             this.modifierFunctions.add(this.convertTuple(tuple.getModifier(), tuple.getFunction()));
-            double tempDamage = checkNotNull(tuple.getFunction().applyAsDouble(finalDamage));
+            double tempDamage = Objects.requireNonNull(tuple.getFunction().applyAsDouble(finalDamage));
             finalDamage += tempDamage;
             modifierMapBuilder.add(new Tuple<>(tuple.getModifier(), tempDamage));
             mapBuilder.put(tuple.getModifier(), tempDamage);
@@ -79,7 +78,7 @@ public abstract class AbstractModifierEvent<T extends ModifierFunction<M>, M> ex
         double tempAmount = baseAmount;
         this.modifiers.clear();
         for (T entry : this.modifierFunctions) {
-            double modifierAmount = checkNotNull(entry.getFunction().applyAsDouble(tempAmount));
+            double modifierAmount = Objects.requireNonNull(entry.getFunction().applyAsDouble(tempAmount));
             if (this.modifiers.containsKey(entry.getModifier())) {
                 double oldAmount = this.modifiers.get(entry.getModifier());
                 double difference = oldAmount - modifierAmount;
@@ -98,7 +97,7 @@ public abstract class AbstractModifierEvent<T extends ModifierFunction<M>, M> ex
     protected double getFinalAmount(double baseAmount) {
         double damage = baseAmount;
         for (T entry : this.modifierFunctions) {
-            damage += checkNotNull(entry.getFunction().applyAsDouble(damage));
+            damage += Objects.requireNonNull(entry.getFunction().applyAsDouble(damage));
         }
         return damage;
     }

--- a/src/main/java/org/spongepowered/api/event/impl/entity/AbstractSpawnEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/entity/AbstractSpawnEntityEvent.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.event.impl.entity;
 
-import com.google.common.base.Preconditions;
 import org.spongepowered.api.event.EventContextKeys;
 import org.spongepowered.api.event.entity.SpawnEntityEvent;
 import org.spongepowered.api.event.impl.AbstractEvent;
@@ -33,6 +32,8 @@ public abstract class AbstractSpawnEntityEvent extends AbstractEvent implements 
 
     @Override
     protected void init() {
-        Preconditions.checkState(getContext().containsKey(EventContextKeys.SPAWN_TYPE), "SpawnType not set for SpawnEvent as required per contract!");
+        if (!this.getContext().containsKey(EventContextKeys.SPAWN_TYPE)) {
+            throw new IllegalStateException("SpawnType not set for SpawnEvent! Please use StackFrame.addContext(EventContextKeys.SPAWN_TYPE, SpawnTypes.<your spawn type here>); before constructing a SpawnEvent.");
+        }
     }
 }

--- a/src/main/java/org/spongepowered/api/event/impl/entity/ai/goal/AbstractGoalEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/entity/ai/goal/AbstractGoalEvent.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.event.impl.entity.ai.goal;
 
-import com.google.common.base.Preconditions;
 import org.spongepowered.api.event.entity.ai.goal.GoalEvent;
 import org.spongepowered.api.event.impl.AbstractEvent;
 
@@ -32,7 +31,8 @@ public abstract class AbstractGoalEvent extends AbstractEvent implements GoalEve
 
     @Override
     public void init() {
-        Preconditions.checkArgument(this.getGoal().getOwner() == this.getAgent(),
-                String.format("The target entity '%s' is not the owner of the goal '%s'!", this.getAgent(), this.getGoal()));
+        if (this.getGoal().getOwner() != this.getAgent()) {
+            throw new IllegalArgumentException(String.format("The target entity '%s' is not the owner of the goal '%s'!", this.getAgent(), this.getGoal()));
+        }
     }
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.item.inventory;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockSnapshot;
@@ -43,10 +42,10 @@ import org.spongepowered.api.entity.attribute.type.AttributeType;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.equipment.EquipmentType;
-import org.spongepowered.api.item.inventory.equipment.EquipmentTypes;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -353,7 +352,7 @@ public interface ItemStack extends SerializableDataHolder.Mutable {
          * @return This builder, for chaining
          */
         default Builder fromBlockState(BlockState blockState) {
-            checkNotNull(blockState);
+            Objects.requireNonNull(blockState);
             final BlockType blockType = blockState.getType();
             checkArgument(blockType.getItem().isPresent(), "Missing valid ItemType for BlockType: " + blockType.getKey().toString());
             itemType(blockType.getItem().get());
@@ -369,7 +368,7 @@ public interface ItemStack extends SerializableDataHolder.Mutable {
          * @return This builder, for chaining
          */
         default Builder fromBlockState(Supplier<? extends BlockState> blockState) {
-            checkNotNull(blockState);
+            Objects.requireNonNull(blockState);
             final BlockType blockType = blockState.get().getType();
             checkArgument(blockType.getItem().isPresent(), "Missing valid ItemType for BlockType: " + blockType.getKey().toString());
             itemType(blockType.getItem().get());

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.item.inventory;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.BlockState;
@@ -354,8 +352,7 @@ public interface ItemStack extends SerializableDataHolder.Mutable {
         default Builder fromBlockState(BlockState blockState) {
             Objects.requireNonNull(blockState);
             final BlockType blockType = blockState.getType();
-            checkArgument(blockType.getItem().isPresent(), "Missing valid ItemType for BlockType: " + blockType.getKey().toString());
-            itemType(blockType.getItem().get());
+            itemType(blockType.getItem().orElseThrow(() -> new IllegalArgumentException("Missing valid ItemType for BlockType: " + blockType.getKey().toString())));
             blockState.getValues().forEach(this::add);
             return this;
         }
@@ -370,8 +367,7 @@ public interface ItemStack extends SerializableDataHolder.Mutable {
         default Builder fromBlockState(Supplier<? extends BlockState> blockState) {
             Objects.requireNonNull(blockState);
             final BlockType blockType = blockState.get().getType();
-            checkArgument(blockType.getItem().isPresent(), "Missing valid ItemType for BlockType: " + blockType.getKey().toString());
-            itemType(blockType.getItem().get());
+            itemType(blockType.getItem().orElseThrow(() -> new IllegalArgumentException("Missing valid ItemType for BlockType: " + blockType.getKey().toString())));
             blockState.get().getValues().forEach(this::add);
             return this;
         }

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackBuilderPopulators.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackBuilderPopulators.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.item.inventory;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static org.spongepowered.api.util.weighted.VariableAmount.baseWithRandomAddition;
 import static org.spongepowered.api.util.weighted.VariableAmount.fixed;
 
@@ -256,7 +255,9 @@ public final class ItemStackBuilderPopulators {
         Objects.requireNonNull(key, "Key cannot be null!");
         Objects.requireNonNull(elementPool, "Element pool cannot be null!");
         Objects.requireNonNull(amount, "VariableAmount cannot be null!");
-        checkArgument(!elementPool.isEmpty(), "Element pool cannot be empty!");
+        if (elementPool.isEmpty()) {
+            throw new IllegalArgumentException("Element pool cannot be empty!");
+        }
         WeightedTable<E> elementTable = new WeightedTable<>(amount);
         for (E element : elementPool) {
             elementTable.add(Objects.requireNonNull(element, "Element cannot be null!"), 1);
@@ -398,7 +399,9 @@ public final class ItemStackBuilderPopulators {
         Objects.requireNonNull(key, "Key cannot be null!");
         Objects.requireNonNull(elementPool, "Element pool cannot be null!");
         Objects.requireNonNull(amount, "VariableAmount cannot be null!");
-        checkArgument(!elementPool.isEmpty());
+        if (elementPool.isEmpty()) {
+            throw new IllegalArgumentException("Element pool cannot be empty!");
+        }
         WeightedTable<E> elementTable = new WeightedTable<>(amount);
         for (E element : elementPool) {
             elementTable.add(element, 1);
@@ -420,7 +423,9 @@ public final class ItemStackBuilderPopulators {
     public static <E> BiConsumer<ItemStack.Builder, Random> setValues(Key<? extends SetValue.Mutable<E>> key, WeightedTable<E> weightedTable) {
         Objects.requireNonNull(weightedTable, "WeightedTable cannot be null!");
         Objects.requireNonNull(key, "Key cannot be null!");
-        checkArgument(!weightedTable.isEmpty(), "WeightedTable cannot be empty!");
+        if (weightedTable.isEmpty()) {
+            throw new IllegalArgumentException("WeightedTable cannot be empty!");
+        }
         return setValue(key, random -> ImmutableSet.copyOf(weightedTable.get(random)));
     }
 

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackBuilderPopulators.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackBuilderPopulators.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.item.inventory;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.spongepowered.api.util.weighted.VariableAmount.baseWithRandomAddition;
 import static org.spongepowered.api.util.weighted.VariableAmount.fixed;
 
@@ -47,6 +46,7 @@ import org.spongepowered.api.util.weighted.WeightedTable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -73,7 +73,7 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static BiConsumer<ItemStack.Builder, Random> itemStack(ItemStackSnapshot snapshot) {
-        checkNotNull(snapshot, "ItemStackSnapshot cannot be null!");
+        Objects.requireNonNull(snapshot, "ItemStackSnapshot cannot be null!");
         return (builder, random) -> builder.fromSnapshot(snapshot);
     }
 
@@ -87,11 +87,11 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static BiConsumer<ItemStack.Builder, Random> itemStacks(ItemStackSnapshot snapshot, ItemStackSnapshot... snapshots) {
-        checkNotNull(snapshot, "ItemStackSnapshot cannot be null!");
+        Objects.requireNonNull(snapshot, "ItemStackSnapshot cannot be null!");
         final WeightedTable<ItemStackSnapshot> table = new WeightedTable<>(1);
         table.add(snapshot, 1);
         for (ItemStackSnapshot stackSnapshot : snapshots) {
-            table.add(checkNotNull(stackSnapshot, "ItemStackSnapshot cannot be null!"), 1);
+            table.add(Objects.requireNonNull(stackSnapshot, "ItemStackSnapshot cannot be null!"), 1);
         }
         return (builder, random) -> builder.fromSnapshot(table.get(random).get(0));
     }
@@ -104,7 +104,7 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static BiConsumer<ItemStack.Builder, Random> item(ItemType itemType) {
-        checkNotNull(itemType, "ItemType cannot be null!");
+        Objects.requireNonNull(itemType, "ItemType cannot be null!");
         return (builder, random) -> builder.itemType(itemType);
     }
 
@@ -121,8 +121,8 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static BiConsumer<ItemStack.Builder, Random> item(Supplier<? extends ItemType> supplier) {
-        checkNotNull(supplier, "Supplier cannot be null!");
-        return (builder, random) -> builder.itemType(checkNotNull(supplier.get(), "Supplier returned a null ItemType"));
+        Objects.requireNonNull(supplier, "Supplier cannot be null!");
+        return (builder, random) -> builder.itemType(Objects.requireNonNull(supplier.get(), "Supplier returned a null ItemType"));
     }
 
     /**
@@ -164,7 +164,7 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static BiConsumer<ItemStack.Builder, Random> quantity(VariableAmount amount) {
-        checkNotNull(amount, "VariableAmount cannot be null!");
+        Objects.requireNonNull(amount, "VariableAmount cannot be null!");
         return (builder, random) -> builder.quantity(amount.getFlooredAmount(random));
     }
 
@@ -181,7 +181,7 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static BiConsumer<ItemStack.Builder, Random> quantity(Supplier<VariableAmount> supplier) {
-        checkNotNull(supplier, "Supplier cannot be null!");
+        Objects.requireNonNull(supplier, "Supplier cannot be null!");
         return (builder, random) -> builder.quantity(supplier.get().getFlooredAmount(random));
     }
 
@@ -222,11 +222,11 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static <E> BiConsumer<ItemStack.Builder, Random> keyValues(Key<? extends Value<E>> key, Iterable<E> values) {
-        checkNotNull(values, "Iterable cannot be null!");
-        checkNotNull(key, "Key cannot be null!");
+        Objects.requireNonNull(values, "Iterable cannot be null!");
+        Objects.requireNonNull(key, "Key cannot be null!");
         WeightedTable<E> tableEntries = new WeightedTable<>(1);
         for (E e : values) {
-            tableEntries.add(checkNotNull(e, "Value cannot be null!"), 1);
+            tableEntries.add(Objects.requireNonNull(e, "Value cannot be null!"), 1);
         }
         return (builder, random) -> {
             final ItemStack itemStack = builder.build();
@@ -253,13 +253,13 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static <E> BiConsumer<ItemStack.Builder, Random> listValues(Key<? extends ListValue.Mutable<E>> key, List<E> elementPool, VariableAmount amount) {
-        checkNotNull(key, "Key cannot be null!");
-        checkNotNull(elementPool, "Element pool cannot be null!");
-        checkNotNull(amount, "VariableAmount cannot be null!");
+        Objects.requireNonNull(key, "Key cannot be null!");
+        Objects.requireNonNull(elementPool, "Element pool cannot be null!");
+        Objects.requireNonNull(amount, "VariableAmount cannot be null!");
         checkArgument(!elementPool.isEmpty(), "Element pool cannot be empty!");
         WeightedTable<E> elementTable = new WeightedTable<>(amount);
         for (E element : elementPool) {
-            elementTable.add(checkNotNull(element, "Element cannot be null!"), 1);
+            elementTable.add(Objects.requireNonNull(element, "Element cannot be null!"), 1);
         }
         return listValues(key, elementTable);
     }
@@ -300,8 +300,8 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static <E> BiConsumer<ItemStack.Builder, Random> listValues(Key<? extends ListValue.Mutable<E>> key, WeightedTable<E> weightedTable) {
-        checkNotNull(weightedTable, "Weighted table cannot be null!");
-        checkNotNull(key, "Key cannot be null!");
+        Objects.requireNonNull(weightedTable, "Weighted table cannot be null!");
+        Objects.requireNonNull(key, "Key cannot be null!");
         return setValue(key, random -> ImmutableList.copyOf(weightedTable.get(random)));
 
     }
@@ -329,8 +329,8 @@ public final class ItemStackBuilderPopulators {
      */
     public static <E> BiConsumer<ItemStack.Builder, Random> listValueSuppliers(Key<? extends ListValue<E>> key,
             WeightedTable<Function<Random, E>> weightedTable) {
-        checkNotNull(key, "Key cannot be null!");
-        checkNotNull(weightedTable, "WeightedTable cannot be null!");
+        Objects.requireNonNull(key, "Key cannot be null!");
+        Objects.requireNonNull(weightedTable, "WeightedTable cannot be null!");
         return (builder, random) -> {
             final ItemStack itemStack = builder.build();
             final List<Function<Random, E>> suppliers = weightedTable.get(random);
@@ -346,8 +346,8 @@ public final class ItemStackBuilderPopulators {
 
     public static <E> BiConsumer<ItemStack.Builder, Random> listValueSuppliers(Supplier<? extends Key<? extends ListValue<E>>> key,
                                                                                WeightedTable<Function<Random, E>> weightedTable) {
-        checkNotNull(key, "Key cannot be null!");
-        checkNotNull(weightedTable, "WeightedTable cannot be null!");
+        Objects.requireNonNull(key, "Key cannot be null!");
+        Objects.requireNonNull(weightedTable, "WeightedTable cannot be null!");
         return (builder, random) -> {
             final ItemStack itemStack = builder.build();
             final List<Function<Random, E>> suppliers = weightedTable.get(random);
@@ -376,8 +376,8 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static <E> BiConsumer<ItemStack.Builder, Random> setValues(Key<? extends SetValue.Mutable<E>> key, Set<E> elementPool) {
-        checkNotNull(key, "Key cannot be null!");
-        checkNotNull(elementPool, "ElementPool cannot be null!");
+        Objects.requireNonNull(key, "Key cannot be null!");
+        Objects.requireNonNull(elementPool, "ElementPool cannot be null!");
         return setValues(key, elementPool, baseWithRandomAddition(1, elementPool.size() - 1));
     }
 
@@ -395,9 +395,9 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static <E> BiConsumer<ItemStack.Builder, Random> setValues(Key<? extends SetValue.Mutable<E>> key, Set<E> elementPool, VariableAmount amount) {
-        checkNotNull(key, "Key cannot be null!");
-        checkNotNull(elementPool, "Element pool cannot be null!");
-        checkNotNull(amount, "VariableAmount cannot be null!");
+        Objects.requireNonNull(key, "Key cannot be null!");
+        Objects.requireNonNull(elementPool, "Element pool cannot be null!");
+        Objects.requireNonNull(amount, "VariableAmount cannot be null!");
         checkArgument(!elementPool.isEmpty());
         WeightedTable<E> elementTable = new WeightedTable<>(amount);
         for (E element : elementPool) {
@@ -418,8 +418,8 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static <E> BiConsumer<ItemStack.Builder, Random> setValues(Key<? extends SetValue.Mutable<E>> key, WeightedTable<E> weightedTable) {
-        checkNotNull(weightedTable, "WeightedTable cannot be null!");
-        checkNotNull(key, "Key cannot be null!");
+        Objects.requireNonNull(weightedTable, "WeightedTable cannot be null!");
+        Objects.requireNonNull(key, "Key cannot be null!");
         checkArgument(!weightedTable.isEmpty(), "WeightedTable cannot be empty!");
         return setValue(key, random -> ImmutableSet.copyOf(weightedTable.get(random)));
     }
@@ -466,7 +466,7 @@ public final class ItemStackBuilderPopulators {
     public static <E, V extends Value<E>> BiConsumer<ItemStack.Builder, Random> values(Iterable<V> values) {
         WeightedTable<V> tableEntries = new WeightedTable<>(1);
         for (V value : values) {
-            tableEntries.add(checkNotNull(value, "Value cannot be null!"), 1);
+            tableEntries.add(Objects.requireNonNull(value, "Value cannot be null!"), 1);
         }
         return ((builder, random) -> {
             final V value = tableEntries.get(random).get(0);
@@ -489,8 +489,8 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static BiConsumer<ItemStack.Builder, Random> values(Collection<Value.Immutable<?>> manipulators, VariableAmount rolls) {
-        checkNotNull(manipulators, "Manipulators cannot be null!");
-        checkNotNull(rolls, "VariableAmount cannot be null!");
+        Objects.requireNonNull(manipulators, "Manipulators cannot be null!");
+        Objects.requireNonNull(rolls, "VariableAmount cannot be null!");
         final ImmutableList<Value.Immutable<?>> copied = ImmutableList.copyOf(manipulators);
         final WeightedTable<Value.Immutable<?>> table = new WeightedTable<>();
         table.setRolls(rolls);
@@ -508,7 +508,7 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static BiConsumer<ItemStack.Builder, Random> values(WeightedTable<Value.Immutable<?>> weightedTable) {
-        checkNotNull(weightedTable, "WeightedTable cannot be null!");
+        Objects.requireNonNull(weightedTable, "WeightedTable cannot be null!");
         return (builder, random) -> weightedTable.get(random).forEach(builder::add);
     }
 
@@ -534,8 +534,8 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static BiConsumer<ItemStack.Builder, Random> enchantment(VariableAmount level, EnchantmentType enchantmentType) {
-        checkNotNull(level, "VariableAmount cannot be null!");
-        checkNotNull(enchantmentType, "EnchantmentType cannot be null!");
+        Objects.requireNonNull(level, "VariableAmount cannot be null!");
+        Objects.requireNonNull(enchantmentType, "EnchantmentType cannot be null!");
         return enchantments(fixed(1), ImmutableList.of(new Tuple<>(enchantmentType, level)));
     }
 
@@ -579,11 +579,11 @@ public final class ItemStackBuilderPopulators {
      */
     public static BiConsumer<ItemStack.Builder, Random> enchantmentsWithVanillaLevelVariance(VariableAmount amount,
             Collection<EnchantmentType> itemEnchantmentTypes) {
-        checkNotNull(amount, "Variable amount cannot be null!");
-        checkNotNull(itemEnchantmentTypes, "EnchantmentType collection cannot be null!");
+        Objects.requireNonNull(amount, "Variable amount cannot be null!");
+        Objects.requireNonNull(itemEnchantmentTypes, "EnchantmentType collection cannot be null!");
         List<Tuple<EnchantmentType, VariableAmount>> list = itemEnchantmentTypes.stream()
                 .map(enchantment -> {
-                    checkNotNull(enchantment, "EnchantmentType cannot be null!");
+                    Objects.requireNonNull(enchantment, "EnchantmentType cannot be null!");
                     final int minimum = enchantment.getMinimumLevel();
                     final int maximum = enchantment.getMaximumLevel();
                     return new Tuple<>(enchantment, baseWithRandomAddition(minimum, maximum - minimum));
@@ -605,7 +605,7 @@ public final class ItemStackBuilderPopulators {
      */
     public static BiConsumer<ItemStack.Builder, Random> enchantments(VariableAmount amount,
             Collection<Tuple<EnchantmentType, VariableAmount>> enchantments) {
-        checkNotNull(amount, "VariableAmount cannot be null!");
+        Objects.requireNonNull(amount, "VariableAmount cannot be null!");
         final WeightedTable<Function<Random, Enchantment>> suppliers = new WeightedTable<>(amount);
         for (Tuple<EnchantmentType, VariableAmount> enchantment : enchantments) {
             suppliers.add(random ->

--- a/src/main/java/org/spongepowered/api/item/inventory/transaction/SlotTransaction.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/transaction/SlotTransaction.java
@@ -24,12 +24,12 @@
  */
 package org.spongepowered.api.item.inventory.transaction;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.Slot;
+
+import java.util.Objects;
 
 public class SlotTransaction extends Transaction<ItemStackSnapshot> {
     
@@ -46,7 +46,7 @@ public class SlotTransaction extends Transaction<ItemStackSnapshot> {
      */
     public SlotTransaction(Slot slot, ItemStackSnapshot original, ItemStackSnapshot defaultReplacement) {
         super(original, defaultReplacement);
-        this.slot = checkNotNull(slot, "Slot cannot be null!");
+        this.slot = Objects.requireNonNull(slot, "Slot cannot be null!");
     }
 
     /**
@@ -56,7 +56,7 @@ public class SlotTransaction extends Transaction<ItemStackSnapshot> {
      * @param stack The stack
      */
     public void setCustom(ItemStack stack) {
-        setCustom(checkNotNull(stack, "ItemStack was null").createSnapshot());
+        setCustom(Objects.requireNonNull(stack, "ItemStack was null").createSnapshot());
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/item/merchant/VillagerRegistry.java
+++ b/src/main/java/org/spongepowered/api/item/merchant/VillagerRegistry.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.item.merchant;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import org.spongepowered.api.data.type.ProfessionType;
@@ -33,6 +31,7 @@ import org.spongepowered.api.data.type.ProfessionType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 
 public interface VillagerRegistry {
@@ -56,7 +55,10 @@ public interface VillagerRegistry {
      * @return The collection of trade offer mutators, if available
      */
     default Collection<TradeOfferListMutator> getMutatorsForProfession(ProfessionType profession, int level) {
-        final Multimap<Integer, TradeOfferListMutator> map = getTradeOfferLevelMap(checkNotNull(profession, "Profession cannot be null!"));
+        final Multimap<Integer, TradeOfferListMutator> map = getTradeOfferLevelMap(Objects.requireNonNull(
+            profession,
+            "Profession cannot be null!"
+        ));
         final Collection<TradeOfferListMutator> mutators = map.get(level);
         return ImmutableList.copyOf(mutators);
     }
@@ -126,7 +128,7 @@ public interface VillagerRegistry {
      * @return The generated list of trade offers
      */
     default Collection<TradeOffer> generateTradeOffers(Merchant merchant, ProfessionType profession, int level, Random random) {
-        checkNotNull(random, "Random cannot be null!");
+        Objects.requireNonNull(random, "Random cannot be null!");
         List<TradeOffer> generatedList = new ArrayList<>();
         this.getMutatorsForProfession(profession, level)
                 .forEach(mutator -> mutator.accept(merchant, generatedList, random));

--- a/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingResult.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingResult.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.item.recipe.cooking;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
@@ -50,7 +49,7 @@ public final class CookingResult {
      */
     @SuppressWarnings("ConstantConditions")
     public CookingResult(ItemStackSnapshot result, double experience) {
-        checkNotNull(result, "result");
+        Objects.requireNonNull(result, "result");
         checkArgument(!result.isEmpty(), "The result must not be empty.");
         checkArgument(experience >= 0, "The experience must be non-negative.");
 

--- a/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingResult.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingResult.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.item.recipe.cooking;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.base.MoreObjects;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 
@@ -50,8 +48,12 @@ public final class CookingResult {
     @SuppressWarnings("ConstantConditions")
     public CookingResult(ItemStackSnapshot result, double experience) {
         Objects.requireNonNull(result, "result");
-        checkArgument(!result.isEmpty(), "The result must not be empty.");
-        checkArgument(experience >= 0, "The experience must be non-negative.");
+        if (result.isEmpty()) {
+            throw new IllegalArgumentException("The resulting snapshot must not be empty");
+        }
+        if (experience < 0) {
+            throw new IllegalArgumentException("The experience must be non-negative.");
+        }
 
         this.result = result;
         this.experience = experience;

--- a/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingResult.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingResult.java
@@ -24,10 +24,10 @@
  */
 package org.spongepowered.api.item.recipe.cooking;
 
-import com.google.common.base.MoreObjects;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 
 import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * The result of fulfilling a {@link CookingRecipe}.
@@ -46,7 +46,7 @@ public final class CookingResult {
      * @param experience The experience that should be created from this result
      */
     @SuppressWarnings("ConstantConditions")
-    public CookingResult(ItemStackSnapshot result, double experience) {
+    public CookingResult(final ItemStackSnapshot result, final double experience) {
         Objects.requireNonNull(result, "result");
         if (result.isEmpty()) {
             throw new IllegalArgumentException("The resulting snapshot must not be empty");
@@ -85,14 +85,14 @@ public final class CookingResult {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) {
             return true;
         }
         if (!(o instanceof CookingResult)) {
             return false;
         }
-        CookingResult that = (CookingResult) o;
+        final CookingResult that = (CookingResult) o;
         return Double.compare(that.experience, this.experience) == 0 && Objects.equals(this.result, that.result);
     }
 
@@ -103,9 +103,9 @@ public final class CookingResult {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("result", this.result)
-                .add("experience", this.experience)
-                .toString();
+        return new StringJoiner(", ", CookingResult.class.getSimpleName() + "[", "]")
+            .add("result=" + this.result)
+            .add("experience=" + this.experience)
+            .toString();
     }
 }

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeResult.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeResult.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.item.recipe.crafting;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
@@ -55,10 +53,14 @@ public final class RecipeResult {
     @SuppressWarnings("ConstantConditions")
     public RecipeResult(ItemStackSnapshot result, List<ItemStackSnapshot> remainingItems) {
         Objects.requireNonNull(result, "result");
-        checkArgument(!result.isEmpty(), "The result must not be empty.");
+        if (result.isEmpty()) {
+            throw new IllegalArgumentException("The result must not be empty!");
+        }
         Objects.requireNonNull(remainingItems, "remainingItems");
-        checkArgument(!remainingItems.isEmpty(), "The remainingItems list must not be empty."
+        if (remainingItems.isEmpty()) {
+            throw new IllegalArgumentException("The remainingItems list must not be empty."
                 + " It should contain empty ItemStackSnapshot values for slots which should be cleared.");
+        }
 
         this.result = result;
         this.remainingItems = ImmutableList.copyOf(remainingItems);

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeResult.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeResult.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.item.recipe.crafting;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
@@ -33,6 +32,7 @@ import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.crafting.CraftingGridInventory;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The result of fulfilling a {@link CraftingRecipe}.
@@ -54,9 +54,9 @@ public final class RecipeResult {
      */
     @SuppressWarnings("ConstantConditions")
     public RecipeResult(ItemStackSnapshot result, List<ItemStackSnapshot> remainingItems) {
-        checkNotNull(result, "result");
+        Objects.requireNonNull(result, "result");
         checkArgument(!result.isEmpty(), "The result must not be empty.");
-        checkNotNull(remainingItems, "remainingItems");
+        Objects.requireNonNull(remainingItems, "remainingItems");
         checkArgument(!remainingItems.isEmpty(), "The remainingItems list must not be empty."
                 + " It should contain empty ItemStackSnapshot values for slots which should be cleared.");
 

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeResult.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeResult.java
@@ -24,13 +24,13 @@
  */
 package org.spongepowered.api.item.recipe.crafting;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.crafting.CraftingGridInventory;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * The result of fulfilling a {@link CraftingRecipe}.
@@ -118,10 +118,9 @@ public final class RecipeResult {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("result", this.result)
-                .add("remainingItems", this.remainingItems)
-                .toString();
+        return new StringJoiner(", ", RecipeResult.class.getSimpleName() + "[", "]")
+            .add("result=" + this.result)
+            .add("remainingItems=" + this.remainingItems)
+            .toString();
     }
-
 }

--- a/src/main/java/org/spongepowered/api/profile/GameProfile.java
+++ b/src/main/java/org/spongepowered/api/profile/GameProfile.java
@@ -33,6 +33,7 @@ import org.spongepowered.api.user.UserManager;
 import org.spongepowered.api.util.Identifiable;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
@@ -54,7 +55,7 @@ public interface GameProfile extends Identifiable, Identity, DataSerializable {
      * @return The created profile
      */
     static GameProfile of(final UUID uniqueId) {
-        return of(uniqueId, null);
+        return GameProfile.of(uniqueId, null);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/service/ban/Ban.java
+++ b/src/main/java/org/spongepowered/api/service/ban/Ban.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.service.ban;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.Sponge;
@@ -34,6 +32,7 @@ import org.spongepowered.api.util.CopyableBuilder;
 
 import java.net.InetAddress;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -189,7 +188,7 @@ public interface Ban {
          * @return This builder
          */
         default Builder type(Supplier<? extends BanType> type) {
-            return this.type(checkNotNull(type.get()));
+            return this.type(Objects.requireNonNull(type.get()));
         }
 
         /**

--- a/src/main/java/org/spongepowered/api/service/context/Context.java
+++ b/src/main/java/org/spongepowered/api/service/context/Context.java
@@ -24,11 +24,10 @@
  */
 package org.spongepowered.api.service.context;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.collect.Maps;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Encapsulates a single attribute about the state or circumstances of a
@@ -69,8 +68,8 @@ public final class Context implements Map.Entry<String, String> {
      * @param value Context value. Must not be null.
      */
     public Context(String key, String value) {
-        checkNotNull(key, "key");
-        checkNotNull(value, "value");
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(value, "value");
         this.wrapped = Maps.immutableEntry(key, value);
     }
 

--- a/src/main/java/org/spongepowered/api/service/pagination/PaginationList.java
+++ b/src/main/java/org/spongepowered/api/service/pagination/PaginationList.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.service.pagination;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -33,6 +31,7 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.util.CopyableBuilder;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -146,7 +145,7 @@ public interface PaginationList {
      * @param page The page to send
      */
     default void sendTo(final Iterable<Audience> receivers, final int page) {
-        checkNotNull(receivers, "The iterable of receivers cannot be null!");
+        Objects.requireNonNull(receivers, "The iterable of receivers cannot be null!");
         for (final Audience receiver : receivers) {
             this.sendTo(receiver, page);
         }
@@ -262,7 +261,7 @@ public interface PaginationList {
          * @return The constructed pagination list
          */
         default PaginationList sendTo(final Iterable<Audience> receivers) {
-            checkNotNull(receivers, "The iterable of receivers cannot be null!");
+            Objects.requireNonNull(receivers, "The iterable of receivers cannot be null!");
             final PaginationList list = this.build();
             for (final Audience r : receivers) {
                 list.sendTo(r);

--- a/src/main/java/org/spongepowered/api/service/permission/MemorySubjectData.java
+++ b/src/main/java/org/spongepowered/api/service/permission/MemorySubjectData.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.service.permission;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -39,6 +37,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
@@ -66,7 +65,7 @@ public class MemorySubjectData implements SubjectData {
      * @param subject The subject this data belongs to
      */
     public MemorySubjectData(Subject subject) {
-        this.subject = checkNotNull(subject, "subject");
+        this.subject = Objects.requireNonNull(subject, "subject");
     }
 
     /**
@@ -105,21 +104,21 @@ public class MemorySubjectData implements SubjectData {
      * @return The node tree
      */
     public NodeTree getNodeTree(Set<Context> contexts) {
-        NodeTree perms = this.permissions.get(checkNotNull(contexts, "contexts"));
+        NodeTree perms = this.permissions.get(Objects.requireNonNull(contexts, "contexts"));
         return perms == null ? NodeTree.of(ImmutableMap.of()) : perms;
     }
 
     @Override
     public Map<String, Boolean> getPermissions(Set<Context> contexts) {
-        NodeTree perms = this.permissions.get(checkNotNull(contexts, "contexts"));
+        NodeTree perms = this.permissions.get(Objects.requireNonNull(contexts, "contexts"));
         return perms == null ? ImmutableMap.of() : perms.asMap();
     }
 
     @Override
     public CompletableFuture<Boolean> setPermission(Set<Context> contexts, String permission, Tristate value) {
-        checkNotNull(contexts, "contexts");
-        checkNotNull(permission, "permission");
-        checkNotNull(value, "value");
+        Objects.requireNonNull(contexts, "contexts");
+        Objects.requireNonNull(permission, "permission");
+        Objects.requireNonNull(value, "value");
         contexts = ImmutableSet.copyOf(contexts);
         while (true) {
             NodeTree oldTree = this.permissions.get(contexts);
@@ -153,7 +152,7 @@ public class MemorySubjectData implements SubjectData {
 
     @Override
     public CompletableFuture<Boolean> clearPermissions(Set<Context> context) {
-        boolean ret = this.permissions.remove(checkNotNull(context, "context")) != null;
+        boolean ret = this.permissions.remove(Objects.requireNonNull(context, "context")) != null;
         if (ret) {
             onUpdate();
         }
@@ -167,13 +166,13 @@ public class MemorySubjectData implements SubjectData {
 
     @Override
     public List<SubjectReference> getParents(Set<Context> contexts) {
-        return this.parents.getOrDefault(checkNotNull(contexts, "contexts"), ImmutableList.of());
+        return this.parents.getOrDefault(Objects.requireNonNull(contexts, "contexts"), ImmutableList.of());
     }
 
     @Override
     public CompletableFuture<Boolean> addParent(Set<Context> contexts, SubjectReference parent) {
-        checkNotNull(contexts, "contexts");
-        checkNotNull(parent, "parent");
+        Objects.requireNonNull(contexts, "contexts");
+        Objects.requireNonNull(parent, "parent");
         contexts = ImmutableSet.copyOf(contexts);
         while (true) {
             List<SubjectReference> oldParents = this.parents.get(contexts);
@@ -203,8 +202,8 @@ public class MemorySubjectData implements SubjectData {
 
     @Override
     public CompletableFuture<Boolean> removeParent(Set<Context> contexts, SubjectReference parent) {
-        checkNotNull(contexts, "contexts");
-        checkNotNull(parent, "parent");
+        Objects.requireNonNull(contexts, "contexts");
+        Objects.requireNonNull(parent, "parent");
         contexts = ImmutableSet.copyOf(contexts);
         while (true) {
             List<SubjectReference> oldParents = this.parents.get(contexts);
@@ -234,7 +233,7 @@ public class MemorySubjectData implements SubjectData {
 
     @Override
     public CompletableFuture<Boolean> clearParents(Set<Context> contexts) {
-        boolean ret = this.parents.remove(checkNotNull(contexts, "contexts")) != null;
+        boolean ret = this.parents.remove(Objects.requireNonNull(contexts, "contexts")) != null;
         if (ret) {
             onUpdate();
         }
@@ -248,13 +247,13 @@ public class MemorySubjectData implements SubjectData {
 
     @Override
     public Map<String, String> getOptions(Set<Context> contexts) {
-        return this.options.getOrDefault(checkNotNull(contexts, "contexts"), ImmutableMap.of());
+        return this.options.getOrDefault(Objects.requireNonNull(contexts, "contexts"), ImmutableMap.of());
     }
 
     @Override
     public CompletableFuture<Boolean> setOption(Set<Context> contexts, String key, @Nullable String value) {
-        checkNotNull(contexts, "contexts");
-        checkNotNull(key, "key");
+        Objects.requireNonNull(contexts, "contexts");
+        Objects.requireNonNull(key, "key");
         Map<String, String> origMap = this.options.get(contexts);
         Map<String, String> newMap;
 
@@ -297,7 +296,7 @@ public class MemorySubjectData implements SubjectData {
 
     @Override
     public CompletableFuture<Boolean> clearOptions(Set<Context> contexts) {
-        boolean ret = this.options.remove(checkNotNull(contexts, "contexts")) != null;
+        boolean ret = this.options.remove(Objects.requireNonNull(contexts, "contexts")) != null;
         if (ret) {
             onUpdate();
         }

--- a/src/main/java/org/spongepowered/api/service/permission/SubjectCollection.java
+++ b/src/main/java/org/spongepowered/api/service/permission/SubjectCollection.java
@@ -24,11 +24,11 @@
  */
 package org.spongepowered.api.service.permission;
 
-import com.google.common.base.Preconditions;
 import org.spongepowered.api.service.context.Context;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -196,7 +196,7 @@ public interface SubjectCollection {
      * @return A future which will complete when the operation has finished
      */
     default CompletableFuture<Void> applyToAll(Consumer<Subject> action) {
-        Preconditions.checkNotNull(action, "action");
+        Objects.requireNonNull(action, "action");
         return CompletableFuture.runAsync(() -> {
             Set<String> identifiers = getAllIdentifiers().join();
             applyToAll(action, identifiers).join();
@@ -222,8 +222,8 @@ public interface SubjectCollection {
      * @return A future which will complete when the operation has finished
      */
     default CompletableFuture<Void> applyToAll(Consumer<Subject> action, Set<String> identifiers) {
-        Preconditions.checkNotNull(action, "action");
-        Preconditions.checkNotNull(identifiers, "identifiers");
+        Objects.requireNonNull(action, "action");
+        Objects.requireNonNull(identifiers, "identifiers");
         return CompletableFuture.runAsync(() -> {
             for (String id : identifiers) {
                 Subject subject = loadSubject(id).join();

--- a/src/main/java/org/spongepowered/api/util/AABB.java
+++ b/src/main/java/org/spongepowered/api/util/AABB.java
@@ -25,12 +25,12 @@
 package org.spongepowered.api.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.math.vector.Vector3d;
 import org.spongepowered.math.vector.Vector3i;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -58,7 +58,7 @@ public class AABB {
      * @param secondCorner The second corner
      */
     public AABB(Vector3i firstCorner, Vector3i secondCorner) {
-        this(checkNotNull(firstCorner, "firstCorner").toDouble(), checkNotNull(secondCorner, "secondCorner").toDouble());
+        this(Objects.requireNonNull(firstCorner, "firstCorner").toDouble(), Objects.requireNonNull(secondCorner, "secondCorner").toDouble());
     }
 
     /**
@@ -84,8 +84,8 @@ public class AABB {
      * @param secondCorner The second corner
      */
     public AABB(Vector3d firstCorner, Vector3d secondCorner) {
-        checkNotNull(firstCorner, "firstCorner");
-        checkNotNull(secondCorner, "secondCorner");
+        Objects.requireNonNull(firstCorner, "firstCorner");
+        Objects.requireNonNull(secondCorner, "secondCorner");
         this.min = firstCorner.min(secondCorner);
         this.max = firstCorner.max(secondCorner);
         checkArgument(this.min.getX() != this.max.getX(), "The box is degenerate on x");
@@ -142,7 +142,7 @@ public class AABB {
      * @return Whether or not the box contains the point
      */
     public boolean contains(Vector3i point) {
-        checkNotNull(point, "point");
+        Objects.requireNonNull(point, "point");
         return contains(point.getX(), point.getY(), point.getZ());
     }
 
@@ -153,7 +153,7 @@ public class AABB {
      * @return Whether or not the box contains the point
      */
     public boolean contains(Vector3d point) {
-        checkNotNull(point, "point");
+        Objects.requireNonNull(point, "point");
         return contains(point.getX(), point.getY(), point.getZ());
     }
 
@@ -178,7 +178,7 @@ public class AABB {
      * @return Whether this bounding box intersects with the other
      */
     public boolean intersects(AABB other) {
-        checkNotNull(other, "other");
+        Objects.requireNonNull(other, "other");
         return this.max.getX() >= other.getMin().getX() && other.getMax().getX() >= this.min.getX()
                && this.max.getY() >= other.getMin().getY() && other.getMax().getY() >= this.min.getY()
                && this.max.getZ() >= other.getMin().getZ() && other.getMax().getZ() >= this.min.getZ();
@@ -193,8 +193,8 @@ public class AABB {
      * @return An intersection point its normal, if any
      */
     public Optional<Tuple<Vector3d, Vector3d>> intersects(Vector3d start, Vector3d direction) {
-        checkNotNull(start, "start");
-        checkNotNull(direction, "direction");
+        Objects.requireNonNull(start, "start");
+        Objects.requireNonNull(direction, "direction");
         // Adapted from: https://github.com/flow/react/blob/develop/src/main/java/com/flowpowered/react/collision/RayCaster.java#L156
         // The box is interpreted as 6 infinite perpendicular places, one for each face (being expanded infinitely)
         // "t" variables are multipliers: start + direction * t gives the intersection point
@@ -341,7 +341,7 @@ public class AABB {
      * @return The new offset box
      */
     public AABB offset(Vector3i offset) {
-        checkNotNull(offset, "offset");
+        Objects.requireNonNull(offset, "offset");
         return offset(offset.getX(), offset.getY(), offset.getZ());
     }
 
@@ -352,7 +352,7 @@ public class AABB {
      * @return The new offset box
      */
     public AABB offset(Vector3d offset) {
-        checkNotNull(offset, "offset");
+        Objects.requireNonNull(offset, "offset");
         return offset(offset.getX(), offset.getY(), offset.getZ());
     }
 
@@ -377,7 +377,7 @@ public class AABB {
      * @return The new expanded box
      */
     public AABB expand(Vector3i amount) {
-        checkNotNull(amount, "amount");
+        Objects.requireNonNull(amount, "amount");
         return expand(amount.getX(), amount.getY(), amount.getZ());
     }
 
@@ -390,7 +390,7 @@ public class AABB {
      * @return The new expanded box
      */
     public AABB expand(Vector3d amount) {
-        checkNotNull(amount, "amount");
+        Objects.requireNonNull(amount, "amount");
         return expand(amount.getX(), amount.getY(), amount.getZ());
     }
 

--- a/src/main/java/org/spongepowered/api/util/AABB.java
+++ b/src/main/java/org/spongepowered/api/util/AABB.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.util;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.math.vector.Vector3d;
 import org.spongepowered.math.vector.Vector3i;
@@ -88,9 +86,15 @@ public class AABB {
         Objects.requireNonNull(secondCorner, "secondCorner");
         this.min = firstCorner.min(secondCorner);
         this.max = firstCorner.max(secondCorner);
-        checkArgument(this.min.getX() != this.max.getX(), "The box is degenerate on x");
-        checkArgument(this.min.getY() != this.max.getY(), "The box is degenerate on y");
-        checkArgument(this.min.getZ() != this.max.getZ(), "The box is degenerate on z");
+        if (this.min.getX() == this.max.getX()) {
+            throw new IllegalArgumentException("The box is generate on x!");
+        }
+        if (this.min.getY() == this.max.getY()) {
+            throw new IllegalArgumentException("The box is generate on y!");
+        }
+        if (this.min.getZ() == this.max.getZ()) {
+            throw new IllegalArgumentException("The box is generate on z!");
+        }
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/util/BlockReaderAwareMatcher.java
+++ b/src/main/java/org/spongepowered/api/util/BlockReaderAwareMatcher.java
@@ -24,13 +24,13 @@
  */
 package org.spongepowered.api.util;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.world.volume.game.PrimitiveGameVolume;
 import org.spongepowered.math.vector.Vector3i;
+
+import java.util.Objects;
 
 public interface BlockReaderAwareMatcher<T> {
 
@@ -41,7 +41,7 @@ public interface BlockReaderAwareMatcher<T> {
     }
 
     static BlockReaderAwareMatcher<BlockState> forBlock(BlockType type) {
-        checkNotNull(type, "BlockType cannot be null");
+        Objects.requireNonNull(type, "BlockType cannot be null");
         return (state, volume, position) -> state != null && state.getType() == type;
     }
 

--- a/src/main/java/org/spongepowered/api/util/Coerce.java
+++ b/src/main/java/org/spongepowered/api/util/Coerce.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.util;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Booleans;
 import com.google.common.primitives.Bytes;
@@ -49,6 +47,7 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -171,7 +170,7 @@ public final class Coerce {
      */
     @SuppressWarnings("unchecked")
     public static <T> List<T> toListOf(@Nullable Object obj, Class<T> ofClass) {
-        checkNotNull(ofClass, "ofClass");
+        Objects.requireNonNull(ofClass, "ofClass");
         List<T> filteredList = Lists.newArrayList();
 
         for (Object o : Coerce.toList(obj)) {
@@ -588,8 +587,8 @@ public final class Coerce {
      * @return Coerced enum value
      */
     public static <E extends Enum<E>> E toEnum(@Nullable Object obj, Class<E> enumClass, E defaultValue) {
-        checkNotNull(enumClass, "enumClass");
-        checkNotNull(defaultValue, "defaultValue");
+        Objects.requireNonNull(enumClass, "enumClass");
+        Objects.requireNonNull(defaultValue, "defaultValue");
         if (obj == null) {
             return defaultValue;
         }
@@ -631,9 +630,9 @@ public final class Coerce {
      * @return Coerced value or default if coercion fails
      */
     public static <T> T toPseudoEnum(@Nullable Object obj, Class<T> pseudoEnumClass, Class<?> dictionaryClass, T defaultValue) {
-        checkNotNull(pseudoEnumClass, "pseudoEnumClass");
-        checkNotNull(dictionaryClass, "dictionaryClass");
-        checkNotNull(defaultValue, "defaultValue");
+        Objects.requireNonNull(pseudoEnumClass, "pseudoEnumClass");
+        Objects.requireNonNull(dictionaryClass, "dictionaryClass");
+        Objects.requireNonNull(defaultValue, "defaultValue");
         if (obj == null) {
             return defaultValue;
         }

--- a/src/main/java/org/spongepowered/api/util/Color.java
+++ b/src/main/java/org/spongepowered/api/util/Color.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.util;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import net.kyori.adventure.util.RGBLike;
 import org.checkerframework.common.value.qual.IntRange;
 import org.spongepowered.api.data.persistence.DataContainer;
@@ -174,7 +172,9 @@ public final class Color implements DataSerializable, RGBLike {
      */
     public static Color mixColors(Color... colors) {
         Objects.requireNonNull(colors, "No null colors allowed!");
-        checkArgument(colors.length > 0, "Cannot have an empty color array!");
+        if (colors.length <= 0) {
+            throw new IllegalArgumentException("Cannot have an empty color array!");
+        }
         if (colors.length == 1) {
             return colors[0];
         }

--- a/src/main/java/org/spongepowered/api/util/DiscreteTransform2.java
+++ b/src/main/java/org/spongepowered/api/util/DiscreteTransform2.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.util;
 
-import com.google.common.base.Preconditions;
 import org.spongepowered.math.GenericMath;
 import org.spongepowered.math.imaginary.Complexd;
 import org.spongepowered.math.matrix.Matrix3d;
@@ -223,8 +222,12 @@ public class DiscreteTransform2 {
      * @return The scaled transform as a copy
      */
     public DiscreteTransform2 withScale(int x, int y) {
-        Preconditions.checkArgument(x != 0, "x == 0");
-        Preconditions.checkArgument(y != 0, "y == 0");
+        if (x == 0) {
+            throw new IllegalArgumentException("x == 0");
+        }
+        if (y == 0) {
+            throw new IllegalArgumentException("y == 0");
+        }
         return new DiscreteTransform2(this.matrix.scale(x, y, 1));
     }
 
@@ -370,8 +373,12 @@ public class DiscreteTransform2 {
      * @return The new scale transform
      */
     public static DiscreteTransform2 fromScale(int x, int y) {
-        Preconditions.checkArgument(x != 0, "x == 0");
-        Preconditions.checkArgument(y != 0, "y == 0");
+        if (x == 0) {
+            throw new IllegalArgumentException("x == 0");
+        }
+        if (y == 0) {
+            throw new IllegalArgumentException("y == 0");
+        }
         return new DiscreteTransform2(Matrix3d.createScaling(x, y, 1));
     }
 
@@ -448,13 +455,19 @@ public class DiscreteTransform2 {
      * @return The new rotation transform
      */
     public static DiscreteTransform2 rotationAroundCenter(int quarterTurns, Vector2i size) {
-        Preconditions.checkArgument(size.getX() > 0, "The size on x must be positive");
-        Preconditions.checkArgument(size.getY() > 0, "The size on y must be positive");
+        if (size.getX() <= 0) {
+            throw new IllegalArgumentException("The size on x must be positive");
+        }
+        if (size.getY() <= 0) {
+            throw new IllegalArgumentException("The size on y must be positive");
+        }
         final boolean mul180 = (quarterTurns & 1) == 0;
         final boolean xEven = (size.getX() & 1) == 0;
         final boolean yEven = (size.getY() & 1) == 0;
-        Preconditions.checkArgument(mul180 || xEven == yEven, "The size must have the same parity on all axes for rotations that are "
-            + "not a multiple of 180 degrees");
+        if (!mul180 || xEven != yEven) {
+            throw new IllegalArgumentException("The size must have the same parity on all axes for rotations that are "
+                + "not a multiple of 180 degrees");
+        }
         final Vector2i center = size.sub(1, 1).div(2);
         if (mul180) {
             return fromRotation(quarterTurns, center, xEven, yEven);

--- a/src/main/java/org/spongepowered/api/util/DiscreteTransform3.java
+++ b/src/main/java/org/spongepowered/api/util/DiscreteTransform3.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.util;
 
-import com.google.common.base.Preconditions;
 import org.spongepowered.math.GenericMath;
 import org.spongepowered.math.imaginary.Quaterniond;
 import org.spongepowered.math.matrix.Matrix3d;
@@ -267,9 +266,15 @@ public class DiscreteTransform3 {
      * @return The scaled transform as a copy
      */
     public DiscreteTransform3 withScale(int x, int y, int z) {
-        Preconditions.checkArgument(x != 0, "x == 0");
-        Preconditions.checkArgument(y != 0, "y == 0");
-        Preconditions.checkArgument(z != 0, "z == 0");
+        if (x == 0) {
+            throw new IllegalArgumentException("x == 0");
+        }
+        if (y == 0) {
+            throw new IllegalArgumentException("y == 0");
+        }
+        if (z == 0) {
+            throw new IllegalArgumentException("z == 0");
+        }
         return new DiscreteTransform3(this.matrix.scale(x, y, z, 1));
     }
 
@@ -430,9 +435,15 @@ public class DiscreteTransform3 {
      * @return The new scale transform
      */
     public static DiscreteTransform3 fromScale(int x, int y, int z) {
-        Preconditions.checkArgument(x != 0, "x == 0");
-        Preconditions.checkArgument(y != 0, "y == 0");
-        Preconditions.checkArgument(z != 0, "z == 0");
+        if (x == 0) {
+            throw new IllegalArgumentException("x == 0");
+        }
+        if (y == 0) {
+            throw new IllegalArgumentException("y == 0");
+        }
+        if (z == 0) {
+            throw new IllegalArgumentException("z == 0");
+        }
         return new DiscreteTransform3(Matrix4d.createScaling(x, y, z, 1));
     }
 
@@ -521,9 +532,15 @@ public class DiscreteTransform3 {
      * @return The new rotation transform
      */
     public static DiscreteTransform3 rotationAroundCenter(int quarterTurns, Axis axis, Vector3i size) {
-        Preconditions.checkArgument(size.getX() > 0, "The size on x must be positive");
-        Preconditions.checkArgument(size.getY() > 0, "The size on y must be positive");
-        Preconditions.checkArgument(size.getZ() > 0, "The size on z must be positive");
+        if (size.getX() <= 0) {
+            throw new IllegalArgumentException("The size on x must be positive!");
+        }
+        if (size.getY() <= 0) {
+            throw new IllegalArgumentException("The size on y must be positive");
+        }
+        if (size.getZ() <= 0) {
+            throw new IllegalArgumentException("The size on z must be positive!");
+        }
         final Matrix4d rotation3;
         switch (axis) {
             case X: {

--- a/src/main/java/org/spongepowered/api/util/RespawnLocation.java
+++ b/src/main/java/org/spongepowered/api/util/RespawnLocation.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.util;
 
-import com.google.common.base.Preconditions;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
@@ -63,8 +62,8 @@ public final class RespawnLocation implements DataSerializable {
     private final boolean forced;
 
     RespawnLocation(Builder builder) {
-        this.world = Preconditions.checkNotNull(builder.world);
-        this.position = Preconditions.checkNotNull(builder.position);
+        this.world = Objects.requireNonNull(builder.world);
+        this.position = Objects.requireNonNull(builder.position);
         this.forced = builder.forced;
     }
 
@@ -176,7 +175,7 @@ public final class RespawnLocation implements DataSerializable {
          * @return This builder, for chaining
          */
         public Builder world(final ServerWorld world) {
-            return world(Preconditions.checkNotNull(world).getKey());
+            return world(Objects.requireNonNull(world).getKey());
         }
 
         /**
@@ -186,7 +185,7 @@ public final class RespawnLocation implements DataSerializable {
          * @return This builder, for chaining
          */
         public Builder world(final ResourceKey key) {
-            this.world = Preconditions.checkNotNull(key);
+            this.world = Objects.requireNonNull(key);
             return this;
         }
 
@@ -198,7 +197,7 @@ public final class RespawnLocation implements DataSerializable {
          * @return This builder, for chaining
          */
         public Builder location(final ServerLocation location) {
-            Preconditions.checkNotNull(location);
+            Objects.requireNonNull(location);
             final ServerWorld world = location.getWorld();
             this.position(location.getPosition());
             this.world(world);
@@ -212,7 +211,7 @@ public final class RespawnLocation implements DataSerializable {
          * @return This builder, for chaining
          */
         public Builder position(final Vector3d position) {
-            this.position = Preconditions.checkNotNull(position);
+            this.position = Objects.requireNonNull(position);
             return this;
         }
 
@@ -254,7 +253,7 @@ public final class RespawnLocation implements DataSerializable {
 
         @Override
         public Builder from(final RespawnLocation value) {
-            Preconditions.checkNotNull(value);
+            Objects.requireNonNull(value);
 
             this.world = value.world;
             this.position = value.getPosition();
@@ -268,8 +267,8 @@ public final class RespawnLocation implements DataSerializable {
          * @return The new respawn location
          */
         public RespawnLocation build() {
-            Preconditions.checkNotNull(this.world);
-            Preconditions.checkNotNull(this.position);
+            Objects.requireNonNull(this.world);
+            Objects.requireNonNull(this.position);
 
             return new RespawnLocation(this);
         }

--- a/src/main/java/org/spongepowered/api/util/Tuple.java
+++ b/src/main/java/org/spongepowered/api/util/Tuple.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.util;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
@@ -61,8 +59,8 @@ public class Tuple<K, V> {
      * @param second The second object
      */
     public Tuple(K first, V second) {
-        this.first = checkNotNull(first);
-        this.second = checkNotNull(second);
+        this.first = java.util.Objects.requireNonNull(first);
+        this.second = java.util.Objects.requireNonNull(second);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/util/Tuple.java
+++ b/src/main/java/org/spongepowered/api/util/Tuple.java
@@ -24,8 +24,10 @@
  */
 package org.spongepowered.api.util;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * A tuple of objects.
@@ -45,7 +47,7 @@ public class Tuple<K, V> {
      * @param <V> The type of second object
      * @return The new Tuple
      */
-    public static <K, V> Tuple<K, V> of(K first, V second) {
+    public static <K, V> Tuple<K, V> of(final K first, final V second) {
         return new Tuple<>(first, second);
     }
 
@@ -58,9 +60,9 @@ public class Tuple<K, V> {
      * @param first The first object
      * @param second The second object
      */
-    public Tuple(K first, V second) {
-        this.first = java.util.Objects.requireNonNull(first);
-        this.second = java.util.Objects.requireNonNull(second);
+    public Tuple(final K first, final V second) {
+        this.first = Objects.requireNonNull(first);
+        this.second = Objects.requireNonNull(second);
     }
 
     /**
@@ -83,28 +85,28 @@ public class Tuple<K, V> {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("first", this.first)
-            .add("second", this.second)
+        return new StringJoiner(", ", Tuple.class.getSimpleName() + "[", "]")
+            .add("first=" + this.first)
+            .add("second=" + this.second)
             .toString();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.first, this.second);
+        return Objects.hash(this.first, this.second);
     }
 
     @SuppressWarnings("rawtypes")
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(final @Nullable Object obj) {
         if (this == obj) {
             return true;
         }
-        if (obj == null || getClass() != obj.getClass()) {
+        if (obj == null || this.getClass() != obj.getClass()) {
             return false;
         }
         final Tuple other = (Tuple) obj;
-        return Objects.equal(this.first, other.first)
-                && Objects.equal(this.second, other.second);
+        return Objects.equals(this.first, other.first)
+                && Objects.equals(this.second, other.second);
     }
 }

--- a/src/main/java/org/spongepowered/api/util/file/CopyFileVisitor.java
+++ b/src/main/java/org/spongepowered/api/util/file/CopyFileVisitor.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.util.file;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.IOException;
@@ -36,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Objects;
 
 /**
  * Represents a {@link FileVisitor} which will create a copy of a directory
@@ -61,8 +60,8 @@ public final class CopyFileVisitor extends SimpleFileVisitor<Path> {
      * @param options Optional options for the copy operations
      */
     public CopyFileVisitor(Path target, CopyOption... options) {
-        this.target = checkNotNull(target, "target");
-        this.options = checkNotNull(options, "options");
+        this.target = Objects.requireNonNull(target, "target");
+        this.options = Objects.requireNonNull(options, "options");
     }
 
     private void copy(Path source, Path dest) throws IOException {

--- a/src/main/java/org/spongepowered/api/util/file/ForwardingFileVisitor.java
+++ b/src/main/java/org/spongepowered/api/util/file/ForwardingFileVisitor.java
@@ -24,19 +24,18 @@
  */
 package org.spongepowered.api.util.file;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Objects;
 
 public abstract class ForwardingFileVisitor<T> implements FileVisitor<T> {
 
     private final FileVisitor<T> visitor;
 
     protected ForwardingFileVisitor(FileVisitor<T> visitor) {
-        this.visitor = checkNotNull(visitor, "visitor");
+        this.visitor = Objects.requireNonNull(visitor, "visitor");
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/util/weighted/EmptyObject.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/EmptyObject.java
@@ -24,10 +24,11 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import com.google.common.base.MoreObjects;
 import org.spongepowered.api.data.persistence.DataContainer;
 import org.spongepowered.api.data.persistence.DataSerializable;
 import org.spongepowered.api.data.persistence.Queries;
+
+import java.util.StringJoiner;
 
 /**
  * Represents an entry in a table which has no associated object. Used to have
@@ -54,8 +55,8 @@ public class EmptyObject<T> extends TableEntry<T> implements DataSerializable {
     @Override
     public DataContainer toContainer() {
         return DataContainer.createNew()
-                .set(Queries.CONTENT_VERSION, getContentVersion())
-                .set(Queries.WEIGHTED_SERIALIZABLE_WEIGHT, getWeight());
+                .set(Queries.CONTENT_VERSION, this.getContentVersion())
+                .set(Queries.WEIGHTED_SERIALIZABLE_WEIGHT, this.getWeight());
     }
 
     @Override
@@ -67,19 +68,21 @@ public class EmptyObject<T> extends TableEntry<T> implements DataSerializable {
             return false;
         }
         EmptyObject<?> c = (EmptyObject<?>) o;
-        return getWeight() == c.getWeight();
+        return this.getWeight() == c.getWeight();
     }
 
     @Override
     public int hashCode() {
         int r = 1;
-        long w = Double.doubleToLongBits(getWeight());
+        long w = Double.doubleToLongBits(this.getWeight());
         r = r * 37 + (int) (w ^ (w >>> 32));
         return r;
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("weight", getWeight()).toString();
+        return new StringJoiner(", ", EmptyObject.class.getSimpleName() + "[", "]")
+            .add("weight=" + this.getWeight())
+            .toString();
     }
 }

--- a/src/main/java/org/spongepowered/api/util/weighted/LootTable.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/LootTable.java
@@ -24,14 +24,13 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 
 /**
@@ -57,7 +56,7 @@ public class LootTable<T> {
      * @param table The new table
      */
     public void addTable(RandomObjectTable<T> table) {
-        this.pool.add(checkNotNull(table));
+        this.pool.add(Objects.requireNonNull(table));
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/util/weighted/LootTable.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/LootTable.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -32,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
+import java.util.StringJoiner;
 
 /**
  * Represents a pool of tables which are rolled sequentially when retrieving
@@ -41,7 +41,7 @@ import java.util.Random;
  */
 public class LootTable<T> {
 
-    private List<RandomObjectTable<T>> pool = new ArrayList<>();
+    private final List<RandomObjectTable<T>> pool = new ArrayList<>();
 
     /**
      * Creates a new {@link LootTable}.
@@ -55,7 +55,7 @@ public class LootTable<T> {
      * 
      * @param table The new table
      */
-    public void addTable(RandomObjectTable<T> table) {
+    public void addTable(final RandomObjectTable<T> table) {
         this.pool.add(Objects.requireNonNull(table));
     }
 
@@ -64,7 +64,7 @@ public class LootTable<T> {
      * 
      * @param other The other loot table
      */
-    public void addAll(LootTable<T> other) {
+    public void addAll(final LootTable<T> other) {
         this.pool.addAll(other.pool);
     }
 
@@ -74,7 +74,7 @@ public class LootTable<T> {
      * @param table The table to remove
      * @return If the pool contained the table
      */
-    public boolean removeTable(RandomObjectTable<T> table) {
+    public boolean removeTable(final RandomObjectTable<T> table) {
         return this.pool.remove(table);
     }
     
@@ -100,23 +100,23 @@ public class LootTable<T> {
      * @param rand The random object to use
      * @return The retrieved entries
      */
-    public List<T> get(Random rand) {
-        List<T> results = Lists.newArrayList();
-        for (RandomObjectTable<T> pool : this.pool) {
+    public List<T> get(final Random rand) {
+        final List<T> results = Lists.newArrayList();
+        for (final RandomObjectTable<T> pool : this.pool) {
             results.addAll(pool.get(rand));
         }
         return results;
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (o == this) {
             return true;
         }
         if (!(o instanceof LootTable)) {
             return false;
         }
-        LootTable<?> c = (LootTable<?>) o;
+        final LootTable<?> c = (LootTable<?>) o;
         if (this.pool.size() != c.pool.size()) {
             return false;
         }
@@ -131,7 +131,7 @@ public class LootTable<T> {
     @Override
     public int hashCode() {
         int r = 1;
-        for (RandomObjectTable<T> table : this.pool) {
+        for (final RandomObjectTable<T> table : this.pool) {
             r = r * 37 + table.hashCode();
         }
         return r;
@@ -139,7 +139,8 @@ public class LootTable<T> {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("pool", this.pool).toString();
+        return new StringJoiner(", ", LootTable.class.getSimpleName() + "[", "]")
+            .add("pool=" + this.pool)
+            .toString();
     }
-
 }

--- a/src/main/java/org/spongepowered/api/util/weighted/NestedTableEntry.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/NestedTableEntry.java
@@ -24,11 +24,10 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.base.MoreObjects;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 
 /**
@@ -50,7 +49,7 @@ public class NestedTableEntry<T> extends TableEntry<T> {
      */
     public NestedTableEntry(double weight, RandomObjectTable<T> table) {
         super(weight);
-        this.table = checkNotNull(table);
+        this.table = Objects.requireNonNull(table);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/util/weighted/NestedTableEntry.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/NestedTableEntry.java
@@ -24,11 +24,10 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import com.google.common.base.MoreObjects;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
+import java.util.StringJoiner;
 
 /**
  * Represents a {@link RandomObjectTable} which is nested inside the entry of
@@ -47,7 +46,7 @@ public class NestedTableEntry<T> extends TableEntry<T> {
      * @param weight The weight to apply to the entry
      * @param table The table itself
      */
-    public NestedTableEntry(double weight, RandomObjectTable<T> table) {
+    public NestedTableEntry(final double weight, final RandomObjectTable<T> table) {
         super(weight);
         this.table = Objects.requireNonNull(table);
     }
@@ -58,26 +57,26 @@ public class NestedTableEntry<T> extends TableEntry<T> {
      * @param rand The random object to use
      * @return The retrieved entries
      */
-    public List<T> get(Random rand) {
+    public List<T> get(final Random rand) {
         return this.table.get(rand);
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (o == this) {
             return true;
         }
         if (!(o instanceof NestedTableEntry)) {
             return false;
         }
-        NestedTableEntry<?> c = (NestedTableEntry<?>) o;
+        final NestedTableEntry<?> c = (NestedTableEntry<?>) o;
         return this.table.equals(c.table);
     }
 
     @Override
     public int hashCode() {
         int r = 1;
-        long w = Double.doubleToLongBits(getWeight());
+        final long w = Double.doubleToLongBits(this.getWeight());
         r = r * 37 + (int) (w ^ (w >>> 32));
         r = r * 37 + this.table.hashCode();
         return r;
@@ -85,7 +84,8 @@ public class NestedTableEntry<T> extends TableEntry<T> {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("table", this.table).toString();
+        return new StringJoiner(", ", NestedTableEntry.class.getSimpleName() + "[", "]")
+            .add("table=" + this.table)
+            .toString();
     }
-
 }

--- a/src/main/java/org/spongepowered/api/util/weighted/RandomObjectTable.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/RandomObjectTable.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.util.weighted;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -33,6 +32,7 @@ import com.google.common.collect.Lists;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 
 /**
@@ -64,7 +64,7 @@ public abstract class RandomObjectTable<T> implements Collection<TableEntry<T>> 
      * @param rolls the rolls
      */
     public RandomObjectTable(VariableAmount rolls) {
-        this.rolls = checkNotNull(rolls);
+        this.rolls = Objects.requireNonNull(rolls);
     }
 
     /**
@@ -83,7 +83,7 @@ public abstract class RandomObjectTable<T> implements Collection<TableEntry<T>> 
      * @param rolls The new roll count
      */
     public void setRolls(VariableAmount rolls) {
-        this.rolls = checkNotNull(rolls);
+        this.rolls = Objects.requireNonNull(rolls);
     }
 
     /**
@@ -98,7 +98,7 @@ public abstract class RandomObjectTable<T> implements Collection<TableEntry<T>> 
 
     @Override
     public boolean add(TableEntry<T> entry) {
-        checkNotNull(entry);
+        Objects.requireNonNull(entry);
         checkArgument(entry.getWeight() >= 0, "Weight cannot be negative");
         return this.entries.add(entry);
     }
@@ -111,7 +111,7 @@ public abstract class RandomObjectTable<T> implements Collection<TableEntry<T>> 
      * @return If the object was successfully added
      */
     public boolean add(T object, double weight) {
-        checkNotNull(object);
+        Objects.requireNonNull(object);
         checkArgument(weight >= 0, "Weight cannot be negative");
         return add(new WeightedObject<>(object, weight));
     }

--- a/src/main/java/org/spongepowered/api/util/weighted/RandomObjectTable.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/RandomObjectTable.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -53,7 +51,9 @@ public abstract class RandomObjectTable<T> implements Collection<TableEntry<T>> 
      * @param rolls the rolls
      */
     public RandomObjectTable(int rolls) {
-        checkArgument(rolls >= 0, "Rolls cannot be negative");
+        if (rolls < 0) {
+            throw new IllegalArgumentException("Rolls cannot be negative!");
+        }
         this.rolls = VariableAmount.fixed(rolls);
     }
 
@@ -92,14 +92,18 @@ public abstract class RandomObjectTable<T> implements Collection<TableEntry<T>> 
      * @param rolls The new roll count
      */
     public void setRolls(int rolls) {
-        checkArgument(rolls >= 0, "Rolls cannot be negative");
+        if (rolls < 0) {
+            throw new IllegalArgumentException("Rolls cannot be negative!");
+        }
         this.rolls = VariableAmount.fixed(rolls);
     }
 
     @Override
     public boolean add(TableEntry<T> entry) {
         Objects.requireNonNull(entry);
-        checkArgument(entry.getWeight() >= 0, "Weight cannot be negative");
+        if (entry.getWeight() < 0) {
+            throw new IllegalArgumentException("Weight cannot be negative!");
+        }
         return this.entries.add(entry);
     }
 
@@ -112,7 +116,9 @@ public abstract class RandomObjectTable<T> implements Collection<TableEntry<T>> 
      */
     public boolean add(T object, double weight) {
         Objects.requireNonNull(object);
-        checkArgument(weight >= 0, "Weight cannot be negative");
+        if (weight < 0) {
+            throw new IllegalArgumentException("Weight cannot be negative!");
+        }
         return add(new WeightedObject<>(object, weight));
     }
 

--- a/src/main/java/org/spongepowered/api/util/weighted/TableEntry.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/TableEntry.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 /**
  * An abstract entry which may be contained in any table.
  *
@@ -41,7 +39,9 @@ public abstract class TableEntry<T> {
      * @param weight The weight to associate with this entry
      */
     public TableEntry(double weight) {
-        checkArgument(weight >= 0, "Weight cannot be negative");
+        if (weight < 0) {
+            throw new IllegalArgumentException("Weight cannot be negative");
+        }
         this.weight = weight;
     }
 

--- a/src/main/java/org/spongepowered/api/util/weighted/UnmodifiableWeightedTable.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/UnmodifiableWeightedTable.java
@@ -24,11 +24,10 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import com.google.common.base.Objects;
-
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Spliterator;
 import java.util.function.Consumer;
@@ -51,7 +50,7 @@ public class UnmodifiableWeightedTable<T> extends WeightedTable<T> {
      *
      * @param table The table to provide
      */
-    public UnmodifiableWeightedTable(WeightedTable<T> table) {
+    public UnmodifiableWeightedTable(final WeightedTable<T> table) {
         super();
         this.table = table;
     }
@@ -63,7 +62,7 @@ public class UnmodifiableWeightedTable<T> extends WeightedTable<T> {
      * @param table The table
      * @param rolls The rolls
      */
-    public UnmodifiableWeightedTable(WeightedTable<T> table, int rolls) {
+    public UnmodifiableWeightedTable(final WeightedTable<T> table, final int rolls) {
         super(rolls);
         this.table = table;
     }
@@ -75,7 +74,7 @@ public class UnmodifiableWeightedTable<T> extends WeightedTable<T> {
      * @param table The table
      * @param rolls The rolls
      */
-    public UnmodifiableWeightedTable(WeightedTable<T> table, VariableAmount rolls) {
+    public UnmodifiableWeightedTable(final WeightedTable<T> table, final VariableAmount rolls) {
         super(rolls);
         this.table = table;
     }
@@ -83,52 +82,52 @@ public class UnmodifiableWeightedTable<T> extends WeightedTable<T> {
     // FORBIDDEN METHODS
 
     @Override
-    public boolean add(TableEntry<T> entry) {
+    public boolean add(final TableEntry<T> entry) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean add(T object, double weight) {
+    public boolean add(final T object, final double weight) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean addAll(Collection<? extends TableEntry<T>> c) {
+    public boolean addAll(final Collection<? extends TableEntry<T>> c) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void setRolls(VariableAmount rolls) {
+    public void setRolls(final VariableAmount rolls) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void setRolls(int rolls) {
+    public void setRolls(final int rolls) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean remove(Object entry) {
+    public boolean remove(final Object entry) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean removeObject(Object entry) {
+    public boolean removeObject(final Object entry) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean removeAll(Collection<?> c) {
+    public boolean removeAll(final Collection<?> c) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean removeIf(Predicate<? super TableEntry<T>> filter) {
+    public boolean removeIf(final Predicate<? super TableEntry<T>> filter) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean retainAll(Collection<?> c) {
+    public boolean retainAll(final Collection<?> c) {
         throw new UnsupportedOperationException();
     }
 
@@ -141,7 +140,7 @@ public class UnmodifiableWeightedTable<T> extends WeightedTable<T> {
 
     @Override
     public Iterator<TableEntry<T>> iterator() {
-        Iterator<TableEntry<T>> it = this.table.iterator();
+        final Iterator<TableEntry<T>> it = this.table.iterator();
         return new Iterator<TableEntry<T>>() {
             @Override
             public boolean hasNext() {
@@ -159,14 +158,14 @@ public class UnmodifiableWeightedTable<T> extends WeightedTable<T> {
             }
 
             @Override
-            public void forEachRemaining(Consumer<? super TableEntry<T>> action) {
+            public void forEachRemaining(final Consumer<? super TableEntry<T>> action) {
                 it.forEachRemaining(action);
             }
         };
     }
 
     @Override
-    public boolean contains(Object o) {
+    public boolean contains(final Object o) {
         return this.table.contains(o);
     }
 
@@ -176,22 +175,22 @@ public class UnmodifiableWeightedTable<T> extends WeightedTable<T> {
     }
 
     @Override
-    public List<T> get(Random rand) {
+    public List<T> get(final Random rand) {
         return this.table.get(rand);
     }
 
     @Override
-    public boolean containsObject(Object obj) {
+    public boolean containsObject(final Object obj) {
         return this.table.containsObject(obj);
     }
 
     @Override
-    public boolean containsAll(Collection<?> c) {
+    public boolean containsAll(final Collection<?> c) {
         return this.table.containsAll(c);
     }
 
     @Override
-    public boolean containsAllObjects(Collection<?> c) {
+    public boolean containsAllObjects(final Collection<?> c) {
         return this.table.containsAllObjects(c);
     }
 
@@ -216,7 +215,7 @@ public class UnmodifiableWeightedTable<T> extends WeightedTable<T> {
     }
 
     @Override
-    public <R> R[] toArray(R[] a) {
+    public <R> R[] toArray(final R[] a) {
         return this.table.toArray(a);
     }
 
@@ -236,7 +235,7 @@ public class UnmodifiableWeightedTable<T> extends WeightedTable<T> {
     }
 
     @Override
-    public void forEach(Consumer<? super TableEntry<T>> action) {
+    public void forEach(final Consumer<? super TableEntry<T>> action) {
         this.table.forEach(action);
     }
 
@@ -251,17 +250,17 @@ public class UnmodifiableWeightedTable<T> extends WeightedTable<T> {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (o == null || this.getClass() != o.getClass()) {
             return false;
         }
         if (!super.equals(o)) {
             return false;
         }
-        UnmodifiableWeightedTable<?> that = (UnmodifiableWeightedTable<?>) o;
-        return Objects.equal(this.table, that.table);
+        final UnmodifiableWeightedTable<?> that = (UnmodifiableWeightedTable<?>) o;
+        return Objects.equals(this.table, that.table);
     }
 }

--- a/src/main/java/org/spongepowered/api/util/weighted/VariableAmount.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/VariableAmount.java
@@ -24,13 +24,13 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import com.google.common.base.MoreObjects;
 import org.spongepowered.api.data.persistence.DataContainer;
 import org.spongepowered.api.data.persistence.DataSerializable;
 import org.spongepowered.api.data.persistence.Queries;
 import org.spongepowered.math.GenericMath;
 
 import java.util.Random;
+import java.util.StringJoiner;
 
 /**
  * Represents a value which may vary randomly.
@@ -49,7 +49,7 @@ public interface VariableAmount extends DataSerializable {
      * @param value The fixed value
      * @return A variable amount representation
      */
-    static VariableAmount fixed(double value) {
+    static VariableAmount fixed(final double value) {
         return new Fixed(value);
     }
 
@@ -61,8 +61,8 @@ public interface VariableAmount extends DataSerializable {
      * @param max The maximum of the range (exclusive)
      * @return A variable amount representation
      */
-    static VariableAmount range(double min, double max) {
-        return new BaseAndAddition(min, fixed(max - min));
+    static VariableAmount range(final double min, final double max) {
+        return new BaseAndAddition(min, VariableAmount.fixed(max - min));
     }
 
     /**
@@ -74,7 +74,7 @@ public interface VariableAmount extends DataSerializable {
      * @param variance The variance
      * @return A variable amount representation
      */
-    static VariableAmount baseWithVariance(double base, double variance) {
+    static VariableAmount baseWithVariance(final double base, final double variance) {
         return new BaseAndVariance(base, VariableAmount.fixed(variance));
     }
 
@@ -87,7 +87,7 @@ public interface VariableAmount extends DataSerializable {
      * @param variance The variance
      * @return A variable amount representation
      */
-    static VariableAmount baseWithVariance(double base, VariableAmount variance) {
+    static VariableAmount baseWithVariance(final double base, final VariableAmount variance) {
         return new BaseAndVariance(base, variance);
     }
 
@@ -100,7 +100,7 @@ public interface VariableAmount extends DataSerializable {
      * @param addition The additional amount
      * @return A variable amount representation
      */
-    static VariableAmount baseWithRandomAddition(double base, double addition) {
+    static VariableAmount baseWithRandomAddition(final double base, final double addition) {
         return new BaseAndAddition(base, VariableAmount.fixed(addition));
     }
 
@@ -113,7 +113,7 @@ public interface VariableAmount extends DataSerializable {
      * @param addition The additional amount
      * @return A variable amount representation
      */
-    static VariableAmount baseWithRandomAddition(double base, VariableAmount addition) {
+    static VariableAmount baseWithRandomAddition(final double base, final VariableAmount addition) {
         return new BaseAndAddition(base, addition);
     }
 
@@ -130,8 +130,8 @@ public interface VariableAmount extends DataSerializable {
      * @param chance The chance to apply the variance
      * @return A variable amount representation
      */
-    static VariableAmount baseWithOptionalVariance(double base, double variance, double chance) {
-        return new OptionalAmount(base, chance, baseWithVariance(base, variance));
+    static VariableAmount baseWithOptionalVariance(final double base, final double variance, final double chance) {
+        return new OptionalAmount(base, chance, VariableAmount.baseWithVariance(base, variance));
     }
 
     /**
@@ -147,8 +147,8 @@ public interface VariableAmount extends DataSerializable {
      * @param chance The chance to apply the variance
      * @return A variable amount representation
      */
-    static VariableAmount baseWithOptionalVariance(double base, VariableAmount variance, double chance) {
-        return new OptionalAmount(base, chance, baseWithVariance(base, variance));
+    static VariableAmount baseWithOptionalVariance(final double base, final VariableAmount variance, final double chance) {
+        return new OptionalAmount(base, chance, VariableAmount.baseWithVariance(base, variance));
     }
 
     /**
@@ -165,8 +165,8 @@ public interface VariableAmount extends DataSerializable {
      * @param chance The chance to apply the additional amount
      * @return A variable amount representation
      */
-    static VariableAmount baseWithOptionalAddition(double base, double addition, double chance) {
-        return new OptionalAmount(base, chance, baseWithRandomAddition(base, addition));
+    static VariableAmount baseWithOptionalAddition(final double base, final double addition, final double chance) {
+        return new OptionalAmount(base, chance, VariableAmount.baseWithRandomAddition(base, addition));
     }
 
     /**
@@ -183,8 +183,8 @@ public interface VariableAmount extends DataSerializable {
      * @param chance The chance to apply the additional amount
      * @return A variable amount representation
      */
-    static VariableAmount baseWithOptionalAddition(double base, VariableAmount addition, double chance) {
-        return new OptionalAmount(base, chance, baseWithRandomAddition(base, addition));
+    static VariableAmount baseWithOptionalAddition(final double base, final VariableAmount addition, final double chance) {
+        return new OptionalAmount(base, chance, VariableAmount.baseWithRandomAddition(base, addition));
     }
 
     /**
@@ -203,8 +203,8 @@ public interface VariableAmount extends DataSerializable {
      * @param rand The random object
      * @return The floored amount
      */
-    default int getFlooredAmount(Random rand) {
-        return GenericMath.floor(getAmount(rand));
+    default int getFlooredAmount(final Random rand) {
+        return GenericMath.floor(this.getAmount(rand));
     }
 
     // This is overridden to allow this to be a functional interface as this
@@ -225,31 +225,33 @@ public interface VariableAmount extends DataSerializable {
      */
     class Fixed implements VariableAmount {
 
-        private double amount;
+        private final double amount;
 
-        Fixed(double amount) {
+        Fixed(final double amount) {
             this.amount = amount;
         }
 
         @Override
-        public double getAmount(Random rand) {
+        public double getAmount(final Random rand) {
             return this.amount;
         }
 
         @Override
         public String toString() {
-            return MoreObjects.toStringHelper(this).add("amount", this.amount).toString();
+            return new StringJoiner(", ", Fixed.class.getSimpleName() + "[", "]")
+                .add("amount=" + this.amount)
+                .toString();
         }
 
         @Override
-        public boolean equals(Object obj) {
+        public boolean equals(final Object obj) {
             if (this == obj) {
                 return true;
             }
             if (!(obj instanceof Fixed)) {
                 return false;
             }
-            Fixed amount = (Fixed) obj;
+            final Fixed amount = (Fixed) obj;
             return amount.amount == this.amount;
         }
 
@@ -263,7 +265,7 @@ public interface VariableAmount extends DataSerializable {
         @Override
         public DataContainer toContainer() {
             return DataContainer.createNew()
-                    .set(Queries.CONTENT_VERSION, getContentVersion())
+                    .set(Queries.CONTENT_VERSION, this.getContentVersion())
                     .set(Queries.VARIABLE_AMOUNT, this.amount);
         }
 
@@ -280,34 +282,37 @@ public interface VariableAmount extends DataSerializable {
      */
     class BaseAndVariance implements VariableAmount {
 
-        private double base;
-        private VariableAmount variance;
+        private final double base;
+        private final VariableAmount variance;
 
-        BaseAndVariance(double base, VariableAmount variance) {
+        BaseAndVariance(final double base, final VariableAmount variance) {
             this.base = base;
             this.variance = variance;
         }
 
         @Override
-        public double getAmount(Random rand) {
-            double var = this.variance.getAmount(rand);
+        public double getAmount(final Random rand) {
+            final double var = this.variance.getAmount(rand);
             return this.base + rand.nextDouble() * var * 2 - var;
         }
 
         @Override
         public String toString() {
-            return MoreObjects.toStringHelper(this).add("base", this.base).add("variance", this.variance).toString();
+            return new StringJoiner(", ", BaseAndVariance.class.getSimpleName() + "[", "]")
+                .add("base=" + this.base)
+                .add("variance=" + this.variance)
+                .toString();
         }
 
         @Override
-        public boolean equals(Object obj) {
+        public boolean equals(final Object obj) {
             if (this == obj) {
                 return true;
             }
             if (!(obj instanceof BaseAndVariance)) {
                 return false;
             }
-            BaseAndVariance amount = (BaseAndVariance) obj;
+            final BaseAndVariance amount = (BaseAndVariance) obj;
             return amount.base == this.base && amount.variance == this.variance;
         }
 
@@ -322,7 +327,7 @@ public interface VariableAmount extends DataSerializable {
         @Override
         public DataContainer toContainer() {
             return DataContainer.createNew()
-                    .set(Queries.CONTENT_VERSION, getContentVersion())
+                    .set(Queries.CONTENT_VERSION, this.getContentVersion())
                     .set(Queries.VARIABLE_BASE, this.base)
                     .set(Queries.VARIABLE_VARIANCE, this.variance);
         }
@@ -341,33 +346,36 @@ public interface VariableAmount extends DataSerializable {
      */
     class BaseAndAddition implements VariableAmount {
 
-        private double base;
-        private VariableAmount addition;
+        private final double base;
+        private final VariableAmount addition;
 
-        BaseAndAddition(double base, VariableAmount addition) {
+        BaseAndAddition(final double base, final VariableAmount addition) {
             this.base = base;
             this.addition = addition;
         }
 
         @Override
-        public double getAmount(Random rand) {
+        public double getAmount(final Random rand) {
             return this.base + (rand.nextDouble() * this.addition.getAmount(rand));
         }
 
         @Override
         public String toString() {
-            return MoreObjects.toStringHelper(this).add("base", this.base).add("addition", this.addition).toString();
+            return new StringJoiner(", ", BaseAndAddition.class.getSimpleName() + "[", "]")
+                .add("base=" + this.base)
+                .add("addition=" + this.addition)
+                .toString();
         }
 
         @Override
-        public boolean equals(Object obj) {
+        public boolean equals(final Object obj) {
             if (this == obj) {
                 return true;
             }
             if (!(obj instanceof BaseAndAddition)) {
                 return false;
             }
-            BaseAndAddition amount = (BaseAndAddition) obj;
+            final BaseAndAddition amount = (BaseAndAddition) obj;
             return amount.base == this.base && amount.addition == this.addition;
         }
 
@@ -382,7 +390,7 @@ public interface VariableAmount extends DataSerializable {
         @Override
         public DataContainer toContainer() {
             return DataContainer.createNew()
-                    .set(Queries.CONTENT_VERSION, getContentVersion())
+                    .set(Queries.CONTENT_VERSION, this.getContentVersion())
                     .set(Queries.VARIABLE_BASE, this.base)
                     .set(Queries.VARIABLE_VARIANCE, this.addition);
         }
@@ -400,18 +408,18 @@ public interface VariableAmount extends DataSerializable {
      */
     class OptionalAmount implements VariableAmount {
 
-        private double chance;
-        private double base;
-        private VariableAmount inner;
+        private final double chance;
+        private final double base;
+        private final VariableAmount inner;
 
-        OptionalAmount(double base, double chance, VariableAmount inner) {
+        OptionalAmount(final double base, final double chance, final VariableAmount inner) {
             this.base = base;
             this.inner = inner;
             this.chance = chance;
         }
 
         @Override
-        public double getAmount(Random rand) {
+        public double getAmount(final Random rand) {
             if (rand.nextDouble() < this.chance) {
                 return this.inner.getAmount(rand);
             }
@@ -420,18 +428,26 @@ public interface VariableAmount extends DataSerializable {
 
         @Override
         public String toString() {
-            return MoreObjects.toStringHelper(this).add("base", this.base).add("chance", this.chance).add("inner", this.inner).toString();
+            return new StringJoiner(
+                ", ",
+                OptionalAmount.class.getSimpleName() + "[",
+                "]"
+            )
+                .add("chance=" + this.chance)
+                .add("base=" + this.base)
+                .add("inner=" + this.inner)
+                .toString();
         }
 
         @Override
-        public boolean equals(Object obj) {
+        public boolean equals(final Object obj) {
             if (this == obj) {
                 return true;
             }
             if (!(obj instanceof OptionalAmount)) {
                 return false;
             }
-            OptionalAmount amount = (OptionalAmount) obj;
+            final OptionalAmount amount = (OptionalAmount) obj;
             return this.inner.equals(amount.inner) && amount.base == this.base && this.chance == amount.chance;
         }
 
@@ -447,7 +463,7 @@ public interface VariableAmount extends DataSerializable {
         @Override
         public DataContainer toContainer() {
             return DataContainer.createNew()
-                    .set(Queries.CONTENT_VERSION, getContentVersion())
+                    .set(Queries.CONTENT_VERSION, this.getContentVersion())
                     .set(Queries.VARIABLE_CHANCE, this.chance)
                     .set(Queries.VARIABLE_BASE, this.base)
                     .set(Queries.VARIABLE_VARIANCE, this.inner);

--- a/src/main/java/org/spongepowered/api/util/weighted/WeightedObject.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/WeightedObject.java
@@ -24,9 +24,9 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
 
 /**
  * An entry which contains an object.
@@ -46,7 +46,7 @@ public class WeightedObject<T> extends TableEntry<T> {
      */
     public WeightedObject(T obj, double weight) {
         super(weight);
-        this.object = checkNotNull(obj);
+        this.object = Objects.requireNonNull(obj);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/util/weighted/WeightedObject.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/WeightedObject.java
@@ -24,9 +24,8 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import com.google.common.base.MoreObjects;
-
 import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * An entry which contains an object.
@@ -44,7 +43,7 @@ public class WeightedObject<T> extends TableEntry<T> {
      * @param obj The object
      * @param weight The weight of the object
      */
-    public WeightedObject(T obj, double weight) {
+    public WeightedObject(final T obj, final double weight) {
         super(weight);
         this.object = Objects.requireNonNull(obj);
     }
@@ -59,21 +58,21 @@ public class WeightedObject<T> extends TableEntry<T> {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (o == this) {
             return true;
         }
         if (!(o instanceof WeightedObject)) {
             return false;
         }
-        WeightedObject<?> c = (WeightedObject<?>) o;
-        return this.object.equals(c.object) && getWeight() == c.getWeight();
+        final WeightedObject<?> c = (WeightedObject<?>) o;
+        return this.object.equals(c.object) && this.getWeight() == c.getWeight();
     }
 
     @Override
     public int hashCode() {
         int r = 1;
-        long w = Double.doubleToLongBits(getWeight());
+        final long w = Double.doubleToLongBits(this.getWeight());
         r = r * 37 + (int) (w ^ (w >>> 32));
         r = r * 37 + this.object.hashCode();
         return r;
@@ -81,6 +80,8 @@ public class WeightedObject<T> extends TableEntry<T> {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("object", this.object).toString();
+        return new StringJoiner(", ", WeightedObject.class.getSimpleName() + "[", "]")
+            .add("object=" + this.object)
+            .toString();
     }
 }

--- a/src/main/java/org/spongepowered/api/util/weighted/WeightedSerializableObject.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/WeightedSerializableObject.java
@@ -24,10 +24,11 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import com.google.common.base.MoreObjects;
 import org.spongepowered.api.data.persistence.DataContainer;
 import org.spongepowered.api.data.persistence.DataSerializable;
 import org.spongepowered.api.data.persistence.Queries;
+
+import java.util.StringJoiner;
 
 /**
  * An entry which contains an object with the added restriction that the object
@@ -44,29 +45,29 @@ public class WeightedSerializableObject<T extends DataSerializable> extends Weig
      * @param object The serializable object
      * @param weight The weight
      */
-    public WeightedSerializableObject(T object, int weight) {
+    public WeightedSerializableObject(final T object, final int weight) {
         super(object, weight);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("object", get())
-                .add("weight", getWeight())
-                .toString();
+        return new StringJoiner(", ", WeightedSerializableObject.class.getSimpleName() + "[", "]")
+            .add("object=" + this.get())
+            .add("weight=" + this.getWeight())
+            .toString();
     }
 
     @SuppressWarnings("rawtypes")
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) {
             return true;
         }
         if (!(o instanceof WeightedSerializableObject)) {
             return false;
         }
-        WeightedSerializableObject object = (WeightedSerializableObject) o;
-        return get().equals(object.get()) && getWeight() == object.getWeight();
+        final WeightedSerializableObject object = (WeightedSerializableObject) o;
+        return this.get().equals(object.get()) && this.getWeight() == object.getWeight();
     }
 
     @Override
@@ -77,8 +78,8 @@ public class WeightedSerializableObject<T extends DataSerializable> extends Weig
     @Override
     public DataContainer toContainer() {
         return DataContainer.createNew()
-                .set(Queries.CONTENT_VERSION, getContentVersion())
-                .set(Queries.WEIGHTED_SERIALIZABLE, get())
-                .set(Queries.WEIGHTED_SERIALIZABLE_WEIGHT, getWeight());
+                .set(Queries.CONTENT_VERSION, this.getContentVersion())
+                .set(Queries.WEIGHTED_SERIALIZABLE, this.get())
+                .set(Queries.WEIGHTED_SERIALIZABLE_WEIGHT, this.getWeight());
     }
 }

--- a/src/main/java/org/spongepowered/api/world/ProtoWorld.java
+++ b/src/main/java/org/spongepowered/api/world/ProtoWorld.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.world;
 
-import com.google.common.base.Preconditions;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.util.RandomProvider;
 import org.spongepowered.api.world.chunk.ProtoChunk;
@@ -41,6 +40,8 @@ import org.spongepowered.api.world.volume.game.MutableGameVolume;
 import org.spongepowered.api.world.volume.game.ReadableRegion;
 import org.spongepowered.api.world.volume.game.UpdatableVolume;
 import org.spongepowered.math.vector.Vector3i;
+
+import java.util.Objects;
 
 public interface ProtoWorld<P extends ProtoWorld<P>> extends
         ReadableRegion<P>,
@@ -74,9 +75,9 @@ public interface ProtoWorld<P extends ProtoWorld<P>> extends
 
     @Override
     default boolean setBlock(Vector3i position, BlockState state, BlockChangeFlag flag) {
-        Preconditions.checkNotNull(position);
-        Preconditions.checkNotNull(state);
-        Preconditions.checkNotNull(flag);
+        Objects.requireNonNull(position);
+        Objects.requireNonNull(state);
+        Objects.requireNonNull(flag);
 
         return this.setBlock(position.getX(), position.getY(), position.getZ(), state, flag);
     }
@@ -86,7 +87,7 @@ public interface ProtoWorld<P extends ProtoWorld<P>> extends
 
     @Override
     default boolean removeBlock(Vector3i position) {
-        Preconditions.checkNotNull(position);
+        Objects.requireNonNull(position);
         return this.removeBlock(position.getX(), position.getY(), position.getZ());
     }
 

--- a/src/main/java/org/spongepowered/api/world/storage/ChunkLayout.java
+++ b/src/main/java/org/spongepowered/api/world/storage/ChunkLayout.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.world.storage;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.util.Direction.Division;
 import org.spongepowered.math.vector.Vector3i;
@@ -337,7 +335,9 @@ public interface ChunkLayout {
      */
     default Optional<Vector3i> moveToChunk(Vector3i chunkCoords, Direction direction, int steps) {
         Objects.requireNonNull(direction, "direction");
-        checkArgument(!direction.isSecondaryOrdinal(), "Secondary cardinal directions can't be used here");
+        if (direction.isSecondaryOrdinal()) {
+            throw new IllegalArgumentException("Secondary cardinal directions cannot be used here");
+        }
         return addToChunk(chunkCoords, direction.asBlockOffset().mul(steps));
     }
 

--- a/src/main/java/org/spongepowered/api/world/storage/ChunkLayout.java
+++ b/src/main/java/org/spongepowered/api/world/storage/ChunkLayout.java
@@ -25,12 +25,12 @@
 package org.spongepowered.api.world.storage;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.util.Direction.Division;
 import org.spongepowered.math.vector.Vector3i;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -91,7 +91,7 @@ public interface ChunkLayout {
      * @return Whether or not the coordinates are valid for chunks
      */
     default boolean isValidChunk(Vector3i coords) {
-        checkNotNull(coords, "coords");
+        Objects.requireNonNull(coords, "coords");
         return isValidChunk(coords.getX(), coords.getY(), coords.getZ());
     }
 
@@ -118,7 +118,7 @@ public interface ChunkLayout {
      * @return Whether or not the coordinates fit in a chunk
      */
     default boolean isInChunk(Vector3i localCoords) {
-        checkNotNull(localCoords, "localCoords");
+        Objects.requireNonNull(localCoords, "localCoords");
         return isInChunk(localCoords.getX(), localCoords.getY(), localCoords.getZ());
     }
 
@@ -142,8 +142,8 @@ public interface ChunkLayout {
      * @return Whether or not the world coordinates fit in the chunk
      */
     default boolean isInChunk(Vector3i worldCoords, Vector3i chunkCoords) {
-        checkNotNull(worldCoords, "worldCoords");
-        checkNotNull(chunkCoords, "chunkCoords");
+        Objects.requireNonNull(worldCoords, "worldCoords");
+        Objects.requireNonNull(chunkCoords, "chunkCoords");
         return isInChunk(worldCoords.getX(), worldCoords.getY(), worldCoords.getZ(), chunkCoords.getX(), chunkCoords.getY(), chunkCoords.getZ());
     }
 
@@ -169,7 +169,7 @@ public interface ChunkLayout {
      * @return The chunk coordinates on success, else nothing
      */
     default Optional<Vector3i> toChunk(Vector3i worldCoords) {
-        checkNotNull(worldCoords, "worldCoords");
+        Objects.requireNonNull(worldCoords, "worldCoords");
         return toChunk(worldCoords.getX(), worldCoords.getY(), worldCoords.getZ());
     }
 
@@ -195,7 +195,7 @@ public interface ChunkLayout {
      * @return The world coordinates on success, else nothing
      */
     default Optional<Vector3i> toWorld(Vector3i chunkCoords) {
-        checkNotNull(chunkCoords, "chunkCoords");
+        Objects.requireNonNull(chunkCoords, "chunkCoords");
         return toWorld(chunkCoords.getX(), chunkCoords.getY(), chunkCoords.getZ());
     }
 
@@ -220,7 +220,7 @@ public interface ChunkLayout {
      * @return The chunk coordinates
      */
     default Vector3i forceToChunk(Vector3i worldCoords) {
-        checkNotNull(worldCoords, "worldCoords");
+        Objects.requireNonNull(worldCoords, "worldCoords");
         return forceToChunk(worldCoords.getX(), worldCoords.getY(), worldCoords.getZ());
     }
 
@@ -243,7 +243,7 @@ public interface ChunkLayout {
      * @return The world coordinates
      */
     default Vector3i forceToWorld(Vector3i chunkCoords) {
-        checkNotNull(chunkCoords, "chunkCoords");
+        Objects.requireNonNull(chunkCoords, "chunkCoords");
         return forceToWorld(chunkCoords.getX(), chunkCoords.getY(), chunkCoords.getZ());
     }
 
@@ -267,8 +267,8 @@ public interface ChunkLayout {
      * @return The new chunk coordinates if they are valid
      */
     default Optional<Vector3i> addToChunk(Vector3i chunkCoords, Vector3i chunkOffset) {
-        checkNotNull(chunkCoords, "chunkCoords");
-        checkNotNull(chunkOffset, "chunkOffset");
+        Objects.requireNonNull(chunkCoords, "chunkCoords");
+        Objects.requireNonNull(chunkOffset, "chunkOffset");
         return addToChunk(chunkCoords.getX(), chunkCoords.getY(), chunkCoords.getZ(), chunkOffset.getX(), chunkOffset.getY(), chunkOffset.getZ());
     }
 
@@ -336,7 +336,7 @@ public interface ChunkLayout {
      * {@link Division#SECONDARY_ORDINAL}
      */
     default Optional<Vector3i> moveToChunk(Vector3i chunkCoords, Direction direction, int steps) {
-        checkNotNull(direction, "direction");
+        Objects.requireNonNull(direction, "direction");
         checkArgument(!direction.isSecondaryOrdinal(), "Secondary cardinal directions can't be used here");
         return addToChunk(chunkCoords, direction.asBlockOffset().mul(steps));
     }

--- a/src/main/java/org/spongepowered/api/world/volume/EntityHit.java
+++ b/src/main/java/org/spongepowered/api/world/volume/EntityHit.java
@@ -24,10 +24,10 @@
  */
 package org.spongepowered.api.world.volume;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.math.vector.Vector3d;
+
+import java.util.Objects;
 
 /**
  * The result of an intersection between a ray and an entity.
@@ -49,9 +49,9 @@ public class EntityHit {
      * @param distance The distance from the start to the intersection
      */
     public EntityHit(Entity entity, Vector3d intersection, Vector3d normal, double distance) {
-        this.entity = checkNotNull(entity, "entity");
-        this.intersection = checkNotNull(intersection, "intersection");
-        this.normal = checkNotNull(normal, "normal");
+        this.entity = Objects.requireNonNull(entity, "entity");
+        this.intersection = Objects.requireNonNull(intersection, "intersection");
+        this.normal = Objects.requireNonNull(normal, "normal");
         this.distance = distance;
     }
 

--- a/src/main/java/org/spongepowered/api/world/volume/Volume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/Volume.java
@@ -24,8 +24,9 @@
  */
 package org.spongepowered.api.world.volume;
 
-import com.google.common.base.Preconditions;
 import org.spongepowered.math.vector.Vector3i;
+
+import java.util.Objects;
 
 public interface Volume {
 
@@ -44,7 +45,7 @@ public interface Volume {
      * @return Whether or not the position has a block in this volume
      */
     default boolean containsBlock(Vector3i position) {
-        Preconditions.checkNotNull(position);
+        Objects.requireNonNull(position);
 
         return this.containsBlock(position.getX(), position.getY(), position.getZ());
     }
@@ -62,7 +63,7 @@ public interface Volume {
     boolean containsBlock(int x, int y, int z);
 
     default boolean isAreaAvailable(Vector3i vector3i) {
-        Preconditions.checkNotNull(vector3i);
+        Objects.requireNonNull(vector3i);
 
         return this.isAreaAvailable(vector3i.getX(), vector3i.getY(), vector3i.getZ());
     }

--- a/src/main/java/org/spongepowered/api/world/volume/block/entity/ReadableBlockEntityVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/block/entity/ReadableBlockEntityVolume.java
@@ -24,13 +24,13 @@
  */
 package org.spongepowered.api.world.volume.block.entity;
 
-import com.google.common.base.Preconditions;
 import org.spongepowered.api.block.entity.BlockEntity;
 import org.spongepowered.api.world.volume.Volume;
 import org.spongepowered.api.world.volume.block.ReadableBlockVolume;
 import org.spongepowered.math.vector.Vector3i;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -63,7 +63,7 @@ public interface ReadableBlockEntityVolume extends ReadableBlockVolume, Volume {
      * @return A collection of filtered entities
      */
     default Collection<? extends BlockEntity> getBlockEntities(Predicate<? super BlockEntity> filter) {
-        Preconditions.checkNotNull(filter);
+        Objects.requireNonNull(filter);
 
         return this.getBlockEntities().stream().filter(filter).collect(Collectors.toList());
     }
@@ -75,7 +75,7 @@ public interface ReadableBlockEntityVolume extends ReadableBlockVolume, Volume {
      * @return The block entity, or {@link Optional#empty()}
      */
     default Optional<? extends BlockEntity> getBlockEntity(Vector3i position) {
-        Preconditions.checkNotNull(position);
+        Objects.requireNonNull(position);
 
         return this.getBlockEntity(position.getX(), position.getY(), position.getZ());
     }

--- a/src/main/java/org/spongepowered/api/world/volume/entity/ReadableEntityVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/entity/ReadableEntityVolume.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.world.volume.entity;
 
-import com.google.common.base.Preconditions;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntityPredicates;
@@ -121,7 +120,9 @@ public interface ReadableEntityVolume extends Volume {
      */
     default Collection<? extends Entity> getNearbyEntities(Vector3d location, double distance) {
         Objects.requireNonNull(location);
-        Preconditions.checkArgument(distance > 0, "distance must be > 0");
+        if (distance <= 0) {
+            throw new IllegalArgumentException("Distance must be a positive number!");
+        }
 
         return this.getEntities(new AABB(location.getX() - distance, location.getY() - distance, location.getZ() - distance,
                 location.getX() + distance, location.getY() + distance, location.getZ() + distance),

--- a/src/main/java/org/spongepowered/api/world/volume/entity/ReadableEntityVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/entity/ReadableEntityVolume.java
@@ -35,6 +35,7 @@ import org.spongepowered.math.vector.Vector3d;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
@@ -70,7 +71,7 @@ public interface ReadableEntityVolume extends Volume {
      * @return All the intersecting entities
      */
     default Collection<? extends Entity> getEntities(AABB box) {
-        Preconditions.checkNotNull(box);
+        Objects.requireNonNull(box);
 
         return this.getEntities(box, entity -> true);
     }
@@ -119,7 +120,7 @@ public interface ReadableEntityVolume extends Volume {
      * @return A collection of nearby entities
      */
     default Collection<? extends Entity> getNearbyEntities(Vector3d location, double distance) {
-        Preconditions.checkNotNull(location);
+        Objects.requireNonNull(location);
         Preconditions.checkArgument(distance > 0, "distance must be > 0");
 
         return this.getEntities(new AABB(location.getX() - distance, location.getY() - distance, location.getZ() - distance,

--- a/src/main/java/org/spongepowered/api/world/volume/game/EnvironmentalVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/game/EnvironmentalVolume.java
@@ -24,12 +24,12 @@
  */
 package org.spongepowered.api.world.volume.game;
 
-import com.google.common.base.Preconditions;
 import org.spongepowered.api.world.LightType;
 import org.spongepowered.api.world.LightTypes;
 import org.spongepowered.api.world.volume.biome.ReadableBiomeVolume;
 import org.spongepowered.math.vector.Vector3i;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 
 public interface EnvironmentalVolume extends PrimitiveGameVolume, ReadableBiomeVolume {
@@ -37,21 +37,21 @@ public interface EnvironmentalVolume extends PrimitiveGameVolume, ReadableBiomeV
     int getLight(LightType type, int x, int y, int z);
 
     default int getLight(final Supplier<? extends LightType> type, final int x, final int y, final int z) {
-        Preconditions.checkNotNull(type);
+        Objects.requireNonNull(type);
 
         return this.getLight(type.get(), x, y, z);
     }
 
     default int getLight(final LightType type, final Vector3i position) {
-        Preconditions.checkNotNull(type);
-        Preconditions.checkNotNull(position);
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(position);
 
         return this.getLight(type, position.getX(), position.getY(), position.getZ());
     }
 
     default int getLight(final Supplier<? extends LightType> type, final Vector3i position) {
-        Preconditions.checkNotNull(type);
-        Preconditions.checkNotNull(position);
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(position);
 
         return this.getLight(type, position.getX(), position.getY(), position.getZ());
     }
@@ -61,13 +61,13 @@ public interface EnvironmentalVolume extends PrimitiveGameVolume, ReadableBiomeV
     }
 
     default int getLight(final Vector3i position) {
-        Preconditions.checkNotNull(position);
+        Objects.requireNonNull(position);
 
         return this.getLight(position.getX(), position.getY(), position.getZ());
     }
 
     default boolean isSkylightMax(final Vector3i position) {
-        Preconditions.checkNotNull(position);
+        Objects.requireNonNull(position);
 
         return this.getLight(LightTypes.SKY, position) >= this.getMaximumLight();
     }

--- a/src/main/java/org/spongepowered/api/world/volume/game/InteractableVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/game/InteractableVolume.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.world.volume.game;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.profile.GameProfile;
@@ -34,6 +32,7 @@ import org.spongepowered.api.world.volume.block.ReadableBlockVolume;
 import org.spongepowered.math.vector.Vector3i;
 
 import java.time.Duration;
+import java.util.Objects;
 
 public interface InteractableVolume extends ReadableBlockVolume, LocationBaseDataHolder {
 
@@ -50,7 +49,7 @@ public interface InteractableVolume extends ReadableBlockVolume, LocationBaseDat
      * @return True if the interact succeeded
      */
     default boolean hitBlock(Vector3i position, Direction side, GameProfile profile) {
-        return hitBlock(checkNotNull(position, "position").getX(), position.getY(), position.getZ(), side, profile);
+        return hitBlock(Objects.requireNonNull(position, "position").getX(), position.getY(), position.getZ(), side, profile);
     }
 
     /**
@@ -78,7 +77,7 @@ public interface InteractableVolume extends ReadableBlockVolume, LocationBaseDat
      * @return True if the interact succeeded
      */
     default boolean interactBlock(Vector3i position, Direction side, GameProfile profile) {
-        return interactBlock(checkNotNull(position, "position").getX(), position.getY(), position.getZ(), side, profile);
+        return interactBlock(Objects.requireNonNull(position, "position").getX(), position.getY(), position.getZ(), side, profile);
     }
 
     /**
@@ -104,7 +103,7 @@ public interface InteractableVolume extends ReadableBlockVolume, LocationBaseDat
      * @return True if the interact succeeded
      */
     default boolean interactBlockWith(Vector3i position, ItemStack itemStack, Direction side, GameProfile profile) {
-        return interactBlockWith(checkNotNull(position, "position").getX(), position.getY(), position.getZ(), itemStack, side, profile);
+        return interactBlockWith(Objects.requireNonNull(position, "position").getX(), position.getY(), position.getZ(), itemStack, side, profile);
     }
 
     /**
@@ -132,7 +131,7 @@ public interface InteractableVolume extends ReadableBlockVolume, LocationBaseDat
      * @return Whether the block was successfully set
      */
     default boolean placeBlock(Vector3i position, BlockState block, Direction side, GameProfile profile) {
-        return placeBlock(checkNotNull(position, "position").getX(), position.getY(), position.getZ(), block, side, profile);
+        return placeBlock(Objects.requireNonNull(position, "position").getX(), position.getY(), position.getZ(), block, side, profile);
     }
 
     /**
@@ -157,7 +156,7 @@ public interface InteractableVolume extends ReadableBlockVolume, LocationBaseDat
      * @return Whether the block was destroyed
      */
     default boolean digBlock(Vector3i position, GameProfile profile) {
-        return digBlock(checkNotNull(position, "position").getX(), position.getY(), position.getZ(), profile);
+        return digBlock(Objects.requireNonNull(position, "position").getX(), position.getY(), position.getZ(), profile);
     }
 
     /**
@@ -181,7 +180,7 @@ public interface InteractableVolume extends ReadableBlockVolume, LocationBaseDat
      * @return Whether the block was destroyed
      */
     default boolean digBlockWith(Vector3i position, ItemStack itemStack, GameProfile profile) {
-        return digBlockWith(checkNotNull(position, "position").getX(), position.getY(), position.getZ(), itemStack, profile);
+        return digBlockWith(Objects.requireNonNull(position, "position").getX(), position.getY(), position.getZ(), itemStack, profile);
     }
 
     /**
@@ -206,7 +205,7 @@ public interface InteractableVolume extends ReadableBlockVolume, LocationBaseDat
      * @return The duration it takes to dig the block
      */
     default Duration getBlockDigTimeWith(Vector3i position, ItemStack itemStack, GameProfile profile) {
-        return getBlockDigTimeWith(checkNotNull(position, "position").getX(), position.getY(), position.getZ(), itemStack, profile);
+        return getBlockDigTimeWith(Objects.requireNonNull(position, "position").getX(), position.getY(), position.getZ(), itemStack, profile);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/world/volume/game/LocationBaseDataHolder.java
+++ b/src/main/java/org/spongepowered/api/world/volume/game/LocationBaseDataHolder.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.world.volume.game;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.collect.ImmutableSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.data.DataHolder;
@@ -42,6 +40,7 @@ import org.spongepowered.api.world.ServerLocation;
 import org.spongepowered.math.vector.Vector3i;
 
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
@@ -418,7 +417,7 @@ public interface LocationBaseDataHolder {
      * @return The data or null
      */
     default <E> E getOrElse(final Vector3i position, final Key<? extends Value<E>> key, final E defaultValue) {
-        return this.get(position.getX(), position.getY(), position.getZ(), key).orElse(checkNotNull(defaultValue));
+        return this.get(position.getX(), position.getY(), position.getZ(), key).orElse(Objects.requireNonNull(defaultValue));
     }
 
     /**
@@ -433,7 +432,7 @@ public interface LocationBaseDataHolder {
      * @return The data or null
      */
     default <E> E getOrElse(final Vector3i position, final Supplier<? extends Key<? extends Value<E>>> key, final E defaultValue) {
-        return this.get(position.getX(), position.getY(), position.getZ(), key.get()).orElse(checkNotNull(defaultValue));
+        return this.get(position.getX(), position.getY(), position.getZ(), key.get()).orElse(Objects.requireNonNull(defaultValue));
     }
 
     /**
@@ -450,7 +449,7 @@ public interface LocationBaseDataHolder {
      * @return The data or null
      */
     default <E> E getOrElse(final int x, final int y, final int z, final Key<? extends Value<E>> key, final E defaultValue) {
-        return this.get(x, y, z, key).orElse(checkNotNull(defaultValue));
+        return this.get(x, y, z, key).orElse(Objects.requireNonNull(defaultValue));
     }
 
     /**
@@ -467,7 +466,7 @@ public interface LocationBaseDataHolder {
      * @return The data or null
      */
     default <E> E getOrElse(final int x, final int y, final int z, final Supplier<? extends Key<? extends Value<E>>> key, final E defaultValue) {
-        return this.get(x, y, z, key.get()).orElse(checkNotNull(defaultValue));
+        return this.get(x, y, z, key.get()).orElse(Objects.requireNonNull(defaultValue));
     }
 
 
@@ -483,7 +482,7 @@ public interface LocationBaseDataHolder {
      * @return The data or null
      */
     default <E> E getOrElse(final Vector3i position, final Key<? extends Value<E>> key, final Supplier<? extends E> defaultValue) {
-        return this.get(position.getX(), position.getY(), position.getZ(), key).orElseGet(checkNotNull(defaultValue));
+        return this.get(position.getX(), position.getY(), position.getZ(), key).orElseGet(Objects.requireNonNull(defaultValue));
     }
 
     /**
@@ -498,7 +497,7 @@ public interface LocationBaseDataHolder {
      * @return The data or null
      */
     default <E> E getOrElse(final Vector3i position, final Supplier<? extends Key<? extends Value<E>>> key, final Supplier<? extends E> defaultValue) {
-        return this.get(position.getX(), position.getY(), position.getZ(), key.get()).orElseGet(checkNotNull(defaultValue));
+        return this.get(position.getX(), position.getY(), position.getZ(), key.get()).orElseGet(Objects.requireNonNull(defaultValue));
     }
 
     /**
@@ -515,7 +514,7 @@ public interface LocationBaseDataHolder {
      * @return The data or null
      */
     default <E> E getOrElse(final int x, final int y, final int z, final Key<? extends Value<E>> key, final Supplier<E> defaultValue) {
-        return this.get(x, y, z, key).orElseGet(checkNotNull(defaultValue));
+        return this.get(x, y, z, key).orElseGet(Objects.requireNonNull(defaultValue));
     }
 
     /**
@@ -532,7 +531,7 @@ public interface LocationBaseDataHolder {
      * @return The data or null
      */
     default <E> E getOrElse(final int x, final int y, final int z, final Supplier<? extends Key<? extends Value<E>>> key, final Supplier<? extends E> defaultValue) {
-        return this.get(x, y, z, key.get()).orElseGet(checkNotNull(defaultValue));
+        return this.get(x, y, z, key.get()).orElseGet(Objects.requireNonNull(defaultValue));
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/world/volume/game/PrimitiveGameVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/game/PrimitiveGameVolume.java
@@ -24,12 +24,13 @@
  */
 package org.spongepowered.api.world.volume.game;
 
-import com.google.common.base.Preconditions;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.data.Keys;
 import org.spongepowered.api.world.volume.block.ReadableBlockVolume;
 import org.spongepowered.api.world.volume.block.entity.ReadableBlockEntityVolume;
 import org.spongepowered.math.vector.Vector3i;
+
+import java.util.Objects;
 
 /**
  * A very primitive rudimentary volume that can be used by the {@link Game}
@@ -43,7 +44,7 @@ public interface PrimitiveGameVolume extends ReadableBlockVolume, ReadableBlockE
     }
 
     default int getEmittedLight(Vector3i position) {
-        Preconditions.checkNotNull(position);
+        Objects.requireNonNull(position);
 
         return this.getInt(position, Keys.LIGHT_EMISSION).orElse(0);
     }

--- a/src/main/java/org/spongepowered/api/world/volume/game/ReadableRegion.java
+++ b/src/main/java/org/spongepowered/api/world/volume/game/ReadableRegion.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.world.volume.game;
 
-import com.google.common.base.Preconditions;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.Entity;
@@ -37,6 +36,8 @@ import org.spongepowered.api.world.volume.block.StreamableBlockVolume;
 import org.spongepowered.api.world.volume.block.entity.StreamableBlockEntityVolume;
 import org.spongepowered.api.world.volume.entity.StreamableEntityVolume;
 import org.spongepowered.math.vector.Vector3i;
+
+import java.util.Objects;
 
 public interface ReadableRegion<R extends ReadableRegion<R>> extends
     EnvironmentalVolume,
@@ -91,25 +92,25 @@ public interface ReadableRegion<R extends ReadableRegion<R>> extends
     }
 
     default boolean isBlockLoaded(Vector3i position) {
-        Preconditions.checkNotNull(position);
+        Objects.requireNonNull(position);
 
         return this.isBlockLoaded(position.getX(), position.getY(), position.getZ(), true);
     }
 
     default boolean isBlockLoaded(Vector3i position, boolean allowEmpty) {
-        Preconditions.checkNotNull(position);
+        Objects.requireNonNull(position);
 
         return this.isBlockLoaded(position.getX(), position.getY(), position.getZ(), allowEmpty);
     }
 
     default boolean isAreaLoaded(Vector3i position, int radius) {
-        Preconditions.checkNotNull(position);
+        Objects.requireNonNull(position);
 
         return this.isAreaLoaded(position, radius, true);
     }
 
     default boolean isAreaLoaded(Vector3i center, int radius, boolean allowEmpty) {
-        Preconditions.checkNotNull(center);
+        Objects.requireNonNull(center);
 
         return this.isAreaLoaded(
             center.getX() - radius,


### PR DESCRIPTION
Pretty basic premise, we've got issues with relying on guava, and as Configurate is migrating away from Guava altogether, so shall we (on the basis that we don't really use too much of guava, this is a good chance for cleanup as well).

@zml2008 has got more to do with migrating our usage of TypeTokens.