### PR TITLE
Update Chunk API elements

### DIFF
--- a/src/main/java/org/spongepowered/api/scheduler/ScheduledUpdateList.java
+++ b/src/main/java/org/spongepowered/api/scheduler/ScheduledUpdateList.java
@@ -34,7 +34,7 @@ import java.time.temporal.TemporalUnit;
 import java.util.Collection;
 
 /**
- * A tick based priority scheduled list targeting speicifc types of
+ * A tick based priority scheduled list targeting specific types of
  * objects that need to be ticked. In common cases, there's either
  * a {@link BlockType} or {@link FluidType} being ticked.
  * @param <T> The type of update objects that are being scheduled
@@ -50,7 +50,7 @@ public interface ScheduledUpdateList<T> {
      * @param temporalUnit The unit of the delay
      * @return The scheduled update
      */
-    default ScheduledUpdate<T> schedule(Vector3i pos, T target, int delay, TemporalUnit temporalUnit) {
+    default ScheduledUpdate<T> schedule(final Vector3i pos, final T target, final int delay, final TemporalUnit temporalUnit) {
         return this.schedule(pos.x(), pos.y(), pos.z(), target, delay, temporalUnit, TaskPriorities.NORMAL.get());
     }
 
@@ -61,7 +61,7 @@ public interface ScheduledUpdateList<T> {
      * @param delay The delay with a duration
      * @return The scheduled update
      */
-    default ScheduledUpdate<T> schedule(Vector3i pos, T target, Duration delay) {
+    default ScheduledUpdate<T> schedule(final Vector3i pos, final T target, final Duration delay) {
         return this.schedule(pos.x(), pos.y(), pos.z(), target, delay, TaskPriorities.NORMAL);
     }
 
@@ -75,7 +75,7 @@ public interface ScheduledUpdateList<T> {
      * @param temporalUnit The unit of time
      * @return The scheduled update
      */
-    default ScheduledUpdate<T> schedule(int x, int y, int z, T target, int delay, TemporalUnit temporalUnit) {
+    default ScheduledUpdate<T> schedule(final int x, final int y, final int z, final T target, final int delay, final TemporalUnit temporalUnit) {
         return this.schedule(x, y, z, target, delay, temporalUnit, TaskPriorities.NORMAL.get());
     }
 
@@ -88,7 +88,7 @@ public interface ScheduledUpdateList<T> {
      * @param delay The delay
      * @return The scheduled update
      */
-    default ScheduledUpdate<T> schedule(int x, int y, int z, T target, Duration delay) {
+    default ScheduledUpdate<T> schedule(final int x, final int y, final int z, final T target, final Duration delay) {
         return this.schedule(x, y, z, target, delay, TaskPriorities.NORMAL);
     }
 
@@ -101,7 +101,7 @@ public interface ScheduledUpdateList<T> {
      * @param priority The priority of the scheduled update
      * @return The scheduled update
      */
-    default ScheduledUpdate<T> schedule(Vector3i pos, T target, int delay, TemporalUnit temporalUnit, TaskPriority priority) {
+    default ScheduledUpdate<T> schedule(final Vector3i pos, final T target, final int delay, final TemporalUnit temporalUnit, final TaskPriority priority) {
         return this.schedule(pos.x(), pos.y(), pos.z(), target, Duration.of(delay, temporalUnit), priority);
     }
 
@@ -114,7 +114,7 @@ public interface ScheduledUpdateList<T> {
      * @param priority The priority of the scheduled update
      * @return The scheduled update
      */
-    default ScheduledUpdate<T> schedule(Vector3i pos, T target, int delay, TemporalUnit temporalUnit, DefaultedRegistryReference<? extends TaskPriority> priority) {
+    default ScheduledUpdate<T> schedule(final Vector3i pos, final T target, final int delay, final TemporalUnit temporalUnit, final DefaultedRegistryReference<? extends TaskPriority> priority) {
         return this.schedule(pos.x(), pos.y(), pos.z(), target, Duration.of(delay, temporalUnit), priority.get());
     }
 
@@ -126,7 +126,7 @@ public interface ScheduledUpdateList<T> {
      * @param priority The priority of the scheduled update
      * @return The scheduled update
      */
-    default ScheduledUpdate<T> schedule(Vector3i pos, T target, Duration delay, TaskPriority priority) {
+    default ScheduledUpdate<T> schedule(final Vector3i pos, final T target, final Duration delay, final TaskPriority priority) {
         return this.schedule(pos.x(), pos.y(), pos.z(), target, delay, priority);
     }
 
@@ -138,7 +138,7 @@ public interface ScheduledUpdateList<T> {
      * @param priority The priority of the scheduled update
      * @return The scheduled update
      */
-    default ScheduledUpdate<T> schedule(Vector3i pos, T target, Duration delay, DefaultedRegistryReference<? extends TaskPriority> priority) {
+    default ScheduledUpdate<T> schedule(final Vector3i pos, final T target, final Duration delay, final DefaultedRegistryReference<? extends TaskPriority> priority) {
         return this.schedule(pos.x(), pos.y(), pos.z(), target, delay, priority.get());
     }
 
@@ -153,7 +153,8 @@ public interface ScheduledUpdateList<T> {
      * @param priority The priority of the scheduled update
      * @return The scheduled update
      */
-    default ScheduledUpdate<T> schedule(int x, int y, int z, T target, int delay, TemporalUnit temporalUnit, TaskPriority priority) {
+    default ScheduledUpdate<T> schedule(
+            final int x, final int y, final int z, final T target, final int delay, final TemporalUnit temporalUnit, final TaskPriority priority) {
         return this.schedule(x, y, z, target, Duration.of(delay, temporalUnit), priority);
     }
 
@@ -168,7 +169,8 @@ public interface ScheduledUpdateList<T> {
      * @param priority The priority of the scheduled update
      * @return The scheduled update
      */
-    default ScheduledUpdate<T> schedule(int x, int y, int z, T target, int delay, TemporalUnit temporalUnit, DefaultedRegistryReference<? extends TaskPriority> priority) {
+    default ScheduledUpdate<T> schedule(
+            final int x, final int y, final int z, final T target, final int delay, final TemporalUnit temporalUnit, final DefaultedRegistryReference<? extends TaskPriority> priority) {
         return this.schedule(x, y, z, target, Duration.of(delay, temporalUnit), priority.get());
     }
 
@@ -194,7 +196,7 @@ public interface ScheduledUpdateList<T> {
      * @param priority The priority of the scheduled update
      * @return The scheduled update
      */
-    default ScheduledUpdate<T> schedule(int x, int y, int z, T target, Duration delay, DefaultedRegistryReference<? extends TaskPriority> priority) {
+    default ScheduledUpdate<T> schedule(final int x, final int y, final int z, final T target, final Duration delay, final DefaultedRegistryReference<? extends TaskPriority> priority) {
         return this.schedule(x, y, z, target, delay, priority.get());
     }
 
@@ -205,7 +207,7 @@ public interface ScheduledUpdateList<T> {
      * @param target The target
      * @return True if there's an update scheduled
      */
-    default boolean isScheduled(Vector3i pos, T target) {
+    default boolean isScheduled(final Vector3i pos, final T target) {
         return this.isScheduled(pos.x(), pos.y(), pos.z(), target);
     }
 
@@ -224,7 +226,7 @@ public interface ScheduledUpdateList<T> {
      * @param pos The position
      * @return The collection of scheduled updates at the desired position
      */
-    default Collection<? extends ScheduledUpdate<T>> scheduledAt(Vector3i pos) {
+    default Collection<? extends ScheduledUpdate<T>> scheduledAt(final Vector3i pos) {
         return this.scheduledAt(pos.x(), pos.y(), pos.z());
     }
 

--- a/src/main/java/org/spongepowered/api/util/BlockReaderAwareMatcher.java
+++ b/src/main/java/org/spongepowered/api/util/BlockReaderAwareMatcher.java
@@ -38,11 +38,11 @@ public interface BlockReaderAwareMatcher<T> {
         return (state, volume, position) -> true;
     }
 
-    static BlockReaderAwareMatcher<BlockState> forBlock(BlockState filter) {
+    static BlockReaderAwareMatcher<BlockState> forBlock(final BlockState filter) {
         return (state, volume, position) -> state == filter;
     }
 
-    static BlockReaderAwareMatcher<BlockState> forBlock(BlockType type) {
+    static BlockReaderAwareMatcher<BlockState> forBlock(final BlockType type) {
         Objects.requireNonNull(type, "BlockType cannot be null");
         return (state, volume, position) -> state != null && state.type() == type;
     }

--- a/src/main/java/org/spongepowered/api/world/chunk/Chunk.java
+++ b/src/main/java/org/spongepowered/api/world/chunk/Chunk.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.world.chunk;
 
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.util.Direction;
+import org.spongepowered.api.util.Ticks;
 import org.spongepowered.api.util.annotation.DoNotStore;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.volume.entity.EntityVolume;
@@ -39,7 +40,6 @@ import java.util.Optional;
  * <p>In Minecraft, the chunk is 16 by 16 blocks on the X and Z axes. The height
  * of each chunk varies between worlds.</p>
  */
-@DoNotStore
 public interface Chunk extends ProtoChunk<Chunk>, EntityVolume.Mutable<Chunk> {
 
     /**
@@ -47,35 +47,7 @@ public interface Chunk extends ProtoChunk<Chunk>, EntityVolume.Mutable<Chunk> {
      *
      * @return The world
      */
-    @Override
     World<?, ?> world();
-
-    /**
-     * Loads this chunk, and generates if specified and required.
-     *
-     * @param generate Whether or not to generate the chunk if it does not yet
-     *     exist
-     * @return If the chunk was successfully loaded
-     */
-    boolean loadChunk(boolean generate);
-
-    /**
-     * Unloads this chunk, if possible.
-     *
-     * @return Whether or not the chunk unloaded
-     */
-    boolean unloadChunk();
-
-    /**
-     * Gets the number of ticks players have been present in this chunk, used
-     * for calculation of the regional difficulty factor. In vanilla, it is
-     * increased by the number of players in the chunk every tick, and is capped
-     * at 3,600,000 ticks (50 hours).
-     *
-     * @return The number of ticks
-     */
-    @Override
-    long inhabitedTime();
 
     /**
      * Gets the chunk in the given direction from this chunk, if it exists.
@@ -99,5 +71,31 @@ public interface Chunk extends ProtoChunk<Chunk>, EntityVolume.Mutable<Chunk> {
         final Optional<Vector3i> neighborPosition = Sponge.server().chunkLayout().moveToChunk(this.chunkPosition(), direction);
         return neighborPosition.flatMap(vector3i -> this.world().loadChunk(vector3i, shouldLoad));
     }
+
+    /**
+     * Gets the regional difficulty factor for this chunk. In vanilla, it is
+     * dependent on the playtime of the world, inhabited time of the chunk, the
+     * phase of the moon, and the current difficulty setting. This number ranges
+     * from 0.75-1.5 on easy, 1.5-4.0 on normal, and 2.25-6.75 on hard.
+     *
+     * <p>This value is used for display only in vanilla.</p>
+     *
+     * @return The regional difficulty factor for this chunk
+     */
+    double regionalDifficultyFactor();
+
+    /**
+     * Gets the regional difficulty percentage for this chunk. It is calculated
+     * by taking the regional difficulty factor and using the following rules:
+     * If the factor is less than 2.0, the percentage is 0%. If the factor is
+     * greater than 4.0, the percentage is 100%. Otherwise, the percentage is
+     * the factor minus 2.0, divided by 2.0.
+     *
+     * <p>This is the value that is used in vanilla to find which effects are
+     * caused by the regional difficulty.</p>
+     *
+     * @return The regional difficulty percentage for this chunk
+     */
+    double regionalDifficultyPercentage();
 
 }

--- a/src/main/java/org/spongepowered/api/world/chunk/ChunkStates.java
+++ b/src/main/java/org/spongepowered/api/world/chunk/ChunkStates.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.world.chunk;
 
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.entity.BlockEntity;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
@@ -45,19 +46,18 @@ public final class ChunkStates {
 
     // SORTFIELDS:ON
 
-    /**
-     * A {@link ProtoChunk} that is at this state means that it is being generated
-     * with a "base" layer of terrain.
-     * The chunk should not have any {@link Entity} instances or {@link BlockEntity}
-     * instances and may have a valid {@link ProtoWorld} used for world generation.
-     */
-    public static final DefaultedRegistryReference<ChunkState> BASE = ChunkStates.key(ResourceKey.minecraft("base"));
 
     /**
-     * A {@link ProtoChunk} that is being "carved out" for general terrain features
-     * that require things like "caves" or "canyons".
+     * A {@link ProtoChunk} that is having its {@link Biome biomes}
+     * assigned.
      */
-    public static final DefaultedRegistryReference<ChunkState> CARVED = ChunkStates.key(ResourceKey.minecraft("carved"));
+    public static final DefaultedRegistryReference<ChunkState> BIOMES = ChunkStates.key(ResourceKey.minecraft("biomes"));
+
+    /**
+     * A {@link ProtoChunk} that is being "carved out" for general terrain
+     * features that require things like "caves" or "canyons".
+     */
+    public static final DefaultedRegistryReference<ChunkState> CARVERS = ChunkStates.key(ResourceKey.minecraft("carvers"));
 
     /**
      * A {@link ProtoChunk} state that is being populated by world generation,
@@ -74,32 +74,31 @@ public final class ChunkStates {
     public static final DefaultedRegistryReference<ChunkState> EMPTY = ChunkStates.key(ResourceKey.minecraft("empty"));
 
     /**
-     * A {@link ProtoChunk} state that is being used for entity spawning.
-     * Generally requires that the neighboring chunks are adequately populated,
-     * and requires that this chunk has proper lighting, for mob placement logic.
+     * A {@link ProtoChunk} has been carved out, and is now being decorated with
+     * features, such as leaves and tall grass.
      */
-    public static final DefaultedRegistryReference<ChunkState> ENTITIES_SPAWNED = ChunkStates.key(ResourceKey.minecraft("entities_spawned"));
+    public static final DefaultedRegistryReference<ChunkState> FEATURES = ChunkStates.key(ResourceKey.minecraft("features"));
+
+    /**
+     * State for a {@link ProtoChunk} marking it being used by a world, and not
+     * in the process of either world generation, or deserialization from
+     * storage. Only {@link Chunk}s should provide this state, other
+     * {@link ProtoChunk}s would be invalid with this state.
+     */
+    public static final DefaultedRegistryReference<ChunkState> FULL = ChunkStates.key(ResourceKey.minecraft("full"));
 
     /**
      * A {@link ProtoChunk} state that is "cleaning" up remnant objects of a
      * chunk in process of world generation. Generally, height maps are being
      * calculated at this point as entity spawning can affect block placement.
      */
-    public static final DefaultedRegistryReference<ChunkState> FINALIZED = ChunkStates.key(ResourceKey.minecraft("finalized"));
-
-    /**
-     * A {@link ProtoChunk} that has completed world generation tasks and can be
-     * added to a level ready {@link World}. Likewise can be utilized during
-     * chunk deserialization prior to a {@link Chunk} being fully added to a
-     * {@link World} instance.
-     */
-    public static final DefaultedRegistryReference<ChunkState> GENERATED = ChunkStates.key(ResourceKey.minecraft("generated"));
+    public static final DefaultedRegistryReference<ChunkState> HEIGHTMAPS = ChunkStates.key(ResourceKey.minecraft("heightmaps"));
 
     /**
      * A {@link ProtoChunk} state that is being "carved" with liquid cave
      * features, such as underwater ravines, underwater caves, etc.
      */
-    public static final DefaultedRegistryReference<ChunkState> LIQUID_CARVED = ChunkStates.key(ResourceKey.minecraft("liquid_carved"));
+    public static final DefaultedRegistryReference<ChunkState> LIQUID_CARVERS = ChunkStates.key(ResourceKey.minecraft("liquid_carvers"));
 
     /**
      * A {@link ProtoChunk} state that has yet been processed with lighting in
@@ -107,15 +106,43 @@ public final class ChunkStates {
      * to last step in the world generation pipeline for a chunk to be marked
      * as ready for being added to a {@link World}.
      */
-    public static final DefaultedRegistryReference<ChunkState> LIT = ChunkStates.key(ResourceKey.minecraft("lit"));
+    public static final DefaultedRegistryReference<ChunkState> LIGHT = ChunkStates.key(ResourceKey.minecraft("light"));
 
     /**
-     * State for a {@link ProtoChunk} marking it being used by a world, and not
-     * in the process of either world generation, or deserialization from storage.
-     * Should have an instance of {@link Chunk} providing this state only, as
-     * other {@link ProtoChunk}s would assuredly be invalid with this state.
+     * A {@link ProtoChunk} where the {@link BlockState block states} are being
+     * set and structure locations are set.
      */
-    public static final DefaultedRegistryReference<ChunkState> WORLD_READY = ChunkStates.key(ResourceKey.minecraft("world_ready"));
+    public static final DefaultedRegistryReference<ChunkState> NOISE = ChunkStates.key(ResourceKey.minecraft("noise"));
+
+    /**
+     * A {@link ProtoChunk} state that is being used for entity spawning.
+     * Generally requires that the neighboring chunks are adequately populated,
+     * and requires that this chunk has proper lighting, for mob placement
+     * logic.
+     */
+    public static final DefaultedRegistryReference<ChunkState> SPAWN = ChunkStates.key(ResourceKey.minecraft("spawn"));
+
+    /**
+     * A {@link ProtoChunk} where the structures to be placed in the chunk are
+     * being determined and primed for placement.
+     */
+    public static final DefaultedRegistryReference<ChunkState> STRUCTURE_STARTS = ChunkStates.key(ResourceKey.minecraft("structure_starts"));
+
+    /**
+     * A {@link ProtoChunk} where final validity checks are being performed on
+     * structures that are primed to be placed in the chunk.
+     */
+    public static final DefaultedRegistryReference<ChunkState> STRUCTURE_REFERENCES = ChunkStates.key(ResourceKey.minecraft("structure_references"));
+
+    /**
+     * A {@link ProtoChunk} that is at this state means that it is being
+     * generated with a "base" layer of terrain.
+     *
+     * <p>The chunk should not have any {@link Entity} instances or
+     * {@link BlockEntity} instances and may have a valid {@link ProtoWorld}
+     * used for world generation.</p>
+     */
+    public static final DefaultedRegistryReference<ChunkState> SURFACE = ChunkStates.key(ResourceKey.minecraft("surface"));
 
     // SORTFIELDS:OFF
 
@@ -127,4 +154,5 @@ public final class ChunkStates {
     private static DefaultedRegistryReference<ChunkState> key(final ResourceKey location) {
         return RegistryKey.of(RegistryTypes.CHUNK_STATE, location).asDefaultedReference(() -> Sponge.game().registries());
     }
+
 }

--- a/src/main/java/org/spongepowered/api/world/chunk/ProtoChunk.java
+++ b/src/main/java/org/spongepowered/api/world/chunk/ProtoChunk.java
@@ -24,11 +24,12 @@
  */
 package org.spongepowered.api.world.chunk;
 
-import org.spongepowered.api.Game;
-import org.spongepowered.api.Server;
 import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.util.Ticks;
+import org.spongepowered.api.util.annotation.DoNotStore;
 import org.spongepowered.api.world.ProtoWorld;
 import org.spongepowered.api.world.World;
+import org.spongepowered.api.world.generation.GenerationRegion;
 import org.spongepowered.api.world.volume.biome.BiomeVolume;
 import org.spongepowered.api.world.volume.block.BlockVolume;
 import org.spongepowered.api.world.volume.block.entity.BlockEntityVolume;
@@ -45,7 +46,11 @@ import org.spongepowered.math.vector.Vector3i;
  * chunk loading from storage, or empty chunks on clients. Traditionally, a
  * usable "live" proto chunk instance will be a {@link Chunk} with a valid
  * {@link World} instance.</p>
+ *
+ * <p>A chunk may not be attached to a {@link World} or {@link GenerationRegion}
+ * if it is in the process of being generated.</p>
  */
+@DoNotStore
 public interface ProtoChunk<P extends ProtoChunk<P>> extends
     BlockVolume.Mutable<P>,
     BlockEntityVolume.Mutable<P>,
@@ -60,7 +65,7 @@ public interface ProtoChunk<P extends ProtoChunk<P>> extends
      * does play a role in whether an entity can be directly added or not.
      *
      * <p>This method should realistically be used only during world
-     * generation, and therefor will likely emit warnings if attempting to
+     * generation, and therefore will likely emit warnings if attempting to
      * add entities to live {@link Chunk} instances.</p>
      *
      * @param entity The entity to add
@@ -70,19 +75,21 @@ public interface ProtoChunk<P extends ProtoChunk<P>> extends
     /**
      * Gets this {@link ProtoChunk}'s current {@link ChunkState}.
      * The {@link ChunkState} stipulates the potential validity of various
-     * operations that can be performed, including but not limited to:
-     * {@link #world()}, etc. Usually,
-     * this {@link ProtoChunk} is tied always to a {@link ProtoWorld},
-     * but the validity of that world may also be questionable for feature
-     * processing.
+     * operations that can be performed.
      *
-     * <p>It can be expected however that if {@link #isEmpty()} returns
-     * {@code false}, usually this status will likewise be {@link ChunkStates#EMPTY}.</p>
+     * <p>A fully generated chunk will return {@link ChunkStates#FULL} - though
+     * care should be taken as the chunk may be an {@link #isEmpty() empty} one.
+     * </p>
      *
      * @return This chunk's state
      */
     ChunkState state();
 
+    /**
+     * Gets whether this chunk is empty.
+     *
+     * @return Whether this chunk is empty
+     */
     boolean isEmpty();
 
     /**
@@ -98,49 +105,22 @@ public interface ProtoChunk<P extends ProtoChunk<P>> extends
     Vector3i chunkPosition();
 
     /**
-     * Gets the containing {@link ProtoWorld} of this {@link ProtoChunk}. As
-     * it may vary based on the status of both {@link Game} and {@link Server},
-     * this {@link ProtoChunk} may be likewise used for world generation, in
-     * which case, the {@link ProtoWorld} would not be a {@link World} instance.
+     * Gets the {@link Ticks number of ticks} players have been present in this
+     * chunk, used for calculation of the regional difficulty factor. In vanilla,
+     * it is increased by the number of players in the chunk every tick, and is
+     * capped at 3,600,000 ticks (50 hours).
      *
-     * <p>It can be inferred however, that if {@link #state()} returns
-     * {@link ChunkStates#WORLD_READY}, the {@link ProtoWorld} would be a
-     * {@link World} instance. Inversely, if {@link #state()} returns
-     * {@link ChunkStates#EMPTY}, the {@link ProtoWorld} would not be a
-     * valid {@link World} object.</p>
-     *
-     * @return The parented world
+     * @return The number of ticks
      */
-    ProtoWorld<?> world();
+    Ticks inhabitedTime();
 
     /**
-     * Gets the regional difficulty factor for this chunk. In vanilla, it is
-     * dependent on the playtime of the world, inhabited time of the chunk, the
-     * phase of the moon, and the current difficulty setting. This number ranges
-     * from 0.75-1.5 on easy, 1.5-4.0 on normal, and 2.25-6.75 on hard.
+     * Sets the {@link Ticks number of ticks} players have been present in this
+     * chunk.
      *
-     * <p>This value is used for display only in vanilla.</p>
-     *
-     * @return The regional difficulty factor for this chunk
+     * @see #inhabitedTime()
+     * @param newInhabitedTime The {@link Ticks} to set this value to
      */
-    double regionalDifficultyFactor();
-
-    /**
-     * Gets the regional difficulty percentage for this chunk. It is calculated
-     * by taking the regional difficulty factor and using the following rules:
-     * If the factor is less than 2.0, the percentage is 0%. If the factor is
-     * greater than 4.0, the percentage is 100%. Otherwise, the percentage is
-     * the factor minus 2.0, divided by 2.0.
-     *
-     * <p>This is the value that is used in vanilla to find which effects are
-     * caused by the regional difficulty.</p>
-     *
-     * @return The regional difficulty percentage for this chunk
-     */
-    double regionalDifficultyPercentage();
-
-    void setInhabitedTime(long newInhabitedTime);
-
-    long inhabitedTime();
+    void setInhabitedTime(Ticks newInhabitedTime);
 
 }

--- a/src/main/java/org/spongepowered/api/world/generation/PrimitiveChunk.java
+++ b/src/main/java/org/spongepowered/api/world/generation/PrimitiveChunk.java
@@ -28,6 +28,4 @@ import org.spongepowered.api.world.chunk.ProtoChunk;
 
 public interface PrimitiveChunk extends ProtoChunk<PrimitiveChunk> {
 
-    @Override
-    GenerationRegion world();
 }


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/3222)

I took a look at updating the Chunk API (stepping out of comfort zone!) from invalid and... it's been more of a journey than I thought. This is not near being done but I haven't really touched this area of the code before so I want to make sure I'm doing the right things.

The biggest thing (at the moment!) is that I've changed `HeightTypes` and `ChunkState` to mirror the MCP entries. There will likely need to be some rejigging of the ProtoChunk and PrimitiveChunk interfaces. I also don't think `loadChunk` and `unloadChunk` should be on this interface - that should be on the associated `World`.

See the associated Common PR for the implementation.