### PR TITLE
api: Introduce NotificationTickets

### DIFF
--- a/src/main/java/org/spongepowered/api/block/transaction/NotificationTicket.java
+++ b/src/main/java/org/spongepowered/api/block/transaction/NotificationTicket.java
@@ -22,37 +22,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.event.block;
+package org.spongepowered.api.block.transaction;
 
-import org.spongepowered.api.block.transaction.NotificationTicket;
-import org.spongepowered.api.event.Cancellable;
-import org.spongepowered.api.event.Event;
+import org.spongepowered.api.block.BlockSnapshot;
+import org.spongepowered.api.world.LocatableBlock;
 import org.spongepowered.math.vector.Vector3i;
 
-import java.util.List;
-import java.util.function.Predicate;
+public interface NotificationTicket {
 
-/**
- *
- */
-public interface NotifyNeighborBlockEvent extends Event, Cancellable {
+    LocatableBlock notifier();
 
-    List<NotificationTicket> tickets();
-
-    default void filterTargetPositions(final Predicate<Vector3i> predicate) {
-        this.tickets().forEach(ticket -> {
-            if (predicate.test(ticket.targetPosition())) {
-                ticket.valid(false);
-            }
-        });
+    default Vector3i notifierPosition() {
+        return this.notifier().blockPosition();
     }
 
-    default void filterTickets(final Predicate<NotificationTicket> predicate) {
-        this.tickets().forEach(ticket ->{
-            if (predicate.test(ticket)) {
-                ticket.valid(false);
-            }
-        });
+    BlockSnapshot target();
+
+    default Vector3i targetPosition() {
+        return this.target().position();
     }
+
+    boolean valid();
+
+    void valid(boolean valid);
 
 }

--- a/src/main/java/org/spongepowered/api/block/transaction/NotificationTicket.java
+++ b/src/main/java/org/spongepowered/api/block/transaction/NotificationTicket.java
@@ -44,6 +44,6 @@ public interface NotificationTicket {
 
     boolean valid();
 
-    void valid(boolean valid);
+    void setValid(boolean valid);
 
 }

--- a/src/main/java/org/spongepowered/api/event/block/NotifyNeighborBlockEvent.java
+++ b/src/main/java/org/spongepowered/api/event/block/NotifyNeighborBlockEvent.java
@@ -42,7 +42,7 @@ public interface NotifyNeighborBlockEvent extends Event, Cancellable {
     default void filterTargetPositions(final Predicate<Vector3i> predicate) {
         this.tickets().forEach(ticket -> {
             if (predicate.test(ticket.targetPosition())) {
-                ticket.valid(false);
+                ticket.setValid(false);
             }
         });
     }
@@ -50,7 +50,7 @@ public interface NotifyNeighborBlockEvent extends Event, Cancellable {
     default void filterTickets(final Predicate<NotificationTicket> predicate) {
         this.tickets().forEach(ticket ->{
             if (predicate.test(ticket)) {
-                ticket.valid(false);
+                ticket.setValid(false);
             }
         });
     }


### PR DESCRIPTION
**API** | [Sponge](https://github.com/SpongePowered/Sponge/pull/3314)

This revamps the previously meticulous brain-ache
NotifyNeighborBlockEvent into a more
streamlined event similar to ChangeBlock event. As
the batching system has proven useful, this can
safely expose directional suppliers
without explicitly relying on legacy logic of
"Always notify every neighbor on a target position"

Signed-off-by: Gabriel Harris-Rouquette <gabizou@me.com>