### PR TITLE
[WIP] Just brainstorming ideas for further registry work.

### DIFF
--- a/src/main/java/org/spongepowered/api/Game.java
+++ b/src/main/java/org/spongepowered/api/Game.java
@@ -30,10 +30,13 @@ import org.spongepowered.api.config.ConfigManager;
 import org.spongepowered.api.data.DataManager;
 import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.data.persistence.DataSerializable;
+import org.spongepowered.api.data.type.MatterType;
 import org.spongepowered.api.event.EventManager;
 import org.spongepowered.api.network.channel.ChannelRegistry;
 import org.spongepowered.api.plugin.PluginManager;
 import org.spongepowered.api.registry.GameRegistry;
+import org.spongepowered.api.registry.Registry;
+import org.spongepowered.api.registry.RegistryManager;
 import org.spongepowered.api.scheduler.Scheduler;
 import org.spongepowered.api.sql.SqlManager;
 import org.spongepowered.api.util.metric.MetricsConfigManager;
@@ -121,6 +124,8 @@ public interface Game {
      * @return The current implementation
      */
     Platform getPlatform();
+
+    RegistryManager getRegistryManager();
 
     /**
      * Gets the {@link GameRegistry}.

--- a/src/main/java/org/spongepowered/api/registry/Registries.java
+++ b/src/main/java/org/spongepowered/api/registry/Registries.java
@@ -22,24 +22,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.type;
+package org.spongepowered.api.registry;
 
 import org.spongepowered.api.ResourceKey;
-import org.spongepowered.api.registry.Registries;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.type.MatterType;
 
-import java.util.Locale;
-import java.util.function.Supplier;
+public final class Registries {
 
-public enum MatterTypes implements Supplier<MatterType> {
-
-    GAS,
-    LIQUID,
-    SOLID;
-
-    private final Supplier<MatterType> supplier = Registries.MATTER_TYPE.getSupplier(ResourceKey.sponge(this.name().toLowerCase(Locale.ROOT)));
-
-    @Override
-    public MatterType get() {
-        return this.supplier.get();
-    }
+    public static final Registry<MatterType> MATTER_TYPE = Sponge.getGame().getRegistryManager().findRegistry(ResourceKey.sponge("matter_type"));
 }

--- a/src/main/java/org/spongepowered/api/registry/Registry.java
+++ b/src/main/java/org/spongepowered/api/registry/Registry.java
@@ -22,24 +22,46 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.type;
+package org.spongepowered.api.registry;
 
 import org.spongepowered.api.ResourceKey;
-import org.spongepowered.api.registry.Registries;
 
-import java.util.Locale;
+import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
-public enum MatterTypes implements Supplier<MatterType> {
+public interface Registry<V> extends Iterable<RegistryEntry<V>> {
 
-    GAS,
-    LIQUID,
-    SOLID;
+    ResourceKey getKey();
 
-    private final Supplier<MatterType> supplier = Registries.MATTER_TYPE.getSupplier(ResourceKey.sponge(this.name().toLowerCase(Locale.ROOT)));
+    Optional<ResourceKey> getKey(V value);
 
-    @Override
-    public MatterType get() {
-        return this.supplier.get();
-    }
+    Optional<RegistryEntry<V>> getValue(ResourceKey key);
+
+    Supplier<V> getSupplier(ResourceKey key);
+
+    Stream<RegistryEntry<V>> stream();
+
+    /**
+     * Returns if this registry supports adding additional values.
+     *
+     * @return True if the registry can add additional values
+     */
+    boolean isDynamic();
+
+    /**
+     * Registers a new value to this registry.
+     *
+     * <p>It is recommended to check if {@link Registry#isDynamic()} returns {@code TRUE}
+     * before registering the new value. If it is not dynamic, this will throw an
+     * {@link IllegalStateException}.</p>
+     *
+     * <p>If the key already exists in the registry, a {@link DuplicateRegistrationException}
+     * will be thrown.</p>
+     *
+     * @param key The key to register under
+     * @param value The value to register
+     * @return The added {@link RegistryEntry}
+     */
+    RegistryEntry<V> register(ResourceKey key, V value);
 }

--- a/src/main/java/org/spongepowered/api/registry/RegistryEntry.java
+++ b/src/main/java/org/spongepowered/api/registry/RegistryEntry.java
@@ -22,24 +22,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.type;
+package org.spongepowered.api.registry;
 
 import org.spongepowered.api.ResourceKey;
-import org.spongepowered.api.registry.Registries;
 
-import java.util.Locale;
-import java.util.function.Supplier;
+public interface RegistryEntry<V> {
 
-public enum MatterTypes implements Supplier<MatterType> {
+    ResourceKey getKey();
 
-    GAS,
-    LIQUID,
-    SOLID;
-
-    private final Supplier<MatterType> supplier = Registries.MATTER_TYPE.getSupplier(ResourceKey.sponge(this.name().toLowerCase(Locale.ROOT)));
-
-    @Override
-    public MatterType get() {
-        return this.supplier.get();
-    }
+    V getValue();
 }

--- a/src/main/java/org/spongepowered/api/registry/RegistryManager.java
+++ b/src/main/java/org/spongepowered/api/registry/RegistryManager.java
@@ -22,24 +22,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.data.type;
+package org.spongepowered.api.registry;
 
 import org.spongepowered.api.ResourceKey;
-import org.spongepowered.api.registry.Registries;
 
-import java.util.Locale;
-import java.util.function.Supplier;
+public interface RegistryManager {
 
-public enum MatterTypes implements Supplier<MatterType> {
-
-    GAS,
-    LIQUID,
-    SOLID;
-
-    private final Supplier<MatterType> supplier = Registries.MATTER_TYPE.getSupplier(ResourceKey.sponge(this.name().toLowerCase(Locale.ROOT)));
-
-    @Override
-    public MatterType get() {
-        return this.supplier.get();
-    }
+    /**
+     * Finds a {@link Registry registry} by its {@link ResourceKey key}.
+     *
+     * <p>If no registry is found, this will throw an {@link IllegalStateException}.
+     * Mostly provided for cleaner access in various API classes and when plugin
+     * developers are 100% sure the registry will always exist. See {@link Registries}
+     * for an example.</p>
+     *
+     * @param key The key
+     * @param <V> The value type
+     * @return The registry
+     */
+    <V> Registry<V> findRegistry(ResourceKey key);
 }


### PR DESCRIPTION
Perks of the changes, so far:

- Types go back to being enums (as long as they do not have generic parameters) which brings back the ease of use to plugin devs
- Suppliers now available for all registries and under any key, not just for Sponge
- Dynamic registration now available after lifecycle

Much more to come, seeking feedback before applying these changes on a wide scale.

Signed-off-by: Chris Sanders <zidane@spongepowered.org>