### PR TITLE
adventure: Expose component resolution to API

### DIFF
--- a/src/main/java/org/spongepowered/api/adventure/ResolveOperation.java
+++ b/src/main/java/org/spongepowered/api/adventure/ResolveOperation.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.adventure;
+
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
+/**
+ * A type of rendering operation that can be performed on a component.
+ */
+@CatalogedBy(ResolveOperations.class)
+public interface ResolveOperation {
+
+}

--- a/src/main/java/org/spongepowered/api/adventure/ResolveOperations.java
+++ b/src/main/java/org/spongepowered/api/adventure/ResolveOperations.java
@@ -58,6 +58,11 @@ public class ResolveOperations {
      * resource pack-provided translations. Those translations are already
      * resolved clientside, so the information is not loaded on the server.</p>
      *
+     * <p>In normal message sending to players and consoles, custom translations
+     * are automatically resolved. This resolution operation is primarily
+     * intended for performing analysis of components
+     * before (or without) sending.</p>
+     *
      * @see GlobalTranslator to register translations
      */
     public static final DefaultedRegistryReference<ResolveOperation> CUSTOM_TRANSLATIONS = ResolveOperations.key(ResourceKey.sponge("custom_translations"));

--- a/src/main/java/org/spongepowered/api/adventure/ResolveOperations.java
+++ b/src/main/java/org/spongepowered/api/adventure/ResolveOperations.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.adventure;
+
+import net.kyori.adventure.translation.GlobalTranslator;
+import org.spongepowered.api.ResourceKey;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.registry.DefaultedRegistryReference;
+import org.spongepowered.api.registry.RegistryKey;
+import org.spongepowered.api.registry.RegistryScope;
+import org.spongepowered.api.registry.RegistryScopes;
+import org.spongepowered.api.registry.RegistryTypes;
+
+/**
+ * Types of rendering that can be applied to components.
+ */
+@RegistryScopes(scopes = RegistryScope.GAME)
+public class ResolveOperations {
+
+    // @formatter:off
+    // SORTFIELDS:ON
+
+    /**
+     * Resolve contextual components.
+     *
+     * <p>Some components (Selectors, NBT, and Score) must be resolved based on
+     * server information before being sent to the client. This performs that
+     * resolution.</p>
+     */
+    public static final DefaultedRegistryReference<ResolveOperation> CONTEXTUAL_COMPONENTS = ResolveOperations.key(ResourceKey.sponge("contextual_components"));
+
+    /**
+     * Apply custom translations.
+     *
+     * <p>These are translations registered by plugins, <em>not</em> Vanilla or
+     * resource pack-provided translations. Those translations are already
+     * resolved clientside, so the information is not loaded on the server.</p>
+     *
+     * @see GlobalTranslator to register translations
+     */
+    public static final DefaultedRegistryReference<ResolveOperation> CUSTOM_TRANSLATIONS = ResolveOperations.key(ResourceKey.sponge("custom_translations"));
+
+    // SORTFIELDS:OFF
+    // @formatter:ON
+
+    private ResolveOperations() {
+    }
+
+    private static DefaultedRegistryReference<ResolveOperation> key(final ResourceKey location) {
+        return RegistryKey.of(RegistryTypes.RESOLVE_OPERATION, location).asDefaultedReference(() -> Sponge.getGame().registries());
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/adventure/SpongeComponents.java
+++ b/src/main/java/org/spongepowered/api/adventure/SpongeComponents.java
@@ -31,6 +31,8 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandCause;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.registry.DefaultedRegistryReference;
 
 import java.util.function.Consumer;
 
@@ -51,6 +53,48 @@ public final class SpongeComponents {
      */
     public static ClickEvent executeCallback(final Consumer<CommandCause> callback) {
         return Sponge.getGame().getFactoryProvider().provide(Factory.class).callbackClickEvent(callback);
+    }
+
+    /**
+     * Render a component for viewer-specific context.
+     *
+     * @param component the component to render
+     * @param senderContext the context to render in
+     * @param viewer the viewer to render for
+     * @param resolver the first resolver
+     * @param otherResolvers any other resolvers to apply
+     * @return the rendered component
+     */
+    @SafeVarargs
+    public static Component resolve(
+        final Component component,
+        final CommandCause senderContext,
+        final Entity viewer,
+        final DefaultedRegistryReference<ResolveOperation> resolver,
+        final DefaultedRegistryReference<ResolveOperation>... otherResolvers
+    ) {
+        return Sponge.getGame().getFactoryProvider().provide(Factory.class).render(component, senderContext, viewer, resolver, otherResolvers);
+    }
+
+    /**
+     * Render a component for sender-specific context.
+     *
+     * <p>Viewer-specific information will not be available</p>
+     *
+     * @param component the component to render
+     * @param senderContext the context to render in
+     * @param resolver the first resolver
+     * @param otherResolvers any other resolvers to apply
+     * @return the rendered component
+     */
+    @SafeVarargs
+    public static Component resolve(
+        final Component component,
+        final CommandCause senderContext,
+        final DefaultedRegistryReference<ResolveOperation> resolver,
+        final DefaultedRegistryReference<ResolveOperation>... otherResolvers
+    ) {
+        return Sponge.getGame().getFactoryProvider().provide(Factory.class).render(component, senderContext, resolver, otherResolvers);
     }
 
     /**
@@ -139,6 +183,23 @@ public final class SpongeComponents {
         GsonComponentSerializer gsonSerializer();
 
         PlainComponentSerializer plainSerializer();
+
+        @SuppressWarnings("unchecked")
+        Component render(
+            final Component component,
+            final CommandCause senderContext,
+            final Entity viewer,
+            final DefaultedRegistryReference<ResolveOperation> resolver,
+            final DefaultedRegistryReference<ResolveOperation>... otherResolvers
+        );
+
+        @SuppressWarnings("unchecked")
+        Component render(
+            final Component component,
+            final CommandCause senderContext,
+            final DefaultedRegistryReference<ResolveOperation> resolver,
+            final DefaultedRegistryReference<ResolveOperation>... otherResolvers
+        );
 
     }
 }

--- a/src/main/java/org/spongepowered/api/adventure/SpongeComponents.java
+++ b/src/main/java/org/spongepowered/api/adventure/SpongeComponents.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.adventure;
 
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
@@ -31,7 +32,6 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandCause;
-import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
 
 import java.util.function.Consumer;
@@ -52,11 +52,16 @@ public final class SpongeComponents {
      * @return The created click event instance
      */
     public static ClickEvent executeCallback(final Consumer<CommandCause> callback) {
-        return Sponge.getGame().getFactoryProvider().provide(Factory.class).callbackClickEvent(callback);
+        return SpongeComponents.factory().callbackClickEvent(callback);
     }
 
     /**
      * Render a component for viewer-specific context.
+     *
+     * <p>The {@code viewer} must refer to a single viewer, not multiple viewers,
+     * in order to gather any useful context. If an audience cannot be resolved
+     * to a single viewer, this method will behave as if no viewer had
+     * been defined.</p>
      *
      * @param component the component to render
      * @param senderContext the context to render in
@@ -69,11 +74,11 @@ public final class SpongeComponents {
     public static Component resolve(
         final Component component,
         final CommandCause senderContext,
-        final Entity viewer,
+        final Audience viewer,
         final DefaultedRegistryReference<ResolveOperation> resolver,
         final DefaultedRegistryReference<ResolveOperation>... otherResolvers
     ) {
-        return Sponge.getGame().getFactoryProvider().provide(Factory.class).render(component, senderContext, viewer, resolver, otherResolvers);
+        return SpongeComponents.factory().render(component, senderContext, viewer, resolver, otherResolvers);
     }
 
     /**
@@ -94,7 +99,7 @@ public final class SpongeComponents {
         final DefaultedRegistryReference<ResolveOperation> resolver,
         final DefaultedRegistryReference<ResolveOperation>... otherResolvers
     ) {
-        return Sponge.getGame().getFactoryProvider().provide(Factory.class).render(component, senderContext, resolver, otherResolvers);
+        return SpongeComponents.factory().render(component, senderContext, resolver, otherResolvers);
     }
 
     /**
@@ -110,7 +115,7 @@ public final class SpongeComponents {
      * @return a section serializer
      */
     public static LegacyComponentSerializer legacySectionSerializer() {
-        return Sponge.getGame().getFactoryProvider().provide(Factory.class).legacySectionSerializer();
+        return SpongeComponents.factory().legacySectionSerializer();
     }
 
     /**
@@ -126,7 +131,7 @@ public final class SpongeComponents {
      * @return a legacy serializer using ampersands
      */
     public static LegacyComponentSerializer legacyAmpersandSerializer() {
-        return Sponge.getGame().getFactoryProvider().provide(Factory.class).legacyAmpersandSerializer();
+        return SpongeComponents.factory().legacyAmpersandSerializer();
     }
 
     /**
@@ -141,7 +146,7 @@ public final class SpongeComponents {
      * @return a legacy serializer using ampersands
      */
     public static LegacyComponentSerializer legacySerializer(final char formatChar) {
-        return Sponge.getGame().getFactoryProvider().provide(Factory.class).legacySerializer(formatChar);
+        return SpongeComponents.factory().legacySerializer(formatChar);
     }
 
     /**
@@ -155,7 +160,7 @@ public final class SpongeComponents {
      * @return a json component serializer
      */
     public static GsonComponentSerializer gsonSerializer() {
-        return Sponge.getGame().getFactoryProvider().provide(Factory.class).gsonSerializer();
+        return SpongeComponents.factory().gsonSerializer();
     }
 
     /**
@@ -168,7 +173,11 @@ public final class SpongeComponents {
      * @return a serializer to plain text
      */
     public static PlainComponentSerializer plainSerializer() {
-        return Sponge.getGame().getFactoryProvider().provide(Factory.class).plainSerializer();
+        return SpongeComponents.factory().plainSerializer();
+    }
+
+    private static Factory factory() {
+        return Sponge.getGame().getFactoryProvider().provide(Factory.class);
     }
 
     public interface Factory {
@@ -188,7 +197,7 @@ public final class SpongeComponents {
         Component render(
             final Component component,
             final CommandCause senderContext,
-            final Entity viewer,
+            final Audience viewer,
             final DefaultedRegistryReference<ResolveOperation> resolver,
             final DefaultedRegistryReference<ResolveOperation>... otherResolvers
         );

--- a/src/main/java/org/spongepowered/api/registry/RegistryTypes.java
+++ b/src/main/java/org/spongepowered/api/registry/RegistryTypes.java
@@ -242,8 +242,6 @@ public final class RegistryTypes {
 
     public static final DefaultedRegistryType<ComparatorMode> COMPARATOR_MODE = RegistryTypes.spongeKeyInGame("comparator_mode");
 
-    public static final DefaultedRegistryType<ResolveOperation> RESOLVE_OPERATION = RegistryTypes.spongeKeyInGame("resolve_operation");
-
     public static final DefaultedRegistryType<Criterion> CRITERION = RegistryTypes.spongeKeyInGame("criterion");
 
     public static final DefaultedRegistryType<Currency> CURRENCY = RegistryTypes.spongeKeyInGame("currency");
@@ -347,6 +345,8 @@ public final class RegistryTypes {
     public static final DefaultedRegistryType<RaidStatus> RAID_STATUS = RegistryTypes.spongeKeyInGame("raid_status");
 
     public static final DefaultedRegistryType<RailDirection> RAIL_DIRECTION = RegistryTypes.spongeKeyInGame("rail_direction");
+
+    public static final DefaultedRegistryType<ResolveOperation> RESOLVE_OPERATION = RegistryTypes.spongeKeyInGame("resolve_operation");
 
     public static final DefaultedRegistryType<Rotation> ROTATION = RegistryTypes.spongeKeyInGame("rotation");
 

--- a/src/main/java/org/spongepowered/api/registry/RegistryTypes.java
+++ b/src/main/java/org/spongepowered/api/registry/RegistryTypes.java
@@ -28,12 +28,12 @@ import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.advancement.AdvancementType;
 import org.spongepowered.api.advancement.criteria.trigger.Trigger;
+import org.spongepowered.api.adventure.ResolveOperation;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.block.entity.BlockEntityType;
 import org.spongepowered.api.block.transaction.Operation;
 import org.spongepowered.api.command.parameter.managed.ValueParameter;
 import org.spongepowered.api.command.parameter.managed.clientcompletion.ClientCompletionType;
-import org.spongepowered.api.command.registrar.CommandRegistrar;
 import org.spongepowered.api.command.registrar.CommandRegistrarType;
 import org.spongepowered.api.command.registrar.tree.ClientCompletionKey;
 import org.spongepowered.api.command.selector.SelectorSortAlgorithm;
@@ -241,6 +241,8 @@ public final class RegistryTypes {
     public static final DefaultedRegistryType<CommandRegistrarType<?>> COMMAND_REGISTRAR_TYPE = RegistryTypes.spongeKeyInGame("command_registrar_type");
 
     public static final DefaultedRegistryType<ComparatorMode> COMPARATOR_MODE = RegistryTypes.spongeKeyInGame("comparator_mode");
+
+    public static final DefaultedRegistryType<ResolveOperation> RESOLVE_OPERATION = RegistryTypes.spongeKeyInGame("resolve_operation");
 
     public static final DefaultedRegistryType<Criterion> CRITERION = RegistryTypes.spongeKeyInGame("criterion");
 


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/3312)

This exposes the component resolution functionality needed to display score, selector, and NBT components to plugins, in a way that is fairly close to what Vanilla provides.

Some things I'm still thinking about:
- Is `Entity` the most appropriate type for a receiver? Perhaps `Audience` would make more sense for the API
- Not sure I like the name `resolve` -- my original choice was `render` to match `ComponentRenderer` in the adventure API, but that makes it sound like a client-side graphics thing.
- Would it make sense to allow plugins to register other renderers?