### PR TITLE
Registry update for latest snapshots

### DIFF
--- a/src/main/java/org/spongepowered/api/block/BlockTypes.java
+++ b/src/main/java/org/spongepowered/api/block/BlockTypes.java
@@ -27,22 +27,19 @@ package org.spongepowered.api.block;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
+import org.spongepowered.api.registry.RegistryTypes;
 
 /**
- * An enumeration of all possible {@link BlockType}s in vanilla minecraft.
+ * An enumeration of all possible {@link BlockType}s in vanilla Minecraft.
  */
 @SuppressWarnings("unused")
 @RegistryScopes(scopes = RegistryScope.GAME)
 public final class BlockTypes {
 
     // @formatter:off
-
-    // SORTFIELDS:ON
-
     public static final DefaultedRegistryReference<BlockType> ACACIA_BUTTON = BlockTypes.key(ResourceKey.minecraft("acacia_button"));
 
     public static final DefaultedRegistryReference<BlockType> ACACIA_DOOR = BlockTypes.key(ResourceKey.minecraft("acacia_door"));
@@ -99,6 +96,12 @@ public final class BlockTypes {
 
     public static final DefaultedRegistryReference<BlockType> ATTACHED_PUMPKIN_STEM = BlockTypes.key(ResourceKey.minecraft("attached_pumpkin_stem"));
 
+    public static final DefaultedRegistryReference<BlockType> AZALEA = BlockTypes.key(ResourceKey.minecraft("azalea"));
+
+    public static final DefaultedRegistryReference<BlockType> AZALEA_LEAVES = BlockTypes.key(ResourceKey.minecraft("azalea_leaves"));
+
+    public static final DefaultedRegistryReference<BlockType> AZALEA_LEAVES_FLOWERS = BlockTypes.key(ResourceKey.minecraft("azalea_leaves_flowers"));
+
     public static final DefaultedRegistryReference<BlockType> AZURE_BLUET = BlockTypes.key(ResourceKey.minecraft("azure_bluet"));
 
     public static final DefaultedRegistryReference<BlockType> BAMBOO = BlockTypes.key(ResourceKey.minecraft("bamboo"));
@@ -122,6 +125,10 @@ public final class BlockTypes {
     public static final DefaultedRegistryReference<BlockType> BEETROOTS = BlockTypes.key(ResourceKey.minecraft("beetroots"));
 
     public static final DefaultedRegistryReference<BlockType> BELL = BlockTypes.key(ResourceKey.minecraft("bell"));
+
+    public static final DefaultedRegistryReference<BlockType> BIG_DRIPLEAF = BlockTypes.key(ResourceKey.minecraft("big_dripleaf"));
+
+    public static final DefaultedRegistryReference<BlockType> BIG_DRIPLEAF_STEM = BlockTypes.key(ResourceKey.minecraft("big_dripleaf_stem"));
 
     public static final DefaultedRegistryReference<BlockType> BIRCH_BUTTON = BlockTypes.key(ResourceKey.minecraft("birch_button"));
 
@@ -311,6 +318,10 @@ public final class BlockTypes {
 
     public static final DefaultedRegistryReference<BlockType> CAVE_AIR = BlockTypes.key(ResourceKey.minecraft("cave_air"));
 
+    public static final DefaultedRegistryReference<BlockType> CAVE_VINES_BODY = BlockTypes.key(ResourceKey.minecraft("cave_vines_body"));
+
+    public static final DefaultedRegistryReference<BlockType> CAVE_VINES_HEAD = BlockTypes.key(ResourceKey.minecraft("cave_vines_head"));
+
     public static final DefaultedRegistryReference<BlockType> CHAIN = BlockTypes.key(ResourceKey.minecraft("chain"));
 
     public static final DefaultedRegistryReference<BlockType> CHAIN_COMMAND_BLOCK = BlockTypes.key(ResourceKey.minecraft("chain_command_block"));
@@ -318,6 +329,8 @@ public final class BlockTypes {
     public static final DefaultedRegistryReference<BlockType> CHEST = BlockTypes.key(ResourceKey.minecraft("chest"));
 
     public static final DefaultedRegistryReference<BlockType> CHIPPED_ANVIL = BlockTypes.key(ResourceKey.minecraft("chipped_anvil"));
+
+    public static final DefaultedRegistryReference<BlockType> CHISELED_DEEPSLATE = BlockTypes.key(ResourceKey.minecraft("chiseled_deepslate"));
 
     public static final DefaultedRegistryReference<BlockType> CHISELED_NETHER_BRICKS = BlockTypes.key(ResourceKey.minecraft("chiseled_nether_bricks"));
 
@@ -342,6 +355,14 @@ public final class BlockTypes {
     public static final DefaultedRegistryReference<BlockType> COAL_ORE = BlockTypes.key(ResourceKey.minecraft("coal_ore"));
 
     public static final DefaultedRegistryReference<BlockType> COARSE_DIRT = BlockTypes.key(ResourceKey.minecraft("coarse_dirt"));
+
+    public static final DefaultedRegistryReference<BlockType> COBBLED_DEEPSLATE = BlockTypes.key(ResourceKey.minecraft("cobbled_deepslate"));
+
+    public static final DefaultedRegistryReference<BlockType> COBBLED_DEEPSLATE_SLAB = BlockTypes.key(ResourceKey.minecraft("cobbled_deepslate_slab"));
+
+    public static final DefaultedRegistryReference<BlockType> COBBLED_DEEPSLATE_STAIRS = BlockTypes.key(ResourceKey.minecraft("cobbled_deepslate_stairs"));
+
+    public static final DefaultedRegistryReference<BlockType> COBBLED_DEEPSLATE_WALL = BlockTypes.key(ResourceKey.minecraft("cobbled_deepslate_wall"));
 
     public static final DefaultedRegistryReference<BlockType> COBBLESTONE = BlockTypes.key(ResourceKey.minecraft("cobblestone"));
 
@@ -541,6 +562,34 @@ public final class BlockTypes {
 
     public static final DefaultedRegistryReference<BlockType> DEAD_TUBE_CORAL_WALL_FAN = BlockTypes.key(ResourceKey.minecraft("dead_tube_coral_wall_fan"));
 
+    public static final DefaultedRegistryReference<BlockType> DEEPSLATE = BlockTypes.key(ResourceKey.minecraft("deepslate"));
+
+    public static final DefaultedRegistryReference<BlockType> DEEPSLATE_BRICK_SLAB = BlockTypes.key(ResourceKey.minecraft("deepslate_brick_slab"));
+
+    public static final DefaultedRegistryReference<BlockType> DEEPSLATE_BRICK_STAIRS = BlockTypes.key(ResourceKey.minecraft("deepslate_brick_stairs"));
+
+    public static final DefaultedRegistryReference<BlockType> DEEPSLATE_BRICK_WALL = BlockTypes.key(ResourceKey.minecraft("deepslate_brick_wall"));
+
+    public static final DefaultedRegistryReference<BlockType> DEEPSLATE_BRICKS = BlockTypes.key(ResourceKey.minecraft("deepslate_bricks"));
+
+    public static final DefaultedRegistryReference<BlockType> DEEPSLATE_DIAMOND_ORE = BlockTypes.key(ResourceKey.minecraft("deepslate_diamond_ore"));
+
+    public static final DefaultedRegistryReference<BlockType> DEEPSLATE_GOLD_ORE = BlockTypes.key(ResourceKey.minecraft("deepslate_gold_ore"));
+
+    public static final DefaultedRegistryReference<BlockType> DEEPSLATE_IRON_ORE = BlockTypes.key(ResourceKey.minecraft("deepslate_iron_ore"));
+
+    public static final DefaultedRegistryReference<BlockType> DEEPSLATE_LAPIS_ORE = BlockTypes.key(ResourceKey.minecraft("deepslate_lapis_ore"));
+
+    public static final DefaultedRegistryReference<BlockType> DEEPSLATE_REDSTONE_ORE = BlockTypes.key(ResourceKey.minecraft("deepslate_redstone_ore"));
+
+    public static final DefaultedRegistryReference<BlockType> DEEPSLATE_TILE_SLAB = BlockTypes.key(ResourceKey.minecraft("deepslate_tile_slab"));
+
+    public static final DefaultedRegistryReference<BlockType> DEEPSLATE_TILE_STAIRS = BlockTypes.key(ResourceKey.minecraft("deepslate_tile_stairs"));
+
+    public static final DefaultedRegistryReference<BlockType> DEEPSLATE_TILE_WALL = BlockTypes.key(ResourceKey.minecraft("deepslate_tile_wall"));
+
+    public static final DefaultedRegistryReference<BlockType> DEEPSLATE_TILES = BlockTypes.key(ResourceKey.minecraft("deepslate_tiles"));
+
     public static final DefaultedRegistryReference<BlockType> DETECTOR_RAIL = BlockTypes.key(ResourceKey.minecraft("detector_rail"));
 
     public static final DefaultedRegistryReference<BlockType> DIAMOND_BLOCK = BlockTypes.key(ResourceKey.minecraft("diamond_block"));
@@ -599,6 +648,14 @@ public final class BlockTypes {
 
     public static final DefaultedRegistryReference<BlockType> ENDER_CHEST = BlockTypes.key(ResourceKey.minecraft("ender_chest"));
 
+    public static final DefaultedRegistryReference<BlockType> EXPOSED_COPPER = BlockTypes.key(ResourceKey.minecraft("exposed_copper"));
+
+    public static final DefaultedRegistryReference<BlockType> EXPOSED_CUT_COPPER = BlockTypes.key(ResourceKey.minecraft("exposed_cut_copper"));
+
+    public static final DefaultedRegistryReference<BlockType> EXPOSED_CUT_COPPER_SLAB = BlockTypes.key(ResourceKey.minecraft("exposed_cut_copper_slab"));
+
+    public static final DefaultedRegistryReference<BlockType> EXPOSED_CUT_COPPER_STAIRS = BlockTypes.key(ResourceKey.minecraft("exposed_cut_copper_stairs"));
+
     public static final DefaultedRegistryReference<BlockType> FARMLAND = BlockTypes.key(ResourceKey.minecraft("farmland"));
 
     public static final DefaultedRegistryReference<BlockType> FERN = BlockTypes.key(ResourceKey.minecraft("fern"));
@@ -616,6 +673,8 @@ public final class BlockTypes {
     public static final DefaultedRegistryReference<BlockType> FLETCHING_TABLE = BlockTypes.key(ResourceKey.minecraft("fletching_table"));
 
     public static final DefaultedRegistryReference<BlockType> FLOWER_POT = BlockTypes.key(ResourceKey.minecraft("flower_pot"));
+
+    public static final DefaultedRegistryReference<BlockType> FLOWERING_AZALEA = BlockTypes.key(ResourceKey.minecraft("flowering_azalea"));
 
     public static final DefaultedRegistryReference<BlockType> FROSTED_ICE = BlockTypes.key(ResourceKey.minecraft("frosted_ice"));
 
@@ -706,6 +765,8 @@ public final class BlockTypes {
     public static final DefaultedRegistryReference<BlockType> GREEN_WOOL = BlockTypes.key(ResourceKey.minecraft("green_wool"));
 
     public static final DefaultedRegistryReference<BlockType> GRINDSTONE = BlockTypes.key(ResourceKey.minecraft("grindstone"));
+
+    public static final DefaultedRegistryReference<BlockType> HANGING_ROOTS = BlockTypes.key(ResourceKey.minecraft("hanging_roots"));
 
     public static final DefaultedRegistryReference<BlockType> HAY_BLOCK = BlockTypes.key(ResourceKey.minecraft("hay_block"));
 
@@ -867,14 +928,6 @@ public final class BlockTypes {
 
     public static final DefaultedRegistryReference<BlockType> LIGHT_WEIGHTED_PRESSURE_PLATE = BlockTypes.key(ResourceKey.minecraft("light_weighted_pressure_plate"));
 
-    public static final DefaultedRegistryReference<BlockType> LIGHTLY_WEATHERED_COPPER_BLOCK = BlockTypes.key(ResourceKey.minecraft("lightly_weathered_copper_block"));
-
-    public static final DefaultedRegistryReference<BlockType> LIGHTLY_WEATHERED_CUT_COPPER = BlockTypes.key(ResourceKey.minecraft("lightly_weathered_cut_copper"));
-
-    public static final DefaultedRegistryReference<BlockType> LIGHTLY_WEATHERED_CUT_COPPER_SLAB = BlockTypes.key(ResourceKey.minecraft("lightly_weathered_cut_copper_slab"));
-
-    public static final DefaultedRegistryReference<BlockType> LIGHTLY_WEATHERED_CUT_COPPER_STAIRS = BlockTypes.key(ResourceKey.minecraft("lightly_weathered_cut_copper_stairs"));
-
     public static final DefaultedRegistryReference<BlockType> LIGHTNING_ROD = BlockTypes.key(ResourceKey.minecraft("lightning_rod"));
 
     public static final DefaultedRegistryReference<BlockType> LILAC = BlockTypes.key(ResourceKey.minecraft("lilac"));
@@ -950,6 +1003,10 @@ public final class BlockTypes {
     public static final DefaultedRegistryReference<BlockType> MELON = BlockTypes.key(ResourceKey.minecraft("melon"));
 
     public static final DefaultedRegistryReference<BlockType> MELON_STEM = BlockTypes.key(ResourceKey.minecraft("melon_stem"));
+
+    public static final DefaultedRegistryReference<BlockType> MOSS_BLOCK = BlockTypes.key(ResourceKey.minecraft("moss_block"));
+
+    public static final DefaultedRegistryReference<BlockType> MOSS_CARPET = BlockTypes.key(ResourceKey.minecraft("moss_carpet"));
 
     public static final DefaultedRegistryReference<BlockType> MOSSY_COBBLESTONE = BlockTypes.key(ResourceKey.minecraft("mossy_cobblestone"));
 
@@ -1067,6 +1124,14 @@ public final class BlockTypes {
 
     public static final DefaultedRegistryReference<BlockType> OXEYE_DAISY = BlockTypes.key(ResourceKey.minecraft("oxeye_daisy"));
 
+    public static final DefaultedRegistryReference<BlockType> OXIDIZED_COPPER = BlockTypes.key(ResourceKey.minecraft("oxidized_copper"));
+
+    public static final DefaultedRegistryReference<BlockType> OXIDIZED_CUT_COPPER = BlockTypes.key(ResourceKey.minecraft("oxidized_cut_copper"));
+
+    public static final DefaultedRegistryReference<BlockType> OXIDIZED_CUT_COPPER_SLAB = BlockTypes.key(ResourceKey.minecraft("oxidized_cut_copper_slab"));
+
+    public static final DefaultedRegistryReference<BlockType> OXIDIZED_CUT_COPPER_STAIRS = BlockTypes.key(ResourceKey.minecraft("oxidized_cut_copper_stairs"));
+
     public static final DefaultedRegistryReference<BlockType> PACKED_ICE = BlockTypes.key(ResourceKey.minecraft("packed_ice"));
 
     public static final DefaultedRegistryReference<BlockType> PEONY = BlockTypes.key(ResourceKey.minecraft("peony"));
@@ -1142,6 +1207,14 @@ public final class BlockTypes {
     public static final DefaultedRegistryReference<BlockType> POLISHED_BLACKSTONE_STAIRS = BlockTypes.key(ResourceKey.minecraft("polished_blackstone_stairs"));
 
     public static final DefaultedRegistryReference<BlockType> POLISHED_BLACKSTONE_WALL = BlockTypes.key(ResourceKey.minecraft("polished_blackstone_wall"));
+
+    public static final DefaultedRegistryReference<BlockType> POLISHED_DEEPSLATE = BlockTypes.key(ResourceKey.minecraft("polished_deepslate"));
+
+    public static final DefaultedRegistryReference<BlockType> POLISHED_DEEPSLATE_SLAB = BlockTypes.key(ResourceKey.minecraft("polished_deepslate_slab"));
+
+    public static final DefaultedRegistryReference<BlockType> POLISHED_DEEPSLATE_STAIRS = BlockTypes.key(ResourceKey.minecraft("polished_deepslate_stairs"));
+
+    public static final DefaultedRegistryReference<BlockType> POLISHED_DEEPSLATE_WALL = BlockTypes.key(ResourceKey.minecraft("polished_deepslate_wall"));
 
     public static final DefaultedRegistryReference<BlockType> POLISHED_DIORITE = BlockTypes.key(ResourceKey.minecraft("polished_diorite"));
 
@@ -1359,6 +1432,8 @@ public final class BlockTypes {
 
     public static final DefaultedRegistryReference<BlockType> RESPAWN_ANCHOR = BlockTypes.key(ResourceKey.minecraft("respawn_anchor"));
 
+    public static final DefaultedRegistryReference<BlockType> ROOTED_DIRT = BlockTypes.key(ResourceKey.minecraft("rooted_dirt"));
+
     public static final DefaultedRegistryReference<BlockType> ROSE_BUSH = BlockTypes.key(ResourceKey.minecraft("rose_bush"));
 
     public static final DefaultedRegistryReference<BlockType> SAND = BlockTypes.key(ResourceKey.minecraft("sand"));
@@ -1381,14 +1456,6 @@ public final class BlockTypes {
 
     public static final DefaultedRegistryReference<BlockType> SEAGRASS = BlockTypes.key(ResourceKey.minecraft("seagrass"));
 
-    public static final DefaultedRegistryReference<BlockType> SEMI_WEATHERED_COPPER_BLOCK = BlockTypes.key(ResourceKey.minecraft("semi_weathered_copper_block"));
-
-    public static final DefaultedRegistryReference<BlockType> SEMI_WEATHERED_CUT_COPPER = BlockTypes.key(ResourceKey.minecraft("semi_weathered_cut_copper"));
-
-    public static final DefaultedRegistryReference<BlockType> SEMI_WEATHERED_CUT_COPPER_SLAB = BlockTypes.key(ResourceKey.minecraft("semi_weathered_cut_copper_slab"));
-
-    public static final DefaultedRegistryReference<BlockType> SEMI_WEATHERED_CUT_COPPER_STAIRS = BlockTypes.key(ResourceKey.minecraft("semi_weathered_cut_copper_stairs"));
-
     public static final DefaultedRegistryReference<BlockType> SHROOMLIGHT = BlockTypes.key(ResourceKey.minecraft("shroomlight"));
 
     public static final DefaultedRegistryReference<BlockType> SHULKER_BOX = BlockTypes.key(ResourceKey.minecraft("shulker_box"));
@@ -1401,9 +1468,13 @@ public final class BlockTypes {
 
     public static final DefaultedRegistryReference<BlockType> SMALL_AMETHYST_BUD = BlockTypes.key(ResourceKey.minecraft("small_amethyst_bud"));
 
+    public static final DefaultedRegistryReference<BlockType> SMALL_DRIPLEAF = BlockTypes.key(ResourceKey.minecraft("small_dripleaf"));
+
     public static final DefaultedRegistryReference<BlockType> SMITHING_TABLE = BlockTypes.key(ResourceKey.minecraft("smithing_table"));
 
     public static final DefaultedRegistryReference<BlockType> SMOKER = BlockTypes.key(ResourceKey.minecraft("smoker"));
+
+    public static final DefaultedRegistryReference<BlockType> SMOOTH_BASALT = BlockTypes.key(ResourceKey.minecraft("smooth_basalt"));
 
     public static final DefaultedRegistryReference<BlockType> SMOOTH_QUARTZ = BlockTypes.key(ResourceKey.minecraft("smooth_quartz"));
 
@@ -1448,6 +1519,8 @@ public final class BlockTypes {
     public static final DefaultedRegistryReference<BlockType> SPAWNER = BlockTypes.key(ResourceKey.minecraft("spawner"));
 
     public static final DefaultedRegistryReference<BlockType> SPONGE = BlockTypes.key(ResourceKey.minecraft("sponge"));
+
+    public static final DefaultedRegistryReference<BlockType> SPORE_BLOSSOM = BlockTypes.key(ResourceKey.minecraft("spore_blossom"));
 
     public static final DefaultedRegistryReference<BlockType> SPRUCE_BUTTON = BlockTypes.key(ResourceKey.minecraft("spruce_button"));
 
@@ -1623,7 +1696,7 @@ public final class BlockTypes {
 
     public static final DefaultedRegistryReference<BlockType> WATER_CAULDRON = BlockTypes.key(ResourceKey.minecraft("water_cauldron"));
 
-    public static final DefaultedRegistryReference<BlockType> WAXED_COPPER = BlockTypes.key(ResourceKey.minecraft("waxed_copper"));
+    public static final DefaultedRegistryReference<BlockType> WAXED_COPPER_BLOCK = BlockTypes.key(ResourceKey.minecraft("waxed_copper_block"));
 
     public static final DefaultedRegistryReference<BlockType> WAXED_CUT_COPPER = BlockTypes.key(ResourceKey.minecraft("waxed_cut_copper"));
 
@@ -1631,23 +1704,23 @@ public final class BlockTypes {
 
     public static final DefaultedRegistryReference<BlockType> WAXED_CUT_COPPER_STAIRS = BlockTypes.key(ResourceKey.minecraft("waxed_cut_copper_stairs"));
 
-    public static final DefaultedRegistryReference<BlockType> WAXED_LIGHTLY_WEATHERED_COPPER = BlockTypes.key(ResourceKey.minecraft("waxed_lightly_weathered_copper"));
+    public static final DefaultedRegistryReference<BlockType> WAXED_EXPOSED_COPPER = BlockTypes.key(ResourceKey.minecraft("waxed_exposed_copper"));
 
-    public static final DefaultedRegistryReference<BlockType> WAXED_LIGHTLY_WEATHERED_CUT_COPPER = BlockTypes.key(ResourceKey.minecraft("waxed_lightly_weathered_cut_copper"));
+    public static final DefaultedRegistryReference<BlockType> WAXED_EXPOSED_CUT_COPPER = BlockTypes.key(ResourceKey.minecraft("waxed_exposed_cut_copper"));
 
-    public static final DefaultedRegistryReference<BlockType> WAXED_LIGHTLY_WEATHERED_CUT_COPPER_SLAB = BlockTypes.key(ResourceKey.minecraft("waxed_lightly_weathered_cut_copper_slab"));
+    public static final DefaultedRegistryReference<BlockType> WAXED_EXPOSED_CUT_COPPER_SLAB = BlockTypes.key(ResourceKey.minecraft("waxed_exposed_cut_copper_slab"));
 
-    public static final DefaultedRegistryReference<BlockType> WAXED_LIGHTLY_WEATHERED_CUT_COPPER_STAIRS = BlockTypes.key(ResourceKey.minecraft("waxed_lightly_weathered_cut_copper_stairs"));
+    public static final DefaultedRegistryReference<BlockType> WAXED_EXPOSED_CUT_COPPER_STAIRS = BlockTypes.key(ResourceKey.minecraft("waxed_exposed_cut_copper_stairs"));
 
-    public static final DefaultedRegistryReference<BlockType> WAXED_SEMI_WEATHERED_COPPER = BlockTypes.key(ResourceKey.minecraft("waxed_semi_weathered_copper"));
+    public static final DefaultedRegistryReference<BlockType> WAXED_WEATHERED_COPPER = BlockTypes.key(ResourceKey.minecraft("waxed_weathered_copper"));
 
-    public static final DefaultedRegistryReference<BlockType> WAXED_SEMI_WEATHERED_CUT_COPPER = BlockTypes.key(ResourceKey.minecraft("waxed_semi_weathered_cut_copper"));
+    public static final DefaultedRegistryReference<BlockType> WAXED_WEATHERED_CUT_COPPER = BlockTypes.key(ResourceKey.minecraft("waxed_weathered_cut_copper"));
 
-    public static final DefaultedRegistryReference<BlockType> WAXED_SEMI_WEATHERED_CUT_COPPER_SLAB = BlockTypes.key(ResourceKey.minecraft("waxed_semi_weathered_cut_copper_slab"));
+    public static final DefaultedRegistryReference<BlockType> WAXED_WEATHERED_CUT_COPPER_SLAB = BlockTypes.key(ResourceKey.minecraft("waxed_weathered_cut_copper_slab"));
 
-    public static final DefaultedRegistryReference<BlockType> WAXED_SEMI_WEATHERED_CUT_COPPER_STAIRS = BlockTypes.key(ResourceKey.minecraft("waxed_semi_weathered_cut_copper_stairs"));
+    public static final DefaultedRegistryReference<BlockType> WAXED_WEATHERED_CUT_COPPER_STAIRS = BlockTypes.key(ResourceKey.minecraft("waxed_weathered_cut_copper_stairs"));
 
-    public static final DefaultedRegistryReference<BlockType> WEATHERED_COPPER_BLOCK = BlockTypes.key(ResourceKey.minecraft("weathered_copper_block"));
+    public static final DefaultedRegistryReference<BlockType> WEATHERED_COPPER = BlockTypes.key(ResourceKey.minecraft("weathered_copper"));
 
     public static final DefaultedRegistryReference<BlockType> WEATHERED_CUT_COPPER = BlockTypes.key(ResourceKey.minecraft("weathered_cut_copper"));
 
@@ -1731,10 +1804,7 @@ public final class BlockTypes {
 
     public static final DefaultedRegistryReference<BlockType> ZOMBIE_WALL_HEAD = BlockTypes.key(ResourceKey.minecraft("zombie_wall_head"));
 
-    // SORTFIELDS:OFF
-
     // @formatter:on
-
     private BlockTypes() {
     }
 

--- a/src/main/java/org/spongepowered/api/block/entity/BlockEntityTypes.java
+++ b/src/main/java/org/spongepowered/api/block/entity/BlockEntityTypes.java
@@ -27,22 +27,19 @@ package org.spongepowered.api.block.entity;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
+import org.spongepowered.api.registry.RegistryTypes;
 
 /**
- * An enumeration of all {@link BlockEntityType}s in vanilla Minecraft.
+ * An enumeration of all possible {@link BlockEntityType}s in vanilla Minecraft.
  */
 @SuppressWarnings("unused")
 @RegistryScopes(scopes = RegistryScope.GAME)
 public final class BlockEntityTypes {
 
     // @formatter:off
-
-    // SORTFIELDS:ON
-
     public static final DefaultedRegistryReference<BlockEntityType> BANNER = BlockEntityTypes.key(ResourceKey.minecraft("banner"));
 
     public static final DefaultedRegistryReference<BlockEntityType> BARREL = BlockEntityTypes.key(ResourceKey.minecraft("barrel"));
@@ -75,13 +72,13 @@ public final class BlockEntityTypes {
 
     public static final DefaultedRegistryReference<BlockEntityType> DROPPER = BlockEntityTypes.key(ResourceKey.minecraft("dropper"));
 
-    public static final DefaultedRegistryReference<BlockEntityType> ENCHANTMENT_TABLE = BlockEntityTypes.key(ResourceKey.minecraft("enchantment_table"));
-
-    public static final DefaultedRegistryReference<BlockEntityType> ENDER_CHEST = BlockEntityTypes.key(ResourceKey.minecraft("ender_chest"));
+    public static final DefaultedRegistryReference<BlockEntityType> ENCHANTING_TABLE = BlockEntityTypes.key(ResourceKey.minecraft("enchanting_table"));
 
     public static final DefaultedRegistryReference<BlockEntityType> END_GATEWAY = BlockEntityTypes.key(ResourceKey.minecraft("end_gateway"));
 
     public static final DefaultedRegistryReference<BlockEntityType> END_PORTAL = BlockEntityTypes.key(ResourceKey.minecraft("end_portal"));
+
+    public static final DefaultedRegistryReference<BlockEntityType> ENDER_CHEST = BlockEntityTypes.key(ResourceKey.minecraft("ender_chest"));
 
     public static final DefaultedRegistryReference<BlockEntityType> FURNACE = BlockEntityTypes.key(ResourceKey.minecraft("furnace"));
 
@@ -97,6 +94,8 @@ public final class BlockEntityTypes {
 
     public static final DefaultedRegistryReference<BlockEntityType> PISTON = BlockEntityTypes.key(ResourceKey.minecraft("piston"));
 
+    public static final DefaultedRegistryReference<BlockEntityType> SCULK_SENSOR = BlockEntityTypes.key(ResourceKey.minecraft("sculk_sensor"));
+
     public static final DefaultedRegistryReference<BlockEntityType> SHULKER_BOX = BlockEntityTypes.key(ResourceKey.minecraft("shulker_box"));
 
     public static final DefaultedRegistryReference<BlockEntityType> SIGN = BlockEntityTypes.key(ResourceKey.minecraft("sign"));
@@ -105,14 +104,11 @@ public final class BlockEntityTypes {
 
     public static final DefaultedRegistryReference<BlockEntityType> SMOKER = BlockEntityTypes.key(ResourceKey.minecraft("smoker"));
 
-    public static final DefaultedRegistryReference<BlockEntityType> STRUCTURE = BlockEntityTypes.key(ResourceKey.minecraft("structure"));
+    public static final DefaultedRegistryReference<BlockEntityType> STRUCTURE_BLOCK = BlockEntityTypes.key(ResourceKey.minecraft("structure_block"));
 
     public static final DefaultedRegistryReference<BlockEntityType> TRAPPED_CHEST = BlockEntityTypes.key(ResourceKey.minecraft("trapped_chest"));
 
-    // SORTFIELDS:OFF
-
     // @formatter:on
-
     private BlockEntityTypes() {
     }
 

--- a/src/main/java/org/spongepowered/api/data/type/ArtTypes.java
+++ b/src/main/java/org/spongepowered/api/data/type/ArtTypes.java
@@ -27,22 +27,19 @@ package org.spongepowered.api.data.type;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
+import org.spongepowered.api.registry.RegistryTypes;
 
 /**
- * An enumeration of vanilla {@link ArtType}s.
+ * An enumeration of all possible {@link ArtType}s in vanilla Minecraft.
  */
 @SuppressWarnings("unused")
 @RegistryScopes(scopes = RegistryScope.GAME)
 public final class ArtTypes {
 
     // @formatter:off
-
-    // SORTFIELDS:ON
-
     public static final DefaultedRegistryReference<ArtType> ALBAN = ArtTypes.key(ResourceKey.minecraft("alban"));
 
     public static final DefaultedRegistryReference<ArtType> AZTEC = ArtTypes.key(ResourceKey.minecraft("aztec"));
@@ -95,10 +92,7 @@ public final class ArtTypes {
 
     public static final DefaultedRegistryReference<ArtType> WITHER = ArtTypes.key(ResourceKey.minecraft("wither"));
 
-    // SORTFIELDS:OFF
-
     // @formatter:on
-
     private ArtTypes() {
     }
 

--- a/src/main/java/org/spongepowered/api/data/type/ProfessionTypes.java
+++ b/src/main/java/org/spongepowered/api/data/type/ProfessionTypes.java
@@ -27,22 +27,19 @@ package org.spongepowered.api.data.type;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
+import org.spongepowered.api.registry.RegistryTypes;
 
 /**
- * An enumeration of vanilla {@link ProfessionType}s.
+ * An enumeration of all possible {@link ProfessionType}s in vanilla Minecraft.
  */
 @SuppressWarnings("unused")
 @RegistryScopes(scopes = RegistryScope.GAME)
 public final class ProfessionTypes {
 
     // @formatter:off
-
-    // SORTFIELDS:ON
-
     public static final DefaultedRegistryReference<ProfessionType> ARMORER = ProfessionTypes.key(ResourceKey.minecraft("armorer"));
 
     public static final DefaultedRegistryReference<ProfessionType> BUTCHER = ProfessionTypes.key(ResourceKey.minecraft("butcher"));
@@ -73,10 +70,7 @@ public final class ProfessionTypes {
 
     public static final DefaultedRegistryReference<ProfessionType> WEAPONSMITH = ProfessionTypes.key(ResourceKey.minecraft("weaponsmith"));
 
-    // SORTFIELDS:OFF
-
     // @formatter:on
-
     private ProfessionTypes() {
     }
 

--- a/src/main/java/org/spongepowered/api/data/type/VillagerTypes.java
+++ b/src/main/java/org/spongepowered/api/data/type/VillagerTypes.java
@@ -27,19 +27,19 @@ package org.spongepowered.api.data.type;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
+import org.spongepowered.api.registry.RegistryTypes;
 
+/**
+ * An enumeration of all possible {@link VillagerType}s in vanilla Minecraft.
+ */
 @SuppressWarnings("unused")
 @RegistryScopes(scopes = RegistryScope.GAME)
 public final class VillagerTypes {
 
     // @formatter:off
-
-    // SORTFIELDS:ON
-
     public static final DefaultedRegistryReference<VillagerType> DESERT = VillagerTypes.key(ResourceKey.minecraft("desert"));
 
     public static final DefaultedRegistryReference<VillagerType> JUNGLE = VillagerTypes.key(ResourceKey.minecraft("jungle"));
@@ -54,10 +54,7 @@ public final class VillagerTypes {
 
     public static final DefaultedRegistryReference<VillagerType> TAIGA = VillagerTypes.key(ResourceKey.minecraft("taiga"));
 
-    // SORTFIELDS:OFF
-
     // @formatter:on
-
     private VillagerTypes() {
     }
 

--- a/src/main/java/org/spongepowered/api/effect/particle/ParticleTypes.java
+++ b/src/main/java/org/spongepowered/api/effect/particle/ParticleTypes.java
@@ -27,22 +27,19 @@ package org.spongepowered.api.effect.particle;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
+import org.spongepowered.api.registry.RegistryTypes;
 
 /**
- * An enumeration of all possible {@link ParticleType}s in vanilla minecraft.
+ * An enumeration of all possible {@link ParticleType}s in vanilla Minecraft.
  */
 @SuppressWarnings("unused")
 @RegistryScopes(scopes = RegistryScope.GAME)
 public final class ParticleTypes {
 
     // @formatter:off
-
-    // SORTFIELDS:ON
-
     public static final DefaultedRegistryReference<ParticleType> AMBIENT_ENTITY_EFFECT = ParticleTypes.key(ResourceKey.minecraft("ambient_entity_effect"));
 
     public static final DefaultedRegistryReference<ParticleType> ANGRY_VILLAGER = ParticleTypes.key(ResourceKey.minecraft("angry_villager"));
@@ -125,6 +122,8 @@ public final class ParticleTypes {
 
     public static final DefaultedRegistryReference<ParticleType> FALLING_OBSIDIAN_TEAR = ParticleTypes.key(ResourceKey.minecraft("falling_obsidian_tear"));
 
+    public static final DefaultedRegistryReference<ParticleType> FALLING_SPORE_BLOSSOM = ParticleTypes.key(ResourceKey.minecraft("falling_spore_blossom"));
+
     public static final DefaultedRegistryReference<ParticleType> FALLING_WATER = ParticleTypes.key(ResourceKey.minecraft("falling_water"));
 
     public static final DefaultedRegistryReference<ParticleType> FIREWORK = ParticleTypes.key(ResourceKey.minecraft("firework"));
@@ -191,6 +190,8 @@ public final class ParticleTypes {
 
     public static final DefaultedRegistryReference<ParticleType> SPLASH = ParticleTypes.key(ResourceKey.minecraft("splash"));
 
+    public static final DefaultedRegistryReference<ParticleType> SPORE_BLOSSOM_AIR = ParticleTypes.key(ResourceKey.minecraft("spore_blossom_air"));
+
     public static final DefaultedRegistryReference<ParticleType> SQUID_INK = ParticleTypes.key(ResourceKey.minecraft("squid_ink"));
 
     public static final DefaultedRegistryReference<ParticleType> SWEEP_ATTACK = ParticleTypes.key(ResourceKey.minecraft("sweep_attack"));
@@ -207,10 +208,7 @@ public final class ParticleTypes {
 
     public static final DefaultedRegistryReference<ParticleType> WITCH = ParticleTypes.key(ResourceKey.minecraft("witch"));
 
-    // SORTFIELDS:OFF
-
     // @formatter:on
-
     private ParticleTypes() {
     }
 

--- a/src/main/java/org/spongepowered/api/effect/potion/PotionEffectTypes.java
+++ b/src/main/java/org/spongepowered/api/effect/potion/PotionEffectTypes.java
@@ -27,10 +27,10 @@ package org.spongepowered.api.effect.potion;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
+import org.spongepowered.api.registry.RegistryTypes;
 
 /**
  * An enumeration of all possible {@link PotionEffectType}s in vanilla Minecraft.
@@ -40,9 +40,6 @@ import org.spongepowered.api.registry.RegistryScopes;
 public final class PotionEffectTypes {
 
     // @formatter:off
-
-    // SORTFIELDS:ON
-
     public static final DefaultedRegistryReference<PotionEffectType> ABSORPTION = PotionEffectTypes.key(ResourceKey.minecraft("absorption"));
 
     public static final DefaultedRegistryReference<PotionEffectType> BAD_OMEN = PotionEffectTypes.key(ResourceKey.minecraft("bad_omen"));
@@ -91,9 +88,9 @@ public final class PotionEffectTypes {
 
     public static final DefaultedRegistryReference<PotionEffectType> SATURATION = PotionEffectTypes.key(ResourceKey.minecraft("saturation"));
 
-    public static final DefaultedRegistryReference<PotionEffectType> SLOWNESS = PotionEffectTypes.key(ResourceKey.minecraft("slowness"));
-
     public static final DefaultedRegistryReference<PotionEffectType> SLOW_FALLING = PotionEffectTypes.key(ResourceKey.minecraft("slow_falling"));
+
+    public static final DefaultedRegistryReference<PotionEffectType> SLOWNESS = PotionEffectTypes.key(ResourceKey.minecraft("slowness"));
 
     public static final DefaultedRegistryReference<PotionEffectType> SPEED = PotionEffectTypes.key(ResourceKey.minecraft("speed"));
 
@@ -107,10 +104,7 @@ public final class PotionEffectTypes {
 
     public static final DefaultedRegistryReference<PotionEffectType> WITHER = PotionEffectTypes.key(ResourceKey.minecraft("wither"));
 
-    // SORTFIELDS:OFF
-
     // @formatter:on
-
     private PotionEffectTypes() {
     }
 

--- a/src/main/java/org/spongepowered/api/effect/sound/SoundTypes.java
+++ b/src/main/java/org/spongepowered/api/effect/sound/SoundTypes.java
@@ -27,22 +27,19 @@ package org.spongepowered.api.effect.sound;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
+import org.spongepowered.api.registry.RegistryTypes;
 
 /**
- * An enumeration of vanilla {@link SoundType}s.
+ * An enumeration of all possible {@link SoundType}s in vanilla Minecraft.
  */
 @SuppressWarnings("unused")
 @RegistryScopes(scopes = RegistryScope.GAME)
 public final class SoundTypes {
 
     // @formatter:off
-
-    // SORTFIELDS:ON
-
     public static final DefaultedRegistryReference<SoundType> AMBIENT_BASALT_DELTAS_ADDITIONS = SoundTypes.key(ResourceKey.minecraft("ambient.basalt_deltas.additions"));
 
     public static final DefaultedRegistryReference<SoundType> AMBIENT_BASALT_DELTAS_LOOP = SoundTypes.key(ResourceKey.minecraft("ambient.basalt_deltas.loop"));
@@ -135,6 +132,26 @@ public final class SoundTypes {
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_ANVIL_USE = SoundTypes.key(ResourceKey.minecraft("block.anvil.use"));
 
+    public static final DefaultedRegistryReference<SoundType> BLOCK_AZALEA_BREAK = SoundTypes.key(ResourceKey.minecraft("block.azalea.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_AZALEA_FALL = SoundTypes.key(ResourceKey.minecraft("block.azalea.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_AZALEA_HIT = SoundTypes.key(ResourceKey.minecraft("block.azalea.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_AZALEA_PLACE = SoundTypes.key(ResourceKey.minecraft("block.azalea.place"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_AZALEA_STEP = SoundTypes.key(ResourceKey.minecraft("block.azalea.step"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_AZALEA_LEAVES_BREAK = SoundTypes.key(ResourceKey.minecraft("block.azalea_leaves.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_AZALEA_LEAVES_FALL = SoundTypes.key(ResourceKey.minecraft("block.azalea_leaves.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_AZALEA_LEAVES_HIT = SoundTypes.key(ResourceKey.minecraft("block.azalea_leaves.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_AZALEA_LEAVES_PLACE = SoundTypes.key(ResourceKey.minecraft("block.azalea_leaves.place"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_AZALEA_LEAVES_STEP = SoundTypes.key(ResourceKey.minecraft("block.azalea_leaves.step"));
+
     public static final DefaultedRegistryReference<SoundType> BLOCK_BAMBOO_BREAK = SoundTypes.key(ResourceKey.minecraft("block.bamboo.break"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_BAMBOO_FALL = SoundTypes.key(ResourceKey.minecraft("block.bamboo.fall"));
@@ -187,6 +204,20 @@ public final class SoundTypes {
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_BELL_USE = SoundTypes.key(ResourceKey.minecraft("block.bell.use"));
 
+    public static final DefaultedRegistryReference<SoundType> BLOCK_BIG_DRIPLEAF_BREAK = SoundTypes.key(ResourceKey.minecraft("block.big_dripleaf.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_BIG_DRIPLEAF_FALL = SoundTypes.key(ResourceKey.minecraft("block.big_dripleaf.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_BIG_DRIPLEAF_HIT = SoundTypes.key(ResourceKey.minecraft("block.big_dripleaf.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_BIG_DRIPLEAF_PLACE = SoundTypes.key(ResourceKey.minecraft("block.big_dripleaf.place"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_BIG_DRIPLEAF_STEP = SoundTypes.key(ResourceKey.minecraft("block.big_dripleaf.step"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_BIG_DRIPLEAF_TILT_DOWN = SoundTypes.key(ResourceKey.minecraft("block.big_dripleaf.tilt_down"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_BIG_DRIPLEAF_TILT_UP = SoundTypes.key(ResourceKey.minecraft("block.big_dripleaf.tilt_up"));
+
     public static final DefaultedRegistryReference<SoundType> BLOCK_BLASTFURNACE_FIRE_CRACKLE = SoundTypes.key(ResourceKey.minecraft("block.blastfurnace.fire_crackle"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_BONE_BLOCK_BREAK = SoundTypes.key(ResourceKey.minecraft("block.bone_block.break"));
@@ -238,6 +269,18 @@ public final class SoundTypes {
     public static final DefaultedRegistryReference<SoundType> BLOCK_CANDLE_PLACE = SoundTypes.key(ResourceKey.minecraft("block.candle.place"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_CANDLE_STEP = SoundTypes.key(ResourceKey.minecraft("block.candle.step"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_CAVE_VINES_BREAK = SoundTypes.key(ResourceKey.minecraft("block.cave_vines.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_CAVE_VINES_FALL = SoundTypes.key(ResourceKey.minecraft("block.cave_vines.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_CAVE_VINES_HIT = SoundTypes.key(ResourceKey.minecraft("block.cave_vines.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_CAVE_VINES_PICK_BERRIES = SoundTypes.key(ResourceKey.minecraft("block.cave_vines.pick_berries"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_CAVE_VINES_PLACE = SoundTypes.key(ResourceKey.minecraft("block.cave_vines.place"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_CAVE_VINES_STEP = SoundTypes.key(ResourceKey.minecraft("block.cave_vines.step"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_CHAIN_BREAK = SoundTypes.key(ResourceKey.minecraft("block.chain.break"));
 
@@ -301,6 +344,36 @@ public final class SoundTypes {
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_CROP_BREAK = SoundTypes.key(ResourceKey.minecraft("block.crop.break"));
 
+    public static final DefaultedRegistryReference<SoundType> BLOCK_DEEPSLATE_BREAK = SoundTypes.key(ResourceKey.minecraft("block.deepslate.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_DEEPSLATE_FALL = SoundTypes.key(ResourceKey.minecraft("block.deepslate.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_DEEPSLATE_HIT = SoundTypes.key(ResourceKey.minecraft("block.deepslate.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_DEEPSLATE_PLACE = SoundTypes.key(ResourceKey.minecraft("block.deepslate.place"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_DEEPSLATE_STEP = SoundTypes.key(ResourceKey.minecraft("block.deepslate.step"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_DEEPSLATE_BRICKS_BREAK = SoundTypes.key(ResourceKey.minecraft("block.deepslate_bricks.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_DEEPSLATE_BRICKS_FALL = SoundTypes.key(ResourceKey.minecraft("block.deepslate_bricks.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_DEEPSLATE_BRICKS_HIT = SoundTypes.key(ResourceKey.minecraft("block.deepslate_bricks.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_DEEPSLATE_BRICKS_PLACE = SoundTypes.key(ResourceKey.minecraft("block.deepslate_bricks.place"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_DEEPSLATE_BRICKS_STEP = SoundTypes.key(ResourceKey.minecraft("block.deepslate_bricks.step"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_DEEPSLATE_TILES_BREAK = SoundTypes.key(ResourceKey.minecraft("block.deepslate_tiles.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_DEEPSLATE_TILES_FALL = SoundTypes.key(ResourceKey.minecraft("block.deepslate_tiles.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_DEEPSLATE_TILES_HIT = SoundTypes.key(ResourceKey.minecraft("block.deepslate_tiles.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_DEEPSLATE_TILES_PLACE = SoundTypes.key(ResourceKey.minecraft("block.deepslate_tiles.place"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_DEEPSLATE_TILES_STEP = SoundTypes.key(ResourceKey.minecraft("block.deepslate_tiles.step"));
+
     public static final DefaultedRegistryReference<SoundType> BLOCK_DISPENSER_DISPENSE = SoundTypes.key(ResourceKey.minecraft("block.dispenser.dispense"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_DISPENSER_FAIL = SoundTypes.key(ResourceKey.minecraft("block.dispenser.fail"));
@@ -336,6 +409,16 @@ public final class SoundTypes {
     public static final DefaultedRegistryReference<SoundType> BLOCK_FIRE_AMBIENT = SoundTypes.key(ResourceKey.minecraft("block.fire.ambient"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_FIRE_EXTINGUISH = SoundTypes.key(ResourceKey.minecraft("block.fire.extinguish"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_FLOWERING_AZALEA_BREAK = SoundTypes.key(ResourceKey.minecraft("block.flowering_azalea.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_FLOWERING_AZALEA_FALL = SoundTypes.key(ResourceKey.minecraft("block.flowering_azalea.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_FLOWERING_AZALEA_HIT = SoundTypes.key(ResourceKey.minecraft("block.flowering_azalea.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_FLOWERING_AZALEA_PLACE = SoundTypes.key(ResourceKey.minecraft("block.flowering_azalea.place"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_FLOWERING_AZALEA_STEP = SoundTypes.key(ResourceKey.minecraft("block.flowering_azalea.step"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_FUNGUS_BREAK = SoundTypes.key(ResourceKey.minecraft("block.fungus.break"));
 
@@ -390,6 +473,16 @@ public final class SoundTypes {
     public static final DefaultedRegistryReference<SoundType> BLOCK_GRAVEL_STEP = SoundTypes.key(ResourceKey.minecraft("block.gravel.step"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_GRINDSTONE_USE = SoundTypes.key(ResourceKey.minecraft("block.grindstone.use"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_HANGING_ROOTS_BREAK = SoundTypes.key(ResourceKey.minecraft("block.hanging_roots.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_HANGING_ROOTS_FALL = SoundTypes.key(ResourceKey.minecraft("block.hanging_roots.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_HANGING_ROOTS_HIT = SoundTypes.key(ResourceKey.minecraft("block.hanging_roots.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_HANGING_ROOTS_PLACE = SoundTypes.key(ResourceKey.minecraft("block.hanging_roots.place"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_HANGING_ROOTS_STEP = SoundTypes.key(ResourceKey.minecraft("block.hanging_roots.step"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_HONEY_BLOCK_BREAK = SoundTypes.key(ResourceKey.minecraft("block.honey_block.break"));
 
@@ -472,6 +565,26 @@ public final class SoundTypes {
     public static final DefaultedRegistryReference<SoundType> BLOCK_METAL_PRESSURE_PLATE_CLICK_OFF = SoundTypes.key(ResourceKey.minecraft("block.metal_pressure_plate.click_off"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_METAL_PRESSURE_PLATE_CLICK_ON = SoundTypes.key(ResourceKey.minecraft("block.metal_pressure_plate.click_on"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_MOSS_BREAK = SoundTypes.key(ResourceKey.minecraft("block.moss.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_MOSS_FALL = SoundTypes.key(ResourceKey.minecraft("block.moss.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_MOSS_HIT = SoundTypes.key(ResourceKey.minecraft("block.moss.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_MOSS_PLACE = SoundTypes.key(ResourceKey.minecraft("block.moss.place"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_MOSS_STEP = SoundTypes.key(ResourceKey.minecraft("block.moss.step"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_MOSS_CARPET_BREAK = SoundTypes.key(ResourceKey.minecraft("block.moss_carpet.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_MOSS_CARPET_FALL = SoundTypes.key(ResourceKey.minecraft("block.moss_carpet.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_MOSS_CARPET_HIT = SoundTypes.key(ResourceKey.minecraft("block.moss_carpet.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_MOSS_CARPET_PLACE = SoundTypes.key(ResourceKey.minecraft("block.moss_carpet.place"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_MOSS_CARPET_STEP = SoundTypes.key(ResourceKey.minecraft("block.moss_carpet.step"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_NETHER_BRICKS_BREAK = SoundTypes.key(ResourceKey.minecraft("block.nether_bricks.break"));
 
@@ -601,6 +714,16 @@ public final class SoundTypes {
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_POINTED_DRIPSTONE_STEP = SoundTypes.key(ResourceKey.minecraft("block.pointed_dripstone.step"));
 
+    public static final DefaultedRegistryReference<SoundType> BLOCK_POLISHED_DEEPSLATE_BREAK = SoundTypes.key(ResourceKey.minecraft("block.polished_deepslate.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_POLISHED_DEEPSLATE_FALL = SoundTypes.key(ResourceKey.minecraft("block.polished_deepslate.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_POLISHED_DEEPSLATE_HIT = SoundTypes.key(ResourceKey.minecraft("block.polished_deepslate.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_POLISHED_DEEPSLATE_PLACE = SoundTypes.key(ResourceKey.minecraft("block.polished_deepslate.place"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_POLISHED_DEEPSLATE_STEP = SoundTypes.key(ResourceKey.minecraft("block.polished_deepslate.step"));
+
     public static final DefaultedRegistryReference<SoundType> BLOCK_PORTAL_AMBIENT = SoundTypes.key(ResourceKey.minecraft("block.portal.ambient"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_PORTAL_TRAVEL = SoundTypes.key(ResourceKey.minecraft("block.portal.travel"));
@@ -628,6 +751,16 @@ public final class SoundTypes {
     public static final DefaultedRegistryReference<SoundType> BLOCK_RESPAWN_ANCHOR_DEPLETE = SoundTypes.key(ResourceKey.minecraft("block.respawn_anchor.deplete"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_RESPAWN_ANCHOR_SET_SPAWN = SoundTypes.key(ResourceKey.minecraft("block.respawn_anchor.set_spawn"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_ROOTED_DIRT_BREAK = SoundTypes.key(ResourceKey.minecraft("block.rooted_dirt.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_ROOTED_DIRT_FALL = SoundTypes.key(ResourceKey.minecraft("block.rooted_dirt.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_ROOTED_DIRT_HIT = SoundTypes.key(ResourceKey.minecraft("block.rooted_dirt.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_ROOTED_DIRT_PLACE = SoundTypes.key(ResourceKey.minecraft("block.rooted_dirt.place"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_ROOTED_DIRT_STEP = SoundTypes.key(ResourceKey.minecraft("block.rooted_dirt.step"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_ROOTS_BREAK = SoundTypes.key(ResourceKey.minecraft("block.roots.break"));
 
@@ -701,6 +834,16 @@ public final class SoundTypes {
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_SMALL_AMETHYST_BUD_PLACE = SoundTypes.key(ResourceKey.minecraft("block.small_amethyst_bud.place"));
 
+    public static final DefaultedRegistryReference<SoundType> BLOCK_SMALL_DRIPLEAF_BREAK = SoundTypes.key(ResourceKey.minecraft("block.small_dripleaf.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_SMALL_DRIPLEAF_FALL = SoundTypes.key(ResourceKey.minecraft("block.small_dripleaf.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_SMALL_DRIPLEAF_HIT = SoundTypes.key(ResourceKey.minecraft("block.small_dripleaf.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_SMALL_DRIPLEAF_PLACE = SoundTypes.key(ResourceKey.minecraft("block.small_dripleaf.place"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_SMALL_DRIPLEAF_STEP = SoundTypes.key(ResourceKey.minecraft("block.small_dripleaf.step"));
+
     public static final DefaultedRegistryReference<SoundType> BLOCK_SMITHING_TABLE_USE = SoundTypes.key(ResourceKey.minecraft("block.smithing_table.use"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_SMOKER_SMOKE = SoundTypes.key(ResourceKey.minecraft("block.smoker.smoke"));
@@ -734,6 +877,16 @@ public final class SoundTypes {
     public static final DefaultedRegistryReference<SoundType> BLOCK_SOUL_SOIL_PLACE = SoundTypes.key(ResourceKey.minecraft("block.soul_soil.place"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_SOUL_SOIL_STEP = SoundTypes.key(ResourceKey.minecraft("block.soul_soil.step"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_SPORE_BLOSSOM_BREAK = SoundTypes.key(ResourceKey.minecraft("block.spore_blossom.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_SPORE_BLOSSOM_FALL = SoundTypes.key(ResourceKey.minecraft("block.spore_blossom.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_SPORE_BLOSSOM_HIT = SoundTypes.key(ResourceKey.minecraft("block.spore_blossom.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_SPORE_BLOSSOM_PLACE = SoundTypes.key(ResourceKey.minecraft("block.spore_blossom.place"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_SPORE_BLOSSOM_STEP = SoundTypes.key(ResourceKey.minecraft("block.spore_blossom.step"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_STEM_BREAK = SoundTypes.key(ResourceKey.minecraft("block.stem.break"));
 
@@ -784,6 +937,14 @@ public final class SoundTypes {
     public static final DefaultedRegistryReference<SoundType> BLOCK_TUFF_PLACE = SoundTypes.key(ResourceKey.minecraft("block.tuff.place"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_TUFF_STEP = SoundTypes.key(ResourceKey.minecraft("block.tuff.step"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_VINE_BREAK = SoundTypes.key(ResourceKey.minecraft("block.vine.break"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_VINE_FALL = SoundTypes.key(ResourceKey.minecraft("block.vine.fall"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_VINE_HIT = SoundTypes.key(ResourceKey.minecraft("block.vine.hit"));
+
+    public static final DefaultedRegistryReference<SoundType> BLOCK_VINE_PLACE = SoundTypes.key(ResourceKey.minecraft("block.vine.place"));
 
     public static final DefaultedRegistryReference<SoundType> BLOCK_VINE_STEP = SoundTypes.key(ResourceKey.minecraft("block.vine.step"));
 
@@ -1691,6 +1852,8 @@ public final class SoundTypes {
 
     public static final DefaultedRegistryReference<SoundType> ENTITY_SKELETON_AMBIENT = SoundTypes.key(ResourceKey.minecraft("entity.skeleton.ambient"));
 
+    public static final DefaultedRegistryReference<SoundType> ENTITY_SKELETON_CONVERTED_TO_STRAY = SoundTypes.key(ResourceKey.minecraft("entity.skeleton.converted_to_stray"));
+
     public static final DefaultedRegistryReference<SoundType> ENTITY_SKELETON_DEATH = SoundTypes.key(ResourceKey.minecraft("entity.skeleton.death"));
 
     public static final DefaultedRegistryReference<SoundType> ENTITY_SKELETON_HURT = SoundTypes.key(ResourceKey.minecraft("entity.skeleton.hurt"));
@@ -2205,10 +2368,7 @@ public final class SoundTypes {
 
     public static final DefaultedRegistryReference<SoundType> WEATHER_RAIN_ABOVE = SoundTypes.key(ResourceKey.minecraft("weather.rain.above"));
 
-    // SORTFIELDS:OFF
-
     // @formatter:on
-
     private SoundTypes() {
     }
 

--- a/src/main/java/org/spongepowered/api/entity/EntityTypes.java
+++ b/src/main/java/org/spongepowered/api/entity/EntityTypes.java
@@ -33,7 +33,6 @@ import org.spongepowered.api.entity.hanging.LeashKnot;
 import org.spongepowered.api.entity.hanging.Painting;
 import org.spongepowered.api.entity.living.ArmorStand;
 import org.spongepowered.api.entity.living.Bat;
-import org.spongepowered.api.entity.living.Human;
 import org.spongepowered.api.entity.living.animal.Axolotl;
 import org.spongepowered.api.entity.living.animal.Bee;
 import org.spongepowered.api.entity.living.animal.Cat;
@@ -147,9 +146,6 @@ import org.spongepowered.api.registry.RegistryScopes;
 public final class EntityTypes {
 
     // @formatter:off
-
-    // SORTFIELDS:ON
-
     public static final DefaultedRegistryReference<EntityType<AreaEffectCloud>> AREA_EFFECT_CLOUD = EntityTypes.key(ResourceKey.minecraft("area_effect_cloud"));
 
     public static final DefaultedRegistryReference<EntityType<ArmorStand>> ARMOR_STAND = EntityTypes.key(ResourceKey.minecraft("armor_stand"));
@@ -194,15 +190,15 @@ public final class EntityTypes {
 
     public static final DefaultedRegistryReference<EntityType<ElderGuardian>> ELDER_GUARDIAN = EntityTypes.key(ResourceKey.minecraft("elder_guardian"));
 
-    public static final DefaultedRegistryReference<EntityType<EndCrystal>> END_CRYSTAL = EntityTypes.key(ResourceKey.minecraft("end_crystal"));
+    public static final DefaultedRegistryReference<EntityType<Enderman>> ENDERMAN = EntityTypes.key(ResourceKey.minecraft("enderman"));
+
+    public static final DefaultedRegistryReference<EntityType<Endermite>> ENDERMITE = EntityTypes.key(ResourceKey.minecraft("endermite"));
 
     public static final DefaultedRegistryReference<EntityType<EnderDragon>> ENDER_DRAGON = EntityTypes.key(ResourceKey.minecraft("ender_dragon"));
 
     public static final DefaultedRegistryReference<EntityType<EnderPearl>> ENDER_PEARL = EntityTypes.key(ResourceKey.minecraft("ender_pearl"));
 
-    public static final DefaultedRegistryReference<EntityType<Enderman>> ENDERMAN = EntityTypes.key(ResourceKey.minecraft("enderman"));
-
-    public static final DefaultedRegistryReference<EntityType<Endermite>> ENDERMITE = EntityTypes.key(ResourceKey.minecraft("endermite"));
+    public static final DefaultedRegistryReference<EntityType<EndCrystal>> END_CRYSTAL = EntityTypes.key(ResourceKey.minecraft("end_crystal"));
 
     public static final DefaultedRegistryReference<EntityType<Evoker>> EVOKER = EntityTypes.key(ResourceKey.minecraft("evoker"));
 
@@ -316,9 +312,9 @@ public final class EntityTypes {
 
     public static final DefaultedRegistryReference<EntityType<SmallFireball>> SMALL_FIREBALL = EntityTypes.key(ResourceKey.minecraft("small_fireball"));
 
-    public static final DefaultedRegistryReference<EntityType<SnowGolem>> SNOW_GOLEM = EntityTypes.key(ResourceKey.minecraft("snow_golem"));
-
     public static final DefaultedRegistryReference<EntityType<Snowball>> SNOWBALL = EntityTypes.key(ResourceKey.minecraft("snowball"));
+
+    public static final DefaultedRegistryReference<EntityType<SnowGolem>> SNOW_GOLEM = EntityTypes.key(ResourceKey.minecraft("snow_golem"));
 
     public static final DefaultedRegistryReference<EntityType<SpawnerMinecart>> SPAWNER_MINECART = EntityTypes.key(ResourceKey.minecraft("spawner_minecart"));
 
@@ -372,12 +368,7 @@ public final class EntityTypes {
 
     public static final DefaultedRegistryReference<EntityType<ZombifiedPiglin>> ZOMBIFIED_PIGLIN = EntityTypes.key(ResourceKey.minecraft("zombified_piglin"));
 
-    // SORTFIELDS:OFF
-
     // @formatter:on
-
-    public static final DefaultedRegistryReference<EntityType<Human>> HUMAN = EntityTypes.key(ResourceKey.sponge("human"));
-
     private EntityTypes() {
     }
 

--- a/src/main/java/org/spongepowered/api/entity/attribute/type/AttributeTypes.java
+++ b/src/main/java/org/spongepowered/api/entity/attribute/type/AttributeTypes.java
@@ -27,56 +27,50 @@ package org.spongepowered.api.entity.attribute.type;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
+import org.spongepowered.api.registry.RegistryTypes;
 
 /**
- * An enumeration of {@link AttributeTypes}s.
+ * An enumeration of all possible {@link AttributeType}s in vanilla Minecraft.
  */
 @SuppressWarnings("unused")
 @RegistryScopes(scopes = RegistryScope.GAME)
 public final class AttributeTypes {
 
     // @formatter:off
+    public static final DefaultedRegistryReference<AttributeType> GENERIC_ARMOR = AttributeTypes.key(ResourceKey.minecraft("generic.armor"));
 
-    // SORTFIELDS:ON
+    public static final DefaultedRegistryReference<AttributeType> GENERIC_ARMOR_TOUGHNESS = AttributeTypes.key(ResourceKey.minecraft("generic.armor_toughness"));
 
-    public static final DefaultedRegistryReference<RangedAttributeType> GENERIC_ARMOR = AttributeTypes.rangedKey(ResourceKey.minecraft("generic.armor"));
+    public static final DefaultedRegistryReference<AttributeType> GENERIC_ATTACK_DAMAGE = AttributeTypes.key(ResourceKey.minecraft("generic.attack_damage"));
 
-    public static final DefaultedRegistryReference<RangedAttributeType> GENERIC_ARMOR_TOUGHNESS = AttributeTypes.rangedKey(ResourceKey.minecraft("generic.armor_toughness"));
+    public static final DefaultedRegistryReference<AttributeType> GENERIC_ATTACK_KNOCKBACK = AttributeTypes.key(ResourceKey.minecraft("generic.attack_knockback"));
 
-    public static final DefaultedRegistryReference<RangedAttributeType> GENERIC_ATTACK_DAMAGE = AttributeTypes.rangedKey(ResourceKey.minecraft("generic.attack_damage"));
+    public static final DefaultedRegistryReference<AttributeType> GENERIC_ATTACK_SPEED = AttributeTypes.key(ResourceKey.minecraft("generic.attack_speed"));
 
-    public static final DefaultedRegistryReference<RangedAttributeType> GENERIC_ATTACK_KNOCKBACK = AttributeTypes.rangedKey(ResourceKey.minecraft("generic.attack_knockback"));
+    public static final DefaultedRegistryReference<AttributeType> GENERIC_FLYING_SPEED = AttributeTypes.key(ResourceKey.minecraft("generic.flying_speed"));
 
-    public static final DefaultedRegistryReference<RangedAttributeType> GENERIC_ATTACK_SPEED = AttributeTypes.rangedKey(ResourceKey.minecraft("generic.attack_speed"));
+    public static final DefaultedRegistryReference<AttributeType> GENERIC_FOLLOW_RANGE = AttributeTypes.key(ResourceKey.minecraft("generic.follow_range"));
 
-    public static final DefaultedRegistryReference<RangedAttributeType> GENERIC_FLYING_SPEED = AttributeTypes.rangedKey(ResourceKey.minecraft("generic.flying_speed"));
+    public static final DefaultedRegistryReference<AttributeType> GENERIC_KNOCKBACK_RESISTANCE = AttributeTypes.key(ResourceKey.minecraft("generic.knockback_resistance"));
 
-    public static final DefaultedRegistryReference<RangedAttributeType> GENERIC_FOLLOW_RANGE = AttributeTypes.rangedKey(ResourceKey.minecraft("generic.follow_range"));
+    public static final DefaultedRegistryReference<AttributeType> GENERIC_LUCK = AttributeTypes.key(ResourceKey.minecraft("generic.luck"));
 
-    public static final DefaultedRegistryReference<RangedAttributeType> GENERIC_KNOCKBACK_RESISTANCE = AttributeTypes.rangedKey(ResourceKey.minecraft("generic.knockback_resistance"));
+    public static final DefaultedRegistryReference<AttributeType> GENERIC_MAX_HEALTH = AttributeTypes.key(ResourceKey.minecraft("generic.max_health"));
 
-    public static final DefaultedRegistryReference<RangedAttributeType> GENERIC_LUCK = AttributeTypes.rangedKey(ResourceKey.minecraft("generic.luck"));
+    public static final DefaultedRegistryReference<AttributeType> GENERIC_MOVEMENT_SPEED = AttributeTypes.key(ResourceKey.minecraft("generic.movement_speed"));
 
-    public static final DefaultedRegistryReference<RangedAttributeType> GENERIC_MAX_HEALTH = AttributeTypes.rangedKey(ResourceKey.minecraft("generic.max_health"));
+    public static final DefaultedRegistryReference<AttributeType> HORSE_JUMP_STRENGTH = AttributeTypes.key(ResourceKey.minecraft("horse.jump_strength"));
 
-    public static final DefaultedRegistryReference<RangedAttributeType> GENERIC_MOVEMENT_SPEED = AttributeTypes.rangedKey(ResourceKey.minecraft("generic.movement_speed"));
-
-    public static final DefaultedRegistryReference<RangedAttributeType> HORSE_JUMP_STRENGTH = AttributeTypes.rangedKey(ResourceKey.minecraft("horse.jump_strength"));
-
-    public static final DefaultedRegistryReference<RangedAttributeType> ZOMBIE_SPAWN_REINFORCEMENTS = AttributeTypes.rangedKey(ResourceKey.minecraft("zombie.spawn_reinforcements"));
-
-    // SORTFIELDS:OFF
+    public static final DefaultedRegistryReference<AttributeType> ZOMBIE_SPAWN_REINFORCEMENTS = AttributeTypes.key(ResourceKey.minecraft("zombie.spawn_reinforcements"));
 
     // @formatter:on
-
     private AttributeTypes() {
     }
 
-    private static DefaultedRegistryReference<RangedAttributeType> rangedKey(final ResourceKey location) {
+    private static DefaultedRegistryReference<AttributeType> key(final ResourceKey location) {
         return RegistryKey.of(RegistryTypes.ATTRIBUTE_TYPE, location).asDefaultedReference(() -> Sponge.getGame().registries());
     }
 }

--- a/src/main/java/org/spongepowered/api/fluid/FluidTypes.java
+++ b/src/main/java/org/spongepowered/api/fluid/FluidTypes.java
@@ -27,19 +27,19 @@ package org.spongepowered.api.fluid;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
+import org.spongepowered.api.registry.RegistryTypes;
 
+/**
+ * An enumeration of all possible {@link FluidType}s in vanilla Minecraft.
+ */
 @SuppressWarnings("unused")
 @RegistryScopes(scopes = RegistryScope.GAME)
 public final class FluidTypes {
 
     // @formatter:off
-
-    // SORTFIELDS:ON
-
     public static final DefaultedRegistryReference<FluidType> EMPTY = FluidTypes.key(ResourceKey.minecraft("empty"));
 
     public static final DefaultedRegistryReference<FluidType> FLOWING_LAVA = FluidTypes.key(ResourceKey.minecraft("flowing_lava"));
@@ -50,10 +50,7 @@ public final class FluidTypes {
 
     public static final DefaultedRegistryReference<FluidType> WATER = FluidTypes.key(ResourceKey.minecraft("water"));
 
-    // SORTFIELDS:OFF
-
     // @formatter:on
-
     private FluidTypes() {
     }
 

--- a/src/main/java/org/spongepowered/api/item/ItemTypes.java
+++ b/src/main/java/org/spongepowered/api/item/ItemTypes.java
@@ -27,22 +27,19 @@ package org.spongepowered.api.item;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
+import org.spongepowered.api.registry.RegistryTypes;
 
 /**
- * An enumeration of all possible {@link ItemType}s in vanilla minecraft.
+ * An enumeration of all possible {@link ItemType}s in vanilla Minecraft.
  */
 @SuppressWarnings("unused")
 @RegistryScopes(scopes = RegistryScope.GAME)
 public final class ItemTypes {
 
     // @formatter:off
-
-    // SORTFIELDS:ON
-
     public static final DefaultedRegistryReference<ItemType> ACACIA_BOAT = ItemTypes.key(ResourceKey.minecraft("acacia_boat"));
 
     public static final DefaultedRegistryReference<ItemType> ACACIA_BUTTON = ItemTypes.key(ResourceKey.minecraft("acacia_button"));
@@ -107,6 +104,12 @@ public final class ItemTypes {
 
     public static final DefaultedRegistryReference<ItemType> AXOLOTL_SPAWN_EGG = ItemTypes.key(ResourceKey.minecraft("axolotl_spawn_egg"));
 
+    public static final DefaultedRegistryReference<ItemType> AZALEA = ItemTypes.key(ResourceKey.minecraft("azalea"));
+
+    public static final DefaultedRegistryReference<ItemType> AZALEA_LEAVES = ItemTypes.key(ResourceKey.minecraft("azalea_leaves"));
+
+    public static final DefaultedRegistryReference<ItemType> AZALEA_LEAVES_FLOWERS = ItemTypes.key(ResourceKey.minecraft("azalea_leaves_flowers"));
+
     public static final DefaultedRegistryReference<ItemType> AZURE_BLUET = ItemTypes.key(ResourceKey.minecraft("azure_bluet"));
 
     public static final DefaultedRegistryReference<ItemType> BAKED_POTATO = ItemTypes.key(ResourceKey.minecraft("baked_potato"));
@@ -140,6 +143,8 @@ public final class ItemTypes {
     public static final DefaultedRegistryReference<ItemType> BEETROOT_SOUP = ItemTypes.key(ResourceKey.minecraft("beetroot_soup"));
 
     public static final DefaultedRegistryReference<ItemType> BELL = ItemTypes.key(ResourceKey.minecraft("bell"));
+
+    public static final DefaultedRegistryReference<ItemType> BIG_DRIPLEAF = ItemTypes.key(ResourceKey.minecraft("big_dripleaf"));
 
     public static final DefaultedRegistryReference<ItemType> BIRCH_BOAT = ItemTypes.key(ResourceKey.minecraft("birch_boat"));
 
@@ -367,6 +372,8 @@ public final class ItemTypes {
 
     public static final DefaultedRegistryReference<ItemType> CHIPPED_ANVIL = ItemTypes.key(ResourceKey.minecraft("chipped_anvil"));
 
+    public static final DefaultedRegistryReference<ItemType> CHISELED_DEEPSLATE = ItemTypes.key(ResourceKey.minecraft("chiseled_deepslate"));
+
     public static final DefaultedRegistryReference<ItemType> CHISELED_NETHER_BRICKS = ItemTypes.key(ResourceKey.minecraft("chiseled_nether_bricks"));
 
     public static final DefaultedRegistryReference<ItemType> CHISELED_POLISHED_BLACKSTONE = ItemTypes.key(ResourceKey.minecraft("chiseled_polished_blackstone"));
@@ -398,6 +405,14 @@ public final class ItemTypes {
     public static final DefaultedRegistryReference<ItemType> COAL_ORE = ItemTypes.key(ResourceKey.minecraft("coal_ore"));
 
     public static final DefaultedRegistryReference<ItemType> COARSE_DIRT = ItemTypes.key(ResourceKey.minecraft("coarse_dirt"));
+
+    public static final DefaultedRegistryReference<ItemType> COBBLED_DEEPSLATE = ItemTypes.key(ResourceKey.minecraft("cobbled_deepslate"));
+
+    public static final DefaultedRegistryReference<ItemType> COBBLED_DEEPSLATE_SLAB = ItemTypes.key(ResourceKey.minecraft("cobbled_deepslate_slab"));
+
+    public static final DefaultedRegistryReference<ItemType> COBBLED_DEEPSLATE_STAIRS = ItemTypes.key(ResourceKey.minecraft("cobbled_deepslate_stairs"));
+
+    public static final DefaultedRegistryReference<ItemType> COBBLED_DEEPSLATE_WALL = ItemTypes.key(ResourceKey.minecraft("cobbled_deepslate_wall"));
 
     public static final DefaultedRegistryReference<ItemType> COBBLESTONE = ItemTypes.key(ResourceKey.minecraft("cobblestone"));
 
@@ -619,6 +634,34 @@ public final class ItemTypes {
 
     public static final DefaultedRegistryReference<ItemType> DEBUG_STICK = ItemTypes.key(ResourceKey.minecraft("debug_stick"));
 
+    public static final DefaultedRegistryReference<ItemType> DEEPSLATE = ItemTypes.key(ResourceKey.minecraft("deepslate"));
+
+    public static final DefaultedRegistryReference<ItemType> DEEPSLATE_BRICK_SLAB = ItemTypes.key(ResourceKey.minecraft("deepslate_brick_slab"));
+
+    public static final DefaultedRegistryReference<ItemType> DEEPSLATE_BRICK_STAIRS = ItemTypes.key(ResourceKey.minecraft("deepslate_brick_stairs"));
+
+    public static final DefaultedRegistryReference<ItemType> DEEPSLATE_BRICK_WALL = ItemTypes.key(ResourceKey.minecraft("deepslate_brick_wall"));
+
+    public static final DefaultedRegistryReference<ItemType> DEEPSLATE_BRICKS = ItemTypes.key(ResourceKey.minecraft("deepslate_bricks"));
+
+    public static final DefaultedRegistryReference<ItemType> DEEPSLATE_DIAMOND_ORE = ItemTypes.key(ResourceKey.minecraft("deepslate_diamond_ore"));
+
+    public static final DefaultedRegistryReference<ItemType> DEEPSLATE_GOLD_ORE = ItemTypes.key(ResourceKey.minecraft("deepslate_gold_ore"));
+
+    public static final DefaultedRegistryReference<ItemType> DEEPSLATE_IRON_ORE = ItemTypes.key(ResourceKey.minecraft("deepslate_iron_ore"));
+
+    public static final DefaultedRegistryReference<ItemType> DEEPSLATE_LAPIS_ORE = ItemTypes.key(ResourceKey.minecraft("deepslate_lapis_ore"));
+
+    public static final DefaultedRegistryReference<ItemType> DEEPSLATE_REDSTONE_ORE = ItemTypes.key(ResourceKey.minecraft("deepslate_redstone_ore"));
+
+    public static final DefaultedRegistryReference<ItemType> DEEPSLATE_TILE_SLAB = ItemTypes.key(ResourceKey.minecraft("deepslate_tile_slab"));
+
+    public static final DefaultedRegistryReference<ItemType> DEEPSLATE_TILE_STAIRS = ItemTypes.key(ResourceKey.minecraft("deepslate_tile_stairs"));
+
+    public static final DefaultedRegistryReference<ItemType> DEEPSLATE_TILE_WALL = ItemTypes.key(ResourceKey.minecraft("deepslate_tile_wall"));
+
+    public static final DefaultedRegistryReference<ItemType> DEEPSLATE_TILES = ItemTypes.key(ResourceKey.minecraft("deepslate_tiles"));
+
     public static final DefaultedRegistryReference<ItemType> DETECTOR_RAIL = ItemTypes.key(ResourceKey.minecraft("detector_rail"));
 
     public static final DefaultedRegistryReference<ItemType> DIAMOND = ItemTypes.key(ResourceKey.minecraft("diamond"));
@@ -729,6 +772,14 @@ public final class ItemTypes {
 
     public static final DefaultedRegistryReference<ItemType> EXPERIENCE_BOTTLE = ItemTypes.key(ResourceKey.minecraft("experience_bottle"));
 
+    public static final DefaultedRegistryReference<ItemType> EXPOSED_COPPER = ItemTypes.key(ResourceKey.minecraft("exposed_copper"));
+
+    public static final DefaultedRegistryReference<ItemType> EXPOSED_CUT_COPPER = ItemTypes.key(ResourceKey.minecraft("exposed_cut_copper"));
+
+    public static final DefaultedRegistryReference<ItemType> EXPOSED_CUT_COPPER_SLAB = ItemTypes.key(ResourceKey.minecraft("exposed_cut_copper_slab"));
+
+    public static final DefaultedRegistryReference<ItemType> EXPOSED_CUT_COPPER_STAIRS = ItemTypes.key(ResourceKey.minecraft("exposed_cut_copper_stairs"));
+
     public static final DefaultedRegistryReference<ItemType> FARMLAND = ItemTypes.key(ResourceKey.minecraft("farmland"));
 
     public static final DefaultedRegistryReference<ItemType> FEATHER = ItemTypes.key(ResourceKey.minecraft("feather"));
@@ -763,6 +814,8 @@ public final class ItemTypes {
 
     public static final DefaultedRegistryReference<ItemType> FLOWER_POT = ItemTypes.key(ResourceKey.minecraft("flower_pot"));
 
+    public static final DefaultedRegistryReference<ItemType> FLOWERING_AZALEA = ItemTypes.key(ResourceKey.minecraft("flowering_azalea"));
+
     public static final DefaultedRegistryReference<ItemType> FOX_SPAWN_EGG = ItemTypes.key(ResourceKey.minecraft("fox_spawn_egg"));
 
     public static final DefaultedRegistryReference<ItemType> FURNACE = ItemTypes.key(ResourceKey.minecraft("furnace"));
@@ -784,6 +837,8 @@ public final class ItemTypes {
     public static final DefaultedRegistryReference<ItemType> GLISTERING_MELON_SLICE = ItemTypes.key(ResourceKey.minecraft("glistering_melon_slice"));
 
     public static final DefaultedRegistryReference<ItemType> GLOBE_BANNER_PATTERN = ItemTypes.key(ResourceKey.minecraft("globe_banner_pattern"));
+
+    public static final DefaultedRegistryReference<ItemType> GLOW_BERRIES = ItemTypes.key(ResourceKey.minecraft("glow_berries"));
 
     public static final DefaultedRegistryReference<ItemType> GLOW_INK_SAC = ItemTypes.key(ResourceKey.minecraft("glow_ink_sac"));
 
@@ -900,6 +955,8 @@ public final class ItemTypes {
     public static final DefaultedRegistryReference<ItemType> GUARDIAN_SPAWN_EGG = ItemTypes.key(ResourceKey.minecraft("guardian_spawn_egg"));
 
     public static final DefaultedRegistryReference<ItemType> GUNPOWDER = ItemTypes.key(ResourceKey.minecraft("gunpowder"));
+
+    public static final DefaultedRegistryReference<ItemType> HANGING_ROOTS = ItemTypes.key(ResourceKey.minecraft("hanging_roots"));
 
     public static final DefaultedRegistryReference<ItemType> HAY_BLOCK = ItemTypes.key(ResourceKey.minecraft("hay_block"));
 
@@ -1111,14 +1168,6 @@ public final class ItemTypes {
 
     public static final DefaultedRegistryReference<ItemType> LIGHT_WEIGHTED_PRESSURE_PLATE = ItemTypes.key(ResourceKey.minecraft("light_weighted_pressure_plate"));
 
-    public static final DefaultedRegistryReference<ItemType> LIGHTLY_WEATHERED_COPPER_BLOCK = ItemTypes.key(ResourceKey.minecraft("lightly_weathered_copper_block"));
-
-    public static final DefaultedRegistryReference<ItemType> LIGHTLY_WEATHERED_CUT_COPPER = ItemTypes.key(ResourceKey.minecraft("lightly_weathered_cut_copper"));
-
-    public static final DefaultedRegistryReference<ItemType> LIGHTLY_WEATHERED_CUT_COPPER_SLAB = ItemTypes.key(ResourceKey.minecraft("lightly_weathered_cut_copper_slab"));
-
-    public static final DefaultedRegistryReference<ItemType> LIGHTLY_WEATHERED_CUT_COPPER_STAIRS = ItemTypes.key(ResourceKey.minecraft("lightly_weathered_cut_copper_stairs"));
-
     public static final DefaultedRegistryReference<ItemType> LIGHTNING_ROD = ItemTypes.key(ResourceKey.minecraft("lightning_rod"));
 
     public static final DefaultedRegistryReference<ItemType> LILAC = ItemTypes.key(ResourceKey.minecraft("lilac"));
@@ -1210,6 +1259,10 @@ public final class ItemTypes {
     public static final DefaultedRegistryReference<ItemType> MOJANG_BANNER_PATTERN = ItemTypes.key(ResourceKey.minecraft("mojang_banner_pattern"));
 
     public static final DefaultedRegistryReference<ItemType> MOOSHROOM_SPAWN_EGG = ItemTypes.key(ResourceKey.minecraft("mooshroom_spawn_egg"));
+
+    public static final DefaultedRegistryReference<ItemType> MOSS_BLOCK = ItemTypes.key(ResourceKey.minecraft("moss_block"));
+
+    public static final DefaultedRegistryReference<ItemType> MOSS_CARPET = ItemTypes.key(ResourceKey.minecraft("moss_carpet"));
 
     public static final DefaultedRegistryReference<ItemType> MOSSY_COBBLESTONE = ItemTypes.key(ResourceKey.minecraft("mossy_cobblestone"));
 
@@ -1385,6 +1438,14 @@ public final class ItemTypes {
 
     public static final DefaultedRegistryReference<ItemType> OXEYE_DAISY = ItemTypes.key(ResourceKey.minecraft("oxeye_daisy"));
 
+    public static final DefaultedRegistryReference<ItemType> OXIDIZED_COPPER = ItemTypes.key(ResourceKey.minecraft("oxidized_copper"));
+
+    public static final DefaultedRegistryReference<ItemType> OXIDIZED_CUT_COPPER = ItemTypes.key(ResourceKey.minecraft("oxidized_cut_copper"));
+
+    public static final DefaultedRegistryReference<ItemType> OXIDIZED_CUT_COPPER_SLAB = ItemTypes.key(ResourceKey.minecraft("oxidized_cut_copper_slab"));
+
+    public static final DefaultedRegistryReference<ItemType> OXIDIZED_CUT_COPPER_STAIRS = ItemTypes.key(ResourceKey.minecraft("oxidized_cut_copper_stairs"));
+
     public static final DefaultedRegistryReference<ItemType> PACKED_ICE = ItemTypes.key(ResourceKey.minecraft("packed_ice"));
 
     public static final DefaultedRegistryReference<ItemType> PAINTING = ItemTypes.key(ResourceKey.minecraft("painting"));
@@ -1480,6 +1541,14 @@ public final class ItemTypes {
     public static final DefaultedRegistryReference<ItemType> POLISHED_BLACKSTONE_STAIRS = ItemTypes.key(ResourceKey.minecraft("polished_blackstone_stairs"));
 
     public static final DefaultedRegistryReference<ItemType> POLISHED_BLACKSTONE_WALL = ItemTypes.key(ResourceKey.minecraft("polished_blackstone_wall"));
+
+    public static final DefaultedRegistryReference<ItemType> POLISHED_DEEPSLATE = ItemTypes.key(ResourceKey.minecraft("polished_deepslate"));
+
+    public static final DefaultedRegistryReference<ItemType> POLISHED_DEEPSLATE_SLAB = ItemTypes.key(ResourceKey.minecraft("polished_deepslate_slab"));
+
+    public static final DefaultedRegistryReference<ItemType> POLISHED_DEEPSLATE_STAIRS = ItemTypes.key(ResourceKey.minecraft("polished_deepslate_stairs"));
+
+    public static final DefaultedRegistryReference<ItemType> POLISHED_DEEPSLATE_WALL = ItemTypes.key(ResourceKey.minecraft("polished_deepslate_wall"));
 
     public static final DefaultedRegistryReference<ItemType> POLISHED_DIORITE = ItemTypes.key(ResourceKey.minecraft("polished_diorite"));
 
@@ -1663,6 +1732,8 @@ public final class ItemTypes {
 
     public static final DefaultedRegistryReference<ItemType> RESPAWN_ANCHOR = ItemTypes.key(ResourceKey.minecraft("respawn_anchor"));
 
+    public static final DefaultedRegistryReference<ItemType> ROOTED_DIRT = ItemTypes.key(ResourceKey.minecraft("rooted_dirt"));
+
     public static final DefaultedRegistryReference<ItemType> ROSE_BUSH = ItemTypes.key(ResourceKey.minecraft("rose_bush"));
 
     public static final DefaultedRegistryReference<ItemType> ROTTEN_FLESH = ItemTypes.key(ResourceKey.minecraft("rotten_flesh"));
@@ -1697,14 +1768,6 @@ public final class ItemTypes {
 
     public static final DefaultedRegistryReference<ItemType> SEAGRASS = ItemTypes.key(ResourceKey.minecraft("seagrass"));
 
-    public static final DefaultedRegistryReference<ItemType> SEMI_WEATHERED_COPPER_BLOCK = ItemTypes.key(ResourceKey.minecraft("semi_weathered_copper_block"));
-
-    public static final DefaultedRegistryReference<ItemType> SEMI_WEATHERED_CUT_COPPER = ItemTypes.key(ResourceKey.minecraft("semi_weathered_cut_copper"));
-
-    public static final DefaultedRegistryReference<ItemType> SEMI_WEATHERED_CUT_COPPER_SLAB = ItemTypes.key(ResourceKey.minecraft("semi_weathered_cut_copper_slab"));
-
-    public static final DefaultedRegistryReference<ItemType> SEMI_WEATHERED_CUT_COPPER_STAIRS = ItemTypes.key(ResourceKey.minecraft("semi_weathered_cut_copper_stairs"));
-
     public static final DefaultedRegistryReference<ItemType> SHEARS = ItemTypes.key(ResourceKey.minecraft("shears"));
 
     public static final DefaultedRegistryReference<ItemType> SHEEP_SPAWN_EGG = ItemTypes.key(ResourceKey.minecraft("sheep_spawn_egg"));
@@ -1737,9 +1800,13 @@ public final class ItemTypes {
 
     public static final DefaultedRegistryReference<ItemType> SMALL_AMETHYST_BUD = ItemTypes.key(ResourceKey.minecraft("small_amethyst_bud"));
 
+    public static final DefaultedRegistryReference<ItemType> SMALL_DRIPLEAF = ItemTypes.key(ResourceKey.minecraft("small_dripleaf"));
+
     public static final DefaultedRegistryReference<ItemType> SMITHING_TABLE = ItemTypes.key(ResourceKey.minecraft("smithing_table"));
 
     public static final DefaultedRegistryReference<ItemType> SMOKER = ItemTypes.key(ResourceKey.minecraft("smoker"));
+
+    public static final DefaultedRegistryReference<ItemType> SMOOTH_BASALT = ItemTypes.key(ResourceKey.minecraft("smooth_basalt"));
 
     public static final DefaultedRegistryReference<ItemType> SMOOTH_QUARTZ = ItemTypes.key(ResourceKey.minecraft("smooth_quartz"));
 
@@ -1790,6 +1857,8 @@ public final class ItemTypes {
     public static final DefaultedRegistryReference<ItemType> SPLASH_POTION = ItemTypes.key(ResourceKey.minecraft("splash_potion"));
 
     public static final DefaultedRegistryReference<ItemType> SPONGE = ItemTypes.key(ResourceKey.minecraft("sponge"));
+
+    public static final DefaultedRegistryReference<ItemType> SPORE_BLOSSOM = ItemTypes.key(ResourceKey.minecraft("spore_blossom"));
 
     public static final DefaultedRegistryReference<ItemType> SPRUCE_BOAT = ItemTypes.key(ResourceKey.minecraft("spruce_boat"));
 
@@ -2005,7 +2074,7 @@ public final class ItemTypes {
 
     public static final DefaultedRegistryReference<ItemType> WATER_BUCKET = ItemTypes.key(ResourceKey.minecraft("water_bucket"));
 
-    public static final DefaultedRegistryReference<ItemType> WAXED_COPPER = ItemTypes.key(ResourceKey.minecraft("waxed_copper"));
+    public static final DefaultedRegistryReference<ItemType> WAXED_COPPER_BLOCK = ItemTypes.key(ResourceKey.minecraft("waxed_copper_block"));
 
     public static final DefaultedRegistryReference<ItemType> WAXED_CUT_COPPER = ItemTypes.key(ResourceKey.minecraft("waxed_cut_copper"));
 
@@ -2013,23 +2082,23 @@ public final class ItemTypes {
 
     public static final DefaultedRegistryReference<ItemType> WAXED_CUT_COPPER_STAIRS = ItemTypes.key(ResourceKey.minecraft("waxed_cut_copper_stairs"));
 
-    public static final DefaultedRegistryReference<ItemType> WAXED_LIGHTLY_WEATHERED_COPPER = ItemTypes.key(ResourceKey.minecraft("waxed_lightly_weathered_copper"));
+    public static final DefaultedRegistryReference<ItemType> WAXED_EXPOSED_COPPER = ItemTypes.key(ResourceKey.minecraft("waxed_exposed_copper"));
 
-    public static final DefaultedRegistryReference<ItemType> WAXED_LIGHTLY_WEATHERED_CUT_COPPER = ItemTypes.key(ResourceKey.minecraft("waxed_lightly_weathered_cut_copper"));
+    public static final DefaultedRegistryReference<ItemType> WAXED_EXPOSED_CUT_COPPER = ItemTypes.key(ResourceKey.minecraft("waxed_exposed_cut_copper"));
 
-    public static final DefaultedRegistryReference<ItemType> WAXED_LIGHTLY_WEATHERED_CUT_COPPER_SLAB = ItemTypes.key(ResourceKey.minecraft("waxed_lightly_weathered_cut_copper_slab"));
+    public static final DefaultedRegistryReference<ItemType> WAXED_EXPOSED_CUT_COPPER_SLAB = ItemTypes.key(ResourceKey.minecraft("waxed_exposed_cut_copper_slab"));
 
-    public static final DefaultedRegistryReference<ItemType> WAXED_LIGHTLY_WEATHERED_CUT_COPPER_STAIRS = ItemTypes.key(ResourceKey.minecraft("waxed_lightly_weathered_cut_copper_stairs"));
+    public static final DefaultedRegistryReference<ItemType> WAXED_EXPOSED_CUT_COPPER_STAIRS = ItemTypes.key(ResourceKey.minecraft("waxed_exposed_cut_copper_stairs"));
 
-    public static final DefaultedRegistryReference<ItemType> WAXED_SEMI_WEATHERED_COPPER = ItemTypes.key(ResourceKey.minecraft("waxed_semi_weathered_copper"));
+    public static final DefaultedRegistryReference<ItemType> WAXED_WEATHERED_COPPER = ItemTypes.key(ResourceKey.minecraft("waxed_weathered_copper"));
 
-    public static final DefaultedRegistryReference<ItemType> WAXED_SEMI_WEATHERED_CUT_COPPER = ItemTypes.key(ResourceKey.minecraft("waxed_semi_weathered_cut_copper"));
+    public static final DefaultedRegistryReference<ItemType> WAXED_WEATHERED_CUT_COPPER = ItemTypes.key(ResourceKey.minecraft("waxed_weathered_cut_copper"));
 
-    public static final DefaultedRegistryReference<ItemType> WAXED_SEMI_WEATHERED_CUT_COPPER_SLAB = ItemTypes.key(ResourceKey.minecraft("waxed_semi_weathered_cut_copper_slab"));
+    public static final DefaultedRegistryReference<ItemType> WAXED_WEATHERED_CUT_COPPER_SLAB = ItemTypes.key(ResourceKey.minecraft("waxed_weathered_cut_copper_slab"));
 
-    public static final DefaultedRegistryReference<ItemType> WAXED_SEMI_WEATHERED_CUT_COPPER_STAIRS = ItemTypes.key(ResourceKey.minecraft("waxed_semi_weathered_cut_copper_stairs"));
+    public static final DefaultedRegistryReference<ItemType> WAXED_WEATHERED_CUT_COPPER_STAIRS = ItemTypes.key(ResourceKey.minecraft("waxed_weathered_cut_copper_stairs"));
 
-    public static final DefaultedRegistryReference<ItemType> WEATHERED_COPPER_BLOCK = ItemTypes.key(ResourceKey.minecraft("weathered_copper_block"));
+    public static final DefaultedRegistryReference<ItemType> WEATHERED_COPPER = ItemTypes.key(ResourceKey.minecraft("weathered_copper"));
 
     public static final DefaultedRegistryReference<ItemType> WEATHERED_CUT_COPPER = ItemTypes.key(ResourceKey.minecraft("weathered_cut_copper"));
 
@@ -2135,10 +2204,7 @@ public final class ItemTypes {
 
     public static final DefaultedRegistryReference<ItemType> ZOMBIFIED_PIGLIN_SPAWN_EGG = ItemTypes.key(ResourceKey.minecraft("zombified_piglin_spawn_egg"));
 
-    // SORTFIELDS:OFF
-
     // @formatter:on
-
     private ItemTypes() {
     }
 

--- a/src/main/java/org/spongepowered/api/item/enchantment/EnchantmentTypes.java
+++ b/src/main/java/org/spongepowered/api/item/enchantment/EnchantmentTypes.java
@@ -42,9 +42,6 @@ import org.spongepowered.api.registry.RegistryScopes;
 public final class EnchantmentTypes {
 
     // @formatter:off
-
-    // SORTFIELDS:ON
-
     /**
      * Increases regular underwater mining speed.
      *
@@ -278,11 +275,7 @@ public final class EnchantmentTypes {
      */
     public static final DefaultedRegistryReference<EnchantmentType> VANISHING_CURSE = EnchantmentTypes.key(ResourceKey.minecraft("vanishing_curse"));
 
-
-    // SORTFIELDS:OFF
-
     // @formatter:on
-
     private EnchantmentTypes() {
     }
 

--- a/src/main/java/org/spongepowered/api/item/inventory/ContainerTypes.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ContainerTypes.java
@@ -34,29 +34,43 @@ import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
 
 /**
- * An enumeration of all possible {@link ContainerType}s in vanilla minecraft.
+ * An enumeration of all possible {@link ContainerType}s in vanilla Minecraft.
  */
 @SuppressWarnings("unused")
 @RegistryScopes(scopes = RegistryScope.GAME)
-public final class ContainerTypes {
+to
 
     // @formatter:off
+    // Containers with internal Inventory.
+    /**
+     * Size 0. All slots present in the container only: 3.
+     */
+    public static final DefaultedRegistryReference<ContainerType> ANVIL = ContainerTypes.key(ResourceKey.minecraft("anvil"));
 
-    // SORTFIELDS:ON
+    /**
+     * Size 0. All slots present in the container only: 1.
+     */
+    public static final DefaultedRegistryReference<ContainerType> BEACON = ContainerTypes.key(ResourceKey.minecraft("beacon"));
 
     // Containers backed by an inventory.
-
-    // TODO check container creation in 1.14 code especially merchant/horse
-
-
-    // TODO add new inventories
-
     public static final DefaultedRegistryReference<ContainerType> BLAST_FURNACE = ContainerTypes.key(ResourceKey.minecraft("blast_furnace"));
 
     /**
      * Size 5.
      */
     public static final DefaultedRegistryReference<ContainerType> BREWING_STAND = ContainerTypes.key(ResourceKey.minecraft("brewing_stand"));
+
+    public static final DefaultedRegistryReference<ContainerType> CARTOGRAPHY_TABLE = ContainerTypes.key(ResourceKey.minecraft("cartography_table"));
+
+    /**
+     * Size 0. All slots present in the container only: 10 (3x3+1).
+     */
+    public static final DefaultedRegistryReference<ContainerType> CRAFTING = ContainerTypes.key(ResourceKey.minecraft("crafting"));
+
+    /**
+     * Size 0. All slots present in the container only 2.
+     */
+    public static final DefaultedRegistryReference<ContainerType> ENCHANTMENT = ContainerTypes.key(ResourceKey.minecraft("enchantment"));
 
     /**
      * Size 3.
@@ -86,6 +100,8 @@ public final class ContainerTypes {
      */
     public static final DefaultedRegistryReference<ContainerType> GENERIC_9X6 = ContainerTypes.key(ResourceKey.minecraft("generic_9x6"));
 
+    public static final DefaultedRegistryReference<ContainerType> GRINDSTONE = ContainerTypes.key(ResourceKey.minecraft("grindstone"));
+
     /**
      * Size 5 (1x5 grid).
      */
@@ -93,54 +109,26 @@ public final class ContainerTypes {
 
     public static final DefaultedRegistryReference<ContainerType> LECTERN = ContainerTypes.key(ResourceKey.minecraft("lectern"));
 
-    /**
-     * Size 27 (3x9 grid). Shulker boxes are not allowed in shulker boxes.
-     */
-    public static final DefaultedRegistryReference<ContainerType> SHULKER_BOX = ContainerTypes.key(ResourceKey.minecraft("shulker_box"));
-
-    public static final DefaultedRegistryReference<ContainerType> SMOKER = ContainerTypes.key(ResourceKey.minecraft("smoker"));
-
-    // Containers with internal Inventory.
-
-    /**
-     * Size 0. All slots present in the container only: 3.
-     */
-    public static final DefaultedRegistryReference<ContainerType> ANVIL = ContainerTypes.key(ResourceKey.minecraft("anvil"));
-
-    /**
-     * Size 0. All slots present in the container only: 1.
-     */
-    public static final DefaultedRegistryReference<ContainerType> BEACON = ContainerTypes.key(ResourceKey.minecraft("beacon"));
-
-    public static final DefaultedRegistryReference<ContainerType> CARTOGRAPHY_TABLE = ContainerTypes.key(ResourceKey.minecraft("cartography_table"));
-
-    /**
-     * Size 0. All slots present in the container only: 10 (3x3+1).
-     */
-    public static final DefaultedRegistryReference<ContainerType> CRAFTING = ContainerTypes.key(ResourceKey.minecraft("crafting"));
-
-    /**
-     * Size 0. All slots present in the container only 2.
-     */
-    public static final DefaultedRegistryReference<ContainerType> ENCHANTMENT = ContainerTypes.key(ResourceKey.minecraft("enchantment"));
-
-    public static final DefaultedRegistryReference<ContainerType> GRINDSTONE = ContainerTypes.key(ResourceKey.minecraft("grindstone"));
-
     public static final DefaultedRegistryReference<ContainerType> LOOM = ContainerTypes.key(ResourceKey.minecraft("loom"));
 
-    public static final DefaultedRegistryReference<ContainerType> STONECUTTER = ContainerTypes.key(ResourceKey.minecraft("stonecutter"));
-
     // Containers that cannot be opened on their own. Create an Entity to open the container instead.
-
     /**
      * Create a {@link Villager} Entity instead of using this ContainerType.
      */
     public static final DefaultedRegistryReference<ContainerType> MERCHANT = ContainerTypes.key(ResourceKey.minecraft("merchant"));
 
-    // SORTFIELDS:OFF
+    /**
+     * Size 27 (3x9 grid). Shulker boxes are not allowed in shulker boxes.
+     */
+    public static final DefaultedRegistryReference<ContainerType> SHULKER_BOX = ContainerTypes.key(ResourceKey.minecraft("shulker_box"));
+
+    public static final DefaultedRegistryReference<ContainerType> SMITHING = ContainerTypes.key(ResourceKey.minecraft("smithing"));
+
+    public static final DefaultedRegistryReference<ContainerType> SMOKER = ContainerTypes.key(ResourceKey.minecraft("smoker"));
+
+    public static final DefaultedRegistryReference<ContainerType> STONECUTTER = ContainerTypes.key(ResourceKey.minecraft("stonecutter"));
 
     // @formatter:on
-
     private ContainerTypes() {
     }
 

--- a/src/main/java/org/spongepowered/api/item/potion/PotionTypes.java
+++ b/src/main/java/org/spongepowered/api/item/potion/PotionTypes.java
@@ -27,10 +27,10 @@ package org.spongepowered.api.item.potion;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
+import org.spongepowered.api.registry.RegistryTypes;
 
 /**
  * An enumeration of all possible {@link PotionType}s in vanilla Minecraft.
@@ -40,99 +40,93 @@ import org.spongepowered.api.registry.RegistryScopes;
 public final class PotionTypes {
 
     // @formatter:off
+    public static final DefaultedRegistryReference<PotionType> AWKWARD = PotionTypes.key(ResourceKey.minecraft("awkward"));
 
-    // SORTFIELDS:ON
+    public static final DefaultedRegistryReference<PotionType> EMPTY = PotionTypes.key(ResourceKey.minecraft("empty"));
 
-    public static final DefaultedRegistryReference<PotionType> AWKWARD = PotionTypes.key(ResourceKey.sponge("awkward"));
+    public static final DefaultedRegistryReference<PotionType> FIRE_RESISTANCE = PotionTypes.key(ResourceKey.minecraft("fire_resistance"));
 
-    public static final DefaultedRegistryReference<PotionType> EMPTY = PotionTypes.key(ResourceKey.sponge("empty"));
+    public static final DefaultedRegistryReference<PotionType> HARMING = PotionTypes.key(ResourceKey.minecraft("harming"));
 
-    public static final DefaultedRegistryReference<PotionType> FIRE_RESISTANCE = PotionTypes.key(ResourceKey.sponge("fire_resistance"));
+    public static final DefaultedRegistryReference<PotionType> HEALING = PotionTypes.key(ResourceKey.minecraft("healing"));
 
-    public static final DefaultedRegistryReference<PotionType> HARMING = PotionTypes.key(ResourceKey.sponge("harming"));
+    public static final DefaultedRegistryReference<PotionType> INVISIBILITY = PotionTypes.key(ResourceKey.minecraft("invisibility"));
 
-    public static final DefaultedRegistryReference<PotionType> HEALING = PotionTypes.key(ResourceKey.sponge("healing"));
+    public static final DefaultedRegistryReference<PotionType> LEAPING = PotionTypes.key(ResourceKey.minecraft("leaping"));
 
-    public static final DefaultedRegistryReference<PotionType> INVISIBILITY = PotionTypes.key(ResourceKey.sponge("invisibility"));
+    public static final DefaultedRegistryReference<PotionType> LONG_FIRE_RESISTANCE = PotionTypes.key(ResourceKey.minecraft("long_fire_resistance"));
 
-    public static final DefaultedRegistryReference<PotionType> LEAPING = PotionTypes.key(ResourceKey.sponge("leaping"));
+    public static final DefaultedRegistryReference<PotionType> LONG_INVISIBILITY = PotionTypes.key(ResourceKey.minecraft("long_invisibility"));
 
-    public static final DefaultedRegistryReference<PotionType> LONG_FIRE_RESISTANCE = PotionTypes.key(ResourceKey.sponge("long_fire_resistance"));
+    public static final DefaultedRegistryReference<PotionType> LONG_LEAPING = PotionTypes.key(ResourceKey.minecraft("long_leaping"));
 
-    public static final DefaultedRegistryReference<PotionType> LONG_INVISIBILITY = PotionTypes.key(ResourceKey.sponge("long_invisibility"));
+    public static final DefaultedRegistryReference<PotionType> LONG_NIGHT_VISION = PotionTypes.key(ResourceKey.minecraft("long_night_vision"));
 
-    public static final DefaultedRegistryReference<PotionType> LONG_LEAPING = PotionTypes.key(ResourceKey.sponge("long_leaping"));
+    public static final DefaultedRegistryReference<PotionType> LONG_POISON = PotionTypes.key(ResourceKey.minecraft("long_poison"));
 
-    public static final DefaultedRegistryReference<PotionType> LONG_NIGHT_VISION = PotionTypes.key(ResourceKey.sponge("long_night_vision"));
+    public static final DefaultedRegistryReference<PotionType> LONG_REGENERATION = PotionTypes.key(ResourceKey.minecraft("long_regeneration"));
 
-    public static final DefaultedRegistryReference<PotionType> LONG_POISON = PotionTypes.key(ResourceKey.sponge("long_poison"));
+    public static final DefaultedRegistryReference<PotionType> LONG_SLOW_FALLING = PotionTypes.key(ResourceKey.minecraft("long_slow_falling"));
 
-    public static final DefaultedRegistryReference<PotionType> LONG_REGENERATION = PotionTypes.key(ResourceKey.sponge("long_regeneration"));
+    public static final DefaultedRegistryReference<PotionType> LONG_SLOWNESS = PotionTypes.key(ResourceKey.minecraft("long_slowness"));
 
-    public static final DefaultedRegistryReference<PotionType> LONG_SLOW_FALLING = PotionTypes.key(ResourceKey.sponge("long_slow_falling"));
+    public static final DefaultedRegistryReference<PotionType> LONG_STRENGTH = PotionTypes.key(ResourceKey.minecraft("long_strength"));
 
-    public static final DefaultedRegistryReference<PotionType> LONG_SLOWNESS = PotionTypes.key(ResourceKey.sponge("long_slowness"));
+    public static final DefaultedRegistryReference<PotionType> LONG_SWIFTNESS = PotionTypes.key(ResourceKey.minecraft("long_swiftness"));
 
-    public static final DefaultedRegistryReference<PotionType> LONG_STRENGTH = PotionTypes.key(ResourceKey.sponge("long_strength"));
+    public static final DefaultedRegistryReference<PotionType> LONG_TURTLE_MASTER = PotionTypes.key(ResourceKey.minecraft("long_turtle_master"));
 
-    public static final DefaultedRegistryReference<PotionType> LONG_SWIFTNESS = PotionTypes.key(ResourceKey.sponge("long_swiftness"));
+    public static final DefaultedRegistryReference<PotionType> LONG_WATER_BREATHING = PotionTypes.key(ResourceKey.minecraft("long_water_breathing"));
 
-    public static final DefaultedRegistryReference<PotionType> LONG_TURTLE_MASTER = PotionTypes.key(ResourceKey.sponge("long_turtle_master"));
+    public static final DefaultedRegistryReference<PotionType> LONG_WEAKNESS = PotionTypes.key(ResourceKey.minecraft("long_weakness"));
 
-    public static final DefaultedRegistryReference<PotionType> LONG_WATER_BREATHING = PotionTypes.key(ResourceKey.sponge("long_water_breathing"));
+    public static final DefaultedRegistryReference<PotionType> LUCK = PotionTypes.key(ResourceKey.minecraft("luck"));
 
-    public static final DefaultedRegistryReference<PotionType> LONG_WEAKNESS = PotionTypes.key(ResourceKey.sponge("long_weakness"));
+    public static final DefaultedRegistryReference<PotionType> MUNDANE = PotionTypes.key(ResourceKey.minecraft("mundane"));
 
-    public static final DefaultedRegistryReference<PotionType> LUCK = PotionTypes.key(ResourceKey.sponge("luck"));
+    public static final DefaultedRegistryReference<PotionType> NIGHT_VISION = PotionTypes.key(ResourceKey.minecraft("night_vision"));
 
-    public static final DefaultedRegistryReference<PotionType> MUNDANE = PotionTypes.key(ResourceKey.sponge("mundane"));
+    public static final DefaultedRegistryReference<PotionType> POISON = PotionTypes.key(ResourceKey.minecraft("poison"));
 
-    public static final DefaultedRegistryReference<PotionType> NIGHT_VISION = PotionTypes.key(ResourceKey.sponge("night_vision"));
+    public static final DefaultedRegistryReference<PotionType> REGENERATION = PotionTypes.key(ResourceKey.minecraft("regeneration"));
 
-    public static final DefaultedRegistryReference<PotionType> POISON = PotionTypes.key(ResourceKey.sponge("poison"));
+    public static final DefaultedRegistryReference<PotionType> SLOW_FALLING = PotionTypes.key(ResourceKey.minecraft("slow_falling"));
 
-    public static final DefaultedRegistryReference<PotionType> REGENERATION = PotionTypes.key(ResourceKey.sponge("regeneration"));
+    public static final DefaultedRegistryReference<PotionType> SLOWNESS = PotionTypes.key(ResourceKey.minecraft("slowness"));
 
-    public static final DefaultedRegistryReference<PotionType> SLOW_FALLING = PotionTypes.key(ResourceKey.sponge("slow_falling"));
+    public static final DefaultedRegistryReference<PotionType> STRENGTH = PotionTypes.key(ResourceKey.minecraft("strength"));
 
-    public static final DefaultedRegistryReference<PotionType> SLOWNESS = PotionTypes.key(ResourceKey.sponge("slowness"));
+    public static final DefaultedRegistryReference<PotionType> STRONG_HARMING = PotionTypes.key(ResourceKey.minecraft("strong_harming"));
 
-    public static final DefaultedRegistryReference<PotionType> STRENGTH = PotionTypes.key(ResourceKey.sponge("strength"));
+    public static final DefaultedRegistryReference<PotionType> STRONG_HEALING = PotionTypes.key(ResourceKey.minecraft("strong_healing"));
 
-    public static final DefaultedRegistryReference<PotionType> STRONG_HARMING = PotionTypes.key(ResourceKey.sponge("strong_harming"));
+    public static final DefaultedRegistryReference<PotionType> STRONG_LEAPING = PotionTypes.key(ResourceKey.minecraft("strong_leaping"));
 
-    public static final DefaultedRegistryReference<PotionType> STRONG_HEALING = PotionTypes.key(ResourceKey.sponge("strong_healing"));
+    public static final DefaultedRegistryReference<PotionType> STRONG_POISON = PotionTypes.key(ResourceKey.minecraft("strong_poison"));
 
-    public static final DefaultedRegistryReference<PotionType> STRONG_LEAPING = PotionTypes.key(ResourceKey.sponge("strong_leaping"));
+    public static final DefaultedRegistryReference<PotionType> STRONG_REGENERATION = PotionTypes.key(ResourceKey.minecraft("strong_regeneration"));
 
-    public static final DefaultedRegistryReference<PotionType> STRONG_POISON = PotionTypes.key(ResourceKey.sponge("strong_poison"));
+    public static final DefaultedRegistryReference<PotionType> STRONG_SLOWNESS = PotionTypes.key(ResourceKey.minecraft("strong_slowness"));
 
-    public static final DefaultedRegistryReference<PotionType> STRONG_REGENERATION = PotionTypes.key(ResourceKey.sponge("strong_regeneration"));
+    public static final DefaultedRegistryReference<PotionType> STRONG_STRENGTH = PotionTypes.key(ResourceKey.minecraft("strong_strength"));
 
-    public static final DefaultedRegistryReference<PotionType> STRONG_SLOWNESS = PotionTypes.key(ResourceKey.sponge("strong_slowness"));
+    public static final DefaultedRegistryReference<PotionType> STRONG_SWIFTNESS = PotionTypes.key(ResourceKey.minecraft("strong_swiftness"));
 
-    public static final DefaultedRegistryReference<PotionType> STRONG_STRENGTH = PotionTypes.key(ResourceKey.sponge("strong_strength"));
+    public static final DefaultedRegistryReference<PotionType> STRONG_TURTLE_MASTER = PotionTypes.key(ResourceKey.minecraft("strong_turtle_master"));
 
-    public static final DefaultedRegistryReference<PotionType> STRONG_SWIFTNESS = PotionTypes.key(ResourceKey.sponge("strong_swiftness"));
+    public static final DefaultedRegistryReference<PotionType> SWIFTNESS = PotionTypes.key(ResourceKey.minecraft("swiftness"));
 
-    public static final DefaultedRegistryReference<PotionType> STRONG_TURTLE_MASTER = PotionTypes.key(ResourceKey.sponge("strong_turtle_master"));
+    public static final DefaultedRegistryReference<PotionType> THICK = PotionTypes.key(ResourceKey.minecraft("thick"));
 
-    public static final DefaultedRegistryReference<PotionType> SWIFTNESS = PotionTypes.key(ResourceKey.sponge("swiftness"));
+    public static final DefaultedRegistryReference<PotionType> TURTLE_MASTER = PotionTypes.key(ResourceKey.minecraft("turtle_master"));
 
-    public static final DefaultedRegistryReference<PotionType> THICK = PotionTypes.key(ResourceKey.sponge("thick"));
+    public static final DefaultedRegistryReference<PotionType> WATER = PotionTypes.key(ResourceKey.minecraft("water"));
 
-    public static final DefaultedRegistryReference<PotionType> TURTLE_MASTER = PotionTypes.key(ResourceKey.sponge("turtle_master"));
+    public static final DefaultedRegistryReference<PotionType> WATER_BREATHING = PotionTypes.key(ResourceKey.minecraft("water_breathing"));
 
-    public static final DefaultedRegistryReference<PotionType> WATER = PotionTypes.key(ResourceKey.sponge("water"));
-
-    public static final DefaultedRegistryReference<PotionType> WATER_BREATHING = PotionTypes.key(ResourceKey.sponge("water_breathing"));
-
-    public static final DefaultedRegistryReference<PotionType> WEAKNESS = PotionTypes.key(ResourceKey.sponge("weakness"));
-
-    // SORTFIELDS:OFF
+    public static final DefaultedRegistryReference<PotionType> WEAKNESS = PotionTypes.key(ResourceKey.minecraft("weakness"));
 
     // @formatter:on
-
     private PotionTypes() {
     }
 

--- a/src/main/java/org/spongepowered/api/item/recipe/RecipeTypes.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/RecipeTypes.java
@@ -44,27 +44,21 @@ import org.spongepowered.api.registry.RegistryScopes;
 public final class RecipeTypes {
 
     // @formatter:off
+    public static final DefaultedRegistryReference<RecipeType<CookingRecipe>> BLASTING = RecipeTypes.key(ResourceKey.minecraft("blasting"));
 
-    // SORTFIELDS:ON
+    public static final DefaultedRegistryReference<RecipeType<CookingRecipe>> CAMPFIRE_COOKING = RecipeTypes.key(ResourceKey.minecraft("campfire_cooking"));
 
     public static final DefaultedRegistryReference<RecipeType<CraftingRecipe>> CRAFTING = RecipeTypes.key(ResourceKey.minecraft("crafting"));
 
     public static final DefaultedRegistryReference<RecipeType<CookingRecipe>> SMELTING = RecipeTypes.key(ResourceKey.minecraft("smelting"));
 
-    public static final DefaultedRegistryReference<RecipeType<CookingRecipe>> BLASTING = RecipeTypes.key(ResourceKey.minecraft("blasting"));
+    public static final DefaultedRegistryReference<RecipeType<SmithingRecipe>> SMITHING = RecipeTypes.key(ResourceKey.minecraft("smithing"));
 
     public static final DefaultedRegistryReference<RecipeType<CookingRecipe>> SMOKING = RecipeTypes.key(ResourceKey.minecraft("smoking"));
 
-    public static final DefaultedRegistryReference<RecipeType<CookingRecipe>> CAMPFIRE_COOKING = RecipeTypes.key(ResourceKey.minecraft("campfire_cooking"));
-
     public static final DefaultedRegistryReference<RecipeType<StoneCutterRecipe>> STONECUTTING = RecipeTypes.key(ResourceKey.minecraft("stonecutting"));
 
-    public static final DefaultedRegistryReference<RecipeType<SmithingRecipe>> SMITHING = RecipeTypes.key(ResourceKey.minecraft("smithing"));
-
-    // SORTFIELDS:OFF
-
     // @formatter:on
-
     private RecipeTypes() {
     }
 

--- a/src/main/java/org/spongepowered/api/statistic/Statistics.java
+++ b/src/main/java/org/spongepowered/api/statistic/Statistics.java
@@ -27,22 +27,19 @@ package org.spongepowered.api.statistic;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
+import org.spongepowered.api.registry.RegistryTypes;
 
 /**
- * An enumeration of all available {@link Statistic}s from the vanilla game.
+ * An enumeration of all possible {@link Statistic}s in vanilla Minecraft.
  */
 @SuppressWarnings("unused")
 @RegistryScopes(scopes = RegistryScope.GAME)
 public final class Statistics {
 
     // @formatter:off
-
-    // SORTFIELDS:ON
-
     public static final DefaultedRegistryReference<Statistic> ANIMALS_BRED = Statistics.key(ResourceKey.minecraft("animals_bred"));
 
     public static final DefaultedRegistryReference<Statistic> AVIATE_ONE_CM = Statistics.key(ResourceKey.minecraft("aviate_one_cm"));
@@ -191,10 +188,7 @@ public final class Statistics {
 
     public static final DefaultedRegistryReference<Statistic> WALK_UNDER_WATER_ONE_CM = Statistics.key(ResourceKey.minecraft("walk_under_water_one_cm"));
 
-    // SORTFIELDS:OFF
-
     // @formatter:on
-
     private Statistics() {
     }
 

--- a/src/main/java/org/spongepowered/api/world/WorldTypes.java
+++ b/src/main/java/org/spongepowered/api/world/WorldTypes.java
@@ -32,25 +32,23 @@ import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
 import org.spongepowered.api.registry.RegistryTypes;
 
+/**
+ * An enumeration of all possible {@link WorldType}s in vanilla Minecraft.
+ */
+@SuppressWarnings("unused")
 @RegistryScopes(scopes = RegistryScope.ENGINE)
 public final class WorldTypes {
 
     // @formatter:off
-
-    // SORTFIELDS:ON
-
     public static final DefaultedRegistryReference<WorldType> OVERWORLD = WorldTypes.key(ResourceKey.minecraft("overworld"));
 
     public static final DefaultedRegistryReference<WorldType> OVERWORLD_CAVES = WorldTypes.key(ResourceKey.minecraft("overworld_caves"));
 
-    public static final DefaultedRegistryReference<WorldType> THE_NETHER = WorldTypes.key(ResourceKey.minecraft("the_nether"));
-
     public static final DefaultedRegistryReference<WorldType> THE_END = WorldTypes.key(ResourceKey.minecraft("the_end"));
 
-    // SORTFIELDS:OFF
+    public static final DefaultedRegistryReference<WorldType> THE_NETHER = WorldTypes.key(ResourceKey.minecraft("the_nether"));
 
     // @formatter:on
-
     private WorldTypes() {
     }
 
@@ -58,4 +56,3 @@ public final class WorldTypes {
         return RegistryKey.of(RegistryTypes.WORLD_TYPE, location).asDefaultedReference(() -> Sponge.getServer().registries());
     }
 }
-

--- a/src/main/java/org/spongepowered/api/world/biome/Biomes.java
+++ b/src/main/java/org/spongepowered/api/world/biome/Biomes.java
@@ -25,186 +25,185 @@
 package org.spongepowered.api.world.biome;
 
 import org.spongepowered.api.ResourceKey;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryReference;
 import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
+import org.spongepowered.api.registry.RegistryTypes;
 
+/**
+ * An enumeration of all possible {@link Biomes}s in vanilla Minecraft.
+ */
 @SuppressWarnings("unused")
 @RegistryScopes(scopes = RegistryScope.WORLD)
 public final class Biomes {
 
     // @formatter:off
+    public static final RegistryReference<Biomes> BADLANDS = Biomes.key(ResourceKey.minecraft("badlands"));
 
-    // SORTFIELDS:ON
+    public static final RegistryReference<Biomes> BADLANDS_PLATEAU = Biomes.key(ResourceKey.minecraft("badlands_plateau"));
 
-    public static final RegistryReference<Biome> BADLANDS = Biomes.key(ResourceKey.minecraft("badlands"));
+    public static final RegistryReference<Biomes> BAMBOO_JUNGLE = Biomes.key(ResourceKey.minecraft("bamboo_jungle"));
 
-    public static final RegistryReference<Biome> BADLANDS_PLATEAU = Biomes.key(ResourceKey.minecraft("badlands_plateau"));
+    public static final RegistryReference<Biomes> BAMBOO_JUNGLE_HILLS = Biomes.key(ResourceKey.minecraft("bamboo_jungle_hills"));
 
-    public static final RegistryReference<Biome> BAMBOO_JUNGLE = Biomes.key(ResourceKey.minecraft("bamboo_jungle"));
+    public static final RegistryReference<Biomes> BASALT_DELTAS = Biomes.key(ResourceKey.minecraft("basalt_deltas"));
 
-    public static final RegistryReference<Biome> BAMBOO_JUNGLE_HILLS = Biomes.key(ResourceKey.minecraft("bamboo_jungle_hills"));
+    public static final RegistryReference<Biomes> BEACH = Biomes.key(ResourceKey.minecraft("beach"));
 
-    public static final RegistryReference<Biome> BASALT_DELTAS = Biomes.key(ResourceKey.minecraft("basalt_deltas"));
+    public static final RegistryReference<Biomes> BIRCH_FOREST = Biomes.key(ResourceKey.minecraft("birch_forest"));
 
-    public static final RegistryReference<Biome> BEACH = Biomes.key(ResourceKey.minecraft("beach"));
+    public static final RegistryReference<Biomes> BIRCH_FOREST_HILLS = Biomes.key(ResourceKey.minecraft("birch_forest_hills"));
 
-    public static final RegistryReference<Biome> BIRCH_FOREST = Biomes.key(ResourceKey.minecraft("birch_forest"));
+    public static final RegistryReference<Biomes> COLD_OCEAN = Biomes.key(ResourceKey.minecraft("cold_ocean"));
 
-    public static final RegistryReference<Biome> BIRCH_FOREST_HILLS = Biomes.key(ResourceKey.minecraft("birch_forest_hills"));
+    public static final RegistryReference<Biomes> CRIMSON_FOREST = Biomes.key(ResourceKey.minecraft("crimson_forest"));
 
-    public static final RegistryReference<Biome> COLD_OCEAN = Biomes.key(ResourceKey.minecraft("cold_ocean"));
+    public static final RegistryReference<Biomes> DARK_FOREST = Biomes.key(ResourceKey.minecraft("dark_forest"));
 
-    public static final RegistryReference<Biome> CRIMSON_FOREST = Biomes.key(ResourceKey.minecraft("crimson_forest"));
+    public static final RegistryReference<Biomes> DARK_FOREST_HILLS = Biomes.key(ResourceKey.minecraft("dark_forest_hills"));
 
-    public static final RegistryReference<Biome> DARK_FOREST = Biomes.key(ResourceKey.minecraft("dark_forest"));
+    public static final RegistryReference<Biomes> DEEP_COLD_OCEAN = Biomes.key(ResourceKey.minecraft("deep_cold_ocean"));
 
-    public static final RegistryReference<Biome> DARK_FOREST_HILLS = Biomes.key(ResourceKey.minecraft("dark_forest_hills"));
+    public static final RegistryReference<Biomes> DEEP_FROZEN_OCEAN = Biomes.key(ResourceKey.minecraft("deep_frozen_ocean"));
 
-    public static final RegistryReference<Biome> DEEP_COLD_OCEAN = Biomes.key(ResourceKey.minecraft("deep_cold_ocean"));
+    public static final RegistryReference<Biomes> DEEP_LUKEWARM_OCEAN = Biomes.key(ResourceKey.minecraft("deep_lukewarm_ocean"));
 
-    public static final RegistryReference<Biome> DEEP_FROZEN_OCEAN = Biomes.key(ResourceKey.minecraft("deep_frozen_ocean"));
+    public static final RegistryReference<Biomes> DEEP_OCEAN = Biomes.key(ResourceKey.minecraft("deep_ocean"));
 
-    public static final RegistryReference<Biome> DEEP_LUKEWARM_OCEAN = Biomes.key(ResourceKey.minecraft("deep_lukewarm_ocean"));
+    public static final RegistryReference<Biomes> DEEP_WARM_OCEAN = Biomes.key(ResourceKey.minecraft("deep_warm_ocean"));
 
-    public static final RegistryReference<Biome> DEEP_OCEAN = Biomes.key(ResourceKey.minecraft("deep_ocean"));
+    public static final RegistryReference<Biomes> DESERT = Biomes.key(ResourceKey.minecraft("desert"));
 
-    public static final RegistryReference<Biome> DEEP_WARM_OCEAN = Biomes.key(ResourceKey.minecraft("deep_warm_ocean"));
+    public static final RegistryReference<Biomes> DESERT_HILLS = Biomes.key(ResourceKey.minecraft("desert_hills"));
 
-    public static final RegistryReference<Biome> DESERT = Biomes.key(ResourceKey.minecraft("desert"));
+    public static final RegistryReference<Biomes> DESERT_LAKES = Biomes.key(ResourceKey.minecraft("desert_lakes"));
 
-    public static final RegistryReference<Biome> DESERT_HILLS = Biomes.key(ResourceKey.minecraft("desert_hills"));
+    public static final RegistryReference<Biomes> DRIPSTONE_CAVES = Biomes.key(ResourceKey.minecraft("dripstone_caves"));
 
-    public static final RegistryReference<Biome> DESERT_LAKES = Biomes.key(ResourceKey.minecraft("desert_lakes"));
+    public static final RegistryReference<Biomes> END_BARRENS = Biomes.key(ResourceKey.minecraft("end_barrens"));
 
-    public static final RegistryReference<Biome> END_BARRENS = Biomes.key(ResourceKey.minecraft("end_barrens"));
+    public static final RegistryReference<Biomes> END_HIGHLANDS = Biomes.key(ResourceKey.minecraft("end_highlands"));
 
-    public static final RegistryReference<Biome> END_HIGHLANDS = Biomes.key(ResourceKey.minecraft("end_highlands"));
+    public static final RegistryReference<Biomes> END_MIDLANDS = Biomes.key(ResourceKey.minecraft("end_midlands"));
 
-    public static final RegistryReference<Biome> END_MIDLANDS = Biomes.key(ResourceKey.minecraft("end_midlands"));
+    public static final RegistryReference<Biomes> ERODED_BADLANDS = Biomes.key(ResourceKey.minecraft("eroded_badlands"));
 
-    public static final RegistryReference<Biome> ERODED_BADLANDS = Biomes.key(ResourceKey.minecraft("eroded_badlands"));
+    public static final RegistryReference<Biomes> FLOWER_FOREST = Biomes.key(ResourceKey.minecraft("flower_forest"));
 
-    public static final RegistryReference<Biome> FLOWER_FOREST = Biomes.key(ResourceKey.minecraft("flower_forest"));
+    public static final RegistryReference<Biomes> FOREST = Biomes.key(ResourceKey.minecraft("forest"));
 
-    public static final RegistryReference<Biome> FOREST = Biomes.key(ResourceKey.minecraft("forest"));
+    public static final RegistryReference<Biomes> FROZEN_OCEAN = Biomes.key(ResourceKey.minecraft("frozen_ocean"));
 
-    public static final RegistryReference<Biome> FROZEN_OCEAN = Biomes.key(ResourceKey.minecraft("frozen_ocean"));
+    public static final RegistryReference<Biomes> FROZEN_RIVER = Biomes.key(ResourceKey.minecraft("frozen_river"));
 
-    public static final RegistryReference<Biome> FROZEN_RIVER = Biomes.key(ResourceKey.minecraft("frozen_river"));
+    public static final RegistryReference<Biomes> GIANT_SPRUCE_TAIGA = Biomes.key(ResourceKey.minecraft("giant_spruce_taiga"));
 
-    public static final RegistryReference<Biome> GIANT_SPRUCE_TAIGA = Biomes.key(ResourceKey.minecraft("giant_spruce_taiga"));
+    public static final RegistryReference<Biomes> GIANT_SPRUCE_TAIGA_HILLS = Biomes.key(ResourceKey.minecraft("giant_spruce_taiga_hills"));
 
-    public static final RegistryReference<Biome> GIANT_SPRUCE_TAIGA_HILLS = Biomes.key(ResourceKey.minecraft("giant_spruce_taiga_hills"));
+    public static final RegistryReference<Biomes> GIANT_TREE_TAIGA = Biomes.key(ResourceKey.minecraft("giant_tree_taiga"));
 
-    public static final RegistryReference<Biome> GIANT_TREE_TAIGA = Biomes.key(ResourceKey.minecraft("giant_tree_taiga"));
+    public static final RegistryReference<Biomes> GIANT_TREE_TAIGA_HILLS = Biomes.key(ResourceKey.minecraft("giant_tree_taiga_hills"));
 
-    public static final RegistryReference<Biome> GIANT_TREE_TAIGA_HILLS = Biomes.key(ResourceKey.minecraft("giant_tree_taiga_hills"));
+    public static final RegistryReference<Biomes> GRAVELLY_MOUNTAINS = Biomes.key(ResourceKey.minecraft("gravelly_mountains"));
 
-    public static final RegistryReference<Biome> GRAVELLY_MOUNTAINS = Biomes.key(ResourceKey.minecraft("gravelly_mountains"));
+    public static final RegistryReference<Biomes> ICE_SPIKES = Biomes.key(ResourceKey.minecraft("ice_spikes"));
 
-    public static final RegistryReference<Biome> ICE_SPIKES = Biomes.key(ResourceKey.minecraft("ice_spikes"));
+    public static final RegistryReference<Biomes> JUNGLE = Biomes.key(ResourceKey.minecraft("jungle"));
 
-    public static final RegistryReference<Biome> JUNGLE = Biomes.key(ResourceKey.minecraft("jungle"));
+    public static final RegistryReference<Biomes> JUNGLE_EDGE = Biomes.key(ResourceKey.minecraft("jungle_edge"));
 
-    public static final RegistryReference<Biome> JUNGLE_EDGE = Biomes.key(ResourceKey.minecraft("jungle_edge"));
+    public static final RegistryReference<Biomes> JUNGLE_HILLS = Biomes.key(ResourceKey.minecraft("jungle_hills"));
 
-    public static final RegistryReference<Biome> JUNGLE_HILLS = Biomes.key(ResourceKey.minecraft("jungle_hills"));
+    public static final RegistryReference<Biomes> LUKEWARM_OCEAN = Biomes.key(ResourceKey.minecraft("lukewarm_ocean"));
 
-    public static final RegistryReference<Biome> LUKEWARM_OCEAN = Biomes.key(ResourceKey.minecraft("lukewarm_ocean"));
+    public static final RegistryReference<Biomes> MODIFIED_BADLANDS_PLATEAU = Biomes.key(ResourceKey.minecraft("modified_badlands_plateau"));
 
-    public static final RegistryReference<Biome> MODIFIED_BADLANDS_PLATEAU = Biomes.key(ResourceKey.minecraft("modified_badlands_plateau"));
+    public static final RegistryReference<Biomes> MODIFIED_GRAVELLY_MOUNTAINS = Biomes.key(ResourceKey.minecraft("modified_gravelly_mountains"));
 
-    public static final RegistryReference<Biome> MODIFIED_GRAVELLY_MOUNTAINS = Biomes.key(ResourceKey.minecraft("modified_gravelly_mountains"));
+    public static final RegistryReference<Biomes> MODIFIED_JUNGLE = Biomes.key(ResourceKey.minecraft("modified_jungle"));
 
-    public static final RegistryReference<Biome> MODIFIED_JUNGLE = Biomes.key(ResourceKey.minecraft("modified_jungle"));
+    public static final RegistryReference<Biomes> MODIFIED_JUNGLE_EDGE = Biomes.key(ResourceKey.minecraft("modified_jungle_edge"));
 
-    public static final RegistryReference<Biome> MODIFIED_JUNGLE_EDGE = Biomes.key(ResourceKey.minecraft("modified_jungle_edge"));
+    public static final RegistryReference<Biomes> MODIFIED_WOODED_BADLANDS_PLATEAU = Biomes.key(ResourceKey.minecraft("modified_wooded_badlands_plateau"));
 
-    public static final RegistryReference<Biome> MODIFIED_WOODED_BADLANDS_PLATEAU = Biomes.key(ResourceKey.minecraft("modified_wooded_badlands_plateau"));
+    public static final RegistryReference<Biomes> MOUNTAIN_EDGE = Biomes.key(ResourceKey.minecraft("mountain_edge"));
 
-    public static final RegistryReference<Biome> MOUNTAIN_EDGE = Biomes.key(ResourceKey.minecraft("mountain_edge"));
+    public static final RegistryReference<Biomes> MOUNTAINS = Biomes.key(ResourceKey.minecraft("mountains"));
 
-    public static final RegistryReference<Biome> MOUNTAINS = Biomes.key(ResourceKey.minecraft("mountains"));
+    public static final RegistryReference<Biomes> MUSHROOM_FIELD_SHORE = Biomes.key(ResourceKey.minecraft("mushroom_field_shore"));
 
-    public static final RegistryReference<Biome> MUSHROOM_FIELD_SHORE = Biomes.key(ResourceKey.minecraft("mushroom_field_shore"));
+    public static final RegistryReference<Biomes> MUSHROOM_FIELDS = Biomes.key(ResourceKey.minecraft("mushroom_fields"));
 
-    public static final RegistryReference<Biome> MUSHROOM_FIELDS = Biomes.key(ResourceKey.minecraft("mushroom_fields"));
+    public static final RegistryReference<Biomes> NETHER_WASTES = Biomes.key(ResourceKey.minecraft("nether_wastes"));
 
-    public static final RegistryReference<Biome> NETHER_WASTES = Biomes.key(ResourceKey.minecraft("nether_wastes"));
+    public static final RegistryReference<Biomes> OCEAN = Biomes.key(ResourceKey.minecraft("ocean"));
 
-    public static final RegistryReference<Biome> OCEAN = Biomes.key(ResourceKey.minecraft("ocean"));
+    public static final RegistryReference<Biomes> PLAINS = Biomes.key(ResourceKey.minecraft("plains"));
 
-    public static final RegistryReference<Biome> PLAINS = Biomes.key(ResourceKey.minecraft("plains"));
+    public static final RegistryReference<Biomes> RIVER = Biomes.key(ResourceKey.minecraft("river"));
 
-    public static final RegistryReference<Biome> RIVER = Biomes.key(ResourceKey.minecraft("river"));
+    public static final RegistryReference<Biomes> SAVANNA = Biomes.key(ResourceKey.minecraft("savanna"));
 
-    public static final RegistryReference<Biome> SAVANNA = Biomes.key(ResourceKey.minecraft("savanna"));
+    public static final RegistryReference<Biomes> SAVANNA_PLATEAU = Biomes.key(ResourceKey.minecraft("savanna_plateau"));
 
-    public static final RegistryReference<Biome> SAVANNA_PLATEAU = Biomes.key(ResourceKey.minecraft("savanna_plateau"));
+    public static final RegistryReference<Biomes> SHATTERED_SAVANNA = Biomes.key(ResourceKey.minecraft("shattered_savanna"));
 
-    public static final RegistryReference<Biome> SHATTERED_SAVANNA = Biomes.key(ResourceKey.minecraft("shattered_savanna"));
+    public static final RegistryReference<Biomes> SHATTERED_SAVANNA_PLATEAU = Biomes.key(ResourceKey.minecraft("shattered_savanna_plateau"));
 
-    public static final RegistryReference<Biome> SHATTERED_SAVANNA_PLATEAU = Biomes.key(ResourceKey.minecraft("shattered_savanna_plateau"));
+    public static final RegistryReference<Biomes> SMALL_END_ISLANDS = Biomes.key(ResourceKey.minecraft("small_end_islands"));
 
-    public static final RegistryReference<Biome> SMALL_END_ISLANDS = Biomes.key(ResourceKey.minecraft("small_end_islands"));
+    public static final RegistryReference<Biomes> SNOWY_BEACH = Biomes.key(ResourceKey.minecraft("snowy_beach"));
 
-    public static final RegistryReference<Biome> SNOWY_BEACH = Biomes.key(ResourceKey.minecraft("snowy_beach"));
+    public static final RegistryReference<Biomes> SNOWY_MOUNTAINS = Biomes.key(ResourceKey.minecraft("snowy_mountains"));
 
-    public static final RegistryReference<Biome> SNOWY_MOUNTAINS = Biomes.key(ResourceKey.minecraft("snowy_mountains"));
+    public static final RegistryReference<Biomes> SNOWY_TAIGA = Biomes.key(ResourceKey.minecraft("snowy_taiga"));
 
-    public static final RegistryReference<Biome> SNOWY_TAIGA = Biomes.key(ResourceKey.minecraft("snowy_taiga"));
+    public static final RegistryReference<Biomes> SNOWY_TAIGA_HILLS = Biomes.key(ResourceKey.minecraft("snowy_taiga_hills"));
 
-    public static final RegistryReference<Biome> SNOWY_TAIGA_HILLS = Biomes.key(ResourceKey.minecraft("snowy_taiga_hills"));
+    public static final RegistryReference<Biomes> SNOWY_TAIGA_MOUNTAINS = Biomes.key(ResourceKey.minecraft("snowy_taiga_mountains"));
 
-    public static final RegistryReference<Biome> SNOWY_TAIGA_MOUNTAINS = Biomes.key(ResourceKey.minecraft("snowy_taiga_mountains"));
+    public static final RegistryReference<Biomes> SNOWY_TUNDRA = Biomes.key(ResourceKey.minecraft("snowy_tundra"));
 
-    public static final RegistryReference<Biome> SNOWY_TUNDRA = Biomes.key(ResourceKey.minecraft("snowy_tundra"));
+    public static final RegistryReference<Biomes> SOUL_SAND_VALLEY = Biomes.key(ResourceKey.minecraft("soul_sand_valley"));
 
-    public static final RegistryReference<Biome> SOUL_SAND_VALLEY = Biomes.key(ResourceKey.minecraft("soul_sand_valley"));
+    public static final RegistryReference<Biomes> STONE_SHORE = Biomes.key(ResourceKey.minecraft("stone_shore"));
 
-    public static final RegistryReference<Biome> STONE_SHORE = Biomes.key(ResourceKey.minecraft("stone_shore"));
+    public static final RegistryReference<Biomes> SUNFLOWER_PLAINS = Biomes.key(ResourceKey.minecraft("sunflower_plains"));
 
-    public static final RegistryReference<Biome> SUNFLOWER_PLAINS = Biomes.key(ResourceKey.minecraft("sunflower_plains"));
+    public static final RegistryReference<Biomes> SWAMP = Biomes.key(ResourceKey.minecraft("swamp"));
 
-    public static final RegistryReference<Biome> SWAMP = Biomes.key(ResourceKey.minecraft("swamp"));
+    public static final RegistryReference<Biomes> SWAMP_HILLS = Biomes.key(ResourceKey.minecraft("swamp_hills"));
 
-    public static final RegistryReference<Biome> SWAMP_HILLS = Biomes.key(ResourceKey.minecraft("swamp_hills"));
+    public static final RegistryReference<Biomes> TAIGA = Biomes.key(ResourceKey.minecraft("taiga"));
 
-    public static final RegistryReference<Biome> TAIGA = Biomes.key(ResourceKey.minecraft("taiga"));
+    public static final RegistryReference<Biomes> TAIGA_HILLS = Biomes.key(ResourceKey.minecraft("taiga_hills"));
 
-    public static final RegistryReference<Biome> TAIGA_HILLS = Biomes.key(ResourceKey.minecraft("taiga_hills"));
+    public static final RegistryReference<Biomes> TAIGA_MOUNTAINS = Biomes.key(ResourceKey.minecraft("taiga_mountains"));
 
-    public static final RegistryReference<Biome> TAIGA_MOUNTAINS = Biomes.key(ResourceKey.minecraft("taiga_mountains"));
+    public static final RegistryReference<Biomes> TALL_BIRCH_FOREST = Biomes.key(ResourceKey.minecraft("tall_birch_forest"));
 
-    public static final RegistryReference<Biome> TALL_BIRCH_FOREST = Biomes.key(ResourceKey.minecraft("tall_birch_forest"));
+    public static final RegistryReference<Biomes> TALL_BIRCH_HILLS = Biomes.key(ResourceKey.minecraft("tall_birch_hills"));
 
-    public static final RegistryReference<Biome> TALL_BIRCH_HILLS = Biomes.key(ResourceKey.minecraft("tall_birch_hills"));
+    public static final RegistryReference<Biomes> THE_END = Biomes.key(ResourceKey.minecraft("the_end"));
 
-    public static final RegistryReference<Biome> THE_END = Biomes.key(ResourceKey.minecraft("the_end"));
+    public static final RegistryReference<Biomes> THE_VOID = Biomes.key(ResourceKey.minecraft("the_void"));
 
-    public static final RegistryReference<Biome> THE_VOID = Biomes.key(ResourceKey.minecraft("the_void"));
+    public static final RegistryReference<Biomes> WARM_OCEAN = Biomes.key(ResourceKey.minecraft("warm_ocean"));
 
-    public static final RegistryReference<Biome> WARM_OCEAN = Biomes.key(ResourceKey.minecraft("warm_ocean"));
+    public static final RegistryReference<Biomes> WARPED_FOREST = Biomes.key(ResourceKey.minecraft("warped_forest"));
 
-    public static final RegistryReference<Biome> WARPED_FOREST = Biomes.key(ResourceKey.minecraft("warped_forest"));
+    public static final RegistryReference<Biomes> WOODED_BADLANDS_PLATEAU = Biomes.key(ResourceKey.minecraft("wooded_badlands_plateau"));
 
-    public static final RegistryReference<Biome> WOODED_BADLANDS_PLATEAU = Biomes.key(ResourceKey.minecraft("wooded_badlands_plateau"));
+    public static final RegistryReference<Biomes> WOODED_HILLS = Biomes.key(ResourceKey.minecraft("wooded_hills"));
 
-    public static final RegistryReference<Biome> WOODED_HILLS = Biomes.key(ResourceKey.minecraft("wooded_hills"));
-
-    public static final RegistryReference<Biome> WOODED_MOUNTAINS = Biomes.key(ResourceKey.minecraft("wooded_mountains"));
-
-    // SORTFIELDS:OFF
+    public static final RegistryReference<Biomes> WOODED_MOUNTAINS = Biomes.key(ResourceKey.minecraft("wooded_mountains"));
 
     // @formatter:on
-
     private Biomes() {
     }
 
-    private static RegistryReference<Biome> key(final ResourceKey location) {
+    private static RegistryReference<Biomes> key(final ResourceKey location) {
         return RegistryKey.of(RegistryTypes.BIOME, location).asReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/generation/structure/Structures.java
+++ b/src/main/java/org/spongepowered/api/world/generation/structure/Structures.java
@@ -28,33 +28,39 @@ import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
 import org.spongepowered.api.registry.RegistryKey;
+import org.spongepowered.api.registry.RegistryScope;
+import org.spongepowered.api.registry.RegistryScopes;
 import org.spongepowered.api.registry.RegistryTypes;
 
+/**
+ * An enumeration of all possible {@link Structure}s in vanilla Minecraft.
+ */
+@SuppressWarnings("unused")
+@RegistryScopes(scopes = RegistryScope.GAME)
 public final class Structures {
 
     // @formatter:off
-
-    // SORTFIELDS:ON
-
     public static final DefaultedRegistryReference<Structure> BASTION_REMNANT = Structures.key(ResourceKey.minecraft("bastion_remnant"));
 
     public static final DefaultedRegistryReference<Structure> BURIED_TREASURE = Structures.key(ResourceKey.minecraft("buried_treasure"));
 
     public static final DefaultedRegistryReference<Structure> DESERT_PYRAMID = Structures.key(ResourceKey.minecraft("desert_pyramid"));
 
-    public static final DefaultedRegistryReference<Structure> END_CITY = Structures.key(ResourceKey.minecraft("endcity"));
+    public static final DefaultedRegistryReference<Structure> ENDCITY = Structures.key(ResourceKey.minecraft("endcity"));
+
+    public static final DefaultedRegistryReference<Structure> FORTRESS = Structures.key(ResourceKey.minecraft("fortress"));
 
     public static final DefaultedRegistryReference<Structure> IGLOO = Structures.key(ResourceKey.minecraft("igloo"));
 
-    public static final DefaultedRegistryReference<Structure> JUNGLE_TEMPLE = Structures.key(ResourceKey.minecraft("jungle_pyramid"));
+    public static final DefaultedRegistryReference<Structure> JUNGLE_PYRAMID = Structures.key(ResourceKey.minecraft("jungle_pyramid"));
+
+    public static final DefaultedRegistryReference<Structure> MANSION = Structures.key(ResourceKey.minecraft("mansion"));
 
     public static final DefaultedRegistryReference<Structure> MINESHAFT = Structures.key(ResourceKey.minecraft("mineshaft"));
 
-    public static final DefaultedRegistryReference<Structure> NETHER_BRIDGE = Structures.key(ResourceKey.minecraft("fortress"));
+    public static final DefaultedRegistryReference<Structure> MONUMENT = Structures.key(ResourceKey.minecraft("monument"));
 
     public static final DefaultedRegistryReference<Structure> NETHER_FOSSIL = Structures.key(ResourceKey.minecraft("nether_fossil"));
-
-    public static final DefaultedRegistryReference<Structure> OCEAN_MONUMENT = Structures.key(ResourceKey.minecraft("monument"));
 
     public static final DefaultedRegistryReference<Structure> OCEAN_RUIN = Structures.key(ResourceKey.minecraft("ocean_ruin"));
 
@@ -70,12 +76,7 @@ public final class Structures {
 
     public static final DefaultedRegistryReference<Structure> VILLAGE = Structures.key(ResourceKey.minecraft("village"));
 
-    public static final DefaultedRegistryReference<Structure> WOODLAND_MANSION = Structures.key(ResourceKey.minecraft("mansion"));
-
-    // SORTFIELDS:OFF
-
     // @formatter:on
-
     private Structures() {
     }
 


### PR DESCRIPTION
The automated update is a little more inflexible with comments. It's also done a bit of a number on ContainerTypes -- thoughts?

This is automatically generated from the `generateApiData` task in `vanilla`, so any comments on this PR will be used to update the generator, with changes applied on the next snapshot.