### PR TITLE
Add ParticleOptions.SCALE back to the API

### DIFF
--- a/src/main/java/org/spongepowered/api/effect/particle/ParticleEffect.java
+++ b/src/main/java/org/spongepowered/api/effect/particle/ParticleEffect.java
@@ -157,6 +157,18 @@ public interface ParticleEffect extends DataSerializable {
         }
 
         /**
+         * Sets the scale of the particle effect.
+         *
+         * <p>The default scale is 1.</p>
+         *
+         * @param scale The scale
+         * @return This builder for chaining
+         */
+        default <V> Builder scale(Double scale) {
+            return this.option(ParticleOptions.SCALE, scale);
+        }
+
+        /**
          * Sets the velocity of the particle effect.
          *
          * <p>The default velocity is {@link Vector3d#ZERO}.</p>

--- a/src/main/java/org/spongepowered/api/effect/particle/ParticleOptions.java
+++ b/src/main/java/org/spongepowered/api/effect/particle/ParticleOptions.java
@@ -133,20 +133,18 @@ public final class ParticleOptions {
      */
     public static final DefaultedRegistryReference<ParticleOption<Integer>> QUANTITY = ParticleOptions.key(ResourceKey.sponge("quantity"));
 
-//    /** TODO
-//     * This option will change the scale of a particle. The only
-//     * vanilla {@link ParticleType}s this option is applicable to are:
-//     *
-//     * <ul>
-//     *   <li>{@link ParticleTypes#EXPLOSION}</li>
-//     *   <li>{@link ParticleTypes#SWEEP_ATTACK}</li>
-//     *   <li>{@link ParticleTypes#DUST}</li>
-//     * </ul>
-//     *
-//     * <p>The scale may never be negative, or a {@link IllegalArgumentException}
-//     * will be thrown when applying.</p>
-//     */
-//    public static final Supplier<ParticleOption<Double>> SCALE = Sponge.getRegistry().getCatalogRegistry().provideSupplier(ParticleOption.class, "scale");
+    /**
+     * This option will change the scale of a particle. The only
+     * vanilla {@link ParticleType}s this option is applicable to is:
+     *
+     * <ul>
+     *   <li>{@link ParticleTypes#DUST}</li>
+     * </ul>
+     *
+     * <p>The scale may never be negative, or a {@link IllegalArgumentException}
+     * will be thrown when applying.</p>
+     */
+    public static final DefaultedRegistryReference<ParticleOption<Double>> SCALE = ParticleOptions.key(ResourceKey.sponge("scale"));
 
 //    /** TODO
 //     * This option will affect whether a particle type will have a lower


### PR DESCRIPTION
This particle type was commented out, I implemented this option in SpongePowered/Sponge#3368 so this PR adds the option back to the API.