### PR TITLE
Expose entity tags

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -564,4 +564,31 @@ public interface Entity extends Identifiable, Locatable, DataHolder, Translatabl
         return getValue(Keys.HAS_GRAVITY).get();
     }
 
+    /**
+     * Gets all the tags stored for this entity.
+     *
+     * @return This entity's tags
+     */
+    Collection<String> getTags();
+
+    /**
+     * Adds a tag for this entity.
+     *
+     * @return Whether the tag has effectively been added
+     */
+    boolean addTag(String tag);
+
+    /**
+     * Removes a tag for this entity.
+     *
+     * @return Whether the tag has effectively been removed
+     */
+    boolean removeTag(String tag);
+
+    /**
+     * Returns whether this entity has the given tag.
+     *
+     * @return True if this entity has the given tag.
+     */
+    boolean hasTag(String tag);
 }

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -574,7 +574,7 @@ public interface Entity extends Identifiable, Locatable, DataHolder, Translatabl
     /**
      * Adds a tag for this entity.
      *
-     * @return Whether the tag has effectively been added
+     * @return Whether the tag is effectively in the set
      */
     boolean addTag(String tag);
 


### PR DESCRIPTION
**[SpongeCommon ](https://github.com/SpongePowered/SpongeCommon/pull/3214)| SpongeAPI**

Hey,

Here is a small PR trying to expose entity tags which can be used as selector arguments in commands.
Until now they were not exposed in the API.

Learn more about tags: https://minecraft.gamepedia.com/Scoreboard#Tags

Thanks for reading this PR.