### PR TITLE
Support Schematic Specification v3

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/EntityArchetype.java
+++ b/src/main/java/org/spongepowered/api/entity/EntityArchetype.java
@@ -52,16 +52,6 @@ public interface EntityArchetype extends Archetype<EntitySnapshot, Entity> {
      * @param type Type of the entity
      * @return An archetype of the given entity type
      */
-    static EntityArchetype of(Supplier<? extends EntityType<?>> type) {
-        return EntityArchetype.builder().type(type).build();
-    }
-
-    /**
-     * Creates a new {@link EntityArchetype} with the specified {@link EntityType}.
-     *
-     * @param type Type of the entity
-     * @return An archetype of the given entity type
-     */
     static EntityArchetype of(EntityType<?> type) {
         return EntityArchetype.builder().type(type).build();
     }
@@ -104,16 +94,6 @@ public interface EntityArchetype extends Archetype<EntitySnapshot, Entity> {
          * @return This builder, for chaining
          */
         Builder from(Entity entity);
-
-        /**
-         * Sets the desired {@link EntityType} of the produced {@link EntityArchetype}.
-         *
-         * @param type The type of entity type
-         * @return This builder, for chaining
-         */
-        default Builder type(Supplier<? extends EntityType<?>> type) {
-            return this.type(type.get());
-        }
 
         /**
          * Sets the desired {@link EntityType} of the produced {@link EntityArchetype}.

--- a/src/main/java/org/spongepowered/api/util/rotation/Rotation.java
+++ b/src/main/java/org/spongepowered/api/util/rotation/Rotation.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.util.rotation;
 
 import org.spongepowered.api.registry.DefaultedRegistryValue;
+import org.spongepowered.api.util.Angle;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 @CatalogedBy(Rotations.class)
@@ -35,8 +36,8 @@ public interface Rotation extends DefaultedRegistryValue {
     /**
      * Gets the the rotation in degrees always in clockwise order.
      *
-     * @return The rotation in degrees
+     * @return The rotation
      */
-    int angle();
+    Angle angle();
 
 }

--- a/src/main/java/org/spongepowered/api/util/rotation/Rotation.java
+++ b/src/main/java/org/spongepowered/api/util/rotation/Rotation.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.util.rotation;
 import org.spongepowered.api.registry.DefaultedRegistryValue;
 import org.spongepowered.api.util.Angle;
 import org.spongepowered.api.util.annotation.CatalogedBy;
+import org.spongepowered.math.matrix.Matrix4d;
 
 @CatalogedBy(Rotations.class)
 public interface Rotation extends DefaultedRegistryValue {
@@ -39,5 +40,38 @@ public interface Rotation extends DefaultedRegistryValue {
      * @return The rotation
      */
     Angle angle();
+
+    /**
+     * Gets the {@link Matrix4d 4D rotation matrix} of this rotation.
+     *
+     * <p>Minecraft's coordinate system is different than traditional systems
+     * applying the semantic meaning behind the {@code x} and {@code z} axis.
+     * These natures are described as below:
+     * </p>
+     * <ul>
+     *     <li>The x-axis indicates the <b>east</b> (when positive) or <b>west</b>
+     *     (when negative) of the origin point {@code (0, 0, 0)}</li>
+     *     <li>The z-axis indicates the <b>south</b> (when positive) or <b>north</b>
+     *     (when negative) of the origin point {@code (0, 0, 0)}</li>
+     * </ul>
+     * <p>
+     * These rules differ from traditional coordinate interpretations and
+     * therefore may be unintuitive when a rotation of {@code 90} degrees will
+     * instead rotate the coordinates {@code (1, 1, 1)} across the pivot
+     * {@code (0, 0, 0)}
+     * </p>
+     *
+     * @return The euler matrix that represents this rotation in the X-Z plane.
+     */
+    default Matrix4d toRotationMatrix() {
+        final int cos = (int) Math.round(Math.cos(Math.toRadians(-this.angle().degrees())));
+        final int sin = (int) Math.round(Math.sin(Math.toRadians(-this.angle().degrees())));
+        return Matrix4d.from(
+            cos, 0, sin, 0,
+            0, 1, 0, 0,
+            -sin, 0, cos, 0,
+            0, 0, 0, 1
+        );
+    }
 
 }

--- a/src/main/java/org/spongepowered/api/util/transformation/Transformation.java
+++ b/src/main/java/org/spongepowered/api/util/transformation/Transformation.java
@@ -1,0 +1,247 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.util.transformation;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.util.Axis;
+import org.spongepowered.api.util.ResettableBuilder;
+import org.spongepowered.api.util.rotation.Rotation;
+import org.spongepowered.api.util.rotation.Rotations;
+import org.spongepowered.math.matrix.Matrix4d;
+import org.spongepowered.math.vector.Vector3d;
+
+/**
+ * Performs spacial transformations on position and direction
+ * {@link Vector3d}s, for general use in block transformations.
+ */
+public interface Transformation {
+
+    /**
+     * Gets a {@link Transformation.Builder} for creating transformations.
+     *
+     * @return A builder
+     */
+    static Transformation.Builder builder() {
+        return Sponge.game().builderProvider().provide(Transformation.Builder.class);
+    }
+
+    /**
+     * Transforms a {@link Vector3d} that represents a position based on the
+     * transformation this object represents.
+     *
+     * @param original The position vector to transform
+     * @return The transformed position vector
+     */
+    Vector3d transformPosition(Vector3d original);
+
+    /**
+     * Transforms a {@link Vector3d} that represents a direction based on the
+     * transformation this object represents.
+     *
+     * <p>Specifically, this transformation will not apply any translational
+     * transformations.</p>
+     *
+     * @param originalDirection The direction vector to transform
+     * @return The transformed direction vector
+     */
+    Vector3d transformDirection(Vector3d originalDirection);
+
+    /**
+     * Gets the {@link Matrix4d matrix} used to perform this transformation
+     * on position vectors.
+     *
+     * @return The {@link Matrix4d}
+     */
+    Matrix4d positionTransformationMatrix();
+
+    /**
+     * Gets the {@link Matrix4d matrix} used to perform this transformation
+     * on direction vectors.
+     *
+     * @return The {@link Matrix4d}
+     */
+    Matrix4d directionTransformationMatrix();
+
+    /**
+     * Gets the origin of the {@linkplain #positionTransformationMatrix()
+     * position transformation matrix}.
+     *
+     * @return The origin of the position transformations
+     */
+    Vector3d origin();
+
+    /**
+     * Gets the {@link Rotation} around the y-axis
+     *
+     * @return The {@link Rotation}
+     */
+    Rotation rotation();
+
+    /**
+     * Returns whether this transformation results in mirroring in the
+     * direction of the provided axis.
+     *
+     * <p>This represents any mirroring that would need to occur
+     * <strong>after</strong> any rotation has occurred. If you require
+     * knowing what the mirror state would be pre-rotation, use
+     * {@link #initialMirror(Axis)} instead.</p>
+     *
+     * @param axis The {@link Axis}
+     * @return true if so
+     */
+    boolean mirror(Axis axis);
+
+    /**
+     * Returns the direction of mirroring in this transformation, if
+     * mirroring was performed before rotation, at the point before
+     * the mirroring occurs. The axis is in the direction of the
+     * mirroring.
+     *
+     * <p>Unlike {@link #mirror(Axis)}, which provides a view to
+     * the direction(s) of mirroring after all transformations have
+     * taken place, this method returns the direction of mirroring
+     * <strong>before any rotation has taken place</strong>, such
+     * that if the {@link #rotation()} was set to
+     * {@link Rotations#NONE}, this would be the direction of
+     * mirroring.</p>
+     *
+     * @param axis The {@link Axis}
+     * @return true if so
+     */
+    boolean initialMirror(Axis axis);
+
+    /**
+     * Gets the {@link Transformation} that reverses this transformation.
+     *
+     * @return The inverse transformation
+     */
+    Transformation inverse();
+
+    /**
+     * If this is {@code true}, then this transformation will attempt to round
+     * the result to reduce the effects of machine precision, which may be
+     * particularly useful for those who expect integer values.
+     *
+     * <p>The rounding should be on the order of 15 decimal places,
+     * though other implementations may choose more sophisticated rounding.</p>
+     *
+     * @return Whether the result will have minor rounding applied.
+     */
+    boolean performsRounding();
+
+    /**
+     * Creates a {@link Builder} that represents this transformation.
+     *
+     * @return The builder.
+     */
+    Builder toBuilder();
+
+    /**
+     * Creates {@link Transformation transformations}.
+     *
+     * <p>Apart from the {@link #origin(Vector3d) origin} transformation, all
+     * actions will be performed in the order specified in the builder. Thus,
+     * a translation then a rotation will not produce the same results as
+     * the reverse.</p>
+     */
+    interface Builder extends ResettableBuilder<Transformation, Builder> {
+
+        /**
+         * Specifies the origin for position transformations.
+         *
+         * <p>This is a special transform in that this translation is performed
+         * before the rest of the transformations are made. Once all
+         * transformations are performed, this transformation is undone. This
+         * is especially useful if you are only transforming around a given
+         * origin which is not at (0, 0, 0), as the rotation will be performed
+         * around this origin instead.</p>
+         *
+         * <p>This does not affect
+         * {@link Transformation#transformDirection(Vector3d)}</p>
+         *
+         * @param origin The origin to transform around
+         * @return This builder, for chaining
+         */
+        Builder origin(Vector3d origin);
+
+        /**
+         * Performs a rotation about the provided {@link Axis} around the given
+         * {@link #origin(Vector3d) origin} around the {@link Axis#Y y-axis}.
+         *
+         * @param rotation The {@link Rotation} to perform
+         * @return This builder, for chaining
+         */
+        Builder rotate(Rotation rotation);
+
+        /**
+         * Performs a reflection of -1 in the direction of the given
+         * {@link Axis}, where the plane from which scaling is performed is
+         * normal to this axis and contains the {@link #origin(Vector3d)}.
+         *
+         * <p>For example, for a point (1, 2, 3), using this transformation
+         * in the direction the x axis where the origin is at (0, 0, 0) will
+         * result in a transformation to (-1, 2, 3).</p>
+         *
+         * <p>This action is effectively a scaling of -1 in the axis
+         * direction.</p>
+         *
+         * @param axis The axis that represents the direction of scaling
+         * @return This builder, for chaining
+         */
+        Builder mirror(Axis axis);
+
+        /**
+         * Performs a simple additive translation of a position {@link Vector3d}
+         * by this supplied vector.
+         *
+         * <p>This does not affect
+         * {@link Transformation#transformDirection(Vector3d)}</p>
+         *
+         * @param translate The translation
+         * @return This builder, for chaining
+         */
+        Builder translate(Vector3d translate);
+
+        /**
+         * Attempts to round the result to attempt to compensate for
+         * machine precision. Defaults to {@code true}.
+         *
+         * @see #performsRounding()
+         *
+         * @param round Whether to perform rounding
+         * @return This builder, for chaining
+         */
+        Builder performRounding(boolean round);
+
+        /**
+         * Builds a {@link Transformation}
+         *
+         * @return A {@link Transformation}
+         */
+        Transformation build();
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/world/ProtoWorld.java
+++ b/src/main/java/org/spongepowered/api/world/ProtoWorld.java
@@ -44,10 +44,10 @@ import java.util.Objects;
 
 public interface ProtoWorld<P extends ProtoWorld<P>> extends
     Region<P>,
-    BiomeVolume.Mutable<P>, // Because this is mutable
-    BlockVolume.Mutable<P>, // Because this is mutable
-    EntityVolume.Mutable<P>, // Because this is mutable
-    BlockEntityVolume.Mutable<P>, // Because this is mutable
+    BiomeVolume.Modifiable<P>, // Because this is mutable
+    BlockVolume.Modifiable<P>, // Because this is mutable
+    EntityVolume.Modifiable<P>, // Because this is mutable
+    BlockEntityVolume.Modifiable<P>, // Because this is mutable
     GenerationVolume.Mutable,
     LocationBaseDataHolder.Mutable,
     UpdatableVolume,

--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -50,8 +50,16 @@ import java.util.function.Predicate;
  * A loaded Minecraft world.
  */
 @DoNotStore
-public interface World<W extends World<W, L>, L extends Location<W, L>> extends ForwardingAudience, ProtoWorld<W>, LocationCreator<W, L>,
-        PhysicsAwareMutableBlockVolume<W>, ContextSource, Viewer, ArchetypeVolumeCreator, WeatherUniverse, ScopedRegistryHolder {
+public interface World<W extends World<W, L>, L extends Location<W, L>> extends
+    ForwardingAudience,
+    ProtoWorld<W>,
+    LocationCreator<W, L>,
+    PhysicsAwareMutableBlockVolume<W>,
+    ContextSource,
+    Viewer,
+    ArchetypeVolumeCreator,
+    WeatherUniverse,
+    ScopedRegistryHolder {
 
     /**
      * Gets the {@link WorldProperties properties}.

--- a/src/main/java/org/spongepowered/api/world/chunk/Chunk.java
+++ b/src/main/java/org/spongepowered/api/world/chunk/Chunk.java
@@ -40,7 +40,7 @@ import java.util.Optional;
  * <p>In Minecraft, the chunk is 16 by 16 blocks on the X and Z axes. The height
  * of each chunk varies between worlds.</p>
  */
-public interface Chunk extends ProtoChunk<Chunk>, EntityVolume.Mutable<Chunk> {
+public interface Chunk extends ProtoChunk<Chunk>, EntityVolume.Modifiable<Chunk> {
 
     /**
      * Gets the world the chunk is in.

--- a/src/main/java/org/spongepowered/api/world/chunk/ProtoChunk.java
+++ b/src/main/java/org/spongepowered/api/world/chunk/ProtoChunk.java
@@ -52,9 +52,9 @@ import org.spongepowered.math.vector.Vector3i;
  */
 @DoNotStore
 public interface ProtoChunk<P extends ProtoChunk<P>> extends
-    BlockVolume.Mutable<P>,
-    BlockEntityVolume.Mutable<P>,
-    BiomeVolume.Mutable<P>,
+    BlockVolume.Modifiable<P>,
+    BlockEntityVolume.Modifiable<P>,
+    BiomeVolume.Modifiable<P>,
     UpdatableVolume,
     LocationBaseDataHolder.Mutable,
     HeightAwareVolume {

--- a/src/main/java/org/spongepowered/api/world/schematic/PaletteType.java
+++ b/src/main/java/org/spongepowered/api/world/schematic/PaletteType.java
@@ -42,7 +42,11 @@ public interface PaletteType<T, R> extends DefaultedRegistryValue {
         return Sponge.game().builderProvider().provide(Builder.class);
     }
 
-    Palette<T, R> create(RegistryHolder holder, RegistryType<R> registryType);
+    default Palette<T, R> create(RegistryHolder holder, RegistryType<R> registryType) {
+        return this.create(holder.registry(registryType));
+    }
+
+    Palette<T, R> create(Registry<R> registry);
 
     BiFunction<String, Registry<R>, Optional<T>> resolver();
 

--- a/src/main/java/org/spongepowered/api/world/schematic/PaletteTypes.java
+++ b/src/main/java/org/spongepowered/api/world/schematic/PaletteTypes.java
@@ -28,6 +28,7 @@ import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.block.entity.BlockEntityType;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
@@ -57,6 +58,8 @@ public final class PaletteTypes {
      * {@link BlockState biome} is registered via {@link Palette.Mutable#orAssign (Object)}
      */
     public static final DefaultedRegistryReference<PaletteType<BlockState, BlockType>> BLOCK_STATE_PALETTE = PaletteTypes.key(ResourceKey.sponge("block_state_palette"));
+
+    public static final DefaultedRegistryReference<PaletteType<BlockEntityType, BlockEntityType>> BLOCK_ENTITY_PALETTE = PaletteTypes.key(ResourceKey.sponge("block_entity_type_palette"));
 
     // SORTFIELDS:OFF
 

--- a/src/main/java/org/spongepowered/api/world/schematic/Schematic.java
+++ b/src/main/java/org/spongepowered/api/world/schematic/Schematic.java
@@ -90,6 +90,11 @@ public interface Schematic extends ArchetypeVolume, LocationBaseDataHolder.Mutab
 
         /**
          * Specifies an archetype volume for the world data of the schematic.
+         * This is to take part of the schematic, so it should not be referenced
+         * outside of the schematic, less modifications are going to be made
+         * also affecting {@link #blockEntities(BlockEntityVolume) the block
+         * entity volume}.
+         *
          *
          * @param volume The archetype volume
          * @return This builder, for chaining

--- a/src/main/java/org/spongepowered/api/world/volume/archetype/ArchetypeVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/archetype/ArchetypeVolume.java
@@ -24,13 +24,73 @@
  */
 package org.spongepowered.api.world.volume.archetype;
 
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.event.CauseStackManager;
+import org.spongepowered.api.event.EventContextKeys;
+import org.spongepowered.api.event.cause.entity.SpawnType;
+import org.spongepowered.api.registry.Registry;
+import org.spongepowered.api.registry.RegistryTypes;
+import org.spongepowered.api.world.BlockChangeFlags;
+import org.spongepowered.api.world.biome.Biome;
+import org.spongepowered.api.world.server.ServerWorld;
 import org.spongepowered.api.world.volume.archetype.block.entity.BlockEntityArchetypeVolume;
 import org.spongepowered.api.world.volume.archetype.entity.EntityArchetypeVolume;
 import org.spongepowered.api.world.volume.biome.BiomeVolume;
 import org.spongepowered.api.world.volume.block.BlockVolume;
+import org.spongepowered.api.world.volume.stream.StreamOptions;
+import org.spongepowered.api.world.volume.stream.VolumeApplicators;
+import org.spongepowered.api.world.volume.stream.VolumeCollectors;
+import org.spongepowered.api.world.volume.stream.VolumePositionTranslators;
+import org.spongepowered.math.vector.Vector3i;
+
+import java.util.Objects;
+import java.util.function.Supplier;
 
 public interface ArchetypeVolume extends BlockVolume.Mutable<ArchetypeVolume>,
     BlockEntityArchetypeVolume.Mutable<ArchetypeVolume>,
     EntityArchetypeVolume.Mutable<ArchetypeVolume>,
     BiomeVolume.Mutable<ArchetypeVolume> {
+
+    Registry<BlockType> blockStateRegistry();
+
+    Registry<Biome> biomeRegistry();
+
+    default void applyToWorld(final ServerWorld target, final Vector3i placement, final Supplier<SpawnType> spawnContext) {
+        Objects.requireNonNull(target, "Target world cannot be null");
+        Objects.requireNonNull(placement, "Target position cannot be null");
+        try (final CauseStackManager.StackFrame frame = Sponge.server().causeStackManager().pushCauseFrame()) {
+            this.blockStateStream(this.blockMin(), this.blockMax(), StreamOptions.lazily())
+                .apply(VolumeCollectors.of(
+                    target,
+                    VolumePositionTranslators.relativeTo(placement),
+                    VolumeApplicators.applyBlocks(BlockChangeFlags.ALL)
+                ));
+
+            this.biomeStream(this.blockMin(), this.blockMax(), StreamOptions.lazily())
+                // It's common that we'll have to be translating back and forth between ResourceKeys because a Biome
+                // is reloadable between worlds (one biome instance can be limited to that world)
+                .map((v, b, x, y, z) -> this.biomeRegistry().valueKey(b.get()))
+                .map((v, key, x, y, z) -> target.registries().registry(RegistryTypes.BIOME).<Biome>value(key.get()))
+                .apply(VolumeCollectors.of(
+                    target,
+                    VolumePositionTranslators.relativeTo(placement),
+                    VolumeApplicators.applyBiomes()
+                ));
+            this.blockEntityArchetypeStream(this.blockMin(), this.blockMax(), StreamOptions.lazily())
+                .apply(VolumeCollectors.of(
+                    target,
+                    VolumePositionTranslators.relativeTo(placement),
+                    VolumeApplicators.applyBlockEntityArchetype()
+                ));
+            frame.addContext(EventContextKeys.SPAWN_TYPE, spawnContext);
+            this.entityArchetypeStream(this.blockMin(), this.blockMax(), StreamOptions.lazily())
+                .apply(VolumeCollectors.of(
+                    target,
+                    VolumePositionTranslators.relativeTo(placement),
+                    VolumeApplicators.applyEntityArchetype()
+                ));
+        }
+    }
+
 }

--- a/src/main/java/org/spongepowered/api/world/volume/archetype/ArchetypeVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/archetype/ArchetypeVolume.java
@@ -28,8 +28,7 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.event.EventContextKeys;
 import org.spongepowered.api.event.cause.entity.SpawnType;
-import org.spongepowered.api.util.mirror.Mirror;
-import org.spongepowered.api.util.rotation.Rotation;
+import org.spongepowered.api.util.transformation.Transformation;
 import org.spongepowered.api.world.BlockChangeFlags;
 import org.spongepowered.api.world.server.ServerWorld;
 import org.spongepowered.api.world.volume.archetype.block.entity.BlockEntityArchetypeVolume;
@@ -40,6 +39,7 @@ import org.spongepowered.api.world.volume.stream.StreamOptions;
 import org.spongepowered.api.world.volume.stream.VolumeApplicators;
 import org.spongepowered.api.world.volume.stream.VolumeCollectors;
 import org.spongepowered.api.world.volume.stream.VolumePositionTranslators;
+import org.spongepowered.math.vector.Vector3d;
 import org.spongepowered.math.vector.Vector3i;
 
 import java.util.Objects;
@@ -49,6 +49,17 @@ public interface ArchetypeVolume extends BlockVolume.Modifiable<ArchetypeVolume>
     BlockEntityArchetypeVolume.Modifiable<ArchetypeVolume>,
     EntityArchetypeVolume.Modifiable<ArchetypeVolume>,
     BiomeVolume.Modifiable<ArchetypeVolume> {
+
+    ArchetypeVolume transform(Transformation transformation);
+
+    /**
+     * Gets the logical center of a volume, considering the decimal coordinates,
+     * the block's center location would have an offset of {@code 0.5}
+     * @return
+     */
+    default Vector3d logicalCenter() {
+        return this.blockMin().toDouble().add(this.blockSize().toDouble().div(2));
+    }
 
     /**
      * Attempts to apply all of the contents of this

--- a/src/main/java/org/spongepowered/api/world/volume/archetype/ArchetypeVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/archetype/ArchetypeVolume.java
@@ -25,14 +25,12 @@
 package org.spongepowered.api.world.volume.archetype;
 
 import org.spongepowered.api.Sponge;
-import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.event.EventContextKeys;
 import org.spongepowered.api.event.cause.entity.SpawnType;
-import org.spongepowered.api.registry.Registry;
-import org.spongepowered.api.registry.RegistryTypes;
+import org.spongepowered.api.util.mirror.Mirror;
+import org.spongepowered.api.util.rotation.Rotation;
 import org.spongepowered.api.world.BlockChangeFlags;
-import org.spongepowered.api.world.biome.Biome;
 import org.spongepowered.api.world.server.ServerWorld;
 import org.spongepowered.api.world.volume.archetype.block.entity.BlockEntityArchetypeVolume;
 import org.spongepowered.api.world.volume.archetype.entity.EntityArchetypeVolume;

--- a/src/main/java/org/spongepowered/api/world/volume/archetype/block/entity/BlockEntityArchetypeVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/archetype/block/entity/BlockEntityArchetypeVolume.java
@@ -91,9 +91,7 @@ public interface BlockEntityArchetypeVolume extends BlockVolume {
 
     }
 
-    interface Mutable<M extends Mutable<M>> extends Streamable<M>,
-        BlockVolume.Mutable<M>,
-        MutableVolume {
+    interface Modifiable<M extends Modifiable<M>> extends Streamable<M>, BlockVolume.Modifiable<M>, MutableVolume {
 
         default void addBlockEntity(final Vector3i pos, final BlockEntity blockEntity) {
             this.addBlockEntity(pos.x(), pos.y(), pos.z(), blockEntity);
@@ -114,6 +112,10 @@ public interface BlockEntityArchetypeVolume extends BlockVolume {
         }
 
         void removeBlockEntity(int x, int y, int z);
+    }
+
+    interface Mutable extends Modifiable<Mutable> {
+
 
     }
 

--- a/src/main/java/org/spongepowered/api/world/volume/archetype/entity/EntityArchetypeVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/archetype/entity/EntityArchetypeVolume.java
@@ -53,6 +53,8 @@ public interface EntityArchetypeVolume extends Volume {
 
     Collection<EntityArchetype> entityArchetypes();
 
+    Collection<EntityArchetypeEntry> entityArchetypesByPosition();
+
     Collection<EntityArchetype> entityArchetypes(Predicate<EntityArchetype> filter);
 
     interface Streamable<B extends Streamable<B>> extends EntityArchetypeVolume {

--- a/src/main/java/org/spongepowered/api/world/volume/archetype/entity/EntityArchetypeVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/archetype/entity/EntityArchetypeVolume.java
@@ -94,7 +94,7 @@ public interface EntityArchetypeVolume extends Volume {
 
     }
 
-    interface Mutable<M extends Mutable<M>> extends Streamable<M>, MutableVolume {
+    interface Modifiable<M extends Modifiable<M>> extends Streamable<M>, MutableVolume {
 
         default void addEntity(final EntityArchetype archetype, final Vector3d position) {
             this.addEntity(EntityArchetypeEntry.of(
@@ -104,6 +104,10 @@ public interface EntityArchetypeVolume extends Volume {
         }
 
         void addEntity(EntityArchetypeEntry entry);
+
+    }
+
+    interface Mutable extends Modifiable<Mutable> {
 
     }
 

--- a/src/main/java/org/spongepowered/api/world/volume/biome/BiomeVolumeFactory.java
+++ b/src/main/java/org/spongepowered/api/world/volume/biome/BiomeVolumeFactory.java
@@ -22,25 +22,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.world.volume.block;
+package org.spongepowered.api.world.volume.biome;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.spongepowered.api.block.BlockState;
-import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.registry.RegistryReference;
+import org.spongepowered.api.world.biome.Biome;
 import org.spongepowered.api.world.schematic.Palette;
+import org.spongepowered.api.world.volume.virtual.UnrealizedBiomeVolume;
 import org.spongepowered.math.vector.Vector3i;
 
-public interface BlockVolumeFactory {
+public interface BiomeVolumeFactory {
 
-    BlockVolume.Mutable empty(Palette<BlockState, BlockType> palette, RegistryReference<BlockType> defaultState, Vector3i min, Vector3i max);
+    BiomeVolume.Mutable empty(Palette<Biome, Biome> palette, RegistryReference<Biome> defaultBiome, Vector3i min, Vector3i max);
 
-    BlockVolume.Mutable copyFromRange(BlockVolume.Streamable<@NonNull ?> existing, Vector3i newMin, Vector3i newMax);
+    BiomeVolume.Mutable copyFromRange(BiomeVolume.Streamable<@NonNull ?> existing, Vector3i newMin, Vector3i newMax);
 
-    BlockVolume.Mutable copy(BlockVolume.Streamable<@NonNull ?> existing);
+    BiomeVolume.Mutable copy(BiomeVolume.Streamable<@NonNull ?> existing);
 
-    BlockVolume.Immutable immutableOf(BlockVolume.Streamable<@NonNull ?> existing);
+    BiomeVolume.Immutable immutableOf(BiomeVolume.Streamable<@NonNull ?> existing);
 
-    BlockVolume.Immutable immutableOf(BlockVolume.Streamable<@NonNull ?> existing, Vector3i newMin, Vector3i newMax);
+    BiomeVolume.Immutable immutableOf(BiomeVolume.Streamable<@NonNull ?> existing, Vector3i newMin, Vector3i newMax);
+
+    UnrealizedBiomeVolume.Mutable empty(Vector3i min, Vector3i max);
 
 }

--- a/src/main/java/org/spongepowered/api/world/volume/block/BlockVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/block/BlockVolume.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.world.volume.block;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
@@ -46,14 +45,6 @@ import org.spongepowered.math.vector.Vector2i;
 import org.spongepowered.math.vector.Vector3i;
 
 public interface BlockVolume extends Volume {
-
-    static BlockVolume.Mutable<@NonNull ?> empty(final Vector3i min, final Vector3i max) {
-        return BlockVolume.empty(PaletteTypes.BLOCK_STATE_PALETTE.get().create(Sponge.game().registries(), RegistryTypes.BLOCK_TYPE), BlockTypes.AIR, min, max);
-    }
-
-    static BlockVolume.Mutable<@NonNull ?> empty(final Palette<BlockState, BlockType> palette, final RegistryReference<BlockType> defaultState, final Vector3i min, final Vector3i max) {
-        return Sponge.game().factoryProvider().provide(BlockVolumeFactory.class).empty(palette, defaultState, min, max);
-    }
 
     BlockState block(int x, int y, int z);
 
@@ -138,7 +129,7 @@ public interface BlockVolume extends Volume {
 
     }
 
-    interface Mutable<M extends Mutable<M>> extends Streamable<M>, MutableVolume {
+    interface Modifiable<M extends Modifiable<M>> extends Streamable<M>, MutableVolume {
 
         /**
          * Sets the block at the given position in the world.
@@ -171,6 +162,19 @@ public interface BlockVolume extends Volume {
         }
 
         boolean removeBlock(int x, int y, int z);
+    }
 
+    interface Mutable extends Modifiable<Mutable> {
+
+        static Mutable empty(final Vector3i min, final Vector3i max) {
+            return Mutable.empty(PaletteTypes.BLOCK_STATE_PALETTE.get().create(Sponge.game().registries(), RegistryTypes.BLOCK_TYPE), BlockTypes.AIR, min, max);
+        }
+
+        static Mutable empty(
+            final Palette<BlockState, BlockType> palette, final RegistryReference<BlockType> defaultState,
+            final Vector3i min, final Vector3i max
+        ) {
+            return Sponge.game().factoryProvider().provide(BlockVolumeFactory.class).empty(palette, defaultState, min, max);
+        }
     }
 }

--- a/src/main/java/org/spongepowered/api/world/volume/block/PhysicsAwareMutableBlockVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/block/PhysicsAwareMutableBlockVolume.java
@@ -30,7 +30,7 @@ import org.spongepowered.api.world.BlockChangeFlag;
 import org.spongepowered.api.world.BlockChangeFlags;
 import org.spongepowered.math.vector.Vector3i;
 
-public interface PhysicsAwareMutableBlockVolume<P extends PhysicsAwareMutableBlockVolume<P>> extends BlockVolume.Mutable<P> {
+public interface PhysicsAwareMutableBlockVolume<P extends PhysicsAwareMutableBlockVolume<P>> extends BlockVolume.Modifiable<P> {
 
     /**
      * {@inheritDoc}

--- a/src/main/java/org/spongepowered/api/world/volume/block/entity/BlockEntityVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/block/entity/BlockEntityVolume.java
@@ -116,7 +116,7 @@ public interface BlockEntityVolume extends BlockVolume, Volume {
 
     }
 
-    interface Mutable<M extends Mutable<M>> extends Streamable<M>, BlockVolume.Mutable<M>, MutableVolume {
+    interface Modifiable<M extends Modifiable<M>> extends Streamable<M>, BlockVolume.Modifiable<M>, MutableVolume {
 
         default void addBlockEntity(final Vector3i pos, final BlockEntity blockEntity) {
             this.addBlockEntity(pos.x(), pos.y(), pos.z(), blockEntity);
@@ -129,6 +129,10 @@ public interface BlockEntityVolume extends BlockVolume, Volume {
         }
 
         void removeBlockEntity(int x, int y, int z);
+    }
+
+    interface Mutable extends Modifiable<Mutable> {
+
 
     }
 }

--- a/src/main/java/org/spongepowered/api/world/volume/entity/EntityVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/entity/EntityVolume.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.world.volume.entity;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.persistence.DataContainer;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.entity.Entity;
@@ -37,6 +38,7 @@ import org.spongepowered.api.world.volume.MutableVolume;
 import org.spongepowered.api.world.volume.UnmodifiableVolume;
 import org.spongepowered.api.world.volume.Volume;
 import org.spongepowered.api.world.volume.block.BlockVolume;
+import org.spongepowered.api.world.volume.block.BlockVolumeFactory;
 import org.spongepowered.api.world.volume.stream.StreamOptions;
 import org.spongepowered.api.world.volume.stream.VolumeStream;
 import org.spongepowered.math.vector.Vector3d;
@@ -156,7 +158,7 @@ public interface EntityVolume extends Volume {
 
     }
 
-    interface Mutable<M extends Mutable<M>> extends Streamable<M>, MutableVolume, BlockVolume.Mutable<M> {
+    interface Modifiable<M extends Modifiable<M>> extends Streamable<M>, MutableVolume, BlockVolume.Modifiable<M> {
 
         /**
          * Create an entity instance at the given position.
@@ -385,6 +387,20 @@ public interface EntityVolume extends Volume {
          * @return The entities which spawned correctly, or empty if none
          */
         Collection<Entity> spawnEntities(Iterable<? extends Entity> entities);
+
+    }
+
+    interface Mutable extends Modifiable<Mutable> {
+
+        static EntityVolume.Mutable empty(Vector3i min, Vector3i max) {
+            return Sponge.game().factoryProvider().provide(EntityVolumeFactory.class).empty(min, max);
+        }
+
+    }
+
+    interface EntityVolumeFactory {
+
+        EntityVolume.Mutable empty(Vector3i min, Vector3i max);
 
     }
 

--- a/src/main/java/org/spongepowered/api/world/volume/stream/VolumeApplicators.java
+++ b/src/main/java/org/spongepowered/api/world/volume/stream/VolumeApplicators.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.world.volume.stream;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.entity.BlockEntity;
 import org.spongepowered.api.block.entity.BlockEntityArchetype;
@@ -99,7 +100,6 @@ public final class VolumeApplicators {
         return (volume, element) -> element.type().apply((ServerLocation) volume.location(element.position()));
     }
 
-    @SuppressWarnings("ConstantConditions")
     public static <M extends BlockEntityArchetypeVolume.Mutable<M>> VolumeApplicator<M, BlockEntityArchetype, Boolean> applyBlockEntityArchetypes() {
         return (volume, element) -> {
             volume.addBlockEntity(element.position(), element.type());
@@ -115,7 +115,8 @@ public final class VolumeApplicators {
         return (volume, element) -> volume.setBiome(element.position(), element.type());
     }
 
-    public static <M extends LocationCreator<?, ? extends ServerLocation> & EntityVolume.Mutable<M>> VolumeApplicator<M, EntityArchetype, Optional<?
+    @SuppressWarnings("RedundantCast")
+    public static <M extends LocationCreator<@NonNull ?, ? extends ServerLocation> & EntityVolume.Mutable<M>> VolumeApplicator<M, EntityArchetype, Optional<?
             extends Entity>> applyEntityArchetype() {
         return (volume, element) -> element.type().apply((ServerLocation) volume.location(element.position()));
     }

--- a/src/main/java/org/spongepowered/api/world/volume/stream/VolumeApplicators.java
+++ b/src/main/java/org/spongepowered/api/world/volume/stream/VolumeApplicators.java
@@ -45,18 +45,55 @@ import org.spongepowered.api.world.volume.entity.EntityVolume;
 import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * A collection of default implemented {@link VolumeApplicator}s for various
+ * "traditional" use cases.
+ */
 public final class VolumeApplicators {
 
-    public static <M extends BlockVolume.Mutable<M>> VolumeApplicator<M, BlockState, Boolean> applyBlocks() {
+    /**
+     * A standard {@link VolumeApplicator} that applies a {@link BlockState} to
+     * any {@link BlockVolume.Modifiable}.
+     *
+     * <p>Note that this has a different side
+     * effect compared to {@link #applyBlocks(BlockChangeFlag)} if the target
+     * {@link BlockVolume volume} is a {@link PhysicsAwareMutableBlockVolume}
+     * due to the nature of applying blocks with a {@link BlockChangeFlag}. It
+     * can be expected that applying blocks directly with this applicator will
+     * likely result in side effects playing out to their full extent per block
+     * changed.</p>
+     *
+     * @param <M> The type of modifiable block volume
+     * @return A blockstate based VolumeApplicator
+     */
+    public static <M extends BlockVolume.Modifiable<M>> VolumeApplicator<M, BlockState, Boolean> applyBlocks() {
         return ((volume, element) -> volume.setBlock(element.position(), element.type()));
     }
 
+    /**
+     * Creates a "physics aware" variation of a {@link VolumeApplicator} that
+     * applies {@link BlockState BlockStates} with side effects in accordance
+     * with the passed in {@link BlockChangeFlag}.
+     *
+     * @param flag The respective change flag to signal what side effects to
+     *      play out on application
+     * @param <M> The target volume type that accepts a BlockChangeFlag
+     * @return A blockstate based VolumeApplicator
+     */
     public static <M extends PhysicsAwareMutableBlockVolume<M>> VolumeApplicator<M, BlockState, Boolean> applyBlocks(final BlockChangeFlag flag) {
         Objects.requireNonNull(flag, "BlockChangeFlag cannot be null!");
         return ((volume, element) -> volume.setBlock(element.position(), element.type(), flag));
     }
 
-    public static <M extends BlockEntityVolume.Mutable<M>> VolumeApplicator<M, BlockEntity, Boolean> applyBlockEntities() {
+    /**
+     * A generic applicator to add a {@link BlockEntity} to a target {@link BlockEntityVolume volume}.
+     * This does have the best intention of attempting to set the target's
+     * container {@link BlockState} prior to adding the {@link BlockEntity}.
+     *
+     * @param <M> The type of modifiable volume
+     * @return An applicator to add block entities
+     */
+    public static <M extends BlockEntityVolume.Modifiable<M>> VolumeApplicator<M, BlockEntity, Boolean> applyBlockEntities() {
         return (volume, element) -> {
             if (volume.setBlock(element.position(), element.type().block())) {
                 volume.addBlockEntity(element.position(), element.type());
@@ -66,7 +103,17 @@ public final class VolumeApplicators {
         };
     }
 
-    public static <M extends BlockEntityVolume.Mutable<M>> VolumeApplicator<M, Optional<? extends BlockEntity>, Boolean> applyOrRemoveBlockEntities() {
+    /**
+     * A potentially useful {@link VolumeApplicator} that conditionally adds or
+     * removes a {@link BlockEntity}/{@link BlockState} based on the element's
+     * {@link Optional} state of being {@link Optional#empty()} or
+     * {@link Optional#isPresent()}.
+     *
+     * @param <M> The type of modifiable block entity volume
+     * @return An applicator that conditionally adds block entities or removes
+     *   blocks
+     */
+    public static <M extends BlockEntityVolume.Modifiable<M>> VolumeApplicator<M, Optional<? extends BlockEntity>, Boolean> applyOrRemoveBlockEntities() {
         return (volume, element) -> {
             final Optional<? extends BlockEntity> blockEntityOpt = element.type();
             if (blockEntityOpt.isPresent()) {
@@ -82,46 +129,94 @@ public final class VolumeApplicators {
         };
     }
 
-    public static <M extends BlockVolume.Mutable<M>> VolumeApplicator<M, Optional<BlockState>, Boolean> applyOrRemoveBlockState() {
+    /**
+     * A potentially useful {@link VolumeApplicator} that conditionally adds or
+     * removes a {@link BlockState} based on the element's
+     * {@link Optional} state of being {@link Optional#empty()} or
+     * {@link Optional#isPresent()}.
+     *
+     * @param <M> The type of modifiable block volume
+     * @return An applicator that conditionally sets a block or removes a block
+     */
+    public static <M extends BlockVolume.Modifiable<M>> VolumeApplicator<M, Optional<BlockState>, Boolean> applyOrRemoveBlockState() {
         return (volume, element) -> element.type()
             .map(blockState -> volume.setBlock(element.position(), blockState))
             .orElseGet(() -> volume.removeBlock(element.position()));
     }
 
+    /**
+     * A potentially useful {@link VolumeApplicator} that conditionally adds or
+     * removes a {@link BlockState} based on the element's
+     * {@link Optional} state of being {@link Optional#empty()} or
+     * {@link Optional#isPresent()}. The added change being the flag
+     *
+     * @param <M> The type of modifiable block volume
+     * @return An applicator that conditionally sets a block or removes a block
+     */
     public static <M extends PhysicsAwareMutableBlockVolume<M>> VolumeApplicator<M, Optional<BlockState>, Boolean> applyOrRemoveBlockState(final BlockChangeFlag flag) {
         return (volume, element) -> element.type()
             .map(blockState -> volume.setBlock(element.position(), blockState, flag))
             .orElseGet(() -> volume.removeBlock(element.position()));
     }
 
-    public static <M extends LocationCreator<?, ? extends ServerLocation> & BlockEntityVolume.Mutable<M>> VolumeApplicator<M, BlockEntityArchetype,
-            Optional<?
-            extends BlockEntity>> applyBlockEntityArchetype() {
-        return (volume, element) -> element.type().apply((ServerLocation) volume.location(element.position()));
+    /**
+     * A potentially useful {@link VolumeApplicator} that attempts to apply a
+     * {@link BlockEntityArchetype} onto a target {@link BlockEntityVolume},
+     * optionally returning a newly placed {@link BlockEntity}.
+     *
+     * @param <M> The type of block entity
+     * @return A volume applicator that applies block entity archetypes
+     */
+    @SuppressWarnings({"unchecked"})
+    public static <M extends BlockEntityVolume.Modifiable<M> & LocationCreator<@NonNull ?, ? extends ServerLocation>> VolumeApplicator<M, BlockEntityArchetype, Optional<? extends BlockEntity>> applyBlockEntityArchetype() {
+        return (volume, element) -> element.type().apply(volume.location(element.position()));
     }
 
-    public static <M extends BlockEntityArchetypeVolume.Mutable<M>> VolumeApplicator<M, BlockEntityArchetype, Boolean> applyBlockEntityArchetypes() {
+    /**
+     * A potentially useful {@link VolumeApplicator} that attempts to apply a
+     * {@link BlockEntityArchetype} onto a target {@link BlockEntityVolume},
+     * optionally returning a newly placed {@link BlockEntity}.
+     *
+     * @param <M> The type of block entity
+     * @return A volume applicator that applies block entity archetypes
+     */
+    public static <M extends BlockEntityArchetypeVolume.Modifiable<M>> VolumeApplicator<M, BlockEntityArchetype, Boolean> applyBlockEntityArchetypes() {
         return (volume, element) -> {
             volume.addBlockEntity(element.position(), element.type());
             return true;
         };
     }
 
-    public static <M extends EntityVolume.Mutable<M>> VolumeApplicator<M, Entity, Boolean> applyEntities() {
+    /**
+     * A potentially useful {@link VolumeApplicator} that attempts to apply a
+     * {@link Entity} onto a target {@link EntityVolume},
+     * returning {@code boolean} whether the entity was successfully spawned.
+     *
+     * @param <M> The type of entity volume
+     * @return A volume applicator that applies entities to volumes
+     */
+    public static <M extends EntityVolume.Modifiable<M>> VolumeApplicator<M, Entity, Boolean> applyEntities() {
         return (volume, element) -> volume.spawnEntity(element.type());
     }
 
-    public static <M extends BiomeVolume.Mutable<M>> VolumeApplicator<M, Biome, Boolean> applyBiomes() {
+    /**
+     * A potentially useful {@link VolumeApplicator} that attempts to apply a
+     * {@link Biome} onto a target {@link BiomeVolume},
+     * returning {@code boolean} whether the biome was successfully set.
+     *
+     * @param <M> The type of biome volume
+     * @return A volume applicator that applies biomes to volumes
+     */
+    public static <M extends BiomeVolume.Modifiable<M>> VolumeApplicator<M, Biome, Boolean> applyBiomes() {
         return (volume, element) -> volume.setBiome(element.position(), element.type());
     }
 
-    @SuppressWarnings("RedundantCast")
-    public static <M extends LocationCreator<@NonNull ?, ? extends ServerLocation> & EntityVolume.Mutable<M>> VolumeApplicator<M, EntityArchetype, Optional<?
-            extends Entity>> applyEntityArchetype() {
-        return (volume, element) -> element.type().apply((ServerLocation) volume.location(element.position()));
+    @SuppressWarnings("unchecked")
+    public static <M extends EntityVolume.Modifiable<M> & LocationCreator<@NonNull ?, ? extends ServerLocation>> VolumeApplicator<M, EntityArchetype, Optional<? extends Entity>> applyEntityArchetype() {
+        return (volume, element) -> element.type().apply(volume.location(element.position()));
     }
 
-    public static <M extends EntityArchetypeVolume.Mutable<M>> VolumeApplicator<M, EntityArchetype, Boolean> applyEntityArchetypes() {
+    public static <M extends EntityArchetypeVolume.Modifiable<M>> VolumeApplicator<M, EntityArchetype, Boolean> applyEntityArchetypes() {
         return (volume, element) -> {
             volume.addEntity(element.type(), element.position().toDouble());
             return true;

--- a/src/main/java/org/spongepowered/api/world/volume/stream/VolumeApplicators.java
+++ b/src/main/java/org/spongepowered/api/world/volume/stream/VolumeApplicators.java
@@ -67,7 +67,7 @@ public final class VolumeApplicators {
      * @return A blockstate based VolumeApplicator
      */
     public static <M extends BlockVolume.Modifiable<M>> VolumeApplicator<M, BlockState, Boolean> applyBlocks() {
-        return ((volume, element) -> volume.setBlock(element.position(), element.type()));
+        return ((volume, element) -> volume.setBlock(element.position().round().toInt(), element.type()));
     }
 
     /**
@@ -82,7 +82,7 @@ public final class VolumeApplicators {
      */
     public static <M extends PhysicsAwareMutableBlockVolume<M>> VolumeApplicator<M, BlockState, Boolean> applyBlocks(final BlockChangeFlag flag) {
         Objects.requireNonNull(flag, "BlockChangeFlag cannot be null!");
-        return ((volume, element) -> volume.setBlock(element.position(), element.type(), flag));
+        return ((volume, element) -> volume.setBlock(element.position().round().toInt(), element.type(), flag));
     }
 
     /**
@@ -95,8 +95,8 @@ public final class VolumeApplicators {
      */
     public static <M extends BlockEntityVolume.Modifiable<M>> VolumeApplicator<M, BlockEntity, Boolean> applyBlockEntities() {
         return (volume, element) -> {
-            if (volume.setBlock(element.position(), element.type().block())) {
-                volume.addBlockEntity(element.position(), element.type());
+            if (volume.setBlock(element.position().round().toInt(), element.type().block())) {
+                volume.addBlockEntity(element.position().round().toInt(), element.type());
                 return true;
             }
             return false;
@@ -118,13 +118,13 @@ public final class VolumeApplicators {
             final Optional<? extends BlockEntity> blockEntityOpt = element.type();
             if (blockEntityOpt.isPresent()) {
                 final BlockEntity blockEntity = blockEntityOpt.get();
-                if (volume.setBlock(element.position(), blockEntity.block())) {
-                    volume.addBlockEntity(element.position(), blockEntity);
+                if (volume.setBlock(element.position().round().toInt(), blockEntity.block())) {
+                    volume.addBlockEntity(element.position().round().toInt(), blockEntity);
                     return true;
                 }
                 return false;
             } else {
-                return volume.removeBlock(element.position());
+                return volume.removeBlock(element.position().round().toInt());
             }
         };
     }
@@ -140,8 +140,8 @@ public final class VolumeApplicators {
      */
     public static <M extends BlockVolume.Modifiable<M>> VolumeApplicator<M, Optional<BlockState>, Boolean> applyOrRemoveBlockState() {
         return (volume, element) -> element.type()
-            .map(blockState -> volume.setBlock(element.position(), blockState))
-            .orElseGet(() -> volume.removeBlock(element.position()));
+            .map(blockState -> volume.setBlock(element.position().round().toInt(), blockState))
+            .orElseGet(() -> volume.removeBlock(element.position().round().toInt()));
     }
 
     /**
@@ -155,8 +155,8 @@ public final class VolumeApplicators {
      */
     public static <M extends PhysicsAwareMutableBlockVolume<M>> VolumeApplicator<M, Optional<BlockState>, Boolean> applyOrRemoveBlockState(final BlockChangeFlag flag) {
         return (volume, element) -> element.type()
-            .map(blockState -> volume.setBlock(element.position(), blockState, flag))
-            .orElseGet(() -> volume.removeBlock(element.position()));
+            .map(blockState -> volume.setBlock(element.position().round().toInt(), blockState, flag))
+            .orElseGet(() -> volume.removeBlock(element.position().round().toInt()));
     }
 
     /**
@@ -182,7 +182,7 @@ public final class VolumeApplicators {
      */
     public static <M extends BlockEntityArchetypeVolume.Modifiable<M>> VolumeApplicator<M, BlockEntityArchetype, Boolean> applyBlockEntityArchetypes() {
         return (volume, element) -> {
-            volume.addBlockEntity(element.position(), element.type());
+            volume.addBlockEntity(element.position().round().toInt(), element.type());
             return true;
         };
     }
@@ -208,7 +208,7 @@ public final class VolumeApplicators {
      * @return A volume applicator that applies biomes to volumes
      */
     public static <M extends BiomeVolume.Modifiable<M>> VolumeApplicator<M, Biome, Boolean> applyBiomes() {
-        return (volume, element) -> volume.setBiome(element.position(), element.type());
+        return (volume, element) -> volume.setBiome(element.position().round().toInt(), element.type());
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/spongepowered/api/world/volume/stream/VolumeConsumer.java
+++ b/src/main/java/org/spongepowered/api/world/volume/stream/VolumeConsumer.java
@@ -29,5 +29,9 @@ import org.spongepowered.api.world.volume.Volume;
 @FunctionalInterface
 public interface VolumeConsumer<V extends Volume, T> {
 
-    void consume(V volume, T type, int x, int y, int z);
+    default void consume(final V volume, final T type, final int x, final int y, final int z) {
+        this.consume(volume, type, x + 0.5, y + 0.5, z + 0.5);
+    }
+
+    void consume(V volume, T type, double x, double y, double z);
 }

--- a/src/main/java/org/spongepowered/api/world/volume/stream/VolumeElement.java
+++ b/src/main/java/org/spongepowered/api/world/volume/stream/VolumeElement.java
@@ -27,7 +27,7 @@ package org.spongepowered.api.world.volume.stream;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.world.volume.Volume;
-import org.spongepowered.math.vector.Vector3i;
+import org.spongepowered.math.vector.Vector3d;
 
 import java.lang.ref.WeakReference;
 import java.util.Objects;
@@ -36,7 +36,7 @@ import java.util.function.Supplier;
 
 public interface VolumeElement<V extends Volume, T> {
 
-    static <W extends Volume, T> VolumeElement<W, T> of(final Supplier<W> volume, final Supplier<? extends T> type, final Vector3i position) {
+    static <W extends Volume, T> VolumeElement<W, T> of(final Supplier<W> volume, final Supplier<? extends T> type, final Vector3d position) {
         return new VolumeElement<W, T>() {
             @Override
             public W volume() {
@@ -44,7 +44,7 @@ public interface VolumeElement<V extends Volume, T> {
             }
 
             @Override
-            public Vector3i position() {
+            public Vector3d position() {
                 return position;
             }
 
@@ -83,13 +83,13 @@ public interface VolumeElement<V extends Volume, T> {
         };
     }
 
-    static <V extends Volume, T> VolumeElement<V, T> of(final V volume, final Supplier<? extends T> type, final Vector3i position) {
+    static <V extends Volume, T> VolumeElement<V, T> of(final V volume, final Supplier<? extends T> type, final Vector3d position) {
         final WeakReference<V> volumeRef = new WeakReference<>(volume);
         final Supplier<V> volumeSupplier = () -> Objects.requireNonNull(volumeRef.get(), "Volume de-referenced");
         return VolumeElement.of(volumeSupplier, type, position);
     }
 
-    static <V extends Volume, T> VolumeElement<V, T> of(final V volume, final T type, final Vector3i position) {
+    static <V extends Volume, T> VolumeElement<V, T> of(final V volume, final T type, final Vector3d position) {
         final WeakReference<V> volumeRef = new WeakReference<>(volume);
         final Supplier<V> volumeSupplier = () -> Objects.requireNonNull(volumeRef.get(), "Volume de-referenced");
         final WeakReference<T> typeRef = new WeakReference<>(type);
@@ -106,7 +106,7 @@ public interface VolumeElement<V extends Volume, T> {
      */
     V volume();
 
-    Vector3i position();
+    Vector3d position();
 
     T type();
 

--- a/src/main/java/org/spongepowered/api/world/volume/stream/VolumeFlatMapper.java
+++ b/src/main/java/org/spongepowered/api/world/volume/stream/VolumeFlatMapper.java
@@ -32,5 +32,9 @@ import java.util.function.Supplier;
 @FunctionalInterface
 public interface VolumeFlatMapper<V extends Volume, T> {
 
-    Optional<? extends T> map(V volume, Supplier<T> value, int x, int y, int z);
+    default Optional<? extends T> map(final V volume, final Supplier<T> value, final int x, final int y, final int z) {
+        return this.map(volume, value, x + 0.5, y + 0.5, z + 0.5);
+    }
+
+    Optional<? extends T> map(V volume, Supplier<T> value, double x, double y, double z);
 }

--- a/src/main/java/org/spongepowered/api/world/volume/stream/VolumeMapper.java
+++ b/src/main/java/org/spongepowered/api/world/volume/stream/VolumeMapper.java
@@ -31,5 +31,9 @@ import java.util.function.Supplier;
 @FunctionalInterface
 public interface VolumeMapper<V extends Volume, T, Out> {
 
-    Out map(V volume, Supplier<T> value, int x, int y, int z);
+    default Out map(final V volume, final Supplier<T> value, final int x, final int y, final int z) {
+        return this.map(volume, value, x + 0.5, y + 0.5, z + 0.5);
+    }
+
+    Out map(V volume, Supplier<T> value, double x, double y, double z);
 }

--- a/src/main/java/org/spongepowered/api/world/volume/stream/VolumePositionTranslators.java
+++ b/src/main/java/org/spongepowered/api/world/volume/stream/VolumePositionTranslators.java
@@ -37,6 +37,8 @@ import java.util.function.Function;
 
 public final class VolumePositionTranslators {
 
+    public static final Vector3d BLOCK_OFFSET = new Vector3d(0.5, 0.5, 0.5);
+
     public static <W extends Volume, E> VolumePositionTranslator<W, E> identity() {
         return element -> element;
     }
@@ -46,24 +48,32 @@ public final class VolumePositionTranslators {
     }
 
     public static <W extends Volume, E> VolumePositionTranslator<W, E> rotateOn(final Vector3i start, final Vector3d center, final Rotation rotation,
-        final BiFunction<Vector3i, E, E> elementRotation
+        final BiFunction<Vector3d, E, E> elementRotation
     ) {
         return element -> {
             final Quaterniond q = Quaterniond.fromAngleDegAxis(rotation.angle().degrees(), 0, 1, 0);
-            final Vector3i v = q.rotate(center).add(element.position().toDouble().sub(start.toDouble())).round().toInt();
+            final Vector3d v = q.rotate(center).add(element.position().sub(start.toDouble()));
             return VolumeElement.of(element.volume(), elementRotation.apply(v, element.type()), v);
         };
     }
 
     public static <W extends Volume, E> VolumePositionTranslator<W, E> relativeTo(final Vector3i newOrigin) {
+        return VolumePositionTranslators.relativeTo(newOrigin.toDouble().add(VolumePositionTranslators.BLOCK_OFFSET));
+    }
+
+    public static <W extends Volume, E> VolumePositionTranslator<W, E> relativeTo(final Vector3d newOrigin) {
         return element -> VolumeElement.of(element.volume(), element.type(), element.position().add(newOrigin));
     }
 
     public static <W extends Volume, E> VolumePositionTranslator<W, E> offset(final Vector3i min) {
+        return VolumePositionTranslators.offset(min.toDouble().add(VolumePositionTranslators.BLOCK_OFFSET));
+    }
+
+    public static <W extends Volume, E> VolumePositionTranslator<W, E> offset(final Vector3d min) {
         return element -> VolumeElement.of(element.volume(), element.type(), element.position().sub(min));
     }
 
-    public static <W extends Volume, E> VolumePositionTranslator<W, E> position(final Function<Vector3i, Vector3i> func) {
+    public static <W extends Volume, E> VolumePositionTranslator<W, E> position(final Function<Vector3d, Vector3d> func) {
         Objects.requireNonNull(func, "Position function cannot be null!");
         return element -> VolumeElement.of(element.volume(), element.type(), func.apply(element.position()));
     }

--- a/src/main/java/org/spongepowered/api/world/volume/stream/VolumePredicate.java
+++ b/src/main/java/org/spongepowered/api/world/volume/stream/VolumePredicate.java
@@ -31,7 +31,11 @@ import java.util.function.Supplier;
 @FunctionalInterface
 public interface VolumePredicate<V extends Volume, T> {
 
-    boolean test(V volume, Supplier<T> element, int x, int y, int z);
+    boolean test(V volume, Supplier<T> element, double x, double y, double z);
+
+    default boolean test(final V volume, final Supplier<T> element, final int x, final int y, final int z) {
+        return this.test(volume, element, x + 0.5, y + 0.5, z + 0.5);
+    }
 
     default VolumePredicate<V, T> and(final VolumePredicate<V, T> other) {
         return (volume, element, x, y, z) -> this.test(volume, element, x, y, z) && other.test(volume, element, x, y, z);

--- a/src/main/java/org/spongepowered/api/world/volume/stream/VolumeStream.java
+++ b/src/main/java/org/spongepowered/api/world/volume/stream/VolumeStream.java
@@ -82,6 +82,8 @@ public interface VolumeStream<V extends Volume, T> {
         return this.flatMap((volume, value, x, y, z) -> mapper.apply(VolumeElement.of(volume, value, new Vector3i(x, y, z))));
     }
 
+    VolumeStream<V, T> transform(VolumePositionTranslator<V, T> transformer);
+
     long count();
 
     boolean allMatch(VolumePredicate<V, ? super T> predicate);

--- a/src/main/java/org/spongepowered/api/world/volume/stream/VolumeStream.java
+++ b/src/main/java/org/spongepowered/api/world/volume/stream/VolumeStream.java
@@ -26,7 +26,7 @@ package org.spongepowered.api.world.volume.stream;
 
 import org.spongepowered.api.world.volume.MutableVolume;
 import org.spongepowered.api.world.volume.Volume;
-import org.spongepowered.math.vector.Vector3i;
+import org.spongepowered.math.vector.Vector3d;
 
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -67,19 +67,19 @@ public interface VolumeStream<V extends Volume, T> {
     VolumeStream<V, T> filter(VolumePredicate<V, T> predicate);
 
     default VolumeStream<V, T> filter(final Predicate<VolumeElement<V, ? super T>> predicate) {
-        return this.filter((volume, element, x, y, z) -> predicate.test(VolumeElement.of(volume, element, new Vector3i(x, y, z))));
+        return this.filter((volume, element, x, y, z) -> predicate.test(VolumeElement.of(volume, element, new Vector3d(x, y, z))));
     }
 
     <Out> VolumeStream<V, Out> map(VolumeMapper<V, T, Out> mapper);
 
     default <Out> VolumeStream<V, Out> map(final Function<VolumeElement<V, T>, ? extends Out> mapper) {
-        return this.map((volume, value, x, y, z) -> mapper.apply(VolumeElement.of(volume, value, new Vector3i(x, y, z))));
+        return this.map((volume, value, x, y, z) -> mapper.apply(VolumeElement.of(volume, value, new Vector3d(x, y, z))));
     }
 
     VolumeStream<V, Optional<? extends T>> flatMap(VolumeFlatMapper<V, T> mapper);
 
     default VolumeStream<V, Optional<? extends T>> flatMap(final Function<VolumeElement<V, T>, Optional<? extends T>> mapper) {
-        return this.flatMap((volume, value, x, y, z) -> mapper.apply(VolumeElement.of(volume, value, new Vector3i(x, y, z))));
+        return this.flatMap((volume, value, x, y, z) -> mapper.apply(VolumeElement.of(volume, value, new Vector3d(x, y, z))));
     }
 
     VolumeStream<V, T> transform(VolumePositionTranslator<V, T> transformer);
@@ -89,19 +89,19 @@ public interface VolumeStream<V extends Volume, T> {
     boolean allMatch(VolumePredicate<V, ? super T> predicate);
 
     default boolean allMatch(final Predicate<VolumeElement<V, ? super T>> predicate) {
-        return this.allMatch((volume, element, x, y, z) -> predicate.test(VolumeElement.of(volume, element, new Vector3i(x, y, z))));
+        return this.allMatch((volume, element, x, y, z) -> predicate.test(VolumeElement.of(volume, element, new Vector3d(x, y, z))));
     }
 
     boolean noneMatch(VolumePredicate<V, ? super T> predicate);
 
     default boolean noneMatch(final Predicate<VolumeElement<V, ? super T>> predicate) {
-        return this.noneMatch((volume, element, x, y, z) -> predicate.test(VolumeElement.of(volume, element, new Vector3i(x, y, z))));
+        return this.noneMatch((volume, element, x, y, z) -> predicate.test(VolumeElement.of(volume, element, new Vector3d(x, y, z))));
     }
 
     boolean anyMatch(VolumePredicate<V, ? super T> predicate);
 
     default boolean anyMatch(final Predicate<VolumeElement<V, ? super T>> predicate) {
-        return this.anyMatch((volume, element, x, y, z) -> predicate.test(VolumeElement.of(volume, element, new Vector3i(x, y, z))));
+        return this.anyMatch((volume, element, x, y, z) -> predicate.test(VolumeElement.of(volume, element, new Vector3d(x, y, z))));
     }
 
     Optional<VolumeElement<V, T>> findFirst();
@@ -119,7 +119,7 @@ public interface VolumeStream<V extends Volume, T> {
     void forEach(VolumeConsumer<V, T> visitor);
 
     default void forEach(final Consumer<VolumeElement<V, T>> consumer) {
-        this.forEach((volume, type, x, y, z) -> consumer.accept(VolumeElement.of(volume, type, new Vector3i(x, y, z))));
+        this.forEach((volume, type, x, y, z) -> consumer.accept(VolumeElement.of(volume, type, new Vector3d(x, y, z))));
     }
 
 }

--- a/src/main/java/org/spongepowered/api/world/volume/virtual/UnrealizedBiomeVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/virtual/UnrealizedBiomeVolume.java
@@ -22,25 +22,40 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.api.world.volume.block;
+package org.spongepowered.api.world.volume.virtual;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.spongepowered.api.block.BlockState;
-import org.spongepowered.api.block.BlockType;
-import org.spongepowered.api.registry.RegistryReference;
-import org.spongepowered.api.world.schematic.Palette;
-import org.spongepowered.math.vector.Vector3i;
+import org.spongepowered.api.world.biome.Biome;
+import org.spongepowered.api.world.volume.biome.BiomeVolume;
 
-public interface BlockVolumeFactory {
+public interface UnrealizedBiomeVolume<B extends BiomeVolume> extends Virtualized<Biome, B> {
 
-    BlockVolume.Mutable empty(Palette<BlockState, BlockType> palette, RegistryReference<BlockType> defaultState, Vector3i min, Vector3i max);
+    interface Streamable<B extends Streamable<B, BU>, BU extends BiomeVolume.Streamable<BU>>
+        extends UnrealizedBiomeVolume<BU>,
+        Virtualized.Streamable<Biome, B, BU> {
 
-    BlockVolume.Mutable copyFromRange(BlockVolume.Streamable<@NonNull ?> existing, Vector3i newMin, Vector3i newMax);
+    }
 
-    BlockVolume.Mutable copy(BlockVolume.Streamable<@NonNull ?> existing);
+    interface Unmodifiable<U extends Unmodifiable<U, BU>, BU extends BiomeVolume.Unmodifiable<BU>>
+        extends UnrealizedBiomeVolume<BU>,
+        Streamable<U, BU>,
+        Virtualized.Unmodifiable<Biome, U, BU> {
 
-    BlockVolume.Immutable immutableOf(BlockVolume.Streamable<@NonNull ?> existing);
+    }
 
-    BlockVolume.Immutable immutableOf(BlockVolume.Streamable<@NonNull ?> existing, Vector3i newMin, Vector3i newMax);
+    interface Modifiable<B extends Modifiable<B, MB>, MB extends BiomeVolume.Modifiable<MB>>
+        extends UnrealizedBiomeVolume<MB>,
+        Streamable<B, MB>,
+        Virtualized.Mutable<Biome, B, MB> {
+
+    }
+
+    interface Mutable extends Modifiable<Mutable, BiomeVolume.Mutable> {
+
+    }
+
+    interface Immutable extends Unmodifiable<Immutable, BiomeVolume.Immutable> {
+
+    }
+
 
 }


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/3300) | [Specification](https://github.com/SpongePowered/Schematic-Specification/pull/20)

DO NOT MERGE

Accompanying changes for enabling Schematic supporting the Spec. Some of the changes are necessitated to represent a Schematic from deserialization.

I'll jot some mental notes here as time permits, but there's some ramifications that arise from having Biomes being Server scoped. I can't imagine that the game scope would change before 1.18, but in effect, biomes are re-created every server instance, so it's very well possible that a Schematic cannot exist between server restarts (like on the client going between single player worlds).