### PR TITLE
Add TwoDimensionalPortal for teleport events

### DIFF
--- a/src/main/java/org/spongepowered/api/event/EventContextKeys.java
+++ b/src/main/java/org/spongepowered/api/event/EventContextKeys.java
@@ -49,6 +49,7 @@ import org.spongepowered.api.world.LocatableBlock;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.explosion.Explosion;
+import org.spongepowered.api.world.portal.Portal;
 import org.spongepowered.api.world.server.ServerLocation;
 import org.spongepowered.api.world.server.ServerWorld;
 import org.spongepowered.math.vector.Vector3d;
@@ -231,6 +232,11 @@ public final class EventContextKeys {
      * Represents a {@link PluginContainer}.
      */
     public static final EventContextKey<PluginContainer> PLUGIN = EventContextKeys.key(ResourceKey.sponge("plugin"), PluginContainer.class);
+
+    /**
+     * Represents a {@link Portal}.
+     */
+    public static final EventContextKey<Portal> PORTAL = EventContextKeys.key(ResourceKey.sponge("portal"), Portal.class);
 
     /**
      * Represents a {@link ProjectileSource}.

--- a/src/main/java/org/spongepowered/api/world/portal/TwoDimensionalPortal.java
+++ b/src/main/java/org/spongepowered/api/world/portal/TwoDimensionalPortal.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.world.portal;
+
+import org.spongepowered.api.util.annotation.DoNotStore;
+import org.spongepowered.api.world.server.ServerLocation;
+
+/**
+ * Represents a {@link Portal} with a known shape.
+ */
+@DoNotStore
+public interface TwoDimensionalPortal extends Portal {
+
+    /**
+     * One corner of the portal.
+     *
+     * @return A location with the corner
+     */
+    default ServerLocation minCorner() {
+        return this.origin();
+    }
+
+    /**
+     * One corner of the portal.
+     *
+     * @return A location with the corner
+     */
+    ServerLocation maxCorner();
+
+}


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/3344)

@Zidane @thibaulthenry 

I think this is the sort of thing you were looking for to expose when a portal does a teleport? Impl will pop the portal onto the context when teleporting via a portal, Nether portals will be this "TwoDimensionalPortal" construct (but I could just fold it into Portal and make the max corner optional, I guess?)