### PR TITLE
Fix contributor guidelines link in CONTIRBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 We will always have a need for developers to help us improve SpongeAPI. There is no such thing as a perfect project and things can always be improved. If you are a developer and are interested in helping then please do not hesitate. Just make sure you follow our guidelines.
 
-Please check our [Contribution Guidelines in the Sponge Documentation](https://docs.spongepowered.org/en/contributing/guidelines.html) for more information.
+Please check our [Contribution Guidelines in the Sponge Documentation](https://docs.spongepowered.org/stable/en/contributing/guidelines.html) for more information.


### PR DESCRIPTION
Just changed the link from https://docs.spongepowered.org/en/contributing/guidelines.html to https://docs.spongepowered.org/stable/en/contributing/guidelines.html