### PR TITLE
Expose portal agents

### DIFF
--- a/src/main/java/org/spongepowered/api/world/PortalType.java
+++ b/src/main/java/org/spongepowered/api/world/PortalType.java
@@ -1,0 +1,8 @@
+package org.spongepowered.api.world;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
+@CatalogedBy(PortalTypes.class)
+public interface PortalType extends CatalogType {
+}

--- a/src/main/java/org/spongepowered/api/world/PortalType.java
+++ b/src/main/java/org/spongepowered/api/world/PortalType.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.api.world;
 
 import org.spongepowered.api.CatalogType;

--- a/src/main/java/org/spongepowered/api/world/PortalTypes.java
+++ b/src/main/java/org/spongepowered/api/world/PortalTypes.java
@@ -1,0 +1,19 @@
+package org.spongepowered.api.world;
+
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+
+public class PortalTypes {
+
+    // SORTFIELDS:ON
+
+    public static final PortalType END = DummyObjectProvider.createFor(PortalType.class, "END");
+
+    public static final PortalType NETHER = DummyObjectProvider.createFor(PortalType.class, "NETHER");
+
+    // SORTFIELDS:OFF
+
+    // Suppress default constructor to ensure non-instantiability.
+    private PortalTypes() {
+        throw new AssertionError("You should not be attempting to instantiate this class.");
+    }
+}

--- a/src/main/java/org/spongepowered/api/world/PortalTypes.java
+++ b/src/main/java/org/spongepowered/api/world/PortalTypes.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.api.world;
 
 import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;

--- a/src/main/java/org/spongepowered/api/world/storage/WorldProperties.java
+++ b/src/main/java/org/spongepowered/api/world/storage/WorldProperties.java
@@ -227,16 +227,15 @@ public interface WorldProperties extends DataSerializable {
      *
      * @return The portal agent map of this world
      */
-    Map<String, String> getPortalAgents();
+    Map<PortalType, String> getPortalAgents();
 
     /**
-     * Set the destination world for a {@link PortalType}
-     * on this world.
+     * Get the destination world properties for a {@link PortalType},
+     * if known.
      *
      * @param portalType The type of the portal
-     * @return The name of the destination world
      */
-    String getPortalDestination(PortalType portalType);
+    Optional<WorldProperties> getPortalDestination(PortalType portalType);
 
     /**
      * Set the destination world for a {@link PortalType}

--- a/src/main/java/org/spongepowered/api/world/storage/WorldProperties.java
+++ b/src/main/java/org/spongepowered/api/world/storage/WorldProperties.java
@@ -36,6 +36,7 @@ import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.world.DimensionType;
 import org.spongepowered.api.world.GeneratorType;
 import org.spongepowered.api.world.PortalAgentType;
+import org.spongepowered.api.world.PortalType;
 import org.spongepowered.api.world.SerializationBehavior;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.difficulty.Difficulty;
@@ -218,6 +219,33 @@ public interface WorldProperties extends DataSerializable {
      * @return The portal agent type
      */
     PortalAgentType getPortalAgentType();
+
+    /**
+     * Gets the portal agent map of this world.
+     * Keys represent dimensions names.
+     * Values represent destination world names.
+     *
+     * @return The portal agent map of this world
+     */
+    Map<String, String> getPortalAgents();
+
+    /**
+     * Set the destination world for a {@link PortalType}
+     * on this world.
+     *
+     * @param portalType The type of the portal
+     * @return The name of the destination world
+     */
+    String getPortalDestination(PortalType portalType);
+
+    /**
+     * Set the destination world for a {@link PortalType}
+     * on this world.
+     *
+     * @param portalType The type of the portal
+     * @param destinationWorldName The destination world name of the portal
+     */
+    void setPortalDestination(PortalType portalType, String destinationWorldName);
 
     /**
      * Gets whether PVP combat is enabled in this world.


### PR DESCRIPTION
**[SpongeCommon ](https://github.com/SpongePowered/SpongeCommon/pull/3212) | SpongeAPI**

In this PR I'm trying to expose the management of portal agents directly from the API.

See the PR in SpongeCommon for more information about implementation.

Thanks for reading this PR.