### PR TITLE
Add missing locked field in Score class

### DIFF
--- a/src/main/java/org/spongepowered/api/scoreboard/Score.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Score.java
@@ -56,6 +56,20 @@ public interface Score {
     void setScore(int score);
 
     /**
+     * Checks for whether the score is locked.
+     *
+     * @return True if the score is locked, false otherwise
+     */
+    boolean isLocked();
+
+    /**
+     * Sets this score as locked.
+     *
+     * @param locked True to lock this score
+     */
+    void setLocked(boolean locked);
+
+    /**
      * Returns a {@link Set} of parent {@link Objective}s this {@link Score} is
      * registered to.
      *


### PR DESCRIPTION
SpongeAPI | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/3210)

As my original issue fix was desired for stable-7, I repost the work of @ImMorpheus 
Fix https://github.com/SpongePowered/SpongeAPI/issues/2230