### PR TITLE
Add recipe, biome, and sound ClientCompletionKeys

### DIFF
--- a/src/main/java/org/spongepowered/api/command/registrar/tree/ClientCompletionKeys.java
+++ b/src/main/java/org/spongepowered/api/command/registrar/tree/ClientCompletionKeys.java
@@ -40,6 +40,12 @@ public final class ClientCompletionKeys {
 
     // SORTFIELDS:ON
 
+    public static final DefaultedRegistryReference<ClientCompletionKey<CommandTreeNode.Basic>> ALL_RECIPES = ClientCompletionKeys.key(ResourceKey.minecraft("all_recipes"));
+
+    public static final DefaultedRegistryReference<ClientCompletionKey<CommandTreeNode.Basic>> AVAILABLE_BIOMES = ClientCompletionKeys.key(ResourceKey.minecraft("available_biomes"));
+
+    public static final DefaultedRegistryReference<ClientCompletionKey<CommandTreeNode.Basic>> AVAILABLE_SOUNDS = ClientCompletionKeys.key(ResourceKey.minecraft("available_sounds"));
+
     public static final DefaultedRegistryReference<ClientCompletionKey<CommandTreeNode.Basic>> BLOCK_STATE = ClientCompletionKeys.key(ResourceKey.minecraft("block_state"));
 
     public static final DefaultedRegistryReference<ClientCompletionKey<CommandTreeNode.Basic>> BLOCK_PREDICATE = ClientCompletionKeys.key(ResourceKey.minecraft("block_predicate"));


### PR DESCRIPTION
[Sponge](https://github.com/SpongePowered/Sponge/pull/3375) | SpongeAPI

Adds `ClientCompletionKey`s for `all_recipes`, `available_biomes`, and `available_sounds`. These are not specific argument types, only suggestion providers. In Vanilla, these suggestion providers are always used in combination with the `ResourceLocationArgument`.