### PR TITLE
ResourceKey improvements

### DIFF
--- a/src/main/java/org/spongepowered/api/ResourceKey.java
+++ b/src/main/java/org/spongepowered/api/ResourceKey.java
@@ -102,7 +102,7 @@ public interface ResourceKey extends Key {
      * @return A new resource key
      */
     static ResourceKey of(final String namespace, final String value) {
-        return builder().namespace(namespace).value(value).build();
+        return ResourceKey.builder().namespace(namespace).value(value).build();
     }
 
     /**
@@ -113,7 +113,7 @@ public interface ResourceKey extends Key {
      * @return A new resource key
      */
     static ResourceKey of(final PluginContainer container, final String value) {
-        return builder().namespace(container).value(value).build();
+        return ResourceKey.builder().namespace(container).value(value).build();
     }
 
     /**
@@ -126,7 +126,7 @@ public interface ResourceKey extends Key {
      * @return A new resource key
      */
     static ResourceKey resolve(final String formatted) {
-        return resolve(formatted, MINECRAFT_NAMESPACE);
+        return ResourceKey.resolve(formatted, MINECRAFT_NAMESPACE);
     }
 
     /**
@@ -140,7 +140,7 @@ public interface ResourceKey extends Key {
      * @return A new resource key
      */
     static ResourceKey resolve(final String formatted, final PluginContainer defaultNamespace) {
-        return resolve(formatted, defaultNamespace.getMetadata().getId());
+        return ResourceKey.resolve(formatted, defaultNamespace.getMetadata().getId());
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/ResourceKey.java
+++ b/src/main/java/org/spongepowered/api/ResourceKey.java
@@ -64,20 +64,20 @@ public interface ResourceKey extends Key {
     String SPONGE_NAMESPACE = "sponge";
 
     /**
-     * Creates a catalog key with a namespace of {@link #MINECRAFT_NAMESPACE minecraft}.
+     * Creates a resource key with a namespace of {@link #MINECRAFT_NAMESPACE minecraft}.
      *
      * @param value The value
-     * @return A new catalog key
+     * @return A new resource key
      */
     static ResourceKey minecraft(final String value) {
         return ResourceKey.of(ResourceKey.MINECRAFT_NAMESPACE, value);
     }
 
     /**
-     * Creates a catalog key with a namespace of {@link #SPONGE_NAMESPACE sponge}.
+     * Creates a resource key with a namespace of {@link #SPONGE_NAMESPACE sponge}.
      *
      * @param value The value
-     * @return A new catalog key
+     * @return A new resource key
      */
     static ResourceKey sponge(final String value) {
         return ResourceKey.of(ResourceKey.SPONGE_NAMESPACE, value);
@@ -95,38 +95,66 @@ public interface ResourceKey extends Key {
     }
 
     /**
-     * Creates a catalog key.
+     * Creates a resource key.
      *
      * @param namespace The namespace
      * @param value The value
-     * @return A new catalog key
+     * @return A new resource key
      */
     static ResourceKey of(final String namespace, final String value) {
-        return Sponge.getRegistry().getBuilderRegistry().provideBuilder(Builder.class).namespace(namespace).value(value).build();
+        return builder().namespace(namespace).value(value).build();
     }
 
     /**
-     * Creates a catalog key
+     * Creates a resource key.
      *
      * @param container The container
      * @param value The value
-     * @return A new catalog key
+     * @return A new resource key
      */
     static ResourceKey of(final PluginContainer container, final String value) {
-        return Sponge.getRegistry().getBuilderRegistry().provideBuilder(Builder.class).namespace(container).value(value).build();
+        return builder().namespace(container).value(value).build();
     }
 
     /**
-     * Resolves a catalog key from a string.
+     * Resolves a resource key from a string.
      *
      * <p>If no namespace is found in {@code string} then
      * {@link #MINECRAFT_NAMESPACE} will be the namespace.</p>
      *
-     * @param value The value
-     * @return A new catalog key
+     * @param formatted The formatted string to parse
+     * @return A new resource key
      */
-    static ResourceKey resolve(final String value) {
-        return Sponge.getRegistry().getBuilderRegistry().provideBuilder(Builder.class).value(value).build();
+    static ResourceKey resolve(final String formatted) {
+        return resolve(formatted, MINECRAFT_NAMESPACE);
+    }
+
+    /**
+     * Resolves a resource key from a string.
+     *
+     * <p>If no namespace is found in {@code formatted} then
+     * the specified default namespace will be used.</p>
+     *
+     * @param formatted The formatted string to parse
+     * @param defaultNamespace The default namespace to use
+     * @return A new resource key
+     */
+    static ResourceKey resolve(final String formatted, final PluginContainer defaultNamespace) {
+        return resolve(formatted, defaultNamespace.getMetadata().getId());
+    }
+
+    /**
+     * Resolves a resource key from a string.
+     *
+     * <p>If no namespace is found in {@code formatted} then
+     * the specified default namespace will be used.</p>
+     *
+     * @param formatted The formatted string to parse
+     * @param defaultNamespace The default namespace to use
+     * @return A new resource key
+     */
+    static ResourceKey resolve(final String formatted, final String defaultNamespace) {
+        return Sponge.getRegistry().getFactoryRegistry().provideFactory(Factory.class).resolve(formatted, defaultNamespace);
     }
 
     /**
@@ -150,10 +178,10 @@ public interface ResourceKey extends Key {
     /**
      * Gets this key as a formatted value.
      *
-     * <p>
-     *     It is up to the implementation to determine the formatting. In vanilla Minecraft,
-     *     keys are formatted as "namespace:value". For example, "minecraft:carrot".
-     * </p>
+     * <p>It is up to the implementation to determine the formatting. In
+     * vanilla Minecraft, keys are formatted as "namespace:value". For example,
+     * "minecraft:carrot".</p>
+     *
      * @return The key, formatted
      */
     default String getFormatted() {
@@ -170,14 +198,65 @@ public interface ResourceKey extends Key {
         return Key.super.compareTo(o);
     }
 
+    /**
+     * A builder to create {@link ResourceKey}s.
+     */
     interface Builder extends ResettableBuilder<ResourceKey, Builder> {
 
+        /**
+         * Sets the key's namespace.
+         *
+         * <p>If using a {@link #MINECRAFT_NAMESPACE} or
+         * {@link #SPONGE_NAMESPACE}, it is preferable to use
+         * {@link ResourceKey#minecraft(String)} or
+         * {@link ResourceKey#sponge(String)} instead.</p>
+         *
+         * @param namespace The namespace to use
+         * @return This builder, for chaining
+         */
         Builder namespace(String namespace);
 
-        Builder namespace(PluginContainer container);
+        /**
+         * Sets the key's namespace based on the provided
+         * {@link PluginContainer}'s identifier.
+         *
+         * @param container The plugin container to fetch from
+         * @return This builder, for chaining
+         */
+        default Builder namespace(PluginContainer container) {
+            return this.namespace(container.getMetadata().getId());
+        }
 
+        /**
+         * Sets the key's value.
+         *
+         * @param value The value to use
+         * @return This builder, for chaining
+         */
         Builder value(String value);
 
+        /**
+         * Builds the {@link ResourceKey}.
+         *
+         * @return The built resource key
+         * @throws IllegalStateException If {@link Builder#namespace(String)} or {@link Builder#value(String)} are not set.
+         */
         ResourceKey build() throws IllegalStateException;
+    }
+
+    /**
+     * A factory to generate {@link ResourceKey}s.
+     */
+    interface Factory {
+
+        /**
+         * Resolves a resource key from a string, using the provided default
+         * namespace if no namespace was found in {@code value}.
+         *
+         * @param formatted The formatted string to parse
+         * @param defaultNamespace The default namespace to use
+         * @return A new resource key
+         */
+        ResourceKey resolve(String formatted, String defaultNamespace);
     }
 }

--- a/src/main/java/org/spongepowered/api/ResourceKey.java
+++ b/src/main/java/org/spongepowered/api/ResourceKey.java
@@ -119,42 +119,14 @@ public interface ResourceKey extends Key {
     /**
      * Resolves a resource key from a string.
      *
-     * <p>If no namespace is found in {@code string} then
+     * <p>If no namespace is found in {@code formatted} then
      * {@link #MINECRAFT_NAMESPACE} will be the namespace.</p>
      *
      * @param formatted The formatted string to parse
      * @return A new resource key
      */
     static ResourceKey resolve(final String formatted) {
-        return ResourceKey.resolve(formatted, MINECRAFT_NAMESPACE);
-    }
-
-    /**
-     * Resolves a resource key from a string.
-     *
-     * <p>If no namespace is found in {@code formatted} then
-     * the specified default namespace will be used.</p>
-     *
-     * @param formatted The formatted string to parse
-     * @param defaultNamespace The default namespace to use
-     * @return A new resource key
-     */
-    static ResourceKey resolve(final String formatted, final PluginContainer defaultNamespace) {
-        return ResourceKey.resolve(formatted, defaultNamespace.getMetadata().getId());
-    }
-
-    /**
-     * Resolves a resource key from a string.
-     *
-     * <p>If no namespace is found in {@code formatted} then
-     * the specified default namespace will be used.</p>
-     *
-     * @param formatted The formatted string to parse
-     * @param defaultNamespace The default namespace to use
-     * @return A new resource key
-     */
-    static ResourceKey resolve(final String formatted, final String defaultNamespace) {
-        return Sponge.getRegistry().getFactoryRegistry().provideFactory(Factory.class).resolve(formatted, defaultNamespace);
+        return Sponge.getRegistry().getFactoryRegistry().provideFactory(Factory.class).resolve(formatted);
     }
 
     /**
@@ -250,13 +222,13 @@ public interface ResourceKey extends Key {
     interface Factory {
 
         /**
-         * Resolves a resource key from a string, using the provided default
-         * namespace if no namespace was found in {@code value}.
+         * Resolves a resource key from a string, using
+         * {@link #MINECRAFT_NAMESPACE} if no namespace is found within
+         * {@code formatted}.
          *
          * @param formatted The formatted string to parse
-         * @param defaultNamespace The default namespace to use
          * @return A new resource key
          */
-        ResourceKey resolve(String formatted, String defaultNamespace);
+        ResourceKey resolve(String formatted);
     }
 }


### PR DESCRIPTION
**SpongeAPI** | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/3217)

- Cleaned up and added more javadocs
- Added new `resolve` methods that let you specify a custom default namespace

EDIT: Also keep in mind now that `ResourceKey.Builder#namespace` must always be set.