### PR TITLE
Add an event to be fired when the game is performing its final shutdown

### DIFF
--- a/src/main/java/org/spongepowered/api/event/lifecycle/StoppedGameEvent.java
+++ b/src/main/java/org/spongepowered/api/event/lifecycle/StoppedGameEvent.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.event.lifecycle;
+
+import org.spongepowered.api.Game;
+
+/**
+ * This event is called at the end of a {@link Game} instance, after the game's
+ * state has shut down.
+ *
+ * <p>This is the last event called by Sponge within a game lifecycle.</p>
+ *
+ * <p>This event may not be fired in the event of an "unclean" shutdown (such
+ * as one due to a crash).</p>
+ *
+ * <p>Most users will want to listen to {@link StoppingEngineEvent} instead, to
+ * do operations tied to the lifecycle of one single engine.</p>
+ */
+public interface StoppedGameEvent extends LifecycleEvent {
+
+}


### PR DESCRIPTION
This is a bit of a dicey event since quite a lot of the game is unavailable at this point, but it does allow plugins with game-scoped thread pools to shut down in an orderly fashion.