### PR TITLE
Remove the restriction that listener methods must be public

### DIFF
--- a/src/ap/java/org/spongepowered/plugin/processor/ListenerProcessor.java
+++ b/src/ap/java/org/spongepowered/plugin/processor/ListenerProcessor.java
@@ -57,7 +57,7 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
 @SupportedAnnotationTypes(ListenerProcessor.LISTENER_ANNOTATION_CLASS)
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedSourceVersion(SourceVersion.RELEASE_16)
 public class ListenerProcessor extends AbstractProcessor {
 
     static final String LISTENER_ANNOTATION_CLASS = "org.spongepowered.api.event.Listener";
@@ -86,24 +86,21 @@ public class ListenerProcessor extends AbstractProcessor {
                 final ExecutableElement method = (ExecutableElement) e;
 
                 if (method.getModifiers().contains(Modifier.STATIC)) {
-                    this.error("method must not be static", method);
-                }
-                if (!method.getModifiers().contains(Modifier.PUBLIC)) {
-                    this.error("method must be public", method);
+                    this.error("Event listener method must not be static", method);
                 }
                 if (method.getModifiers().contains(Modifier.ABSTRACT)) {
-                    this.error("method must not be abstract", method);
+                    this.error("Event listener method must not be abstract", method);
                 }
                 if (method.getEnclosingElement().getKind().isInterface()) {
                     this.error("interfaces cannot declare listeners", method);
                 }
                 if (method.getReturnType().getKind() != TypeKind.VOID) {
-                    this.error("method must return void", method);
+                    this.error("Event listener method must return void", method);
                 }
                 final List<? extends VariableElement> parameters = method.getParameters();
                 final DeclaredType eventType;
                 if (parameters.isEmpty() || !this.isTypeSubclass(parameters.get(0), ListenerProcessor.EVENT_CLASS)) {
-                    this.error("method must have an Event as its first parameter", method);
+                    this.error("Event listener method must have an Event as its first parameter", method);
                     eventType = null;
                 } else {
                     eventType = (DeclaredType) parameters.get(0).asType();

--- a/src/main/java/org/spongepowered/api/event/EventManager.java
+++ b/src/main/java/org/spongepowered/api/event/EventManager.java
@@ -36,13 +36,11 @@ public interface EventManager {
      * Registers {@link Event} methods annotated with @{@link Listener} in the
      * specified object.
      *
-     * <p>Only methods that are public will be registered and the class must be
-     * public as well.</p>
+     * <p>This will not include any methods declared in supertypes, but will
+     * test for private and package-private listener methods.</p>
      *
-     * @param plugin The plugin instance
+     * @param plugin The plugin container
      * @param obj The object
-     * @throws IllegalArgumentException Thrown if {@code plugin} is not a plugin
-     *         instance
      */
     void registerListeners(PluginContainer plugin, Object obj);
 

--- a/src/main/java/org/spongepowered/api/event/Listener.java
+++ b/src/main/java/org/spongepowered/api/event/Listener.java
@@ -32,9 +32,6 @@ import java.lang.annotation.Target;
 
 /**
  * Used to annotate a method as an {@link EventListener}.
- *
- * <p>The method being targeted must be public and must be in a class that is
- * also public.</p>
  */
 @Retention(RUNTIME)
 @Target(METHOD)


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/3467)

The allowed event listeners here are not a strict superset of those allowed in api 8 -- most notably, event methods cannot be picked up from supertypes anymore. This restriction could be relaxed by traversing supertypes, but it would make the class generation logic more complicated, and is imo a fringe use case.