### PR TITLE
More command tweaks

### DIFF
--- a/src/main/java/org/spongepowered/api/command/exception/ArgumentParseException.java
+++ b/src/main/java/org/spongepowered/api/command/exception/ArgumentParseException.java
@@ -45,7 +45,7 @@ public class ArgumentParseException extends CommandException {
      * @param source The source string being parsed
      * @param position The current position in the source string
      */
-    public ArgumentParseException(final Component message, final String source, final int position) {
+    public ArgumentParseException(final @Nullable Component message, final String source, final int position) {
         super(message, true);
         this.source = source;
         this.position = position;
@@ -59,7 +59,7 @@ public class ArgumentParseException extends CommandException {
      * @param source The source string being parsed
      * @param position The current position in the source string
      */
-    public ArgumentParseException(final Component message, final Throwable cause, final String source, final int position) {
+    public ArgumentParseException(final @Nullable Component message, final Throwable cause, final String source, final int position) {
         super(message, cause, true);
         this.source = source;
         this.position = position;

--- a/src/main/java/org/spongepowered/api/command/parameter/ArgumentReader.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/ArgumentReader.java
@@ -242,6 +242,8 @@ public interface ArgumentReader {
          * the client completion should be a {@link ResourceKey}, so that your
          * users will not be told to put their argument in quotation marks.</p>
          *
+         * @param defaultNamespace The default namespace to use when parsing a
+         *                         string that does not contain a colon.
          * @return The {@link ResourceKey}
          * @throws ArgumentParseException if a key could not be parsed
          */

--- a/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
@@ -39,6 +39,7 @@ import org.spongepowered.api.command.CommandExecutor;
 import org.spongepowered.api.command.exception.ArgumentParseException;
 import org.spongepowered.api.command.parameter.managed.ValueCompleter;
 import org.spongepowered.api.command.parameter.managed.ValueParameter;
+import org.spongepowered.api.command.parameter.managed.ValueParameterModifier;
 import org.spongepowered.api.command.parameter.managed.ValueParser;
 import org.spongepowered.api.command.parameter.managed.ValueUsage;
 import org.spongepowered.api.command.parameter.managed.standard.ResourceKeyedValueParameters;
@@ -191,6 +192,7 @@ public interface Parameter {
      * Gets a builder that builds a {@link Parameter.Value}.
      *
      * @param <T> The type of parameter
+     * @param <V> The {@link ValueParameter} to be used as a parser
      * @param parameter The value parameter
      * @param valueClass The type of value class
      * @return The {@link Value.Builder}
@@ -203,6 +205,7 @@ public interface Parameter {
      * Gets a builder that builds a {@link Parameter.Value}.
      *
      * @param <T> The type of parameter
+     * @param <V> The {@link ValueParameter} to be used as a parser
      * @param parameter The value parameter
      * @param typeToken The type of value class as a {@link TypeToken}
      * @return The {@link Value.Builder}
@@ -978,6 +981,14 @@ public interface Parameter {
         ValueCompleter completer();
 
         /**
+         * Gets the {@link ValueParameterModifier} that affects this parameter,
+         * if any.
+         *
+         * @return The {@link ValueParameterModifier}, if set.
+         */
+        Optional<ValueParameterModifier<T>> modifier();
+
+        /**
          * Gets the {@link ValueUsage} associated with this {@link Value}, if
          * any was set.
          *
@@ -994,7 +1005,7 @@ public interface Parameter {
         Predicate<CommandCause> requirement();
 
         /**
-         * Parses the next element(s) in the {@link CommandContext}
+         * Parses the next element(s) in the {@link CommandContext}.
          *
          * @param reader The {@link ArgumentReader.Mutable} containing the strings
          *               that need to be parsed
@@ -1079,7 +1090,8 @@ public interface Parameter {
              * unless this builder's {@link #suggestions(ValueCompleter)}} and
              * {@link #usage(ValueUsage)} methods are specified.
              *
-             * @param parser The {@link ValueParameter} to use
+             * @param <V> The {@link ValueParser} to be used as a parser
+             * @param parser The {@link ValueParser} to use
              * @return This builder, for chaining
              */
             default <V extends ValueParser<? extends T>> Builder<T> addParser(@NonNull final DefaultedRegistryReference<V> parser) {
@@ -1098,6 +1110,29 @@ public interface Parameter {
              * @return This builder, for chaining
              */
             Builder<T> suggestions(@Nullable ValueCompleter completer);
+
+            /**
+             * Provides a modifier that allows for the modification of the
+             * outcome of an argument parse or a completion. This is primarily
+             * intended for use with Mojang/Sponge standard parameters, allowing
+             * developers to tweak the input of a standard parameter without
+             * having to worry about completion types.
+             *
+             * <p>Developers should only use this when they use a parameter
+             * type that they do not control. If you are using this with a
+             * {@link ValueParameter}, {@link ValueParser} or
+             * {@link ValueCompleter} that you control (that is, able to modify
+             * the source of), it is strongly recommended that you do that
+             * instead. For more information about how a modifier should be
+             * used, read the {@link ValueParameterModifier} docs instead.</p>
+             *
+             * <p>Optional. If this is <code>null</code> (or never set), any
+             * outcomes will not be modified.</p>
+             *
+             * @param modifier The modifier
+             * @return This builder, for chaning
+             */
+            Builder<T> modifier(@Nullable ValueParameterModifier<T> modifier);
 
             /**
              * Sets the usage. The {@link Function} accepts the parameter key

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/ValueCompleter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/ValueCompleter.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.command.parameter.managed;
 
+import org.spongepowered.api.command.CommandCause;
 import org.spongepowered.api.command.parameter.CommandContext;
 
 import java.util.List;

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/ValueParameter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/ValueParameter.java
@@ -25,7 +25,15 @@
 package org.spongepowered.api.command.parameter.managed;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.spongepowered.api.command.CommandCause;
+import org.spongepowered.api.command.exception.ArgumentParseException;
+import org.spongepowered.api.command.parameter.ArgumentReader;
+import org.spongepowered.api.command.parameter.CommandContext;
+import org.spongepowered.api.command.parameter.Parameter;
 import org.spongepowered.api.registry.DefaultedRegistryValue;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Combines the {@link ValueParser}, {@link ValueCompleter} and
@@ -43,6 +51,71 @@ public interface ValueParameter<T> extends DefaultedRegistryValue, ValueComplete
     @Override
     default String usage(@NonNull final String key) {
         return key;
+    }
+
+    /**
+     * A {@link ValueParameter} that does not rely on the {@link CommandContext}
+     * or {@link Parameter.Key} to parse its results.
+     *
+     * @param <T> The type of object that is returned from the
+     *            {@link ValueParser} upon successful parsing.
+     */
+    interface Simple<T> extends ValueParameter<T> {
+
+        /**
+         * Gets the value for this parameter.
+         *
+         * <p>This should have no side effects on anything except on the state of
+         * the {@link ArgumentReader}.</p>
+         *
+         * <p>This element may return nothing in the form of an empty optional.
+         * This indicates that a parse succeeded, but no meaningful value was
+         * returned.</p>
+         *
+         * @param commandCause The {@link CommandCause cause} of this parse
+         * @param reader The {@link ArgumentReader} that contains the unparsed
+         *          arguments
+         * @return Returns the value(s)
+         * @throws ArgumentParseException if a parameter could not be parsed
+         */
+        Optional<? extends T> parseValue(CommandCause commandCause, ArgumentReader.Mutable reader) throws ArgumentParseException;
+
+        /**
+         * This should not be overridden by implementations of this class. If
+         * you wish to do so, implement {@link ValueParameter} instead.
+         *
+         * {@inheritDoc}
+         */
+        @Override
+        default Optional<? extends T> parseValue(
+                final Parameter.Key<? super T> parameterKey,
+                final ArgumentReader.Mutable reader,
+                final CommandContext.Builder context) throws ArgumentParseException {
+            return this.parseValue(context.cause(), reader);
+        }
+
+        /**
+         * Gets valid completions for this element, given the supplied
+         * {@link CommandCause} and current input for this element.
+         *
+         * @param context The {@link CommandCause} that contains the parsed
+         *  arguments
+         * @param currentInput The current input for this argument
+         * @return The list of values
+         */
+        List<String> complete(CommandCause context, String currentInput);
+
+        /**
+         * This should not be overridden by implementations of this class. If
+         * you wish to do so, implement {@link ValueParameter} instead.
+         *
+         * {@inheritDoc}
+         */
+        @Override
+        default List<String> complete(final CommandContext context, final String currentInput) {
+            return this.complete(context.cause(), currentInput);
+        }
+
     }
 
 }

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/ValueParameterModifier.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/ValueParameterModifier.java
@@ -1,0 +1,140 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.parameter.managed;
+
+import net.kyori.adventure.text.Component;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.command.CommandExecutor;
+import org.spongepowered.api.command.exception.ArgumentParseException;
+import org.spongepowered.api.command.parameter.ArgumentReader;
+import org.spongepowered.api.command.parameter.CommandContext;
+import org.spongepowered.api.command.parameter.Parameter;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A value parameter modifier is an alternative to attempting to create an
+ * element that extends/wraps around a {@link ValueParameter}, particularly
+ * those that are provided by Sponge on behalf of Minecraft or other
+ * underlying implementation.
+ *
+ * <p>The primary intention of a modifier is to enable custom filtering logic
+ * on in-built parameters so that plugins can refine the user experience when
+ * using their commands while retaining most of the properties of the underlying
+ * parameter. In general, plugins <strong>should not</strong> use modifiers on
+ * their own {@link ValueParameter value parameters} or associated classes.
+ * Further, modifiers are <strong>not</strong> designed to perform any
+ * post-processing on any parsed elements, they should generally only be used to
+ * validate or filter results and completions - post-processing should be
+ * performed in the {@link CommandExecutor command's exectuor} instead, as by
+ * this point you know that your command has been selected.</p>
+ *
+ * <p>These modifier methods are provided the same information as the original
+ * parameter, along with the result of the original parameter - that is, these
+ * modifiers run <strong>after</strong> the associated parameter has run.</p>
+ *
+ * <p><strong>Modifiers are not designed to transform the returned type</strong>
+ * - this is to maintain the integrity of the key typing and to discourage
+ * additional logic in parameter parsing that should actually exist in the
+ * {@link CommandExecutor} of the command instead.</p>
+ *
+ * <p>Users of modifiers should consider the following when modifying the
+ * result:</p>
+ *
+ * <ul>
+ *     <li>Any supplied parameters may have been modified by the associated
+ *     parameter that this is modifying, and are not snapshots from before.</li>
+ *     <li>The {@link ArgumentReader} is <strong>immutable</strong>. This is to
+ *     prevent accidental continued parsing. If you want to use a modifier to
+ *     further parse the input string based on the result of chained parameter,
+ *     create a custom {@link ValueParameter} that follows on from the node in
+ *     question instead - the result of this parse will be available in the
+ *     {@link CommandContext.Builder} in later nodes.</li>
+ *     <li>Modifiers may choose to <strong>not</strong> return a value and
+ *     instead add to the {@link CommandContext.Builder} directly. While this is
+ *     permissible, do not be tempted to use modifiers as a way to perform logic
+ *     this is not directly related to parsing a string to avoid unnecessary
+ *     processing that may not be used if a later node fails to parse and this
+ *     node's result is discarded.</li>
+ *     <li>Modifiers cannot prevent the chained parameter from throwing an
+ *     exception, in the case that they do so this modifier will not be called.
+ *     Instead, add a second {@link ValueParser} to the parameter, and account
+ *     for this in your modifier.</li>
+ *     <li>The use of a modifier will require that any completion requests are
+ *     sent to the server, regardless of whether completions are actually
+ *     modified. If completions are not being modified, consider whether it
+ *     would be better to process the parsed result in the body of your executor
+ *     instead.</li>
+ * </ul>
+ */
+public interface ValueParameterModifier<T> {
+
+    /**
+     * Modifies the result of {@link ValueParser#parseValue(Parameter.Key,
+     * ArgumentReader.Mutable, CommandContext.Builder) the chained parameter's
+     * parse result}.
+     *
+     * @param parameterKey The target {@link Parameter.Key} to fill in the
+     *                     context
+     * @param reader The {@link ArgumentReader.Immutable} that may have been
+     *               advanced by the parser
+     * @param context The {@link CommandContext.Builder} that may have been
+     *                modified by the parser
+     * @param value The value returned by the parser, if any
+     * @return The value to associate with the {@code parameterKey}
+     * @throws ArgumentParseException if the modifier wishes to halt processing
+     *      of this element
+     */
+    Optional<? extends T> modifyResult(
+            Parameter.Key<? super T> parameterKey,
+            ArgumentReader.Immutable reader,
+            CommandContext.Builder context,
+            @Nullable T value) throws ArgumentParseException;
+
+    /**
+     * Modifies the result of {@link ValueCompleter#complete(CommandContext,
+     * String) the chained parameter's completions}.
+     *
+     * @param context The {@link CommandContext}
+     * @param currentInput The input that suggestions are built from
+     * @param completions The completions suggested by the chained parameter
+     * @return The modified completions
+     */
+    List<String> modifyCompletion(
+            final CommandContext context, final String currentInput, final  List<String> completions);
+
+    /**
+     * Modifies the message provided in a {@link ArgumentParseException} if the
+     * modified {@link ValueParser} throws this exception.
+     *
+     * @param exceptionMessage The message provided by the {@link ValueParser}
+     * @return The modified message, or the parameter if it is not to be modified.
+     */
+    default @Nullable Component modifyExceptionMessage(final @Nullable Component exceptionMessage) {
+        return exceptionMessage;
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/ValueParser.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/ValueParser.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.api.command.parameter.managed;
 
-import com.google.common.collect.ImmutableList;
+import org.spongepowered.api.command.CommandCause;
 import org.spongepowered.api.command.CommandExecutor;
 import org.spongepowered.api.command.exception.ArgumentParseException;
 import org.spongepowered.api.command.parameter.ArgumentReader;

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/standard/ResourceKeyedValueParameter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/standard/ResourceKeyedValueParameter.java
@@ -34,6 +34,6 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
  * @param <T> The type of value that the parameter will return.
  */
 @CatalogedBy(ResourceKeyedValueParameters.class)
-public interface ResourceKeyedValueParameter<T> extends ValueParameter<T>, ResourceKeyed {
+public interface ResourceKeyedValueParameter<T> extends ValueParameter.Simple<T>, ResourceKeyed {
 
 }

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/standard/VariableValueParameters.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/standard/VariableValueParameters.java
@@ -59,7 +59,7 @@ public final class VariableValueParameters {
 
     /**
      * Creates a builder that can build a {@link ValueParameter} that returns
-     * an appropriate value via a {@link RegistryHolder} from an argument.
+     * an appropriate {@link Registry registry} entry from an argument.
      *
      * @param holderProvider The provider for a {@link RegistryHolder} to
      *          retrieve the selected {@link Registry} from
@@ -75,7 +75,7 @@ public final class VariableValueParameters {
 
     /**
      * Creates a builder that can build a {@link ValueParameter} that returns
-     * an appropriate value via a {@link RegistryHolder} from an argument.
+     * an appropriate {@link Registry registry} entry from an argument.
      *
      * @param registryProvider A {@link Function} that retrieves an appropriate
      *      {@link Registry} to get objects from
@@ -221,7 +221,7 @@ public final class VariableValueParameters {
 
     /**
      * A builder that creates a {@link ValueParameter} that attempts to get a
-     * specific value from a {@link RegistryHolder} by the supplied ID.
+     * specific {@link Registry registry} entry by the supplied ID.
      */
     public interface RegistryEntryBuilder<T> extends Builder<ValueParameter<T>, RegistryEntryBuilder<T>> {
 
@@ -245,7 +245,7 @@ public final class VariableValueParameters {
 
         /**
          * Adds a prefix that could be prepended to the input argument if it
-         * initially does not match any of the chosen values. Any
+         * initially does not match any of the chosen {@link RegistryKey}s. Any
          * prefixes that are prepended will include the ":" identifier, this
          * should not be part of the supplied prefix in this method.
          *
@@ -652,6 +652,7 @@ public final class VariableValueParameters {
          * instead, providing the appropriate {@link RegistryHolder} instead.</p>
          *
          * @param <T> The type that the target {@link Registry} holds
+         * @param registryProvider The {@link Registry} to get the values from
          * @return The {@link RegistryEntryBuilder}
          */
         <T> RegistryEntryBuilder<T> createRegistryEntryBuilder(final Function<CommandContext, @Nullable ? extends Registry<? extends T>> registryProvider);

--- a/src/main/java/org/spongepowered/api/command/registrar/CommandRegistrarType.java
+++ b/src/main/java/org/spongepowered/api/command/registrar/CommandRegistrarType.java
@@ -48,6 +48,8 @@ public interface CommandRegistrarType<T> extends DefaultedRegistryValue {
     /**
      * Create a new registrar of this type.
      *
+     * @param manager The {@link CommandManager} that has requested the creation
+     *                of the {@link CommandRegistrar} associated with this type
      * @return the newly created registrar
      */
     CommandRegistrar<T> create(final CommandManager.Mutable manager);

--- a/src/main/java/org/spongepowered/api/command/registrar/tree/CommandTreeNode.java
+++ b/src/main/java/org/spongepowered/api/command/registrar/tree/CommandTreeNode.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.command.registrar.tree;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.Command;
@@ -84,7 +85,7 @@ public interface CommandTreeNode<T extends CommandTreeNode<T>> {
      * @return This, for chaining.
      * @see ClientCompletionKeys for keys that will create tree node types
      */
-    T child(final String key, final CommandTreeNode.Argument<?> childNode);
+    T child(final String key, final CommandTreeNode.Argument<@NonNull ?> childNode);
 
     /**
      * Creates a child of this node with the given key that accepts a
@@ -97,6 +98,7 @@ public interface CommandTreeNode<T extends CommandTreeNode<T>> {
      * <p>This variant will create a new node based on the provided key and
      * allow for processing before adding the node as a child</p>
      *
+     * @param <C> The type of {@link CommandTreeNode.Argument} to be created
      * @param key The name of the child node
      * @param type the type of argument to use in the child node
      * @param processor A callback that will receive the created child node
@@ -122,6 +124,7 @@ public interface CommandTreeNode<T extends CommandTreeNode<T>> {
      * <p>This variant will create a new node based on the provided key and
      * allow for processing before adding the node as a child</p>
      *
+     * @param <C> The type of {@link CommandTreeNode.Argument} to be created
      * @param key The name of the child node
      * @param type the type of argument to use in the child node
      * @param processor A callback that will receive the created child node
@@ -147,7 +150,7 @@ public interface CommandTreeNode<T extends CommandTreeNode<T>> {
      * @param redirectTarget The node to redirect to
      * @return This, for chaining
      */
-    T redirect(CommandTreeNode<?> redirectTarget);
+    T redirect(CommandTreeNode<@NonNull ?> redirectTarget);
 
     /**
      * Declares that this element can only be parsed by those with the given
@@ -156,7 +159,7 @@ public interface CommandTreeNode<T extends CommandTreeNode<T>> {
      * @param requirement The requirement
      * @return This, for chaining
      */
-    T requires(Predicate<CommandCause> requirement);
+    T requires(@Nullable Predicate<CommandCause> requirement);
 
     /**
      * Declares that the node this {@link CommandTreeNode} represents is


### PR DESCRIPTION
**SpongeAPI** | [Sponge Impl](https://github.com/SpongePowered/Sponge/pull/3286)

While I've got a minute...

* Introduces `ValueParameter.Simple` which is primarily used to allow the use of Mojang provided parameters that we wrap - they don't need to know about the `CommandContext.Builder` so this allows third party frameworks to use the Mojang provided parameters.
  
  Note that aspirationally, at some point I might associate a `ClientCompletionKey` with each of these to make it clear what parameter links to what key - again, a QoL thing for third party consumers.
  
  This will fix the issue in #2290 insofar as composition is concerned, though the next point will make that moot.
* Adds a `ValueParameterModifier` that modifies the output/completions of a parameter. This is generally going to be easier than trying to recreate a parameter (such as entities) itself.
  
  I have **not** allowed for the transformation of parameter types. As well as it being difficult to do because of the more strongly typed system we have, it's not really encouraged that non-parsing logic should go in a parser - they should do the minimum to validate that a parameter is valid for the context - if a later parameter fails then the work in the parser is wasted and so it is best to do as much work as possible in the executor, when you have a guarantee that your transformations will be used.
  
  This should be a better way of solving the issue in #2290 and basically sidestep the problem in #2289.

