### PR TITLE
API8 - Improve PlayerChatEvent

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/living/player/PlayerChatFormatter.java
+++ b/src/main/java/org/spongepowered/api/entity/living/player/PlayerChatFormatter.java
@@ -25,16 +25,15 @@
 package org.spongepowered.api.entity.living.player;
 
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.text.Component;
+import org.spongepowered.api.entity.living.player.server.ServerPlayer;
+
+import java.util.Optional;
 
 /**
- * A chat router.
+ * A player chat formatter.
  */
-public interface PlayerChatRouter {
-    static PlayerChatRouter toAudience(final Audience audience) {
-        return (player, message) -> audience.sendMessage(player, message, MessageType.CHAT);
-    }
+public interface PlayerChatFormatter {
 
-    void chat(final Player player, final Component message);
+    Optional<Component> format(final ServerPlayer player, final Audience target, final Component message, final Component originalMessage);
 }

--- a/src/main/java/org/spongepowered/api/entity/living/player/server/ServerPlayer.java
+++ b/src/main/java/org/spongepowered/api/entity/living/player/server/ServerPlayer.java
@@ -38,7 +38,7 @@ import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.player.CooldownTracker;
 import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.entity.living.player.PlayerChatRouter;
+import org.spongepowered.api.entity.living.player.PlayerChatFormatter;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.entity.living.player.chat.ChatVisibility;
 import org.spongepowered.api.entity.living.player.tab.TabList;
@@ -348,12 +348,12 @@ public interface ServerPlayer extends Player, Subject {
      *
      * @return The chat router
      */
-    PlayerChatRouter chatRouter();
+    PlayerChatFormatter chatFormatter();
 
     /**
      * Sets the chat router.
      *
      * @param router the chat router
      */
-    void setChatRouter(final PlayerChatRouter router);
+    void setChatFormatter(final PlayerChatFormatter router);
 }

--- a/src/main/java/org/spongepowered/api/event/message/MessageChannelEvent.java
+++ b/src/main/java/org/spongepowered/api/event/message/MessageChannelEvent.java
@@ -24,12 +24,18 @@
  */
 package org.spongepowered.api.event.message;
 
+import com.google.common.collect.Streams;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.adventure.Audiences;
 import org.spongepowered.api.util.annotation.eventgen.GenerateFactoryMethod;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Describes events when a involving a {@link Component} message and {@link Audience}s.
@@ -57,5 +63,16 @@ public interface MessageChannelEvent extends MessageEvent {
      * @param audience The audience to set
      */
     void setAudience(@Nullable Audience audience);
+
+    /**
+     * Filters the current audience with given predicate.
+     *
+     * @param predicate the predicate
+     */
+    default void filterAudience(Predicate<Audience> predicate) {
+        if (this.audience().isPresent()) {
+            this.setAudience(Audiences.filtered(this.audience().get(), predicate).orElse(null));
+        }
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/event/message/PlayerChatEvent.java
+++ b/src/main/java/org/spongepowered/api/event/message/PlayerChatEvent.java
@@ -24,40 +24,43 @@
  */
 package org.spongepowered.api.event.message;
 
+import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.spongepowered.api.entity.living.player.PlayerChatRouter;
+import org.spongepowered.api.entity.living.player.PlayerChatFormatter;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
 
 import java.util.Optional;
 
 /**
- * Fired when the {@link Component} being sent to a {@link PlayerChatRouter} was
+ * Fired when the {@link Component} being sent to a {@link PlayerChatFormatter} was
  * due to chatting.
  */
-public interface PlayerChatEvent extends Event, Cancellable {
+public interface PlayerChatEvent extends MessageChannelEvent, Cancellable {
 
     /**
-     * Gets the original router that this message will be sent to.
+     * Gets the original formatter that this message will be sent through.
      *
-     * @return The original router to send to
+     * @return The original formatter used
      */
-    PlayerChatRouter originalChatRouter();
+    PlayerChatFormatter originalChatFormatter();
 
     /**
-     * Gets the current router that this message will be sent to.
+     * Gets the current formatter that this message will be sent through.
      *
-     * @return The router the message in this event will be sent to
+     * @return The formatter the message in this event will be sent through
      */
-    Optional<PlayerChatRouter> chatRouter();
+    Optional<PlayerChatFormatter> chatFormatter();
 
     /**
-     * Sets the router for this message to go to.
+     * Sets the formatter for this message to go trough.
+     * <p>If the target audience is a {@link net.kyori.adventure.audience.ForwardingAudience}
+     * the {@link PlayerChatFormatter} will be applied to each of its {@link ForwardingAudience#audiences()}</p>
      *
      * @param router The router to set
      */
-    void setChatRouter(@Nullable PlayerChatRouter router);
+    void setChatFormatter(@Nullable PlayerChatFormatter router);
 
     /**
      * Gets the original chat message.


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/3391)
#2259
  - adds an easy way to filter Audiences for `MessageChannelEvent`.
  - `PlayerChatRouter` -> `PlayerChatFormatter` now only handles message formatting. Which is applied to each audience of a `ForwardingAudience`
  - `PlayerChatEvent` extends `MessageChannelEvent` to handle the audience target replacing `PlayerChatRouter`