### PR TITLE
Remove Nameable interface from Trigger

### DIFF
--- a/src/main/java/org/spongepowered/api/advancement/criteria/trigger/Trigger.java
+++ b/src/main/java/org/spongepowered/api/advancement/criteria/trigger/Trigger.java
@@ -56,7 +56,7 @@ import java.util.function.UnaryOperator;
  */
 @SuppressWarnings("unchecked")
 @CatalogedBy(Triggers.class)
-public interface Trigger<C extends FilteredTriggerConfiguration> extends DefaultedRegistryValue, ResourceKeyed, Nameable {
+public interface Trigger<C extends FilteredTriggerConfiguration> extends DefaultedRegistryValue, ResourceKeyed {
 
     /**
      * Creates a new {@link Builder} which can be used to create


### PR DESCRIPTION
See Registry test testplugin PR for reproduction.

Error:

`java.lang.AbstractMethodError: Receiver class net.minecraft.advancements.critereon.TickTrigger does not define or inherit an implementation of the resolved method 'abstract java.lang.String getName()' of interface org.spongepowered.api.util.Nameable.`

`CriterionTrigger`s (minecraft name) aren't Nameable 