### PR TITLE
Add more Selector API

### DIFF
--- a/src/main/java/org/spongepowered/api/command/selector/Selector.java
+++ b/src/main/java/org/spongepowered/api/command/selector/Selector.java
@@ -104,6 +104,20 @@ public interface Selector {
     Collection<Entity> select(CommandCause cause);
 
     /**
+     * Get the limit for how many entities this Selector can select.
+     *
+     * @return The limit for the amount of entities this selector may select
+     */
+    int limit();
+
+    /**
+     * Get whether this selector can only select players, or can select any entity type.
+     *
+     * @return Whether this selector can only select players
+     */
+    boolean playersOnly();
+
+    /**
      * Creates a {@link Selector} based on the provided criteria.
      */
     interface Builder extends org.spongepowered.api.util.Builder<Selector, Builder> {


### PR DESCRIPTION
[Sponge](https://github.com/SpongePowered/Sponge/pull/3370) | SpongeAPI

Adds methods to `Selector` to retrieve
- Whether it is able to select players only or any entity type
- The limit for number of entities it can select

These APIs are particularly useful for external command frameworks when combined with the `ENTITY` `ClientCompletionKey`.