### PR TITLE
Refactor ChangeBlockEvent with All, Post, and Pre

### DIFF
--- a/src/main/java/org/spongepowered/api/CatalogTypes.java
+++ b/src/main/java/org/spongepowered/api/CatalogTypes.java
@@ -31,6 +31,7 @@ import org.spongepowered.api.advancement.AdvancementType;
 import org.spongepowered.api.advancement.criteria.trigger.Trigger;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.block.entity.BlockEntityType;
+import org.spongepowered.api.block.transaction.Operation;
 import org.spongepowered.api.command.selector.SelectorType;
 import org.spongepowered.api.data.persistence.DataFormat;
 import org.spongepowered.api.data.persistence.DataTranslator;
@@ -107,7 +108,6 @@ import org.spongepowered.api.service.economy.transaction.TransactionType;
 import org.spongepowered.api.statistic.Statistic;
 import org.spongepowered.api.statistic.StatisticCategory;
 import org.spongepowered.api.util.orientation.Orientation;
-import org.spongepowered.api.world.SerializationBehavior;
 import org.spongepowered.api.world.WorldArchetype;
 import org.spongepowered.api.world.biome.BiomeType;
 import org.spongepowered.api.world.biome.VirtualBiomeType;
@@ -239,6 +239,8 @@ public final class CatalogTypes {
     public static final Class<NotePitch> NOTE_PITCH = NotePitch.class;
 
     public static final Class<ObjectiveDisplayMode> OBJECTIVE_DISPLAY_MODE = ObjectiveDisplayMode.class;
+
+    public static final Class<Operation> BLOCK_TRANSACTION_OPERATION = Operation.class;
 
     public static final Class<PandaGene> PANDA_GENE = PandaGene.class;
 

--- a/src/main/java/org/spongepowered/api/block/transaction/BlockTransaction.java
+++ b/src/main/java/org/spongepowered/api/block/transaction/BlockTransaction.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.block.transaction;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.block.BlockSnapshot;
+import org.spongepowered.api.data.Transaction;
+import org.spongepowered.api.data.persistence.DataContainer;
+import org.spongepowered.api.data.persistence.Queries;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * A specialized {@link Transaction Transaction&lt;BlockSnapshot&gt;} that covers
+ * the required changes of one {@link BlockSnapshot} to another, with the added benefit
+ * of a contextual understanding of what sort of {@link Operation operation} is being
+ * performed to change from one block to another. It is possible to serialize a
+ * particular transaction, but to associate a transaction with it's "post" state, refer
+ * to {@link BlockTransactionReceipt the receipt variant} that exposes only what
+ * was and what is the final result.
+ */
+public final class BlockTransaction extends Transaction<BlockSnapshot> {
+
+    private final Operation operation;
+
+    public BlockTransaction(final BlockSnapshot original, final BlockSnapshot defaultReplacement,
+        final Operation operation
+    ) {
+        super(original, defaultReplacement);
+        this.operation = operation;
+    }
+
+    public BlockTransaction(final BlockSnapshot original, final BlockSnapshot defaultReplacement,
+        @Nullable final List<? extends BlockSnapshot> intermediary,
+        final Operation operation
+    ) {
+        super(original, defaultReplacement, intermediary);
+        this.operation = operation;
+    }
+
+    public Operation getOperation() {
+        return this.operation;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), this.operation);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || this.getClass() != obj.getClass()) {
+            return false;
+        }
+        final BlockTransaction other = (BlockTransaction) obj;
+        return Objects.equals(this.getOriginal(), other.getOriginal())
+            && Objects.equals(this.getDefault(), other.getDefault())
+            && Objects.equals(this.isValid(), other.isValid())
+            && Objects.equals(this.getCustom(), other.getCustom())
+            && Objects.equals(this.operation, other.operation);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", BlockTransaction.class.getSimpleName() + "[", "]")
+            .add("operation=" + this.operation)
+            .add("original=" + this.getOriginal())
+            .add("default=" + this.getDefault())
+            .add("custom=" + this.getCustom())
+            .add("valid=" + this.isValid())
+            .toString();
+    }
+
+    @Override
+    public int getContentVersion() {
+        return 1;
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return super.toContainer().set(Queries.BLOCK_OPERATION, this.operation);
+    }
+}

--- a/src/main/java/org/spongepowered/api/block/transaction/BlockTransactionReceipt.java
+++ b/src/main/java/org/spongepowered/api/block/transaction/BlockTransactionReceipt.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.block.transaction;
+
+import org.spongepowered.api.block.BlockSnapshot;
+import org.spongepowered.api.data.persistence.DataContainer;
+import org.spongepowered.api.data.persistence.DataSerializable;
+import org.spongepowered.api.data.persistence.Queries;
+
+public final class BlockTransactionReceipt implements DataSerializable {
+
+    private final BlockSnapshot originalBlock;
+    private final BlockSnapshot finalBlock;
+    private final Operation operation;
+
+    public BlockTransactionReceipt(final BlockSnapshot originalBlock, final BlockSnapshot finalBlock,
+        final Operation operation
+    ) {
+        this.originalBlock = originalBlock;
+        this.finalBlock = finalBlock;
+        this.operation = operation;
+    }
+
+    public BlockSnapshot getOriginal() {
+        return this.originalBlock;
+    }
+
+    public BlockSnapshot getFinal() {
+        return this.finalBlock;
+    }
+
+    public Operation getOperation() {
+        return this.operation;
+    }
+
+    @Override
+    public int getContentVersion() {
+        return 1;
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return DataContainer.createNew()
+            .set(Queries.CONTENT_VERSION, this.getContentVersion())
+            .set(Queries.ORIGINAL, this.originalBlock.toContainer())
+            .set(Queries.FINAL_REPLACEMENT, this.finalBlock.toContainer())
+            .set(Queries.BLOCK_OPERATION, this.operation.getKey().asString())
+            ;
+    }
+}

--- a/src/main/java/org/spongepowered/api/block/transaction/Operation.java
+++ b/src/main/java/org/spongepowered/api/block/transaction/Operation.java
@@ -22,17 +22,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.action;
+package org.spongepowered.api.block.transaction;
 
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.Event;
-import org.spongepowered.api.event.entity.AffectEntityEvent;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
 
-public interface LightningEvent extends Event {
-
-    interface Pre extends LightningEvent, Cancellable {}
-
-    interface Strike extends LightningEvent, AffectEntityEvent {}
-
-    interface Post extends LightningEvent {}
+/**
+ * Represents an operation in a {@link org.spongepowered.api.world.server.ServerWorld}
+ * that is an effective contextual "comparison" of what type of transaction is, such as
+ * {@link Operations#PLACE}, {@link Operations#BREAK}, and {@link Operations#MODIFY},
+ * but holds no bearing on the order of a transaction taking place.
+ */
+@CatalogedBy(Operations.class)
+public interface Operation extends CatalogType {
 }

--- a/src/main/java/org/spongepowered/api/block/transaction/Operations.java
+++ b/src/main/java/org/spongepowered/api/block/transaction/Operations.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.block.transaction;
+
+import org.spongepowered.api.Sponge;
+
+import java.util.function.Supplier;
+
+public final class Operations {
+    /**
+     * An {@link Operation} that signifies a {@link org.spongepowered.api.block.BlockState block} is either:
+     * <ul>
+     *     <li>Replacing {@link org.spongepowered.api.block.BlockTypes#AIR an air} block</li>
+     *     <li>A {@link org.spongepowered.api.block.BlockState} that is replaceable when moved, or an
+     *     {@link org.spongepowered.api.item.inventory.ItemStack} can replace it</li>
+     * </ul>
+     */
+    public static final Supplier<Operation> PLACE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Operation.class, "place");
+    /**
+     * An {@link Operation} that signifies a non {@link org.spongepowered.api.block.BlockTypes#AIR air block} being
+     * broken and replaced with {@link org.spongepowered.api.block.BlockTypes#AIR an air block}.
+     */
+    public static final Supplier<Operation> BREAK = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Operation.class, "break");
+    /**
+     * An {@link Operation} that signifies the block change is particularly discernible as though the
+     * {@link org.spongepowered.api.block.BlockState} may be different but the
+     * {@link org.spongepowered.api.block.BlockType} may be the same. Or a congruency of changes that
+     * result to a "similar enough" change that the blocks share a very unique common trait.
+     */
+    public static final Supplier<Operation> MODIFY = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Operation.class, "modify");
+    /**
+     * An {@link Operation} that is considered specially during a plant based block to change into
+     * potentially more blocks, occasionally either a combination of {@link #PLACE} and {@link #MODIFY}
+     * but likewise commonly shared as a "root" plant or some kind.
+     */
+    public static final Supplier<Operation> GROWTH = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Operation.class, "growth");
+
+    public static final Supplier<Operation> DECAY = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Operation.class, "decay");
+    public static final Supplier<Operation> LIQUID_SPREAD = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Operation.class, "liquid_spread");
+    public static final Supplier<Operation> LIQUID_DECAY = Sponge.getRegistry().getCatalogRegistry().provideSupplier(Operation.class, "liquid_decay");
+
+    private Operations() {}
+}

--- a/src/main/java/org/spongepowered/api/data/Transaction.java
+++ b/src/main/java/org/spongepowered/api/data/Transaction.java
@@ -160,6 +160,14 @@ public class Transaction<T extends DataSerializable> implements DataSerializable
         this.valid = valid;
     }
 
+    public final void validate() {
+        this.valid = true;
+    }
+
+    public final void invalidate() {
+        this.valid = false;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(this.original, this.defaultReplacement, this.valid, this.custom);

--- a/src/main/java/org/spongepowered/api/data/persistence/Queries.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/Queries.java
@@ -36,7 +36,9 @@ public final class Queries {
     public static final DataQuery ORIGINAL = of("Original");
     public static final DataQuery DEFAULT_REPLACEMENT = of("DefaultReplacement");
     public static final DataQuery CUSTOM_REPLACEMENT = of("CustomReplacement");
+    public static final DataQuery FINAL_REPLACEMENT = of("FinalReplacement");
     public static final DataQuery VALID = of("IsValid");
+    public static final DataQuery BLOCK_OPERATION = of("Operation");
 
     // WeightedSerializableObject
     public static final DataQuery WEIGHTED_SERIALIZABLE = of("DataSerializable");

--- a/src/main/java/org/spongepowered/api/event/EventContextKeys.java
+++ b/src/main/java/org/spongepowered/api/event/EventContextKeys.java
@@ -29,17 +29,17 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.block.transaction.BlockTransaction;
 import org.spongepowered.api.data.type.HandType;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.User;
-import org.spongepowered.api.event.block.ChangeBlockEvent;
+import org.spongepowered.api.event.cause.entity.DismountType;
+import org.spongepowered.api.event.cause.entity.MovementType;
+import org.spongepowered.api.event.cause.entity.SpawnType;
 import org.spongepowered.api.event.cause.entity.damage.DamageType;
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
-import org.spongepowered.api.event.cause.entity.DismountType;
-import org.spongepowered.api.event.cause.entity.SpawnType;
-import org.spongepowered.api.event.cause.entity.MovementType;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.profile.GameProfile;
 import org.spongepowered.api.projectile.source.ProjectileSource;
@@ -101,12 +101,6 @@ public final class EventContextKeys {
     public static final Supplier<EventContextKey<BlockSnapshot>> BLOCK_TARGET = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "block_target");
 
     /**
-     * Used for {@link org.spongepowered.api.event.block.ChangeBlockEvent.Post} to provide
-     * the block event without relying on existing in the {@link Cause} stack.
-     */
-    public static final Supplier<EventContextKey<ChangeBlockEvent.Break>> BREAK_EVENT = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "break_event");
-
-    /**
      * Represents the command string that was provided to the command processor.
      */
     public static final Supplier<EventContextKey<String>> COMMAND = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "command");
@@ -120,12 +114,6 @@ public final class EventContextKeys {
      * Represents the {@link DamageType} to an entity.
      */
     public static final Supplier<EventContextKey<DamageType>> DAMAGE_TYPE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "damage_type");
-
-    /**
-     * Used for {@link org.spongepowered.api.event.block.ChangeBlockEvent.Post} to provide
-     * the block event without relying on existing in the {@link Cause} stack.
-     */
-    public static final Supplier<EventContextKey<ChangeBlockEvent.Decay>> DECAY_EVENT = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "decay_event");
 
     /**
      * Used when a {@link Player} dismounts from an {@link Entity}.
@@ -153,16 +141,13 @@ public final class EventContextKeys {
     public static final Supplier<EventContextKey<ServerWorld>> FIRE_SPREAD = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "fire_spread");
 
     /**
-     * Used for {@link org.spongepowered.api.event.block.ChangeBlockEvent.Grow} to provide
-     * the origin {@link BlockSnapshot} that is doing the "growing".
+     * Used for {@link org.spongepowered.api.event.block.ChangeBlockEvent} to provide
+     * the origin {@link BlockSnapshot} that is doing the "growing". This is likely
+     * useful to determine what is the origin with {@link BlockTransaction#getOperation()}
+     * when the {@link org.spongepowered.api.block.transaction.Operation operation} is of
+     * {@link org.spongepowered.api.block.transaction.Operations#GROWTH Operations.GROWTH}.
      */
     public static final Supplier<EventContextKey<BlockSnapshot>> GROWTH_ORIGIN = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "growth_origin");
-
-    /**
-     * Used for {@link org.spongepowered.api.event.block.ChangeBlockEvent.Post} to provide
-     * the block event without relying on existing in the {@link Cause} stack.
-     */
-    public static final Supplier<EventContextKey<ChangeBlockEvent.Grow>> GROW_EVENT = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "grow_event");
 
     /**
      * Used when an {@link Living} ignites causing an {@link Explosion}.
@@ -201,12 +186,6 @@ public final class EventContextKeys {
     public static final Supplier<EventContextKey<ServerLocation>> LOCATION = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "location");
 
     /**
-     * Used for {@link org.spongepowered.api.event.block.ChangeBlockEvent.Post} to provide
-     * the block event without relying on existing in the {@link Cause} stack.
-     */
-    public static final Supplier<EventContextKey<ChangeBlockEvent.Modify>> MODIFY_EVENT = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "modify_event");
-
-    /**
      * Represents the {@link MovementType} when an entity moves.
      */
     public static final Supplier<EventContextKey<MovementType>> MOVEMENT_TYPE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "movement_type");
@@ -230,12 +209,6 @@ public final class EventContextKeys {
      * Used when a {@link BlockTypes#PISTON_HEAD} retracts.
      */
     public static final Supplier<EventContextKey<ServerWorld>> PISTON_RETRACT = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "piston_retract");
-
-    /**
-     * Used for {@link org.spongepowered.api.event.block.ChangeBlockEvent.Post} to provide
-     * the block event without relying on existing in the {@link Cause} stack.
-     */
-    public static final Supplier<EventContextKey<ChangeBlockEvent.Place>> PLACE_EVENT = Sponge.getRegistry().getCatalogRegistry().provideSupplier(EventContextKey.class, "place_event");
 
     /**
      * Represents a {@link Player}.

--- a/src/main/java/org/spongepowered/api/event/block/ChangeBlockEvent.java
+++ b/src/main/java/org/spongepowered/api/event/block/ChangeBlockEvent.java
@@ -38,6 +38,7 @@ import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Cause;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.world.ServerLocation;
+import org.spongepowered.api.world.server.ServerWorld;
 
 import java.util.List;
 import java.util.Objects;
@@ -59,13 +60,20 @@ import java.util.stream.Stream;
  * {@code break}, {@code place}, {@code modify}, etc. please refer to the
  * {@link BlockTransaction#getOperation()}</p>
  */
-public interface ChangeBlockEvent extends Event, Cancellable {
+public interface ChangeBlockEvent extends Event {
+
+    /**
+     * Gets the world this event is affecting.
+     *
+     * @return The world encompassing these block changes
+     */
+    ServerWorld getWorld();
 
     /**
      * Called before running specific block logic at one or more 
      * {@link ServerLocation}'s such as {@link BlockTypes#WATER}.
      */
-    interface Pre extends Event, Cancellable {
+    interface Pre extends ChangeBlockEvent, Cancellable {
 
         /**
          * Represents a list of one or more {@link ServerLocation}'s where
@@ -129,7 +137,7 @@ public interface ChangeBlockEvent extends Event, Cancellable {
          * @return The transactions for which the predicate returned
          *     {@code false}
          */
-        default List<BlockTransaction> filter(final Predicate<ServerLocation> predicate) {
+        default List<BlockTransaction> invalidate(final Predicate<ServerLocation> predicate) {
             return this.getTransactions()
                 .stream()
                 .filter(blockTransaction -> {
@@ -146,8 +154,8 @@ public interface ChangeBlockEvent extends Event, Cancellable {
          * Invalidates the list as such that all {@link Transaction}s are
          * marked as "invalid" and will not apply post event.
          */
-        default void filterAll() {
-            this.getTransactions().forEach(transaction -> transaction.setValid(false));
+        default void invalidateAll() {
+            this.getTransactions().forEach(Transaction::invalidate);
         }
     }
 


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/3216)
Previous events were disjointed by a class definition of what possible
operations were being performed, regardless whether an operation was
performed in a specific order. This lead to either logically reading the
transactions in order from the Post event, and deducing changes, or
avoiding transaction ordering entirely. Now, with the new API, the
transaction itself lends the Operation as a signifier about what
operation the transaction is itself, without needing to know whether the
changes were done in a specific order or not, they're always in the
order the engine provides, with the added information for each transaction
to have the operation being performed to achieve the result of the final
block state.

Signed-off-by: Gabriel Harris-Rouquette <gabizou@me.com>