### PR TITLE
Rename methods that don't do well without "get" to "findX/findXOrCreate"

### DIFF
--- a/src/main/java/org/spongepowered/api/profile/GameProfileCache.java
+++ b/src/main/java/org/spongepowered/api/profile/GameProfileCache.java
@@ -75,7 +75,7 @@ public interface GameProfileCache {
      * @return The profile, if present, or {@link Optional#empty()} if
      *     the cache did not contain a profile with the provided id
      */
-    Optional<GameProfile> byId(UUID uniqueId);
+    Optional<GameProfile> findById(UUID uniqueId);
 
     /**
      * Gets {@link GameProfile}s in bulk by their unique id.
@@ -83,7 +83,7 @@ public interface GameProfileCache {
      * @param uniqueIds The unique ids
      * @return A collection of successfully found up profiles
      */
-    Map<UUID, Optional<GameProfile>> byIds(Iterable<UUID> uniqueIds);
+    Map<UUID, Optional<GameProfile>> findByIds(Iterable<UUID> uniqueIds);
 
     /**
      * Gets a {@link GameProfile} from this cache by its name.
@@ -92,7 +92,7 @@ public interface GameProfileCache {
      * @return The profile, if present, or {@link Optional#empty()} if
      *     the cache did not contain a profile with the provided name
      */
-    Optional<GameProfile> byName(String name);
+    Optional<GameProfile> findByName(String name);
 
     /**
      * Gets {@link GameProfile}s in bulk by their name.
@@ -100,7 +100,7 @@ public interface GameProfileCache {
      * @param names The names
      * @return A collection of successfully found up profiles
      */
-    Map<String, Optional<GameProfile>> byNames(Iterable<String> names);
+    Map<String, Optional<GameProfile>> findByNames(Iterable<String> names);
 
     /**
      * Gets a collection of all cached {@link GameProfile}s.

--- a/src/main/java/org/spongepowered/api/scheduler/Scheduler.java
+++ b/src/main/java/org/spongepowered/api/scheduler/Scheduler.java
@@ -42,7 +42,7 @@ public interface Scheduler {
      * @param id The id of the task
      * @return The scheduled or running task, or {@link Optional#empty()}
      */
-    Optional<ScheduledTask> taskById(UUID id);
+    Optional<ScheduledTask> findTask(UUID id);
 
     /**
      * Returns a set of {@link Task}s that match the Regular Expression pattern.
@@ -52,7 +52,7 @@ public interface Scheduler {
      * @return A set of {@link Task}s that have names that match the pattern,
      *         the set will be empty if no names match
      */
-    Set<ScheduledTask> tasksByName(String pattern);
+    Set<ScheduledTask> findTasks(String pattern);
 
     /**
      * Returns a set of all currently scheduled tasks.
@@ -67,7 +67,7 @@ public interface Scheduler {
      * @param plugin The plugin that created the tasks
      * @return A set of scheduled tasks
      */
-    Set<ScheduledTask> tasksByPlugin(PluginContainer plugin);
+    Set<ScheduledTask> tasks(PluginContainer plugin);
 
     /**
      * Creates a new {@link ExecutorService} that can be used to schedule

--- a/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
@@ -127,11 +127,11 @@ public interface Objective {
      * @param name The name of the {@link Score} to get.
      * @return The {@link Score} for te specified {@link Component}, if it exists.
      */
-    default Optional<Score> score(final Component name) {
+    default Optional<Score> findScore(final Component name) {
         if (!this.hasScore(name)) {
             return Optional.empty();
         }
-        return Optional.of(this.scoreOrCreate(name));
+        return Optional.of(this.findOrCreateScore(name));
     }
 
     /**
@@ -142,7 +142,7 @@ public interface Objective {
      * @param name The name of the {@link Score} to get
      * @return The {@link Score} for the specified {@link Component}
      */
-    Score scoreOrCreate(Component name);
+    Score findOrCreateScore(Component name);
 
     /**
      * Removes the specified {@link Score} from this objective, if present.

--- a/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
+++ b/src/main/java/org/spongepowered/api/service/economy/EconomyService.java
@@ -92,7 +92,7 @@ public interface EconomyService extends ContextualService<Account> {
      * @param uuid The {@link UUID} of the account to get.
      * @return The {@link UniqueAccount}, if available.
      */
-    Optional<UniqueAccount> accountOrCreate(UUID uuid);
+    Optional<UniqueAccount> findOrCreateAccount(UUID uuid);
 
     /**
      * Gets the {@link VirtualAccount} with the specified identifier.
@@ -108,7 +108,7 @@ public interface EconomyService extends ContextualService<Account> {
      * @param identifier The identifier of the account to get.
      * @return The {@link Account}, if available.
      */
-    Optional<Account> accountOrCreate(String identifier);
+    Optional<Account> findOrCreateAccount(String identifier);
 
     /**
      * Gets a {@link Stream} of all available {@link UniqueAccount}s.

--- a/src/main/java/org/spongepowered/api/state/State.java
+++ b/src/main/java/org/spongepowered/api/state/State.java
@@ -69,7 +69,7 @@ public interface State<S extends State<S>> extends SerializableDataHolder.Immuta
      * @param name The state property name
      * @return The state property, if available
      */
-    Optional<StateProperty<?>> statePropertyByName(String name);
+    Optional<StateProperty<?>> findStateProperty(String name);
 
     /**
      * Gets the {@link State} with the appropriate value for the given

--- a/src/main/java/org/spongepowered/api/state/StateContainer.java
+++ b/src/main/java/org/spongepowered/api/state/StateContainer.java
@@ -45,6 +45,6 @@ public interface StateContainer<S extends State<S>> {
      * @param name The state property name
      * @return The state property, if available
      */
-    Optional<StateProperty<?>> statePropertyByName(String name);
+    Optional<StateProperty<?>> findStateProperty(String name);
 
 }


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/3374)

See https://github.com/SpongePowered/SpongeAPI/issues/2320. Basically here to ensure that we're okay with the proposed renames.