### PR TITLE
Add Keys#CUSTOM_MODEL_DATA

### DIFF
--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -589,6 +589,14 @@ public final class Keys {
     public static final Supplier<Key<MapValue<EntityType<?>, Double>>> CUSTOM_ATTACK_DAMAGE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "custom_attack_damage");
 
     /**
+     * The resource pack model index of an {@link ItemStack}.
+     *
+     * <p>Resource packs can use the same index in their files to replace the
+     * item model of an ItemStack.</p>
+     */
+    public static final Supplier<Key<Value<Integer>>> CUSTOM_MODEL_DATA = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "custom_model_data");
+
+    /**
      * The custom name of an {@link Entity}.
      */
     public static final Supplier<Key<Value<Component>>> CUSTOM_NAME = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Key.class, "custom_name");


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/3209)

This PR adds support for the `CustomModelData` tag as noted here:
https://minecraft.gamepedia.com/Player.dat_format#General_Tags

And used in resource packs here:
https://minecraft.gamepedia.com/Model#Item_Predicates