### PR TITLE
Add ClientSuggestionProvider to add client-based suggestions for things like biomes

### DIFF
--- a/src/main/java/org/spongepowered/api/command/registrar/tree/ClientSuggestionProvider.java
+++ b/src/main/java/org/spongepowered/api/command/registrar/tree/ClientSuggestionProvider.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.registrar.tree;
+
+import org.spongepowered.api.command.parameter.managed.ValueCompleter;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
+/**
+ * Used with {@link ClientCompletionKeys}, suggestion providers tell the client
+ * what should be suggested, usually without requiring a request to the server.
+ * They do not otherwise affect the parse-time behaviour of a parameter.
+ */
+@CatalogedBy(ClientSuggestionProviders.class)
+public interface ClientSuggestionProvider extends ValueCompleter {
+}

--- a/src/main/java/org/spongepowered/api/command/registrar/tree/ClientSuggestionProviders.java
+++ b/src/main/java/org/spongepowered/api/command/registrar/tree/ClientSuggestionProviders.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.command.registrar.tree;
+
+import org.spongepowered.api.ResourceKey;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.effect.sound.SoundType;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.item.recipe.Recipe;
+import org.spongepowered.api.registry.DefaultedRegistryReference;
+import org.spongepowered.api.registry.RegistryKey;
+import org.spongepowered.api.registry.RegistryTypes;
+import org.spongepowered.api.world.biome.Biome;
+
+/**
+ * The {@link ClientSuggestionProvider suggestion providers} available to raw
+ * command providers.
+ */
+public final class ClientSuggestionProviders {
+
+    // @formatter:off
+
+    // SORTFIELDS:ON
+
+    /**
+     * Instructs the node represented by a {@link CommandTreeNode} to display
+     * all known {@link Recipe recipes}.
+     *
+     * <p>This provider is intended for use with a {@link ResourceKey} parser.
+     * </p>
+     */
+    public static final DefaultedRegistryReference<ClientSuggestionProvider> ALL_RECIPES = ClientSuggestionProviders.key(ResourceKey.minecraft("all_recipes"));
+
+    /**
+     * Instructs the node represented by a {@link CommandTreeNode} to display
+     * all known {@link SoundType sounds}.
+     *
+     * <p>This provider is intended for use with a {@link ResourceKey} parser.
+     * </p>
+     */
+    public static final DefaultedRegistryReference<ClientSuggestionProvider> AVAILABLE_SOUNDS = ClientSuggestionProviders.key(ResourceKey.minecraft("available_sounds"));
+
+    /**
+     * Instructs the node represented by a {@link CommandTreeNode} to display
+     * all known {@link Biome biomes}.
+     *
+     * <p>This provider is intended for use with a {@link ResourceKey} parser.
+     * </p>
+     */
+    public static final DefaultedRegistryReference<ClientSuggestionProvider> AVAILABLE_BIOMES = ClientSuggestionProviders.key(ResourceKey.minecraft("available_biomes"));
+
+    /**
+     * Instructs the node represented by a {@link CommandTreeNode} to display
+     * all known {@link Entity entities} that may be summoned using the
+     * vanilla {@code /summon} command.
+     *
+     * <p>This provider is intended for use with
+     * {@link ClientCompletionKeys#ENTITY_SUMMON}</p>
+     */
+    public static final DefaultedRegistryReference<ClientSuggestionProvider> SUMMONABLE_ENTITIES = ClientSuggestionProviders.key(ResourceKey.minecraft("summonable_entities"));
+
+    // SORTFIELDS:OFF
+
+    // @formatter:on
+
+    private ClientSuggestionProviders() {
+    }
+
+    private static DefaultedRegistryReference<ClientSuggestionProvider> key(final ResourceKey location) {
+        return RegistryKey.of(RegistryTypes.CLIENT_SUGGESTION_PROVIDER, location).asDefaultedReference(() -> Sponge.game().registries());
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/command/registrar/tree/CommandTreeNode.java
+++ b/src/main/java/org/spongepowered/api/command/registrar/tree/CommandTreeNode.java
@@ -171,8 +171,39 @@ public interface CommandTreeNode<T extends CommandTreeNode<T>> {
     T executable();
 
     /**
+     * Declares that the node should use the provided
+     * {@link ClientSuggestionProvider} for generating suggestions on the
+     * client.
+     *
+     * <p>This overrides {@link #customSuggestions()}.</p>
+     *
+     * @param suggestionProvider The provider this node should use
+     * @return This, for chaining
+     */
+    default T suggestions(@Nullable final DefaultedRegistryReference<ClientSuggestionProvider> suggestionProvider) {
+        if (suggestionProvider == null) {
+            return this.suggestions((ClientSuggestionProvider) null);
+        }
+        return this.suggestions(suggestionProvider.get());
+    }
+
+    /**
+     * Declares that the node should use the provided
+     * {@link ClientSuggestionProvider} for generating suggestions on the
+     * client.
+     *
+     * <p>This overrides {@link #customSuggestions()}.</p>
+     *
+     * @param suggestionProvider The provider this node should use
+     * @return This, for chaining
+     */
+    T suggestions(@Nullable ClientSuggestionProvider suggestionProvider);
+
+    /**
      * Declares that this node uses custom suggestions and, as such, tab
      * completions should query the server.
+     *
+     * <p>This overrides {@link #suggestions(ClientSuggestionProvider)}.</p>
      *
      * @return This, for chaining.
      */

--- a/src/main/java/org/spongepowered/api/registry/RegistryTypes.java
+++ b/src/main/java/org/spongepowered/api/registry/RegistryTypes.java
@@ -37,6 +37,7 @@ import org.spongepowered.api.command.parameter.managed.clientcompletion.ClientCo
 import org.spongepowered.api.command.parameter.managed.operator.Operator;
 import org.spongepowered.api.command.registrar.CommandRegistrarType;
 import org.spongepowered.api.command.registrar.tree.ClientCompletionKey;
+import org.spongepowered.api.command.registrar.tree.ClientSuggestionProvider;
 import org.spongepowered.api.command.selector.SelectorSortAlgorithm;
 import org.spongepowered.api.command.selector.SelectorType;
 import org.spongepowered.api.data.persistence.DataFormat;
@@ -236,6 +237,8 @@ public final class RegistryTypes {
     public static final DefaultedRegistryType<ClientCompletionKey<?>> CLIENT_COMPLETION_KEY = RegistryTypes.spongeKeyInGame("client_completion_key");
 
     public static final DefaultedRegistryType<ClientCompletionType> CLIENT_COMPLETION_TYPE = RegistryTypes.spongeKeyInGame("client_completion_type");
+
+    public static final DefaultedRegistryType<ClientSuggestionProvider> CLIENT_SUGGESTION_PROVIDER = RegistryTypes.spongeKeyInGame("client_suggestion_provider");
 
     public static final DefaultedRegistryType<CollisionRule> COLLISION_RULE = RegistryTypes.spongeKeyInGame("collision_rule");
 


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/3376)

Superscedes #2333.

This allows for plugins that use raw/custom registrars to access the suggestion providers that come with Minecraft. See my comment on the supersceded PR as to why additional ClientCompletionKeys is not the answer.

This is intended to be able to fit with Minecraft registries if Mojang ever put the command stuff in the standard registries, which for some reason they don't here...
