### PR TITLE
Implement error-prone for basic analysis

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,5 @@ projectUrl=https://www.spongepowered.org
 projectDescription=A plugin API for Minecraft: Java Edition
 
 org.gradle.parallel=true
+
+errorproneVersion=2.6.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,5 +10,6 @@ pluginManagement {
         id("org.spongepowered.gradle.event-impl-gen") version "7.0.0"
         id("org.cadixdev.licenser") version "0.6.0"
         id("org.jetbrains.gradle.plugin.idea-ext") version "1.0"
+        id("net.ltgt.errorprone") version "2.0.1"
     }
 }

--- a/src/main/java/org/spongepowered/api/ResourceKey.java
+++ b/src/main/java/org/spongepowered/api/ResourceKey.java
@@ -213,6 +213,7 @@ public interface ResourceKey extends Key {
          * @return The built resource key
          * @throws IllegalStateException If {@link Builder#namespace(String)} or {@link Builder#value(String)} are not set.
          */
+        @Override
         ResourceKey build() throws IllegalStateException;
     }
 

--- a/src/main/java/org/spongepowered/api/ResourceKeyed.java
+++ b/src/main/java/org/spongepowered/api/ResourceKeyed.java
@@ -28,6 +28,7 @@ import net.kyori.adventure.key.Keyed;
 
 public interface ResourceKeyed extends Keyed {
 
+    @Override
     ResourceKey key();
 
 }

--- a/src/main/java/org/spongepowered/api/advancement/DisplayInfo.java
+++ b/src/main/java/org/spongepowered/api/advancement/DisplayInfo.java
@@ -222,6 +222,7 @@ public interface DisplayInfo {
          *
          * @return The display info
          */
+        @Override
         DisplayInfo build();
 
     }

--- a/src/main/java/org/spongepowered/api/advancement/criteria/AdvancementCriterion.java
+++ b/src/main/java/org/spongepowered/api/advancement/criteria/AdvancementCriterion.java
@@ -162,6 +162,7 @@ public interface AdvancementCriterion extends Nameable {
          *
          * @return The criterion
          */
+        @Override
         T build();
     }
 

--- a/src/main/java/org/spongepowered/api/advancement/criteria/trigger/FilteredTrigger.java
+++ b/src/main/java/org/spongepowered/api/advancement/criteria/trigger/FilteredTrigger.java
@@ -88,6 +88,7 @@ public interface FilteredTrigger<C extends FilteredTriggerConfiguration> {
          *
          * @return The trigger
          */
+        @Override
         FilteredTrigger<C> build();
     }
 

--- a/src/main/java/org/spongepowered/api/adventure/Audiences.java
+++ b/src/main/java/org/spongepowered/api/adventure/Audiences.java
@@ -49,7 +49,7 @@ public final class Audiences {
      * @return An audience
      */
     public static Audience onlinePlayers() {
-        return Sponge.game().factoryProvider().provide(Factory.class).onlinePlayers();
+        return Audiences.factory().onlinePlayers();
     }
 
     /**
@@ -61,7 +61,7 @@ public final class Audiences {
      */
     public static Audience withPermission(final String permission) {
         Objects.requireNonNull(permission);
-        return Sponge.game().factoryProvider().provide(Factory.class).withPermission(permission);
+        return Audiences.factory().withPermission(permission);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/block/entity/BlockEntityArchetype.java
+++ b/src/main/java/org/spongepowered/api/block/entity/BlockEntityArchetype.java
@@ -182,6 +182,7 @@ public interface BlockEntityArchetype extends Archetype<BlockSnapshot, BlockEnti
          *
          * @return The new instance
          */
+        @Override
         BlockEntityArchetype build();
 
     }

--- a/src/main/java/org/spongepowered/api/block/transaction/BlockTransaction.java
+++ b/src/main/java/org/spongepowered/api/block/transaction/BlockTransaction.java
@@ -83,7 +83,7 @@ public final class BlockTransaction extends Transaction<BlockSnapshot> {
         final BlockTransaction other = (BlockTransaction) obj;
         return Objects.equals(this.original(), other.original())
             && Objects.equals(this.defaultReplacement(), other.defaultReplacement())
-            && Objects.equals(this.isValid(), other.isValid())
+            && this.isValid() == other.isValid()
             && Objects.equals(this.custom(), other.custom())
             && Objects.equals(this.operation, other.operation);
     }

--- a/src/main/java/org/spongepowered/api/command/Command.java
+++ b/src/main/java/org/spongepowered/api/command/Command.java
@@ -176,7 +176,7 @@ public interface Command {
      * Gets the usage string of this command.
      *
      * <p>A usage string may look like
-     * {@code [&lt;world&gt;] &lt;var1&gt; &lt;var2&gt;}.</p>
+     * {@code [<world>] <var1> <var2>}.</p>
      *
      * <p>The string must not contain the command alias.</p>
      *
@@ -606,6 +606,7 @@ public interface Command {
          * @return The command, ready for registration
          * @throws IllegalStateException if the builder is not complete
          */
+        @Override
         Command.Parameterized build();
 
     }

--- a/src/main/java/org/spongepowered/api/command/CommandCause.java
+++ b/src/main/java/org/spongepowered/api/command/CommandCause.java
@@ -257,6 +257,7 @@ public interface CommandCause extends SubjectProxy {
      *
      * @return The {@link Subject} responsible, if any.
      */
+    @Override
     Subject subject();
 
     /**

--- a/src/main/java/org/spongepowered/api/command/CommandResult.java
+++ b/src/main/java/org/spongepowered/api/command/CommandResult.java
@@ -132,6 +132,7 @@ public interface CommandResult {
          *
          * @return A CommandResult with the specified settings
          */
+        @Override
         CommandResult build();
 
     }

--- a/src/main/java/org/spongepowered/api/command/parameter/CommonParameters.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/CommonParameters.java
@@ -41,7 +41,7 @@ import org.spongepowered.math.vector.Vector3d;
  * </p>
  * 
  * <pre> {@code
- * final Parameter.Value&lt;ServerPlayer&gt; parameter = Parameter.player().setKey("player").build();
+ * final Parameter.Value<ServerPlayer> parameter = Parameter.player().setKey("player").build();
  * final Command.Parameterized builder = Command.builder()
  *      .parameter(parameter)
  *      .executor(context -> {

--- a/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
@@ -1255,6 +1255,7 @@ public interface Parameter {
              *
              * @return The {@link Parameter}
              */
+            @Override
             Parameter.Value<T> build();
 
         }
@@ -1311,6 +1312,7 @@ public interface Parameter {
              *
              * @return The {@link Subcommand}
              */
+            @Override
             Subcommand build();
 
         }
@@ -1395,6 +1397,7 @@ public interface Parameter {
          *
          * @return The {@link Parameter}
          */
+        @Override
         Multi build();
 
     }
@@ -1467,6 +1470,7 @@ public interface Parameter {
          *
          * @return The {@link Multi}
          */
+        @Override
         Multi build();
 
     }

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/Flag.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/Flag.java
@@ -224,6 +224,7 @@ public interface Flag {
          * @return A {@link Flag}
          * @throws IllegalStateException if no key or no alias is specified
          */
+        @Override
         Flag build() throws IllegalStateException;
 
     }

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/standard/VariableValueParameters.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/standard/VariableValueParameters.java
@@ -294,6 +294,7 @@ public final class VariableValueParameters {
          *
          * @return The {@link ValueParameter}
          */
+        @Override
         ValueParameter<T> build();
 
     }
@@ -367,6 +368,7 @@ public final class VariableValueParameters {
          * @return The {@link ValueParameter}
          * @throws IllegalStateException if no choices have been specified
          */
+        @Override
         ValueParameter<T> build();
 
     }
@@ -424,6 +426,7 @@ public final class VariableValueParameters {
          * @return The {@link ValueParameter}
          * @throws IllegalStateException if no choices have been specified
          */
+        @Override
         ValueParameter<T> build();
 
     }
@@ -483,6 +486,7 @@ public final class VariableValueParameters {
          * @throws IllegalStateException if the literal and the return object
          *             have not been specified
          */
+        @Override
         ValueParameter<T> build();
 
     }
@@ -533,6 +537,7 @@ public final class VariableValueParameters {
          * @throws IllegalStateException if the {@link ComponentSerializer} has not
          *             been specified
          */
+        @Override
         ValueParameter<Component> build() throws IllegalStateException;
 
     }
@@ -572,6 +577,7 @@ public final class VariableValueParameters {
          * @throws IllegalStateException if the minimum is greater than the
          *              maximum
          */
+        @Override
         ValueParameter<T> build();
 
     }

--- a/src/main/java/org/spongepowered/api/command/selector/Selector.java
+++ b/src/main/java/org/spongepowered/api/command/selector/Selector.java
@@ -476,6 +476,7 @@ public interface Selector {
          * @throws IllegalStateException if the builder could not create a
          *                               selector
          */
+        @Override
         Selector build() throws IllegalStateException;
 
     }

--- a/src/main/java/org/spongepowered/api/data/DataTransactionResult.java
+++ b/src/main/java/org/spongepowered/api/data/DataTransactionResult.java
@@ -699,6 +699,7 @@ public final class DataTransactionResult {
          *
          * @return The newly created transaction result
          */
+        @Override
         public DataTransactionResult build() {
             if (this.resultType == null) {
                 throw new IllegalStateException("ResultType must be set!");

--- a/src/main/java/org/spongepowered/api/data/ImmutableDataProviderBuilder.java
+++ b/src/main/java/org/spongepowered/api/data/ImmutableDataProviderBuilder.java
@@ -46,5 +46,6 @@ public interface ImmutableDataProviderBuilder<H extends DataHolder, V extends Va
 
     ImmutableDataProviderBuilder<H, V, E> supports(final Function<H, Boolean> supports);
 
+    @Override
     DataProvider<? extends Value<E>, E> build();
 }

--- a/src/main/java/org/spongepowered/api/data/KeyValueMatcher.java
+++ b/src/main/java/org/spongepowered/api/data/KeyValueMatcher.java
@@ -219,6 +219,7 @@ public interface KeyValueMatcher<V> extends DataSerializable {
          *
          * @return The key value matcher
          */
+        @Override
         KeyValueMatcher<V> build();
     }
 }

--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -1007,11 +1007,14 @@ public final class Keys {
      *
      * <p>The format of the rotation is represented by:</p>
      *
-     * <ul><li>{@code x -&gt; pitch</code></li><li> <code>y -&gt; yaw</code></li><li><code>z -&gt; roll
-     * }</li></ul>
+     * <ul>
+     *     <li>{@code x -> pitch}</li>
+     * <li> {@code y -> yaw}</li>
+     * <li>{@code z -> roll}</li>
+     * </ul>
      *
      * <p>Note that the pitch will be the same x value returned by
-     * {@link Entity#rotation ()} and Minecraft does not currently support
+     * {@link Entity#rotation()} and Minecraft does not currently support
      * head roll so the z value will always be zero.</p>
      */
     public static final Key<Value<Vector3d>> HEAD_ROTATION = Keys.key(ResourceKey.sponge("head_rotation"), TypeTokens.VECTOR_3D_VALUE_TOKEN);

--- a/src/main/java/org/spongepowered/api/data/MutableDataProviderBuilder.java
+++ b/src/main/java/org/spongepowered/api/data/MutableDataProviderBuilder.java
@@ -63,5 +63,6 @@ public interface MutableDataProviderBuilder<H extends DataHolder.Mutable, V exte
 
     MutableDataProviderBuilder<H, V, E> supports(final Function<H, Boolean> supports);
 
+    @Override
     DataProvider<V, E> build();
 }

--- a/src/main/java/org/spongepowered/api/data/SerializableDataHolder.java
+++ b/src/main/java/org/spongepowered/api/data/SerializableDataHolder.java
@@ -54,7 +54,7 @@ public interface SerializableDataHolder extends DataSerializable, CopyableDataHo
     @Override
     SerializableDataHolder copy();
 
-    interface Mutable extends SerializableDataHolder, CopyableDataHolder.Mutable {
+    interface Mutable extends SerializableDataHolder, DataHolder.Mutable {
 
         /**
          * Attempts to set all data of this {@link DataHolder} according to the

--- a/src/main/java/org/spongepowered/api/data/Transaction.java
+++ b/src/main/java/org/spongepowered/api/data/Transaction.java
@@ -175,7 +175,7 @@ public class Transaction<T extends DataSerializable> implements DataSerializable
 
     @SuppressWarnings("rawtypes")
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(final @Nullable Object obj) {
         if (this == obj) {
             return true;
         }
@@ -185,7 +185,7 @@ public class Transaction<T extends DataSerializable> implements DataSerializable
         final Transaction other = (Transaction) obj;
         return Objects.equals(this.original, other.original)
                && Objects.equals(this.defaultReplacement, other.defaultReplacement)
-               && Objects.equals(this.valid, other.valid)
+               && this.valid == other.valid
                && Objects.equals(this.custom, other.custom);
     }
 

--- a/src/main/java/org/spongepowered/api/data/meta/BannerPatternLayer.java
+++ b/src/main/java/org/spongepowered/api/data/meta/BannerPatternLayer.java
@@ -150,6 +150,7 @@ public interface BannerPatternLayer extends DataSerializable {
          *
          * @return The new pattern layer
          */
+        @Override
         BannerPatternLayer build();
 
         @Override

--- a/src/main/java/org/spongepowered/api/data/persistence/DataView.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/DataView.java
@@ -350,6 +350,7 @@ public interface DataView {
             try {
                 keys.add(ResourceKey.resolve(s));
             } catch (final Exception ignored) {
+                // skip invalid keys
             }
         }
 

--- a/src/main/java/org/spongepowered/api/data/persistence/Queries.java
+++ b/src/main/java/org/spongepowered/api/data/persistence/Queries.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.data.persistence;
 
 import static org.spongepowered.api.data.persistence.DataQuery.of;
 
+@SuppressWarnings("BadImport")
 public final class Queries {
 
     // Content version

--- a/src/main/java/org/spongepowered/api/effect/particle/ParticleEffect.java
+++ b/src/main/java/org/spongepowered/api/effect/particle/ParticleEffect.java
@@ -198,6 +198,7 @@ public interface ParticleEffect extends DataSerializable {
          *
          * @return A new instance of a ParticleEffect
          */
+        @Override
         ParticleEffect build();
     }
 }

--- a/src/main/java/org/spongepowered/api/effect/potion/PotionEffect.java
+++ b/src/main/java/org/spongepowered/api/effect/potion/PotionEffect.java
@@ -198,6 +198,7 @@ public interface PotionEffect extends DataSerializable {
          * @return A new instance of a PotionEffect
          * @throws IllegalStateException If the potion effect is not completed
          */
+        @Override
         PotionEffect build() throws IllegalStateException;
     }
 }

--- a/src/main/java/org/spongepowered/api/entity/ai/goal/AbstractGoal.java
+++ b/src/main/java/org/spongepowered/api/entity/ai/goal/AbstractGoal.java
@@ -69,7 +69,7 @@ public abstract class AbstractGoal<O extends Agent> implements Goal<O> {
      *
      * @param type The type
      */
-    public AbstractGoal(GoalType type) {
+    protected AbstractGoal(final GoalType type) {
         Objects.requireNonNull(type);
         this.type = type;
     }

--- a/src/main/java/org/spongepowered/api/entity/attribute/AttributeModifier.java
+++ b/src/main/java/org/spongepowered/api/entity/attribute/AttributeModifier.java
@@ -138,6 +138,7 @@ public interface AttributeModifier extends Identifiable {
          *
          * @return The attribute modifier.
          */
+        @Override
         AttributeModifier build();
     }
 }

--- a/src/main/java/org/spongepowered/api/entity/living/player/tab/TabListEntry.java
+++ b/src/main/java/org/spongepowered/api/entity/living/player/tab/TabListEntry.java
@@ -208,6 +208,7 @@ public interface TabListEntry {
          *
          * @return The entry
          */
+        @Override
         TabListEntry build();
     }
 

--- a/src/main/java/org/spongepowered/api/event/Cause.java
+++ b/src/main/java/org/spongepowered/api/event/Cause.java
@@ -407,7 +407,7 @@ public final class Cause implements Iterable<Object> {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.cause);
+        return Arrays.hashCode(this.cause);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/event/EventContext.java
+++ b/src/main/java/org/spongepowered/api/event/EventContext.java
@@ -286,6 +286,7 @@ public final class EventContext {
          * 
          * @return The EventContext
          */
+        @Override
         public EventContext build() {
             return new EventContext(this.entries);
         }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
@@ -148,6 +148,7 @@ public interface DamageModifier {
          *
          * @return The newly created damage modifier
          */
+        @Override
         public DamageModifier build() {
             if (this.type == null) {
                 throw new IllegalStateException("The DamageModifierType must not be null!");

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSource.java
@@ -249,6 +249,7 @@ public interface DamageSource {
          * @throws IllegalStateException If a value required to be set
          *     is not set
          */
+        @Override
         T build() throws IllegalStateException;
     }
 

--- a/src/main/java/org/spongepowered/api/event/entity/AttackEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/AttackEntityEvent.java
@@ -118,11 +118,11 @@ import java.util.function.Function;
  * the "base" damage. The implementation for {@link #finalOutputDamage()} can
  * be exemplified like so:</p>
  *
- * <blockquote><pre>{@code double damage = this.baseDamage;<br />
- * for (Map.Entry&lt;DamageModifier, Function&lt;? super Double, Double&gt;&gt;
- * entry : this.modifierFunctions.entrySet()) {<br />
- * &nbsp;&nbsp;damage += checkNotNull(entry.getValue().apply(damage));<br />
- * }<br />
+ * <blockquote><pre>{@code
+ * double damage = this.baseDamage;<br />
+ * for (Map.Entry<DamageModifier, Function<? super Double, Double>> entry : this.modifierFunctions.entrySet()) {
+ *     damage += checkNotNull(entry.getValue().apply(damage));
+ * }
  * return damage;
  * }</pre></blockquote>
  *

--- a/src/main/java/org/spongepowered/api/event/entity/DamageEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/DamageEntityEvent.java
@@ -112,10 +112,12 @@ import java.util.function.DoubleUnaryOperator;
  * the "base" damage. The implementation for {@link #finalDamage()} can be
  * exemplified like so:</p>
  *
- * <blockquote><pre>{@code double damage = this.baseDamage;<br />for
- * (Map.Entry&lt;DamageModifier, Function&lt;? super Double, Double&gt;&gt;
- * entry : this.modifierFunctions.entrySet()) {<br />&nbsp; &nbsp;damage +=
- * checkNotNull(entry.getValue().apply(damage));<br />}<br />return damage;
+ * <blockquote><pre>{@code
+ * double damage = this.baseDamage;<br />
+ * for (Map.Entry<DamageModifier, Function<? super Double, Double>> entry : this.modifierFunctions.entrySet()) {
+ *     damage += checkNotNull(entry.getValue().apply(damage));
+ * }
+ * return damage;
  * }</pre></blockquote>
  *
  * <p>After which, the "final" damage is simply the summation of the

--- a/src/main/java/org/spongepowered/api/event/impl/entity/AbstractModifierEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/entity/AbstractModifierEvent.java
@@ -59,7 +59,7 @@ public abstract class AbstractModifierEvent<T extends ModifierFunction<M>, M> ex
         double finalDamage = originalValue;
         for (T tuple : originalFunctions) {
             this.modifierFunctions.add(this.convertTuple(tuple.modifier(), tuple.function()));
-            final double tempDamage = Objects.requireNonNull(tuple.function().applyAsDouble(finalDamage));
+            final double tempDamage = tuple.function().applyAsDouble(finalDamage);
             finalDamage += tempDamage;
             modifierMapBuilder.add(new Tuple<>(tuple.modifier(), tempDamage));
             mapBuilder.put(tuple.modifier(), tempDamage);
@@ -74,11 +74,11 @@ public abstract class AbstractModifierEvent<T extends ModifierFunction<M>, M> ex
 
     protected abstract T convertTuple(M obj, DoubleUnaryOperator function);
 
-    protected void recalculateDamages(double baseAmount) {
+    protected void recalculateDamages(final double baseAmount) {
         double tempAmount = baseAmount;
         this.modifiers.clear();
         for (T entry : this.modifierFunctions) {
-            final double modifierAmount = Objects.requireNonNull(entry.function().applyAsDouble(tempAmount));
+            final double modifierAmount = entry.function().applyAsDouble(tempAmount);
             if (this.modifiers.containsKey(entry.modifier())) {
                 final double oldAmount = this.modifiers.get(entry.modifier());
                 final double difference = oldAmount - modifierAmount;
@@ -94,10 +94,10 @@ public abstract class AbstractModifierEvent<T extends ModifierFunction<M>, M> ex
         }
     }
 
-    protected double finalAmount(double baseAmount) {
+    protected double finalAmount(final double baseAmount) {
         double damage = baseAmount;
-        for (T entry : this.modifierFunctions) {
-            damage += Objects.requireNonNull(entry.function().applyAsDouble(damage));
+        for (final T entry : this.modifierFunctions) {
+            damage += entry.function().applyAsDouble(damage);
         }
         return damage;
     }

--- a/src/main/java/org/spongepowered/api/event/item/inventory/container/ClickContainerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/container/ClickContainerEvent.java
@@ -81,6 +81,7 @@ public interface ClickContainerEvent extends ChangeInventoryEvent, InteractConta
     /**
      * A double-click with the primary mouse button
      */
+    @SuppressWarnings("JavaLangClash")
     interface Double extends ClickContainerEvent.Primary {}
 
     /**

--- a/src/main/java/org/spongepowered/api/item/FireworkEffect.java
+++ b/src/main/java/org/spongepowered/api/item/FireworkEffect.java
@@ -203,6 +203,7 @@ public interface FireworkEffect extends DataSerializable {
          *
          * @return A newly created firework effect
          */
+        @Override
         FireworkEffect build();
     }
 }

--- a/src/main/java/org/spongepowered/api/item/enchantment/Enchantment.java
+++ b/src/main/java/org/spongepowered/api/item/enchantment/Enchantment.java
@@ -156,6 +156,7 @@ public interface Enchantment extends DataSerializable {
          * @return The created enchantment
          * @throws IllegalStateException If a required value was not specified
          */
+        @Override
         Enchantment build() throws IllegalStateException;
 
     }
@@ -228,6 +229,7 @@ public interface Enchantment extends DataSerializable {
          * @return The created enchantment
          * @throws IllegalStateException If a required value was not specified
          */
+        @Override
         List<Enchantment> build() throws IllegalStateException;
 
     }

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
@@ -410,6 +410,7 @@ public interface ItemStack extends SerializableDataHolder.Mutable {
          * @return A new instance of an ItemStack
          * @throws IllegalStateException If the item stack is not completed
          */
+        @Override
         ItemStack build() throws IllegalStateException;
     }
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackGenerator.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackGenerator.java
@@ -135,6 +135,7 @@ public interface ItemStackGenerator extends Function<Random, ItemStack> {
          *
          * @return The newly created itemstack generator
          */
+        @Override
         ItemStackGenerator build();
 
     }

--- a/src/main/java/org/spongepowered/api/item/inventory/query/Query.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/query/Query.java
@@ -98,6 +98,7 @@ public interface Query {
          *
          * @return The new composity query.
          */
+        @Override
         Query build();
     }
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/transaction/InventoryTransactionResult.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/transaction/InventoryTransactionResult.java
@@ -228,6 +228,7 @@ public interface InventoryTransactionResult {
          *
          * @return A new inventory transaction result
          */
+        @Override
         InventoryTransactionResult build();
 
         interface PollBuilder extends Builder {

--- a/src/main/java/org/spongepowered/api/item/inventory/type/ViewableInventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/type/ViewableInventory.java
@@ -273,6 +273,7 @@ public interface ViewableInventory extends Inventory {
              *
              * @return the new inventory.
              */
+            @Override
             ViewableInventory build();
         }
 

--- a/src/main/java/org/spongepowered/api/item/merchant/TradeOffer.java
+++ b/src/main/java/org/spongepowered/api/item/merchant/TradeOffer.java
@@ -260,6 +260,7 @@ public interface TradeOffer extends DataSerializable {
          * @throws IllegalStateException If the resulting trade offer would be
          *      invalid
          */
+        @Override
         TradeOffer build() throws IllegalStateException;
 
     }

--- a/src/main/java/org/spongepowered/api/item/merchant/TradeOfferGenerator.java
+++ b/src/main/java/org/spongepowered/api/item/merchant/TradeOfferGenerator.java
@@ -158,6 +158,7 @@ public interface TradeOfferGenerator extends BiFunction<Entity, Random, TradeOff
          *
          * @return The newly created generator
          */
+        @Override
         TradeOfferGenerator build();
 
     }

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/Ingredient.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/Ingredient.java
@@ -217,6 +217,7 @@ public interface Ingredient extends Predicate<ItemStack> {
          *
          * @return The new Ingredient
          */
+        @Override
         Ingredient build();
     }
 

--- a/src/main/java/org/spongepowered/api/placeholder/PlaceholderComponent.java
+++ b/src/main/java/org/spongepowered/api/placeholder/PlaceholderComponent.java
@@ -125,6 +125,7 @@ public interface PlaceholderComponent extends ComponentLike {
          *  or the associated {@link PlaceholderParser} could not validate the
          *  built {@link PlaceholderComponent}, if applicable.
          */
+        @Override
         PlaceholderComponent build() throws IllegalStateException;
 
     }

--- a/src/main/java/org/spongepowered/api/placeholder/PlaceholderContext.java
+++ b/src/main/java/org/spongepowered/api/placeholder/PlaceholderContext.java
@@ -164,6 +164,7 @@ public interface PlaceholderContext {
          *  or the associated {@link PlaceholderParser} could not validate the
          *  built {@link PlaceholderComponent}, if applicable.
          */
+        @Override
         PlaceholderContext build() throws IllegalStateException;
 
     }

--- a/src/main/java/org/spongepowered/api/scheduler/Task.java
+++ b/src/main/java/org/spongepowered/api/scheduler/Task.java
@@ -270,6 +270,7 @@ public interface Task {
          *                               no {@link PluginContainer} could be extracted
          *                               from the {@link CauseStackManager}.
          */
+        @Override
         Task build();
     }
 }

--- a/src/main/java/org/spongepowered/api/scoreboard/Scoreboard.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Scoreboard.java
@@ -269,6 +269,7 @@ public interface Scoreboard {
          * @return A new instance of a {@link Scoreboard}
          * @throws IllegalStateException if the {@link Scoreboard} is not complete
          */
+        @Override
         Scoreboard build() throws IllegalStateException;
 
     }

--- a/src/main/java/org/spongepowered/api/scoreboard/Team.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Team.java
@@ -460,6 +460,7 @@ public interface Team {
          * @return A new instance of a {@link Team}
          * @throws IllegalStateException if the {@link Team} is not complete
          */
+        @Override
         Team build() throws IllegalStateException;
 
     }

--- a/src/main/java/org/spongepowered/api/service/ban/Ban.java
+++ b/src/main/java/org/spongepowered/api/service/ban/Ban.java
@@ -232,6 +232,7 @@ public interface Ban {
          *
          * @return A new Ban
          */
+        @Override
         Ban build();
 
     }

--- a/src/main/java/org/spongepowered/api/service/pagination/PaginationList.java
+++ b/src/main/java/org/spongepowered/api/service/pagination/PaginationList.java
@@ -239,6 +239,7 @@ public interface PaginationList {
          * @return The pagination list
          * @throws IllegalStateException If no contents were specified
          */
+        @Override
         PaginationList build();
 
         /**

--- a/src/main/java/org/spongepowered/api/state/StateMatcher.java
+++ b/src/main/java/org/spongepowered/api/state/StateMatcher.java
@@ -200,6 +200,7 @@ public interface StateMatcher<S extends State<S>> extends Predicate<S> {
          *
          * @return The built state matcher
          */
+        @Override
         StateMatcher<S> build();
 
     }

--- a/src/main/java/org/spongepowered/api/util/Builder.java
+++ b/src/main/java/org/spongepowered/api/util/Builder.java
@@ -41,6 +41,7 @@ public interface Builder<T, B extends Builder<T, B>> extends Buildable.Builder<T
      *
      * @return This builder, for chaining
      */
+    @Override
     @SuppressWarnings("unchecked")
     default B reset() {
         return (B) this;

--- a/src/main/java/org/spongepowered/api/util/Coerce.java
+++ b/src/main/java/org/spongepowered/api/util/Coerce.java
@@ -735,7 +735,7 @@ public final class Coerce {
             return "0";
         }
 
-        return string.replace(",", "").split(" ")[0];
+        return string.replace(",", "").split(" ", 0)[0];
     }
 
     private static boolean listBracketsMatch(Matcher candidate) {
@@ -771,10 +771,8 @@ public final class Coerce {
         }
 
         final List<String> list = Lists.newArrayList();
-        for (String part : candidate.group(2).split(",")) {
-            if (part != null) {
-                list.add(part);
-            }
+        for (final String part : candidate.group(2).split(",", -1)) {
+            list.add(part);
         }
         return list;
     }

--- a/src/main/java/org/spongepowered/api/util/CollectionUtils.java
+++ b/src/main/java/org/spongepowered/api/util/CollectionUtils.java
@@ -61,7 +61,8 @@ public final class CollectionUtils {
             } else if (map instanceof ConcurrentHashMap) {
                 return (Map<K, V>) new ConcurrentHashMap<>(map);
             }
-        } catch (Exception ignored) {
+        } catch (final Exception ignored) {
+            // fall back to HashMap
         }
         return new HashMap<>(map);
     }
@@ -85,7 +86,8 @@ public final class CollectionUtils {
             } else if (list instanceof CopyOnWriteArrayList) {
                 return (List<T>) ((CopyOnWriteArrayList<T>) list).clone();
             }
-        } catch (Exception ignored) {
+        } catch (final Exception ignored) {
+            // fall back to a standard copy
         }
         return new ArrayList<>(list);
     }

--- a/src/main/java/org/spongepowered/api/util/Color.java
+++ b/src/main/java/org/spongepowered/api/util/Color.java
@@ -212,6 +212,7 @@ public final class Color implements DataSerializable, RGBLike {
      *
      * @return The red value
      */
+    @Override
     public @IntRange(from = 0x0, to = 0xff) int red() {
         return Color.MASK & this.red;
     }

--- a/src/main/java/org/spongepowered/api/util/Direction.java
+++ b/src/main/java/org/spongepowered/api/util/Direction.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.util;
 
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.spongepowered.math.GenericMath;
 import org.spongepowered.math.TrigMath;
 import org.spongepowered.math.vector.Vector3d;
@@ -83,7 +84,8 @@ public enum Direction {
     private final Vector3d offset;
     private final Vector3i blockOffset;
     private final Division division;
-    private Direction opposite;
+    @SuppressWarnings("ImmutableEnumChecker")
+    private @MonotonicNonNull Direction opposite;
 
     static {
         Direction.NORTH.opposite = Direction.SOUTH;

--- a/src/main/java/org/spongepowered/api/util/MinecraftDayTime.java
+++ b/src/main/java/org/spongepowered/api/util/MinecraftDayTime.java
@@ -98,10 +98,10 @@ public interface MinecraftDayTime {
      *
      * <ul>
      *     <li>{@code day} must be positive;</li>
-     *     <li>{@code hour} is in 24-hour time, and so must be between 0 and 23,
+     *     <li>{@code hours} is in 24-hour time, and so must be between 0 and 23,
      *     <strong>except</strong> on day 1, where it must be between 6 and 23;
      *     and</li>
-     *     <li>{@code minute} must be between 0 and 59.</li>
+     *     <li>{@code minutes} must be between 0 and 59.</li>
      * </ul>
      *
      * <p>In the case where the supplied time does not completely align with a

--- a/src/main/java/org/spongepowered/api/util/OptBool.java
+++ b/src/main/java/org/spongepowered/api/util/OptBool.java
@@ -29,10 +29,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.Optional;
 
 /**
- * Utility for working with {@code Optional&lt;Boolean&gt;}s.
+ * Utility for working with {@code Optional<Boolean>}s.
  *
  * <p>This also saves memory by holding three static instances of
- * {@code Optional&lt;Boolean&gt;}, which represents the possible states it can
+ * {@code Optional<Boolean>}, which represents the possible states it can
  * have.</p>
  */
 public final class OptBool {
@@ -53,27 +53,27 @@ public final class OptBool {
      * The absent value.
      *
      * <p>Also a shorthand for constructing instances
-     * with {@code Optional.&lt;Boolean&gt;empty()}.</p>
+     * with {@code Optional.<Boolean>empty()}.</p>
      */
     public static final Optional<Boolean> EMPTY = Optional.empty();
 
     /**
-     * Constructs a new {@code Optional&lt;Boolean&gt;} from the given boolean.
+     * Constructs a new {@code Optional<Boolean>} from the given boolean.
      *
      * @param bool The boolean
      * @return The constructed Optional
      */
-    public static Optional<Boolean> of(boolean bool) {
+    public static Optional<Boolean> of(final boolean bool) {
         return bool ? OptBool.TRUE : OptBool.FALSE;
     }
 
     /**
-     * Constructs a new {@code Optional&lt;Boolean&gt;} from the given {@link Boolean}.
+     * Constructs a new {@code Optional<Boolean>} from the given {@link Boolean}.
      *
      * @param bool The boolean
      * @return The constructed Optional, or {@link Optional#empty()}
      */
-    public static Optional<Boolean> of(@Nullable Boolean bool) {
+    public static Optional<Boolean> of(final @Nullable Boolean bool) {
         if (bool != null) {
             return OptBool.of(bool.booleanValue());
         }
@@ -81,13 +81,13 @@ public final class OptBool {
     }
 
     /**
-     * Coerces the given {@code Optional&lt;Boolean&gt;} into one of the three
+     * Coerces the given {@code Optional<Boolean>} into one of the three
      * stored states.
      *
      * @param bool The boolean
      * @return The constructed Optional, or {@link Optional#empty()}
      */
-    public static Optional<Boolean> of(Optional<Boolean> bool) {
+    public static Optional<Boolean> of(final Optional<Boolean> bool) {
         if (bool.isPresent()) {
             return OptBool.of(bool.get().booleanValue());
         }

--- a/src/main/java/org/spongepowered/api/util/RespawnLocation.java
+++ b/src/main/java/org/spongepowered/api/util/RespawnLocation.java
@@ -267,6 +267,7 @@ public final class RespawnLocation implements DataSerializable {
          *
          * @return The new respawn location
          */
+        @Override
         public RespawnLocation build() {
             Objects.requireNonNull(this.world);
             Objects.requireNonNull(this.position);

--- a/src/main/java/org/spongepowered/api/util/Ticks.java
+++ b/src/main/java/org/spongepowered/api/util/Ticks.java
@@ -267,7 +267,7 @@ public interface Ticks {
      *      be expected to be run in an ideal scenario.
      */
     static Ticks ofMinecraftHours(final Engine engine, final long hours) {
-        return Ticks.ofMinecraftHours(engine, hours);
+        return Ticks.ofMinecraftMinutes(engine, hours * 60);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/util/weighted/RandomObjectTable.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/RandomObjectTable.java
@@ -50,7 +50,7 @@ public abstract class RandomObjectTable<T> implements Collection<TableEntry<T>> 
      * @see RandomObjectTable#rolls()
      * @param rolls the rolls
      */
-    public RandomObjectTable(int rolls) {
+    protected RandomObjectTable(int rolls) {
         if (rolls < 0) {
             throw new IllegalArgumentException("Rolls cannot be negative!");
         }
@@ -63,7 +63,7 @@ public abstract class RandomObjectTable<T> implements Collection<TableEntry<T>> 
      * @see RandomObjectTable#rolls()
      * @param rolls the rolls
      */
-    public RandomObjectTable(VariableAmount rolls) {
+    protected RandomObjectTable(VariableAmount rolls) {
         this.rolls = Objects.requireNonNull(rolls);
     }
 

--- a/src/main/java/org/spongepowered/api/util/weighted/TableEntry.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/TableEntry.java
@@ -38,7 +38,7 @@ public abstract class TableEntry<T> {
      *
      * @param weight The weight to associate with this entry
      */
-    public TableEntry(double weight) {
+    protected TableEntry(final double weight) {
         if (weight < 0) {
             throw new IllegalArgumentException("Weight cannot be negative");
         }

--- a/src/main/java/org/spongepowered/api/world/LocatableBlock.java
+++ b/src/main/java/org/spongepowered/api/world/LocatableBlock.java
@@ -109,6 +109,7 @@ public interface LocatableBlock extends SerializableDataHolder.Immutable<Locatab
          *
          * @return The new locatable block
          */
+        @Override
         LocatableBlock build();
     }
 

--- a/src/main/java/org/spongepowered/api/world/WorldBorder.java
+++ b/src/main/java/org/spongepowered/api/world/WorldBorder.java
@@ -355,6 +355,7 @@ public interface WorldBorder {
          * 
          * @return The built world border
          */
+        @Override
         WorldBorder build();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/chunk/Chunk.java
+++ b/src/main/java/org/spongepowered/api/world/chunk/Chunk.java
@@ -74,6 +74,7 @@ public interface Chunk extends ProtoChunk<Chunk>, EntityVolume.Mutable<Chunk> {
      *
      * @return The number of ticks
      */
+    @Override
     long inhabitedTime();
 
     /**

--- a/src/main/java/org/spongepowered/api/world/explosion/Explosion.java
+++ b/src/main/java/org/spongepowered/api/world/explosion/Explosion.java
@@ -240,6 +240,7 @@ public interface Explosion extends Locatable {
          * @return The explosion, if successful
          * @throws IllegalArgumentException If any builder parameter is invalid
          */
+        @Override
         Explosion build() throws IllegalArgumentException;
 
     }

--- a/src/main/java/org/spongepowered/api/world/generation/ConfigurableChunkGenerator.java
+++ b/src/main/java/org/spongepowered/api/world/generation/ConfigurableChunkGenerator.java
@@ -31,6 +31,7 @@ public interface ConfigurableChunkGenerator<T extends ChunkGeneratorConfig> exte
 
     T config();
 
+    @Override
     default StructureGenerationConfig structureConfig() {
         return this.config().structureConfig();
     }

--- a/src/main/java/org/spongepowered/api/world/generation/config/WorldGenerationConfig.java
+++ b/src/main/java/org/spongepowered/api/world/generation/config/WorldGenerationConfig.java
@@ -92,6 +92,7 @@ public interface WorldGenerationConfig {
 
             Builder generateBonusChest(boolean generateBonusChest);
 
+            @Override
             WorldGenerationConfig.Mutable build();
         }
     }

--- a/src/main/java/org/spongepowered/api/world/schematic/Schematic.java
+++ b/src/main/java/org/spongepowered/api/world/schematic/Schematic.java
@@ -180,6 +180,7 @@ public interface Schematic extends ArchetypeVolume, LocationBaseDataHolder.Mutab
          * @throws IllegalArgumentException If any required data was not
          *         specified
          */
+        @Override
         Schematic build() throws IllegalArgumentException;
 
     }

--- a/src/main/java/org/spongepowered/api/world/volume/stream/StreamOptions.java
+++ b/src/main/java/org/spongepowered/api/world/volume/stream/StreamOptions.java
@@ -182,6 +182,7 @@ public interface StreamOptions {
 
         Builder setLoadingStyle(LoadingStyle style);
 
+        @Override
         StreamOptions build();
 
     }

--- a/src/main/java/org/spongepowered/api/world/volume/stream/VolumeElement.java
+++ b/src/main/java/org/spongepowered/api/world/volume/stream/VolumeElement.java
@@ -38,14 +38,17 @@ public interface VolumeElement<V extends Volume, T> {
 
     static <W extends Volume, T> VolumeElement<W, T> of(final Supplier<W> volume, final Supplier<? extends T> type, final Vector3i position) {
         return new VolumeElement<W, T>() {
+            @Override
             public W volume() {
                 return volume.get();
             }
 
+            @Override
             public Vector3i position() {
                 return position;
             }
 
+            @Override
             public T type() {
                 return type.get();
             }

--- a/src/main/java/org/spongepowered/api/world/volume/stream/VolumePositionTranslators.java
+++ b/src/main/java/org/spongepowered/api/world/volume/stream/VolumePositionTranslators.java
@@ -55,7 +55,7 @@ public final class VolumePositionTranslators {
     public static <W extends Volume> VolumePositionTranslator<W, BlockEntity> rotateBlockEntitiesOn(final Vector3i center,
         final Rotation rotation
     ) {
-        return VolumePositionTranslators.rotateOn(center, rotation, (blockEntity -> blockEntity.rotate(rotation)));
+        return VolumePositionTranslators.rotateOn(center, rotation, blockEntity -> blockEntity.rotate(rotation));
     }
 
     public static <W extends Volume, E> VolumePositionTranslator<W, E> rotateOn(final Vector3i center, final Rotation rotation,

--- a/src/main/java/org/spongepowered/api/world/volume/stream/VolumeStream.java
+++ b/src/main/java/org/spongepowered/api/world/volume/stream/VolumeStream.java
@@ -73,7 +73,7 @@ public interface VolumeStream<V extends Volume, T> {
     <Out> VolumeStream<V, Out> map(VolumeMapper<V, T, Out> mapper);
 
     default <Out> VolumeStream<V, Out> map(final Function<VolumeElement<V, T>, ? extends Out> mapper) {
-        return this.map(((volume, value, x, y, z) -> mapper.apply(VolumeElement.of(volume, value, new Vector3i(x, y, z)))));
+        return this.map((volume, value, x, y, z) -> mapper.apply(VolumeElement.of(volume, value, new Vector3i(x, y, z))));
     }
 
     VolumeStream<V, Optional<? extends T>> flatMap(VolumeFlatMapper<V, T> mapper);
@@ -87,7 +87,7 @@ public interface VolumeStream<V extends Volume, T> {
     boolean allMatch(VolumePredicate<V, ? super T> predicate);
 
     default boolean allMatch(final Predicate<VolumeElement<V, ? super T>> predicate) {
-        return this.allMatch(((volume, element, x, y, z) -> predicate.test(VolumeElement.of(volume, element, new Vector3i(x, y, z)))));
+        return this.allMatch((volume, element, x, y, z) -> predicate.test(VolumeElement.of(volume, element, new Vector3i(x, y, z))));
     }
 
     boolean noneMatch(VolumePredicate<V, ? super T> predicate);

--- a/src/test/java/org/spongepowered/api/data/DataTransactionBuilderTest.java
+++ b/src/test/java/org/spongepowered/api/data/DataTransactionBuilderTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.spongepowered.api.data.DataTransactionResult.Type;
 
+@SuppressWarnings("BadImport") // limited-scope test, it's ok to import common names
 class DataTransactionBuilderTest {
 
     @Test
@@ -40,7 +41,7 @@ class DataTransactionBuilderTest {
         Assertions.assertEquals(Type.CANCELLED, this.absorbedType(Type.FAILURE, Type.CANCELLED));
     }
     
-    private Type absorbedType(Type builderType, Type resultType) {
+    private Type absorbedType(final Type builderType, final Type resultType) {
         final DataTransactionResult result = DataTransactionResult.builder().result(resultType).build();
         final DataTransactionResult absorbed = DataTransactionResult.builder().result(builderType).absorbResult(result).build();
         return absorbed.type();


### PR DESCRIPTION
[error-prone](https://errorprone.info) is an AP that runs as part of the Java compile performing some helpful checks.

The tool is fairly lenient, and won't fail the build for things that it isn't super confident are bugs. When run on Sponge, it emitted quite a few warnings, but the errors it emitted appeared to all be legitimate bugs. 

This came up almost accidentally when I changed IntelliJ to use error-prone for its own compilation, which ended up affecting the whole workspace. Those checks caught a bad copy & paste in `Ticks`, plus a variety of other odds & ends across the project.

I've disabled some of the more spammy warnings for now, and fixed the easily fixable -- what's left is:

```
> Task :compileJava
C:\Users\zml\dev\mc\sponge\Sponge\SpongeAPI\src\main\java\org\spongepowered\api\registry\Registry.java:121: warning: [TypeParameterUnusedInFormals] Declaring a type parameter that is only used in the return type is a misuse of ge
nerics: operations on the type parameter are unchecked, it hides unsafe casts at invocations of the method, and it interacts badly with method overload resolution.
    <V extends T> V value(ResourceKey key);
                    ^
    (see https://errorprone.info/bugpattern/TypeParameterUnusedInFormals)
C:\Users\zml\dev\mc\sponge\Sponge\SpongeAPI\src\main\java\org\spongepowered\api\registry\Registry.java:129: warning: [TypeParameterUnusedInFormals] Declaring a type parameter that is only used in the return type is a misuse of ge
nerics: operations on the type parameter are unchecked, it hides unsafe casts at invocations of the method, and it interacts badly with method overload resolution.
    default <V extends T> V value(final RegistryKey<T> key) {
                            ^
    (see https://errorprone.info/bugpattern/TypeParameterUnusedInFormals)
C:\Users\zml\dev\mc\sponge\Sponge\SpongeAPI\src\main\java\org\spongepowered\api\world\volume\stream\StreamOptions.java:175: warning: [EmptyBlockTag] A block tag (@param, @return, @throws, @deprecated) has an empty description. Bl
ock tags without descriptions don't add much value for future readers of the code; consider removing the tag entirely or adding a description.
     * @return
       ^
    (see https://google.github.io/styleguide/javaguide.html#s7.1.3-javadoc-block-tags)
  Did you mean '*'?
C:\Users\zml\dev\mc\sponge\Sponge\SpongeAPI\src\main\java\org\spongepowered\api\world\volume\stream\VolumeElement.java:105: warning: [EmptyBlockTag] A block tag (@param, @return, @throws, @deprecated) has an empty description. Bl
ock tags without descriptions don't add much value for future readers of the code; consider removing the tag entirely or adding a description.
     * @return
       ^
    (see https://google.github.io/styleguide/javaguide.html#s7.1.3-javadoc-block-tags)
  Did you mean '*'?
C:\Users\zml\dev\mc\sponge\Sponge\SpongeAPI\src\main\java\org\spongepowered\api\world\volume\stream\VolumePositionTranslator.java:33: warning: [EmptyBlockTag] A block tag (@param, @return, @throws, @deprecated) has an empty descr
iption. Block tags without descriptions don't add much value for future readers of the code; consider removing the tag entirely or adding a description.
 * @param <V>
   ^
    (see https://google.github.io/styleguide/javaguide.html#s7.1.3-javadoc-block-tags)
  Did you mean '*'?
C:\Users\zml\dev\mc\sponge\Sponge\SpongeAPI\src\main\java\org\spongepowered\api\world\volume\stream\VolumePositionTranslator.java:34: warning: [EmptyBlockTag] A block tag (@param, @return, @throws, @deprecated) has an empty descr
iption. Block tags without descriptions don't add much value for future readers of the code; consider removing the tag entirely or adding a description.
 * @param <T>
   ^
    (see https://google.github.io/styleguide/javaguide.html#s7.1.3-javadoc-block-tags)
  Did you mean '*'?
C:\Users\zml\dev\mc\sponge\Sponge\SpongeAPI\src\main\java\org\spongepowered\api\data\DataManipulator.java:500: warning: [CatchAndPrintStackTrace] Logging or rethrowing exceptions should usually be preferred to catching and callin
g printStackTrace
                    e.printStackTrace();
                    ^
    (see https://errorprone.info/bugpattern/CatchAndPrintStackTrace)
C:\Users\zml\dev\mc\sponge\Sponge\SpongeAPI\src\main\java\org\spongepowered\api\data\DataManipulator.java:522: warning: [CatchAndPrintStackTrace] Logging or rethrowing exceptions should usually be preferred to catching and callin
g printStackTrace
                    e.printStackTrace();
                    ^
    (see https://errorprone.info/bugpattern/CatchAndPrintStackTrace)
C:\Users\zml\dev\mc\sponge\Sponge\SpongeAPI\src\main\java\org\spongepowered\api\data\DataAlreadyRegisteredException.java:32: warning: [UnusedVariable] The field 'owningRegistration' is never read.
    private final DataRegistration owningRegistration;
                                   ^
    (see https://errorprone.info/bugpattern/UnusedVariable)
  Did you mean to remove this line?
C:\Users\zml\dev\mc\sponge\Sponge\SpongeAPI\src\main\java\org\spongepowered\api\data\DataAlreadyRegisteredException.java:31: warning: [UnusedVariable] The field 'registeredKey' is never read.
    private final Key<?> registeredKey;
                         ^
    (see https://errorprone.info/bugpattern/UnusedVariable)
  Did you mean to remove this line?
C:\Users\zml\dev\mc\sponge\Sponge\SpongeAPI\src\main\java\org\spongepowered\api\util\Coerce.java:767: warning: [MixedMutabilityReturnType] This method returns both mutable and immutable collections or maps from different paths. T
his may be confusing for users of the method.
    private static List<?> parseStringToList(String string) {
                           ^
    (see https://errorprone.info/bugpattern/MixedMutabilityReturnType)
  Did you mean 'private static ImmutableList<?> parseStringToList(String string) {' or 'private static ImmutableList<?> parseStringToList(String string) {'?
11 warnings
```