### PR TITLE
API8 DataStores

### DIFF
--- a/src/main/java/org/spongepowered/api/data/DataProvider.java
+++ b/src/main/java/org/spongepowered/api/data/DataProvider.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.data;
 
+import com.google.common.reflect.TypeToken;
 import org.spongepowered.api.Server;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.value.Value;
@@ -121,6 +122,8 @@ public interface DataProvider<V extends Value<E>, E> {
      * @return Whether it's supported
      */
     boolean isSupported(DataHolder dataHolder);
+
+    boolean isSupported(TypeToken<? extends DataHolder> dataHolder);
 
     DataTransactionResult offer(DataHolder.Mutable dataHolder, E element);
 

--- a/src/main/java/org/spongepowered/api/data/DataRegistration.java
+++ b/src/main/java/org/spongepowered/api/data/DataRegistration.java
@@ -27,12 +27,14 @@ package org.spongepowered.api.data;
 import com.google.common.reflect.TypeToken;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.persistence.DataQuery;
 import org.spongepowered.api.data.persistence.DataStore;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.util.CatalogBuilder;
 import org.spongepowered.plugin.PluginContainer;
 
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -84,7 +86,7 @@ public interface DataRegistration extends CatalogType {
      * @throws UnregisteredKeyException If the key is not registered in this
      *     registration
      */
-    <V extends Value<E>, E> Optional<DataProvider<V, E>> getProviderFor(Key<V> key) throws UnregisteredKeyException;
+    <V extends Value<E>, E> Collection<DataProvider<V, E>> getProvidersFor(Key<V> key) throws UnregisteredKeyException;
 
     /**
      * Gets the appropriate {@link DataStore} for the context of the
@@ -117,6 +119,21 @@ public interface DataRegistration extends CatalogType {
      * @return The owning plugin container for this registration
      */
     PluginContainer getPluginContainer();
+
+    /**
+     * Creates a DataRegistration for a single key with a DataStore for given data-holders.
+     *
+     *
+     * @param key the data key
+     * @param dataHolders the data-holders
+     * @param <T> the keys value type
+     *
+     * @return The built data registration
+     */
+    static <T> DataRegistration of(Key<Value<T>> key, Class<? extends DataHolder> dataHolder, Class<? extends DataHolder>... dataHolders) {
+        final DataStore dataStore = DataStore.of(key, DataQuery.of(key.getKey().getNamespace(), key.getKey().getValue()), dataHolder, dataHolders);
+        return DataRegistration.builder().dataKey(key).store(dataStore).key(key.getKey()).build();
+    }
 
     /**
      * A standard builder for constructing new {@link DataRegistration}s. It's
@@ -173,7 +190,7 @@ public interface DataRegistration extends CatalogType {
          * @param key The key to register
          * @return This builder, for chaining
          */
-        Builder key(Key<?> key);
+        Builder dataKey(Key<?> key);
 
         /**
          * Gives the {@link Key} to this builder signifying the key is to be
@@ -189,7 +206,7 @@ public interface DataRegistration extends CatalogType {
          * @param others The additional keys
          * @return This builder, for chaining
          */
-        Builder key(Key<?> key, Key<?>... others);
+        Builder dataKey(Key<?> key, Key<?>... others);
 
         /**
          * Gives the {@link Key} to this builder signifying the key is to be
@@ -204,7 +221,7 @@ public interface DataRegistration extends CatalogType {
          * @param keys The key to register
          * @return This builder, for chaining
          */
-        Builder key(Iterable<Key<?>> keys);
+        Builder dataKey(Iterable<Key<?>> keys);
 
         @Override
         Builder reset();

--- a/src/main/java/org/spongepowered/api/data/Key.java
+++ b/src/main/java/org/spongepowered/api/data/Key.java
@@ -137,6 +137,10 @@ public interface Key<V extends Value<?>> extends CatalogType {
      */
     <E extends DataHolder> void registerEvent(PluginContainer plugin, Class<E> holderFilter, EventListener<ChangeDataHolderEvent.ValueChange> listener);
 
+    static <E, V extends Value<E>> Key<V> of(PluginContainer plugin, String name, TypeToken<V> type) {
+        return Key.builder().key(ResourceKey.of(plugin, name)).type(type).build();
+    }
+
     interface Builder<E, V extends Value<E>> extends CatalogBuilder<Key<V>, Builder<E, V>> {
 
         /**

--- a/src/main/java/org/spongepowered/api/world/volume/entity/MutableEntityVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/entity/MutableEntityVolume.java
@@ -36,6 +36,7 @@ import org.spongepowered.math.vector.Vector3i;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public interface MutableEntityVolume<M extends MutableEntityVolume<M>> extends StreamableEntityVolume<M>, MutableVolume, MutableBlockVolume<M> {
 
@@ -68,6 +69,27 @@ public interface MutableEntityVolume<M extends MutableEntityVolume<M>> extends S
      * customized further prior to traditional "ticking" and processing by core
      * systems.</p>
      *
+     * @param type The type supplier
+     * @param position The position
+     * @return An entity, if one was created
+     * @throws IllegalArgumentException If the position or entity type is not
+     *      valid to create
+     * @throws IllegalStateException If a constructor cannot be found
+     */
+    default <E extends Entity> E createEntity(Supplier<EntityType<E>> type, Vector3d position) throws IllegalArgumentException, IllegalStateException {
+        return this.createEntity(type.get(), position);
+    }
+
+    /**
+     * Create an entity instance at the given position.
+     *
+     * <p>Creating an entity does not spawn the entity into the world. An entity
+     * created means the entity can be spawned at the given location. If
+     * {@link Optional#empty()} was returned, the entity is not able to spawn at
+     * the given location. Furthermore, this allows for the {@link Entity} to be
+     * customized further prior to traditional "ticking" and processing by core
+     * systems.</p>
+     *
      * @param type The type
      * @param position The position
      * @return An entity, if one was created
@@ -78,6 +100,27 @@ public interface MutableEntityVolume<M extends MutableEntityVolume<M>> extends S
     default <E extends Entity> E createEntity(EntityType<E> type, Vector3i position) throws IllegalArgumentException, IllegalStateException {
         Objects.requireNonNull(position, "position");
         return this.createEntity(type, position.toDouble());
+    }
+
+    /**
+     * Create an entity instance at the given position.
+     *
+     * <p>Creating an entity does not spawn the entity into the world. An entity
+     * created means the entity can be spawned at the given location. If
+     * {@link Optional#empty()} was returned, the entity is not able to spawn at
+     * the given location. Furthermore, this allows for the {@link Entity} to be
+     * customized further prior to traditional "ticking" and processing by core
+     * systems.</p>
+     *
+     * @param type The type supplier
+     * @param position The position
+     * @return An entity, if one was created
+     * @throws IllegalArgumentException If the position or entity type is not
+     *      valid to create
+     * @throws IllegalStateException If a constructor cannot be found
+     */
+    default <E extends Entity> E createEntity(Supplier<EntityType<E>> type, Vector3i position) throws IllegalArgumentException, IllegalStateException {
+        return this.createEntity(type.get(), position);
     }
 
     /**
@@ -111,6 +154,28 @@ public interface MutableEntityVolume<M extends MutableEntityVolume<M>> extends S
      * customized further prior to traditional "ticking" and processing by core
      * systems.</p>
      *
+     * @param type The type supplier
+     * @param position The position
+     * @return An entity, if one was created
+     * @throws IllegalArgumentException If the position or entity type is not
+     *     valid to create
+     * @throws IllegalStateException If a constructor cannot be found
+     */
+    default <E extends Entity> E createEntityNaturally(Supplier<EntityType<E>> type, Vector3d position) throws IllegalArgumentException, IllegalStateException {
+        return this.createEntityNaturally(type.get(), position);
+    }
+
+    /**
+     * Create an entity instance at the given position with the default
+     * equipment.
+     *
+     * <p>Creating an entity does not spawn the entity into the world. An entity
+     * created means the entity can be spawned at the given location. If
+     * {@link Optional#empty()} was returned, the entity is not able to spawn at
+     * the given location. Furthermore, this allows for the {@link Entity} to be
+     * customized further prior to traditional "ticking" and processing by core
+     * systems.</p>
+     *
      * @param type The type
      * @param position The position
      * @return An entity, if one was created
@@ -121,6 +186,28 @@ public interface MutableEntityVolume<M extends MutableEntityVolume<M>> extends S
     default <E extends Entity> E createEntityNaturally(EntityType<E> type, Vector3i position) throws IllegalArgumentException, IllegalStateException {
         Objects.requireNonNull(position, "position");
         return this.createEntityNaturally(type, position.toDouble());
+    }
+
+    /**
+     * Create an entity instance at the given position with the default
+     * equipment.
+     *
+     * <p>Creating an entity does not spawn the entity into the world. An entity
+     * created means the entity can be spawned at the given location. If
+     * {@link Optional#empty()} was returned, the entity is not able to spawn at
+     * the given location. Furthermore, this allows for the {@link Entity} to be
+     * customized further prior to traditional "ticking" and processing by core
+     * systems.</p>
+     *
+     * @param type The type supplier
+     * @param position The position
+     * @return An entity, if one was created
+     * @throws IllegalArgumentException If the position or entity type is not
+     *     valid to create
+     * @throws IllegalStateException If a constructor cannot be found
+     */
+    default <E extends Entity> E createEntityNaturally(Supplier<EntityType<E>> type, Vector3i position) throws IllegalArgumentException, IllegalStateException {
+        return this.createEntityNaturally(type.get(), position);
     }
 
     /**


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/3192)

DataStores can now be built for
 - custom data (saved under "ForgeData.SpongeData.CustomManipulators") which is what plugins should use
or
- vanilla data (saved on the root dataview corresponding the base CompoundNBT) which is used by Sponge to set data on Archetypes and Snapshots

The DataStoreBuilder features Steps forcing you to call required builder methods at least once.

Adds convenience methods for building very simple dataregistration & datastores.
A dataregistration for a `String` value on an `ItemStack` is now as simple as:
```java
        this.mySimpleDataKey = Key.of(this.plugin, "mysimpledata", TypeTokens.STRING_VALUE_TOKEN);
        event.register(DataRegistration.of(this.mySimpleDataKey, ItemStack.class));
```


