### PR TITLE
Desupply the API

### DIFF
--- a/src/main/java/org/spongepowered/api/advancement/DisplayInfo.java
+++ b/src/main/java/org/spongepowered/api/advancement/DisplayInfo.java
@@ -31,8 +31,6 @@ import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.util.CopyableBuilder;
 
-import java.util.function.Supplier;
-
 public interface DisplayInfo {
 
     /**
@@ -112,17 +110,6 @@ public interface DisplayInfo {
          * @param advancementType The advancement type
          * @return This builder, for chaining
          */
-        default Builder type(Supplier<? extends AdvancementType> advancementType) {
-            return this.type(advancementType.get());
-        }
-
-        /**
-         * Sets the {@link AdvancementType}. Defaults
-         * to {@link AdvancementTypes#TASK}.
-         *
-         * @param advancementType The advancement type
-         * @return This builder, for chaining
-         */
         Builder type(AdvancementType advancementType);
 
         /**
@@ -140,17 +127,6 @@ public interface DisplayInfo {
          * @return This builder, for chaining
          */
         Builder title(Component title);
-
-        /**
-         * Sets the icon of the advancement with the
-         * specified {@link ItemType}.
-         *
-         * @param itemType The item type
-         * @return This builder, for chaining
-         */
-        default Builder icon(Supplier<? extends ItemType> itemType) {
-            return this.icon(itemType.get());
-        }
 
         /**
          * Sets the icon of the advancement with the

--- a/src/main/java/org/spongepowered/api/block/BlockSnapshot.java
+++ b/src/main/java/org/spongepowered/api/block/BlockSnapshot.java
@@ -40,7 +40,6 @@ import org.spongepowered.math.vector.Vector3i;
 
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Supplier;
 
 /**
  * An immutable representation of a {@link BlockState} and any extra data that
@@ -48,14 +47,8 @@ import java.util.function.Supplier;
  */
 public interface BlockSnapshot extends LocatableSnapshot<BlockSnapshot> {
 
-    /**
-     * Represents a {@link BlockSnapshot} with the default state of
-     * {@link BlockTypes#AIR} and a {@link ServerLocation} that cannot be determined.
-     */
-    Supplier<BlockSnapshot> NONE = BlockSnapshot::empty;
-
     static BlockSnapshot empty() {
-        return Sponge.game().builderProvider().provide(Builder.class).empty();
+        return Sponge.game().factoryProvider().provide(Factory.class).empty();
     }
 
     /**
@@ -205,6 +198,9 @@ public interface BlockSnapshot extends LocatableSnapshot<BlockSnapshot> {
          * @return This builder, for chaining
          */
         Builder notifier(UUID uuid);
+    }
+
+    interface Factory {
 
         BlockSnapshot empty();
     }

--- a/src/main/java/org/spongepowered/api/block/BlockState.java
+++ b/src/main/java/org/spongepowered/api/block/BlockState.java
@@ -37,7 +37,6 @@ import org.spongepowered.api.util.rotation.Rotation;
 import org.spongepowered.api.world.server.ServerLocation;
 
 import java.util.Objects;
-import java.util.function.Supplier;
 
 /**
  * Represents a particular "state" that can exist at a {@link ServerLocation} with
@@ -60,16 +59,6 @@ public interface BlockState extends State<BlockState>, DirectionRelativeDataHold
     static BlockState fromString(final String id) {
         Objects.requireNonNull(id);
         return Sponge.game().builderProvider().provide(Builder.class).fromString(id).build();
-    }
-
-    /**
-     * Constructs a new builder to construct a {@link StateMatcher}.
-     *
-     * @param type The block type
-     * @return The builder
-     */
-    static StateMatcher.Builder<BlockState, BlockType> matcher(final Supplier<? extends BlockType> type) {
-        return BlockState.matcher(type.get());
     }
 
     /**
@@ -124,18 +113,6 @@ public interface BlockState extends State<BlockState>, DirectionRelativeDataHold
     BlockState rotate(Rotation rotation);
 
     /**
-     * Gets the appropriate {@link BlockState} for the desired {@link Rotation}. It may
-     * return the same state, but some states may have extra logic associated with rotating
-     * on its axis, much like mirroring.
-     *
-     * @param rotation The rotation
-     * @return The rotated state if not this state
-     */
-    default BlockState rotate(final Supplier<? extends Rotation> rotation) {
-        return this.rotate(rotation.get());
-    }
-
-    /**
      * Gets the appropriate {@link BlockState} for the desired {@link Mirror}. It may
      * return the same state, but some states may have extra logic associated with mirroring
      * on its axis, much like rotation.
@@ -146,18 +123,6 @@ public interface BlockState extends State<BlockState>, DirectionRelativeDataHold
     BlockState mirror(Mirror mirror);
 
     /**
-     * Gets the appropriate {@link BlockState} for the desired {@link Mirror}. It may
-     * return the same state, but some states may have extra logic associated with mirroring
-     * on its axis, much like rotation.
-     *
-     * @param mirror The mirror
-     * @return The mirrored state if not this state
-     */
-    default BlockState mirror(final Supplier<? extends Mirror> mirror) {
-        return this.mirror(mirror.get());
-    }
-
-    /**
      * An {@link org.spongepowered.api.data.DataHolderBuilder.Immutable} for a {@link BlockState}. Just like the
      * {@link org.spongepowered.api.data.DataHolderBuilder.Immutable}, the {@link Value}s passed in to
      * create a {@link BlockState} are copied on creation.
@@ -166,21 +131,6 @@ public interface BlockState extends State<BlockState>, DirectionRelativeDataHold
      * of {@link DataManipulator}s, otherwise exceptions may be thrown.</p>
      */
     interface Builder extends State.Builder<BlockState, Builder> {
-
-        /**
-         * Sets the {@link BlockType} for the {@link BlockState} to build.
-         *
-         * <p>The {@link BlockType} is used for some pre-validation on addition of
-         * {@link DataManipulator}s through {@link #add(DataManipulator)}. It is
-         * important to understand that not all manipulators are compatible with
-         * all {@link BlockType}s.</p>
-         *
-         * @param blockType The block type
-         * @return This builder, for chaining
-         */
-        default Builder blockType(final Supplier<? extends BlockType> blockType) {
-            return this.blockType(blockType.get());
-        }
 
         /**
          * Sets the {@link BlockType} for the {@link BlockState} to build.

--- a/src/main/java/org/spongepowered/api/block/BlockType.java
+++ b/src/main/java/org/spongepowered/api/block/BlockType.java
@@ -34,7 +34,6 @@ import org.spongepowered.api.tag.Taggable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * Describes a base type of block.
@@ -77,16 +76,6 @@ public interface BlockType extends DefaultedRegistryValue, ComponentLike, StateC
      * @return This block's sound group.
      */
     BlockSoundGroup soundGroup();
-
-    /**
-     * Returns true if this type is any of the given block types
-     *
-     * @param types the block types to check
-     *
-     * @return true if this type is any of the given block types
-     */
-    @SuppressWarnings("unchecked")
-    boolean isAnyOf(Supplier<? extends BlockType>... types);
 
     /**
      * Returns true if this type is any of the given block types

--- a/src/main/java/org/spongepowered/api/block/entity/BlockEntity.java
+++ b/src/main/java/org/spongepowered/api/block/entity/BlockEntity.java
@@ -36,8 +36,6 @@ import org.spongepowered.api.world.LocatableBlock;
 import org.spongepowered.api.world.schematic.Schematic;
 import org.spongepowered.api.world.server.ServerLocation;
 
-import java.util.function.Supplier;
-
 /**
  * Represents a block entity. It is a functional block that is
  * continuously updated while residing in a world. It can perform specific
@@ -105,32 +103,12 @@ public interface BlockEntity extends SerializableDataHolder.Mutable, Locatable {
     BlockEntity rotate(Rotation rotation);
 
     /**
-     * Rotates this {@link BlockEntity} for the desired {@link Rotation}.
-     *
-     * @param rotation The rotation
-     * @return The rotated state if not this state
-     */
-    default BlockEntity rotate(final Supplier<? extends Rotation> rotation) {
-        return this.rotate(rotation.get());
-    }
-
-    /**
      * Gets the appropriate {@link BlockEntity} for the desired {@link Mirror}.
      *
      * @param mirror The mirror
      * @return The mirrored BlockEntity
      */
     BlockEntity mirror(Mirror mirror);
-
-    /**
-     * Gets the appropriate {@link BlockEntity} for the desired {@link Mirror}.
-     *
-     * @param mirror The mirror
-     * @return The mirrored BlockEntity
-     */
-    default BlockEntity mirror(final Supplier<? extends Mirror> mirror) {
-        return this.mirror(mirror.get());
-    }
 
     /**
      * Creates a new {@link BlockEntityArchetype} for use with {@link Schematic}s

--- a/src/main/java/org/spongepowered/api/block/entity/BlockEntityArchetype.java
+++ b/src/main/java/org/spongepowered/api/block/entity/BlockEntityArchetype.java
@@ -37,8 +37,6 @@ import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.world.Archetype;
 import org.spongepowered.api.world.server.ServerLocation;
 
-import java.util.function.Supplier;
-
 /**
  * Represents the data of a {@link BlockEntity} which does not exist in the world
  * and may be used to create new {@link BlockEntity}s with the same data.
@@ -129,10 +127,6 @@ public interface BlockEntityArchetype extends Archetype<BlockSnapshot, BlockEnti
          * @return This builder, for chaining
          */
         Builder state(BlockState state);
-
-        default Builder blockEntity(Supplier<? extends BlockEntityType> type) {
-            return this.blockEntity(type.get());
-        }
 
         Builder blockEntity(BlockEntityType type);
 

--- a/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/Parameter.java
@@ -211,7 +211,7 @@ public interface Parameter {
      * @param valueClass The type of value class
      * @return The {@link Value.Builder}
      */
-    static <T, V extends ValueParameter<T>> Value.Builder<T> builder(@NonNull final Class<T> valueClass, @NonNull final DefaultedRegistryReference<V> parameter) {
+    static <T, V extends ValueParameter<T>> Value.Builder<T> builder(@NonNull final Class<T> valueClass, @NonNull final Supplier<V> parameter) {
         return Parameter.builder(valueClass, parameter.get());
     }
 

--- a/src/main/java/org/spongepowered/api/command/selector/Selector.java
+++ b/src/main/java/org/spongepowered/api/command/selector/Selector.java
@@ -41,7 +41,6 @@ import org.spongepowered.math.vector.Vector3d;
 
 import java.util.Collection;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 /**
  * Allows for the selection of {@link Entity entities} in a world based on given
@@ -130,14 +129,6 @@ public interface Selector {
          * @param selectorType The {@link SelectorType}
          * @return This builder, for chaining
          */
-        Builder applySelectorType(Supplier<? extends SelectorType> selectorType);
-
-        /**
-         * Applies the defaults associated with a given {@link SelectorType}
-         *
-         * @param selectorType The {@link SelectorType}
-         * @return This builder, for chaining
-         */
         Builder applySelectorType(SelectorType selectorType);
 
         /**
@@ -178,15 +169,6 @@ public interface Selector {
          * @return This builder, for chaining
          */
         Builder volume(Vector3d corner1, Vector3d corner2);
-
-        /**
-         * Sets the sorting algorithm to use when returning entities from the
-         * selector.
-         *
-         * @param algorithm The {@link SelectorSortAlgorithm}
-         * @return This builder, for chaining
-         */
-        Builder sortAlgorithm(Supplier<? extends SelectorSortAlgorithm> algorithm);
 
         /**
          * Sets the sorting algorithm to use when returning entities from the
@@ -256,29 +238,7 @@ public interface Selector {
          * @param inherit Whether subtypes will also be selected
          * @return This builder, for chaining
          */
-        Builder addEntityType(Supplier<EntityType<?>> type, boolean inherit);
-
-        /**
-         * Adds an {@link EntityType} constraint to this selector, requiring
-         * that all selected entities must be of the given type.
-         *
-         * <p>If {@code inherit} is true, entities may also be a subtype of the
-         * given type.</p>
-         *
-         * @param type The type
-         * @param inherit Whether subtypes will also be selected
-         * @return This builder, for chaining
-         */
         Builder addEntityType(EntityType<?> type, boolean inherit);
-
-        /**
-         * Adds an {@link EntityType} constraint to this selector, requiring
-         * that all selected entities must not be of the given type.
-         *
-         * @param type The type
-         * @return This builder, for chaining
-         */
-        Builder addNotEntityType(Supplier<EntityType<?>> type);
 
         /**
          * Adds an {@link EntityType} constraint to this selector, requiring
@@ -300,17 +260,6 @@ public interface Selector {
 
         /**
          * Adds a {@link GameMode} constraint to the selector, requiring players
-         * be in the given game mode.
-         *
-         * <p>Cannot be used with {@link #addNotGameMode(GameMode)}.</p>
-         *
-         * @param mode The gamemode
-         * @return This builder, for chaining
-         */
-        Builder addGameMode(Supplier<? extends GameMode> mode);
-
-        /**
-         * Adds a {@link GameMode} constraint to the selector, requiring players
          * be in the given game mode
          *
          * <p>Cannot be used with {@link #addNotGameMode(GameMode)}.</p>
@@ -319,17 +268,6 @@ public interface Selector {
          * @return This builder, for chaining
          */
         Builder addGameMode(GameMode mode);
-
-        /**
-         * Adds a {@link GameMode} constraint to the selector, requiring that
-         * players are not in the given game mode
-         *
-         * <p>Cannot be used with {@link #addGameMode(GameMode)}.</p>
-         *
-         * @param mode The gamemode
-         * @return This builder, for chaining
-         */
-        Builder addNotGameMode(Supplier<? extends GameMode> mode);
 
         /**
          * Adds a {@link GameMode} constraint to the selector, requiring that

--- a/src/main/java/org/spongepowered/api/data/DataHolder.java
+++ b/src/main/java/org/spongepowered/api/data/DataHolder.java
@@ -35,7 +35,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * A data holder object allows the access of additional data on the object
@@ -74,24 +73,6 @@ public interface DataHolder extends ValueContainer {
         }
 
         /**
-         * Applies a transformation on the provided {@link Value} such that
-         * the return value of {@link Function#apply(Object)} will become the end
-         * resulting value set into this {@link Mutable}. It is not
-         * necessary that the input is actually present, in which case the
-         * {@link Key}ed data is compatible, but not necessarily present. Writing
-         * a {@link Function} to properly handle the potential for a null input
-         * is required for this method to execute without exception.
-         *
-         * @param key The key linked to
-         * @param function The function to manipulate the value
-         * @param <E> The type of value
-         * @return The end resulting value
-         */
-        default <E> DataTransactionResult transform(Supplier<? extends Key<? extends Value<E>>> key, Function<E, E> function) {
-            return this.transform(key.get(), function);
-        }
-
-        /**
          * Offers the given {@code value} as defined by the provided {@link Key}
          * such that a {@link DataTransactionResult} is returned for any
          * successful, rejected, and replaced {@link Value}s from this
@@ -103,36 +84,6 @@ public interface DataHolder extends ValueContainer {
          * @return The transaction result
          */
         <E> DataTransactionResult offer(Key<? extends Value<E>> key, E value);
-
-        /**
-         * Offers the given {@code value} as defined by the provided {@link Key}
-         * such that a {@link DataTransactionResult} is returned for any
-         * successful, rejected, and replaced {@link Value}s from this
-         * {@link Mutable}.
-         *
-         * @param key The key to the value to set
-         * @param value The value to set
-         * @param <E> The type of value
-         * @return The transaction result
-         */
-        default <E> DataTransactionResult offer(Supplier<? extends Key<? extends Value<E>>> key, E value) {
-            return this.offer(key.get(), value);
-        }
-
-        /**
-         * Offers the given {@code value} as defined by the provided {@link Key}
-         * such that a {@link DataTransactionResult} is returned for any
-         * successful, rejected, and replaced {@link Value}s from this
-         * {@link Mutable}.
-         *
-         * @param key The key to the value to set
-         * @param value The value to set
-         * @param <E> The type of value
-         * @return The transaction result
-         */
-        default <E> DataTransactionResult offer(Supplier<? extends Key<? extends Value<E>>> key, Supplier<? extends E> value) {
-            return this.offer(key.get(), value.get());
-        }
 
         /**
          * Offers the given {@link Value} as defined by the provided
@@ -147,21 +98,9 @@ public interface DataHolder extends ValueContainer {
 
         <E> DataTransactionResult offerSingle(Key<? extends CollectionValue<E, ?>> key, E element);
 
-        default <E> DataTransactionResult offerSingle(Supplier<? extends Key<? extends CollectionValue<E, ?>>> key, E element) {
-            return this.offerSingle(key.get(), element);
-        }
-
         <K, V> DataTransactionResult offerSingle(Key<? extends MapValue<K, V>> key, K valueKey, V value);
 
-        default <K, V> DataTransactionResult offerSingle(Supplier<? extends Key<? extends MapValue<K, V>>> key, K valueKey, V value) {
-            return this.offerSingle(key.get(), valueKey, value);
-        }
-
         <K, V> DataTransactionResult offerAll(Key<? extends MapValue<K, V>> key, Map<? extends K, ? extends V> map);
-
-        default <K, V> DataTransactionResult offerAll(Supplier<? extends Key<? extends MapValue<K, V>>> key, Map<? extends K, ? extends V> map) {
-            return this.offerAll(key.get(), map);
-        }
 
         DataTransactionResult offerAll(MapValue<?, ?> value);
 
@@ -169,37 +108,17 @@ public interface DataHolder extends ValueContainer {
 
         <E> DataTransactionResult offerAll(Key<? extends CollectionValue<E, ?>> key, Collection<? extends E> elements);
 
-        default <E> DataTransactionResult offerAll(Supplier<? extends Key<? extends CollectionValue<E, ?>>> key, Collection<? extends E> elements) {
-            return this.offerAll(key.get(), elements);
-        }
-
         <E> DataTransactionResult removeSingle(Key<? extends CollectionValue<E, ?>> key, E element);
 
-        default <E> DataTransactionResult removeSingle(Supplier<? extends Key<? extends CollectionValue<E, ?>>> key, E element) {
-            return this.removeSingle(key.get(), element);
-        }
-
         <K> DataTransactionResult removeKey(Key<? extends MapValue<K, ?>> key, K mapKey);
-
-        default <K> DataTransactionResult removeKey(Supplier<? extends Key<? extends MapValue<K, ?>>> key, K mapKey) {
-            return this.removeKey(key.get(), mapKey);
-        }
 
         DataTransactionResult removeAll(CollectionValue<?, ?> value);
 
         <E> DataTransactionResult removeAll(Key<? extends CollectionValue<E, ?>> key, Collection<? extends E> elements);
 
-        default <E> DataTransactionResult removeAll(Supplier<? extends Key<? extends CollectionValue<E, ?>>> key, Collection<? extends E> elements) {
-            return this.removeAll(key.get(), elements);
-        }
-
         DataTransactionResult removeAll(MapValue<?, ?> value);
 
         <K, V> DataTransactionResult removeAll(Key<? extends MapValue<K, V>> key, Map<? extends K, ? extends V> map);
-
-        default <K, V> DataTransactionResult removeAll(Supplier<? extends Key<? extends MapValue<K, V>>> key, Map<? extends K, ? extends V> map) {
-            return this.removeAll(key.get(), map);
-        }
 
         /**
          * Offers the given {@code value} as defined by the provided {@link Key}
@@ -216,24 +135,6 @@ public interface DataHolder extends ValueContainer {
          *     incompatibility
          */
         <E> DataTransactionResult tryOffer(Key<? extends Value<E>> key, E value);
-
-        /**
-         * Offers the given {@code value} as defined by the provided {@link Key}
-         * such that a {@link DataTransactionResult} is returned for any
-         * successful {@link Value}s from this {@link Mutable}.
-         * Intentionally, however, this differs from {@link #offer(Key, Object)}
-         * as it will intentionally throw an exception if the result was a failure.
-         *
-         * @param key The key to the value to set
-         * @param value The value to set
-         * @param <E> The type of value
-         * @return The transaction result
-         * @throws IllegalArgumentException If the result is a failure likely due to
-         *     incompatibility
-         */
-        default <E> DataTransactionResult tryOffer(Supplier<? extends Key<? extends Value<E>>> key, E value) {
-            return this.tryOffer(key.get(), value);
-        }
 
         /**
          * Offers the given {@code value} as defined by the provided {@link Key}
@@ -281,20 +182,6 @@ public interface DataHolder extends ValueContainer {
          * @return The transaction result
          */
         DataTransactionResult remove(Key<?> key);
-
-        /**
-         * Attempts to remove the data associated with the provided {@link Key}.
-         * All values that were successfully removed will be provided in
-         * {@link DataTransactionResult#replacedData()}. If the data can not be
-         * removed, the result will be an expected
-         * {@link DataTransactionResult.Type#FAILURE}.
-         *
-         * @param key The key of the data
-         * @return The transaction result
-         */
-        default DataTransactionResult remove(Supplier<? extends Key<?>> key) {
-            return this.remove(key.get());
-        }
 
         /**
          * Attempts to "revert" a {@link DataTransactionResult} such that any
@@ -353,20 +240,6 @@ public interface DataHolder extends ValueContainer {
         <E> Optional<I> transform(Key<? extends Value<E>> key, Function<E, E> function);
 
         /**
-         * Applies a transformation on the provided {@link Value} such that
-         * the return value of {@link Function#apply(Object)} will become the end
-         * resulting value set into the newly created {@link Immutable}.
-         *
-         * @param key The key linked to
-         * @param function The function to manipulate the value
-         * @param <E> The type of value
-         * @return The newly created immutable value store
-         */
-        default <E> Optional<I> transform(Supplier<? extends Key<? extends Value<E>>> key, Function<E, E> function) {
-            return this.transform(key.get(), function);
-        }
-
-        /**
          * Creates a new {@link Immutable} with the provided
          * value by {@link Key}. If the key is supported by this value store,
          * the returned value store will be present.
@@ -377,20 +250,6 @@ public interface DataHolder extends ValueContainer {
          * @return The new immutable value store
          */
         <E> Optional<I> with(Key<? extends Value<E>> key, E value);
-
-        /**
-         * Creates a new {@link Immutable} with the provided
-         * value by {@link Key}. If the key is supported by this value store,
-         * the returned value store will be present.
-         *
-         * @param key The key to the value to set
-         * @param value The value to set
-         * @param <E> The type of value
-         * @return The new immutable value store
-         */
-        default <E> Optional<I> with(Supplier<? extends Key<? extends Value<E>>> key, E value) {
-            return this.with(key.get(), value);
-        }
 
         /**
          * Offers the given {@code value} as defined by the provided {@link Key}
@@ -423,18 +282,6 @@ public interface DataHolder extends ValueContainer {
          * @return The new immutable value store
          */
         Optional<I> without(Key<?> key);
-
-        /**
-         * Creates a new {@link Immutable} without the provided {@link Key}. If the
-         * key is supported by this value store, the returned value store will
-         * be present.
-         *
-         * @param key The key to remove
-         * @return The new immutable value store
-         */
-        default Optional<I> without(Supplier<? extends Key<?>> key) {
-            return this.without(key.get());
-        }
 
         /**
          * Attempts to merge the {@link org.spongepowered.api.data.value.Value.Immutable}s from this

--- a/src/main/java/org/spongepowered/api/data/DataHolderBuilder.java
+++ b/src/main/java/org/spongepowered/api/data/DataHolderBuilder.java
@@ -28,8 +28,6 @@ import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.util.Builder;
 import org.spongepowered.api.util.CopyableBuilder;
 
-import java.util.function.Supplier;
-
 public interface DataHolderBuilder<H extends DataHolder, B extends DataHolderBuilder<H, B>> extends Builder<H, B>, CopyableBuilder<H, B> {
 
     /**
@@ -92,18 +90,6 @@ public interface DataHolderBuilder<H extends DataHolder, B extends DataHolderBui
      * @return This builder, for chaining
      */
     <V> B add(Key<? extends Value<V>> key, V value);
-
-    /**
-     * Adds the given {@link Key} with the given value.
-     *
-     * @param key The key to assign the value with
-     * @param value The value to assign with the key
-     * @param <V> The type of the value
-     * @return This builder, for chaining
-     */
-    default <V> B add(Supplier<? extends Key<? extends Value<V>>> key, V value) {
-        return this.add(key.get(), value);
-    }
 
     /**
      * Copies all known {@link DataManipulator}s from the given

--- a/src/main/java/org/spongepowered/api/data/DataManipulator.java
+++ b/src/main/java/org/spongepowered/api/data/DataManipulator.java
@@ -38,7 +38,6 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 /**
  * Represents a changelist of data that can be applied to a {@link DataHolder.Mutable}.
@@ -456,15 +455,6 @@ public interface DataManipulator extends CopyableValueContainer {
          */
         <E> Mutable set(Key<? extends Value<E>> key, E value);
 
-        default <E, V extends Value<E>> Mutable set(final Supplier<Key<V>> key, final E value) {
-            return this.set(key.get(), value);
-        }
-
-        default <E, V extends Value<E>> Mutable set(final Supplier<Key<V>> key, final Supplier<E> value) {
-            return this.set(Objects.requireNonNull(key, "Key supplier cannot be null").get(),
-                Objects.requireNonNull(value, "Value supplier cannot be null").get());
-        }
-
         /**
          * Sets the supported {@link Value} onto this {@link Mutable}.
          * The requirement for this to succeed is that the {@link Value} is
@@ -476,7 +466,6 @@ public interface DataManipulator extends CopyableValueContainer {
          * @param value The actual value to set
          * @return This manipulator, for chaining
          */
-        @SuppressWarnings("unchecked")
         default Mutable set(final Value<?> value) {
             return this.set((Key<? extends Value<Object>>) value.key(), value.get());
         }
@@ -536,7 +525,7 @@ public interface DataManipulator extends CopyableValueContainer {
          */
         default <E> Mutable transform(final Key<? extends Value<E>> key, final Function<E, E> function) {
             if (!this.supports(key)) {
-                throw new IllegalArgumentException("The provided key is not supported: " + key.toString());
+                throw new IllegalArgumentException("The provided key is not supported: " + key);
             }
             return this.set(key, Objects.requireNonNull(function.apply(this.get(key).get()), "The function can not be returning null!"));
         }

--- a/src/main/java/org/spongepowered/api/data/MutableDataProviderBuilder.java
+++ b/src/main/java/org/spongepowered/api/data/MutableDataProviderBuilder.java
@@ -32,7 +32,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 public interface MutableDataProviderBuilder<H extends DataHolder.Mutable, V extends Value<E>, E> extends
         Builder<DataProvider<V, E>, MutableDataProviderBuilder<H, V, E>> {
@@ -54,8 +53,6 @@ public interface MutableDataProviderBuilder<H extends DataHolder.Mutable, V exte
     MutableDataProviderBuilder<H, V, E> deleteAnd(Function<H, Boolean> delete);
 
     MutableDataProviderBuilder<H, V, E> deleteAndGet(Function<H, DataTransactionResult> delete);
-
-    MutableDataProviderBuilder<H, V, E> resetOnDelete(Supplier<E> resetOnDeleteTo);
 
     MutableDataProviderBuilder<H, V, E> resetOnDelete(Function<H, E> resetOnDeleteTo);
 

--- a/src/main/java/org/spongepowered/api/data/meta/BannerPatternLayer.java
+++ b/src/main/java/org/spongepowered/api/data/meta/BannerPatternLayer.java
@@ -33,36 +33,10 @@ import org.spongepowered.api.data.type.DyeColor;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
 import org.spongepowered.api.util.CopyableBuilder;
 
-import java.util.function.Supplier;
-
 /**
  * A representation on a single layer of a {@link Banner}'s pattern.
  */
 public interface BannerPatternLayer extends DataSerializable {
-
-    /**
-     * Creates a {@link BannerPatternLayer} with the desired
-     * {@link BannerPatternShape} and {@link DyeColor}.
-     *
-     * @param shape The shape
-     * @param color The color
-     * @return The new pattern layer
-     */
-    static BannerPatternLayer of(Supplier<? extends BannerPatternShape> shape, DefaultedRegistryReference<? extends DyeColor> color) {
-        return BannerPatternLayer.of(shape.get(), color.get());
-    }
-
-    /**
-     * Creates a {@link BannerPatternLayer} with the desired
-     * {@link BannerPatternShape} and {@link DyeColor}.
-     *
-     * @param shape The shape
-     * @param color The color
-     * @return The new pattern layer
-     */
-    static BannerPatternLayer of(Supplier<? extends BannerPatternShape> shape, DyeColor color) {
-        return BannerPatternLayer.of(shape.get(), color);
-    }
 
     /**
      * Creates a {@link BannerPatternLayer} with the desired
@@ -117,32 +91,12 @@ public interface BannerPatternLayer extends DataSerializable {
         Builder pattern(BannerPatternShape shape);
 
         /**
-         * Sets the {@link BannerPatternShape} to be used.
-         *
-         * @param shape The shape
-         * @return This builder, for chaining
-         */
-        default Builder pattern(Supplier<? extends BannerPatternShape> shape) {
-            return this.pattern(shape.get());
-        }
-
-        /**
          * Sets the {@link DyeColor} to be used.
          *
          * @param color The color
          * @return This builder, for chaining
          */
         Builder color(DyeColor color);
-
-        /**
-         * Sets the {@link DyeColor} to be used.
-         *
-         * @param color The color
-         * @return This builder, for chaining
-         */
-        default Builder color(Supplier<? extends DyeColor> color) {
-            return this.color(color.get());
-        }
 
         /**
          * Builds a {@link BannerPatternLayer} provided that the

--- a/src/main/java/org/spongepowered/api/data/value/ListValue.java
+++ b/src/main/java/org/spongepowered/api/data/value/ListValue.java
@@ -27,7 +27,6 @@ package org.spongepowered.api.data.value;
 import org.spongepowered.api.data.Key;
 
 import java.util.List;
-import java.util.function.Supplier;
 
 public interface ListValue<E> extends CollectionValue<E, List<E>> {
 
@@ -45,19 +44,6 @@ public interface ListValue<E> extends CollectionValue<E, List<E>> {
     }
 
     /**
-     * Constructs a mutable {@link ListValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <E> The element type
-     * @return The constructed mutable value
-     */
-    static <E> ListValue.Mutable<E> mutableOf(Supplier<? extends Key<? extends ListValue<E>>> key, List<E> element) {
-        return ListValue.mutableOf(key.get(), element);
-    }
-
-    /**
      * Constructs an immutable {@link ListValue} of the appropriate type based
      * on the given {@link Key} and the element.
      *
@@ -68,19 +54,6 @@ public interface ListValue<E> extends CollectionValue<E, List<E>> {
      */
     static <E> ListValue.Immutable<E> immutableOf(Key<? extends ListValue<E>> key, List<E> element) {
         return Value.immutableOf(key, element);
-    }
-
-    /**
-     * Constructs an immutable {@link ListValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <E> The element type
-     * @return The constructed immutable value
-     */
-    static <E> ListValue.Immutable<E> immutableOf(Supplier<? extends Key<? extends ListValue<E>>> key, List<E> element) {
-        return ListValue.immutableOf(key.get(), element);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/data/value/MapValue.java
+++ b/src/main/java/org/spongepowered/api/data/value/MapValue.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 public interface MapValue<K, V> extends Value<Map<K, V>> {
 
@@ -50,20 +49,6 @@ public interface MapValue<K, V> extends Value<Map<K, V>> {
     }
 
     /**
-     * Constructs a mutable {@link MapValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <K> The map key type
-     * @param <V> The map value type
-     * @return The constructed mutable value
-     */
-    static <K, V> MapValue.Mutable<K, V> mutableOf(Supplier<? extends Key<? extends MapValue<K, V>>> key, Map<K, V> element) {
-        return MapValue.mutableOf(key.get(), element);
-    }
-
-    /**
      * Constructs an immutable {@link MapValue} of the appropriate type based
      * on the given {@link Key} and the element.
      *
@@ -75,20 +60,6 @@ public interface MapValue<K, V> extends Value<Map<K, V>> {
      */
     static <K, V> MapValue.Immutable<K, V> immutableOf(Key<? extends MapValue<K, V>> key, Map<K, V> element) {
         return Value.immutableOf(key, element);
-    }
-
-    /**
-     * Constructs an immutable {@link MapValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <K> The map key type
-     * @param <V> The map value type
-     * @return The constructed immutable value
-     */
-    static <K, V> MapValue.Immutable<K, V> immutableOf(Supplier<? extends Key<? extends MapValue<K, V>>> key, Map<K, V> element) {
-        return MapValue.immutableOf(key.get(), element);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/data/value/SetValue.java
+++ b/src/main/java/org/spongepowered/api/data/value/SetValue.java
@@ -27,7 +27,6 @@ package org.spongepowered.api.data.value;
 import org.spongepowered.api.data.Key;
 
 import java.util.Set;
-import java.util.function.Supplier;
 
 public interface SetValue<E> extends CollectionValue<E, Set<E>> {
 
@@ -45,19 +44,6 @@ public interface SetValue<E> extends CollectionValue<E, Set<E>> {
     }
 
     /**
-     * Constructs a mutable {@link SetValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <E> The element type
-     * @return The constructed mutable value
-     */
-    static <E> SetValue.Mutable<E> mutableOf(Supplier<? extends Key<? extends SetValue<E>>> key, Set<E> element) {
-        return SetValue.mutableOf(key.get(), element);
-    }
-
-    /**
      * Constructs an immutable {@link SetValue} of the appropriate type based
      * on the given {@link Key} and the element.
      *
@@ -68,19 +54,6 @@ public interface SetValue<E> extends CollectionValue<E, Set<E>> {
      */
     static <E> SetValue.Immutable<E> immutableOf(Key<? extends SetValue<E>> key, Set<E> element) {
         return Value.immutableOf(key, element);
-    }
-
-    /**
-     * Constructs an immutable {@link SetValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <E> The element type
-     * @return The constructed immutable value
-     */
-    static <E> SetValue.Immutable<E> immutableOf(Supplier<? extends Key<? extends SetValue<E>>> key, Set<E> element) {
-        return SetValue.immutableOf(key.get(), element);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/data/value/Value.java
+++ b/src/main/java/org/spongepowered/api/data/value/Value.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * The abstract base interface for all of the "Value API". In short, a
@@ -76,19 +75,6 @@ public interface Value<E> {
     }
 
     /**
-     * Constructs a mutable {@link Value} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <E> The element type
-     * @return The constructed mutable value
-     */
-    static <E> Value.Mutable<E> mutableOf(Supplier<? extends Key<? extends Value<E>>> key, E element) {
-        return Value.mutableOf(key.get(), element);
-    }
-
-    /**
      * Constructs an immutable {@link Value} of the appropriate type based
      * on the given {@link Key} and the element.
      *
@@ -99,19 +85,6 @@ public interface Value<E> {
      */
     static <E> Value.Immutable<E> immutableOf(Key<? extends Value<E>> key, E element) {
         return Value.genericImmutableOf(key, element).asImmutable();
-    }
-
-    /**
-     * Constructs an immutable {@link Value} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <E> The element type
-     * @return The constructed immutable value
-     */
-    static <E> Value.Immutable<E> immutableOf(Supplier<? extends Key<? extends Value<E>>> key, E element) {
-        return Value.immutableOf(key.get(), element);
     }
 
     /**
@@ -128,19 +101,6 @@ public interface Value<E> {
     }
 
     /**
-     * Constructs a mutable {@link ListValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <E> The element type
-     * @return The constructed mutable value
-     */
-    static <E> ListValue.Mutable<E> mutableOf(Supplier<? extends Key<? extends ListValue<E>>> key, List<E> element) {
-        return Value.mutableOf(key.get(), element);
-    }
-
-    /**
      * Constructs an immutable {@link ListValue} of the appropriate type based
      * on the given {@link Key} and the element.
      *
@@ -151,19 +111,6 @@ public interface Value<E> {
      */
     static <E> ListValue.Immutable<E> immutableOf(Key<? extends ListValue<E>> key, List<E> element) {
         return Value.genericImmutableOf(key, element).asImmutable();
-    }
-
-    /**
-     * Constructs an immutable {@link ListValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <E> The element type
-     * @return The constructed immutable value
-     */
-    static <E> ListValue.Immutable<E> immutableOf(Supplier<? extends Key<? extends ListValue<E>>> key, List<E> element) {
-        return Value.immutableOf(key.get(), element);
     }
 
     /**
@@ -180,19 +127,6 @@ public interface Value<E> {
     }
 
     /**
-     * Constructs a mutable {@link SetValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <E> The element type
-     * @return The constructed mutable value
-     */
-    static <E> SetValue.Mutable<E> mutableOf(Supplier<? extends Key<? extends SetValue<E>>> key, Set<E> element) {
-        return Value.mutableOf(key.get(), element);
-    }
-
-    /**
      * Constructs an immutable {@link SetValue} of the appropriate type based
      * on the given {@link Key} and the element.
      *
@@ -203,19 +137,6 @@ public interface Value<E> {
      */
     static <E> SetValue.Immutable<E> immutableOf(Key<? extends SetValue<E>> key, Set<E> element) {
         return Value.genericImmutableOf(key, element).asImmutable();
-    }
-
-    /**
-     * Constructs an immutable {@link SetValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <E> The element type
-     * @return The constructed immutable value
-     */
-    static <E> SetValue.Immutable<E> immutableOf(Supplier<? extends Key<? extends SetValue<E>>> key, Set<E> element) {
-        return Value.immutableOf(key.get(), element);
     }
 
     /**
@@ -233,20 +154,6 @@ public interface Value<E> {
     }
 
     /**
-     * Constructs a mutable {@link MapValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <K> The map key type
-     * @param <V> The map value type
-     * @return The constructed mutable value
-     */
-    static <K, V> MapValue.Mutable<K, V> mutableOf(Supplier<? extends Key<? extends MapValue<K, V>>> key, Map<K, V> element) {
-        return Value.mutableOf(key.get(), element);
-    }
-
-    /**
      * Constructs an immutable {@link MapValue} of the appropriate type based
      * on the given {@link Key} and the element.
      *
@@ -258,20 +165,6 @@ public interface Value<E> {
      */
     static <K, V> MapValue.Immutable<K, V> immutableOf(Key<? extends MapValue<K, V>> key, Map<K, V> element) {
         return Value.genericImmutableOf(key, element).asImmutable();
-    }
-
-    /**
-     * Constructs an immutable {@link MapValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <K> The map key type
-     * @param <V> The map value type
-     * @return The constructed immutable value
-     */
-    static <K, V> MapValue.Immutable<K, V> immutableOf(Supplier<? extends Key<? extends MapValue<K, V>>> key, Map<K, V> element) {
-        return Value.immutableOf(key.get(), element);
     }
 
     /**
@@ -288,19 +181,6 @@ public interface Value<E> {
     }
 
     /**
-     * Constructs a mutable {@link WeightedCollectionValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <E> The element type
-     * @return The constructed mutable value
-     */
-    static <E> WeightedCollectionValue.Mutable<E> mutableOf(Supplier<? extends Key<? extends WeightedCollectionValue<E>>> key, WeightedTable<E> element) {
-        return Value.mutableOf(key.get(), element);
-    }
-
-    /**
      * Constructs an immutable {@link WeightedCollectionValue} of the appropriate type based
      * on the given {@link Key} and the element.
      *
@@ -311,19 +191,6 @@ public interface Value<E> {
      */
     static <E> WeightedCollectionValue.Immutable<E> immutableOf(Key<? extends WeightedCollectionValue<E>> key, WeightedTable<E> element) {
         return Value.genericImmutableOf(key, element).asImmutable();
-    }
-
-    /**
-     * Constructs an immutable {@link WeightedCollectionValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <E> The element type
-     * @return The constructed immutable value
-     */
-    static <E> WeightedCollectionValue.Immutable<E> immutableOf(Supplier<? extends Key<? extends WeightedCollectionValue<E>>> key, WeightedTable<E> element) {
-        return Value.immutableOf(key.get(), element);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/data/value/WeightedCollectionValue.java
+++ b/src/main/java/org/spongepowered/api/data/value/WeightedCollectionValue.java
@@ -30,7 +30,6 @@ import org.spongepowered.api.util.weighted.WeightedTable;
 
 import java.util.List;
 import java.util.Random;
-import java.util.function.Supplier;
 
 public interface WeightedCollectionValue<E> extends CollectionValue<TableEntry<E>, WeightedTable<E>>  {
 
@@ -48,19 +47,6 @@ public interface WeightedCollectionValue<E> extends CollectionValue<TableEntry<E
     }
 
     /**
-     * Constructs a mutable {@link WeightedCollectionValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <E> The element type
-     * @return The constructed mutable value
-     */
-    static <E> WeightedCollectionValue.Mutable<E> mutableOf(Supplier<? extends Key<? extends WeightedCollectionValue<E>>> key, WeightedTable<E> element) {
-        return WeightedCollectionValue.mutableOf(key.get(), element);
-    }
-
-    /**
      * Constructs an immutable {@link WeightedCollectionValue} of the appropriate type based
      * on the given {@link Key} and the element.
      *
@@ -71,19 +57,6 @@ public interface WeightedCollectionValue<E> extends CollectionValue<TableEntry<E
      */
     static <E> WeightedCollectionValue.Immutable<E> immutableOf(Key<? extends WeightedCollectionValue<E>> key, WeightedTable<E> element) {
         return Value.immutableOf(key, element);
-    }
-
-    /**
-     * Constructs an immutable {@link WeightedCollectionValue} of the appropriate type based
-     * on the given {@link Key} and the element.
-     *
-     * @param key The key
-     * @param element The element
-     * @param <E> The element type
-     * @return The constructed immutable value
-     */
-    static <E> WeightedCollectionValue.Immutable<E> immutableOf(Supplier<? extends Key<? extends WeightedCollectionValue<E>>> key, WeightedTable<E> element) {
-        return WeightedCollectionValue.immutableOf(key.get(), element);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/effect/Viewer.java
+++ b/src/main/java/org/spongepowered/api/effect/Viewer.java
@@ -38,7 +38,6 @@ import org.spongepowered.math.vector.Vector3d;
 import org.spongepowered.math.vector.Vector3i;
 
 import java.util.Objects;
-import java.util.function.Supplier;
 
 /**
  * A Viewer is something that sees effects.

--- a/src/main/java/org/spongepowered/api/effect/particle/ParticleEffect.java
+++ b/src/main/java/org/spongepowered/api/effect/particle/ParticleEffect.java
@@ -32,7 +32,6 @@ import org.spongepowered.math.vector.Vector3d;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * Represents a particle effect that can be send to the Minecraft client.
@@ -62,30 +61,7 @@ public interface ParticleEffect extends DataSerializable {
      * @param <V> The value type
      * @return The option value if present, otherwise {@link Optional#empty()}
      */
-    default <V> Optional<V> option(Supplier<? extends ParticleOption<V>> option) {
-        return this.option(option.get());
-    }
-
-    /**
-     * Gets the value for the specified {@link ParticleOption}.
-     *
-     * @param option The particle option
-     * @param <V> The value type
-     * @return The option value if present, otherwise {@link Optional#empty()}
-     */
     <V> Optional<V> option(ParticleOption<V> option);
-
-    /**
-     * Gets the value for the specified {@link ParticleOption} or
-     * the default value if not present.
-     *
-     * @param option The particle option
-     * @param <V> The value type
-     * @return The option value if present, otherwise {@link Optional#empty()}
-     */
-    default <V> Optional<V> optionOrDefault(Supplier<? extends ParticleOption<V>> option) {
-        return this.optionOrDefault(option.get());
-    }
 
     /**
      * Gets the value for the specified {@link ParticleOption} or
@@ -123,16 +99,6 @@ public interface ParticleEffect extends DataSerializable {
         Builder type(ParticleType particleType);
 
         /**
-         * Sets the particle type for the particle effect.
-         *
-         * @param particleType The particle type
-         * @return This builder for chaining
-         */
-        default Builder type(Supplier<? extends ParticleType> particleType) {
-            return this.type(particleType.get());
-        }
-
-        /**
          * Sets the value of the specified {@link ParticleOption}.
          *
          * @param option The option
@@ -144,19 +110,6 @@ public interface ParticleEffect extends DataSerializable {
         <V> Builder option(ParticleOption<V> option, V value) throws IllegalArgumentException;
 
         /**
-         * Sets the value of the specified {@link ParticleOption}.
-         *
-         * @param option The option
-         * @param value The value
-         * @param <V> The type of option value
-         * @return This builder for chaining
-         * @throws IllegalArgumentException If the specified value isn't valid
-         */
-        default <V> Builder option(final Supplier<? extends ParticleOption<V>> option, V value) throws IllegalArgumentException {
-            return this.option(option.get(), value);
-        }
-
-        /**
          * Sets the scale of the particle effect.
          *
          * <p>The default scale is 1.</p>
@@ -165,7 +118,7 @@ public interface ParticleEffect extends DataSerializable {
          * @return This builder for chaining
          */
         default <V> Builder scale(Double scale) {
-            return this.option(ParticleOptions.SCALE, scale);
+            return this.option(ParticleOptions.SCALE.get(), scale);
         }
 
         /**
@@ -177,7 +130,7 @@ public interface ParticleEffect extends DataSerializable {
          * @return This builder for chaining
          */
         default Builder velocity(Vector3d velocity) {
-            return this.option(ParticleOptions.VELOCITY, velocity);
+            return this.option(ParticleOptions.VELOCITY.get(), velocity);
         }
 
         /**
@@ -189,7 +142,7 @@ public interface ParticleEffect extends DataSerializable {
          * @return This builder for chaining
          */
         default Builder offset(Vector3d offset) {
-            return this.option(ParticleOptions.OFFSET, offset);
+            return this.option(ParticleOptions.OFFSET.get(), offset);
         }
 
         /**
@@ -202,7 +155,7 @@ public interface ParticleEffect extends DataSerializable {
          * @throws IllegalArgumentException If the quantity is less than one
          */
         default Builder quantity(int quantity) throws IllegalArgumentException {
-            return this.option(ParticleOptions.QUANTITY, quantity);
+            return this.option(ParticleOptions.QUANTITY.get(), quantity);
         }
 
         /**

--- a/src/main/java/org/spongepowered/api/effect/particle/ParticleType.java
+++ b/src/main/java/org/spongepowered/api/effect/particle/ParticleType.java
@@ -29,26 +29,12 @@ import org.spongepowered.api.util.annotation.CatalogedBy;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * Represents a particle that can be sent on a Minecraft client.
  */
 @CatalogedBy(ParticleTypes.class)
 public interface ParticleType extends DefaultedRegistryValue {
-
-    /**
-     * Gets the default value for the specified {@link ParticleOption}, it may
-     * return {@link Optional#empty()} if the particle option isn't supported
-     * by this particle type.
-     *
-     * @param option The particle option
-     * @param <V> The value type
-     * @return The option value if present, otherwise {@link Optional#empty()}
-     */
-    default <V> Optional<V> defaultOption(Supplier<? extends ParticleOption<V>> option) {
-        return this.defaultOption(option.get());
-    }
 
     /**
      * Gets the default value for the specified {@link ParticleOption}, it may

--- a/src/main/java/org/spongepowered/api/effect/potion/PotionEffect.java
+++ b/src/main/java/org/spongepowered/api/effect/potion/PotionEffect.java
@@ -31,8 +31,6 @@ import org.spongepowered.api.data.persistence.DataSerializable;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.util.CopyableBuilder;
 
-import java.util.function.Supplier;
-
 /**
  * Represents an effect of a {@link PotionEffectType} for a specified
  * {@link #duration()}, {@link #amplifier()}, {@link #showsParticles()}
@@ -62,20 +60,6 @@ public interface PotionEffect extends DataSerializable {
      * @return The potion effect
      */
     static PotionEffect of(PotionEffectType type, int amplifier, int duration) {
-        return PotionEffect.builder().potionType(type).amplifier(amplifier).duration(duration).build();
-    }
-
-    /**
-     * Creates a new {@link PotionEffect} with the provided
-     * {@link PotionEffectType}, the provided amplifier, and the provided
-     * duration in ticks.
-     *
-     * @param type The potion type
-     * @param amplifier The amplifier
-     * @param duration The duration in ticks
-     * @return The potion effect
-     */
-    static PotionEffect of(Supplier<? extends PotionEffectType> type, int amplifier, int duration) {
         return PotionEffect.builder().potionType(type).amplifier(amplifier).duration(duration).build();
     }
 
@@ -138,16 +122,6 @@ public interface PotionEffect extends DataSerializable {
          * @return This builder, for chaining
          */
         Builder potionType(PotionEffectType potionEffectType);
-
-        /**
-         * Sets the {@link PotionEffectType} of the potion.
-         *
-         * @param potionEffectType The type of item
-         * @return This builder, for chaining
-         */
-        default Builder potionType(Supplier<? extends PotionEffectType> potionEffectType) {
-            return this.potionType(potionEffectType.get());
-        }
 
         /**
          * Sets the duration in ticks of the potion effect.

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -55,7 +55,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 /**
@@ -268,17 +267,6 @@ public interface Entity extends Identifiable, HoverEventSource<HoverEvent.ShowEn
      * within one game tick.
      */
     void remove();
-
-    /**
-     * Damages this {@link Entity} with the given {@link DamageSource}.
-     *
-     * @param damage The damage to deal
-     * @param damageSource The cause of the damage
-     * @return True if damaging the entity was successful
-     */
-    default boolean damage(final double damage, final Supplier<? extends DamageSource> damageSource) {
-        return this.damage(damage, damageSource.get());
-    }
 
     /**
      * Damages this {@link Entity} with the given {@link DamageSource}.

--- a/src/main/java/org/spongepowered/api/entity/EntityArchetype.java
+++ b/src/main/java/org/spongepowered/api/entity/EntityArchetype.java
@@ -33,8 +33,6 @@ import org.spongepowered.api.data.persistence.Queries;
 import org.spongepowered.api.world.Archetype;
 import org.spongepowered.api.world.schematic.Schematic;
 
-import java.util.function.Supplier;
-
 public interface EntityArchetype extends Archetype<EntitySnapshot, Entity> {
 
     /**

--- a/src/main/java/org/spongepowered/api/entity/EntitySnapshot.java
+++ b/src/main/java/org/spongepowered/api/entity/EntitySnapshot.java
@@ -40,7 +40,6 @@ import org.spongepowered.math.vector.Vector3i;
 
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Supplier;
 
 /**
  * Represents a snapshot of an {@link Entity} and all of it's related data in
@@ -125,16 +124,6 @@ public interface EntitySnapshot extends LocatableSnapshot<EntitySnapshot> {
          * @return This builder, for chaining
          */
         Builder world(ServerWorldProperties worldProperties);
-
-        /**
-         * Sets the {@link EntityType} for this {@link EntitySnapshot}.
-         *
-         * @param entityType The EntityType
-         * @return This builder, for chaining
-         */
-        default Builder type(Supplier<? extends EntityType<?>> entityType) {
-            return this.type(entityType.get());
-        }
 
         /**
          * Sets the {@link EntityType} for this {@link EntitySnapshot}.

--- a/src/main/java/org/spongepowered/api/entity/attribute/Attribute.java
+++ b/src/main/java/org/spongepowered/api/entity/attribute/Attribute.java
@@ -30,7 +30,6 @@ import org.spongepowered.api.item.inventory.ItemStack;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Supplier;
 
 /**
  * Represents an instance of an {@link AttributeType} that contains a value.
@@ -82,16 +81,6 @@ public interface Attribute {
      * @return A collection of applied modifiers
      */
     Collection<AttributeModifier> modifiers();
-
-    /**
-     * Gets a collection of applied modifiers with the provided operation.
-     *
-     * @param operation The operation
-     * @return A collection of modifiers
-     */
-    default Collection<AttributeModifier> modifiers(Supplier<? extends AttributeOperation> operation) {
-        return this.modifiers(operation.get());
-    }
 
     /**
      * Gets a collection of applied modifiers with the provided operation.

--- a/src/main/java/org/spongepowered/api/entity/attribute/AttributeHolder.java
+++ b/src/main/java/org/spongepowered/api/entity/attribute/AttributeHolder.java
@@ -28,22 +28,11 @@ import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.attribute.type.AttributeType;
 
 import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * Represents an {@link Entity} which can hold {@link Attribute}s.
  */
 public interface AttributeHolder {
-
-    /**
-     * Gets an {@link Attribute} from this entity
-     *
-     * @param type The attribute type.
-     * @return An attribute, if present.
-     */
-    default Optional<Attribute> attribute(final Supplier<? extends AttributeType> type) {
-        return this.attribute(type.get());
-    }
 
     /**
      * Gets an {@link Attribute} from this entity

--- a/src/main/java/org/spongepowered/api/entity/attribute/AttributeModifier.java
+++ b/src/main/java/org/spongepowered/api/entity/attribute/AttributeModifier.java
@@ -29,7 +29,6 @@ import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.util.Identifiable;
 
 import java.util.UUID;
-import java.util.function.Supplier;
 
 /**
  * Represents a modifier to a value in a {@link Attribute} which is transformed
@@ -113,17 +112,7 @@ public interface AttributeModifier extends Identifiable {
          * @param operation The operation
          * @return This builder
          */
-        default Builder operation(Supplier<? extends AttributeOperation> operation) {
-            return this.operation(operation.get());
-        }
-
-        /**
-         * Sets the operation of this attribute modifier.
-         *
-         * @param operation The operation
-         * @return This builder
-         */
-        Builder operation(final AttributeOperation operation);
+        Builder operation(AttributeOperation operation);
 
         /**
          * Sets the amount of the attribute modifier.

--- a/src/main/java/org/spongepowered/api/event/CauseStackManager.java
+++ b/src/main/java/org/spongepowered/api/event/CauseStackManager.java
@@ -26,7 +26,6 @@ package org.spongepowered.api.event;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * Provides an interface into the system managing the cause and contextual
@@ -123,45 +122,6 @@ public interface CauseStackManager {
     <T> CauseStackManager addContext(EventContextKey<T> key, T value);
 
     /**
-     * Adds the given object to the current context under the given key.
-     *
-     * @param key The context key
-     * @param value The object
-     * @param <T> The type of the value stored with the event context key
-     * @return The cause stack manager, for chaining
-     * @see EventContextKeys
-     */
-    default <T> CauseStackManager addContext(EventContextKey<T> key, Supplier<? extends T> value) {
-        return this.addContext(key, value.get());
-    }
-
-    /**
-     * Adds the given object to the current context under the given key.
-     *
-     * @param key The context key
-     * @param value The object
-     * @param <T> The type of the value stored with the event context key
-     * @return The cause stack manager, for chaining
-     * @see EventContextKeys
-     */
-    default <T> CauseStackManager addContext(Supplier<EventContextKey<T>> key, T value) {
-        return this.addContext(key.get(), value);
-    }
-
-    /**
-     * Adds the given object to the current context under the given key.
-     *
-     * @param key The context key
-     * @param value The object
-     * @param <T> The type of the value stored with the event context key
-     * @return The cause stack manager, for chaining
-     * @see EventContextKeys
-     */
-    default <T> CauseStackManager addContext(Supplier<EventContextKey<T>> key, Supplier<? extends T> value) {
-        return this.addContext(key.get(), value.get());
-    }
-
-    /**
      * Gets the context value with the given key.
      * 
      * @param key The context key
@@ -169,17 +129,6 @@ public interface CauseStackManager {
      * @return The context object, if present
      */
     <T> Optional<T> context(EventContextKey<T> key);
-
-    /**
-     * Gets the context value with the given key.
-     *
-     * @param key The context key
-     * @param <T> The type of the value stored with the event context key
-     * @return The context object, if present
-     */
-    default <T> Optional<T> context(Supplier<EventContextKey<T>> key) {
-        return this.context(key.get());
-    }
 
     /**
      * Gets the context value with the given key.
@@ -199,25 +148,6 @@ public interface CauseStackManager {
         throw new NoSuchElementException(String.format("Could not retrieve value for key '%s'", key.toString()));
     }
 
-
-    /**
-     * Gets the context value with the given key.
-     *
-     * <p>If the key is not available, {@link NoSuchElementException} will be
-     * thrown.</p>
-     *
-     * @param key The context key
-     * @param <T> The type of the value stored with the event context key
-     * @return The context object, if present
-     */
-    default <T> T requireContext(Supplier<EventContextKey<T>> key) {
-        final Optional<T> optional = this.context(key.get());
-        if (optional.isPresent()) {
-            return optional.get();
-        }
-        throw new NoSuchElementException(String.format("Could not retrieve value for key '%s'", key.get().toString()));
-    }
-
     /**
      * Removes the given context key from the current context.
      * 
@@ -227,18 +157,6 @@ public interface CauseStackManager {
      * @see EventContextKeys
      */
     <T> Optional<T> removeContext(EventContextKey<T> key);
-
-    /**
-     * Removes the given context key from the current context.
-     *
-     * @param key The key to clear
-     * @param <T> The type of the value stored with the event context key
-     * @return The existing context value, if it was present
-     * @see EventContextKeys
-     */
-    default <T> Optional<T> removeContext(Supplier<EventContextKey<T>> key) {
-        return this.removeContext(key.get());
-    }
 
     interface StackFrame extends AutoCloseable {
 
@@ -292,48 +210,6 @@ public interface CauseStackManager {
         <T> StackFrame addContext(EventContextKey<T> key, T value);
 
         /**
-         * Adds the given object to the current context under the given key.
-         *
-         * @param key The context key
-         * @param value The object
-         * @param <T> The type of value key
-         * @return The stack frame, for chaining
-         * @see EventContextKeys
-         * @see CauseStackManager#addContext(EventContextKey, Object)
-         */
-        default <T> StackFrame addContext(EventContextKey<T> key, Supplier<? extends T> value) {
-            return this.addContext(key, value.get());
-        }
-
-        /**
-         * Adds the given object to the current context under the given key.
-         *
-         * @param key The context key
-         * @param value The object
-         * @param <T> The type of value key
-         * @return The stack frame, for chaining
-         * @see EventContextKeys
-         * @see CauseStackManager#addContext(EventContextKey, Object)
-         */
-        default <T> StackFrame addContext(Supplier<EventContextKey<T>> key, T value) {
-            return this.addContext(key.get(), value);
-        }
-
-        /**
-         * Adds the given object to the current context under the given key.
-         *
-         * @param key The context key
-         * @param value The object
-         * @param <T> The type of value key
-         * @return The stack frame, for chaining
-         * @see EventContextKeys
-         * @see CauseStackManager#addContext(EventContextKey, Object)
-         */
-        default <T> StackFrame addContext(Supplier<EventContextKey<T>> key, Supplier<? extends T> value) {
-            return this.addContext(key.get(), value.get());
-        }
-
-        /**
          * Removes the given context key from the current context.
          *
          * @param key The key to clear
@@ -343,19 +219,6 @@ public interface CauseStackManager {
          * @see CauseStackManager#removeContext(EventContextKey)
          */
         <T> Optional<T> removeContext(EventContextKey<T> key);
-
-        /**
-         * Removes the given context key from the current context.
-         *
-         * @param key The key to clear
-         * @param <T> The type of value key
-         * @return The existing context value, if it was present
-         * @see EventContextKeys
-         * @see CauseStackManager#removeContext(EventContextKey)
-         */
-        default <T> Optional<T> removeContext(Supplier<EventContextKey<T>> key) {
-            return this.removeContext(key.get());
-        }
 
         @Override
         void close();

--- a/src/main/java/org/spongepowered/api/event/EventContext.java
+++ b/src/main/java/org/spongepowered/api/event/EventContext.java
@@ -37,7 +37,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
-import java.util.function.Supplier;
 
 /**
  * Provides context for an event outside of the direct chain of causes present
@@ -102,19 +101,6 @@ public final class EventContext {
     /**
      * Gets the value corresponding to the given key from the context.
      *
-     * @param key The key
-     * @param <T> The type of the value stored with the key
-     * @return The context value, if found
-     */
-    @SuppressWarnings("unchecked")
-    public <T> Optional<T> get(Supplier<EventContextKey<T>> key) {
-        Objects.requireNonNull(key, "EventContextKey cannot be null");
-        return Optional.ofNullable((T) this.entries.get(key.get()));
-    }
-
-    /**
-     * Gets the value corresponding to the given key from the context.
-     *
      * <p>If the key is not available, {@link NoSuchElementException} will be
      * thrown.</p>
      * 
@@ -131,24 +117,6 @@ public final class EventContext {
     }
 
     /**
-     * Gets the value corresponding to the given key from the context.
-     *
-     * <p>If the key is not available, {@link NoSuchElementException} will be
-     * thrown.</p>
-     *
-     * @param key The key
-     * @param <T> The type of the value stored with the key
-     * @return The context value, if found
-     */
-    public <T> T require(Supplier<EventContextKey<T>> key) {
-        final Optional<T> optional = this.get(key);
-        if (optional.isPresent()) {
-            return optional.get();
-        }
-        throw new NoSuchElementException(String.format("Could not retrieve value for key '%s'", key.get().toString()));
-    }
-
-    /**
      * Gets whether the provided {@link EventContextKey} is included in this
      * context.
      *
@@ -157,17 +125,6 @@ public final class EventContext {
      */
     public boolean containsKey(EventContextKey<?> key) {
         return this.entries.containsKey(key);
-    }
-
-    /**
-     * Gets whether the provided {@link EventContextKey} is included in this
-     * context.
-     *
-     * @param key The context key to check
-     * @return True if the key is used and there is an entry for it
-     */
-    public boolean containsKey(Supplier<? extends EventContextKey<?>> key) {
-        return this.entries.containsKey(key.get());
     }
 
     /**
@@ -223,8 +180,7 @@ public final class EventContext {
         return "Context[" + joiner.toString() + "]";
     }
 
-    public static final class Builder implements org.spongepowered.api.util.Builder<EventContext, Builder>, CopyableBuilder<EventContext,
-        Builder> {
+    public static final class Builder implements org.spongepowered.api.util.Builder<EventContext, Builder>, CopyableBuilder<EventContext, Builder> {
 
         private final Map<EventContextKey<?>, Object> entries = Maps.newHashMap();
 
@@ -246,26 +202,6 @@ public final class EventContext {
                 throw new IllegalArgumentException("Duplicate context keys: " + key.toString());
             }
             this.entries.put(key, value);
-            return this;
-        }
-
-
-        /**
-         * Adds the given context key value pair to the context.
-         *
-         * @param key The key
-         * @param <T> The type of the value stored with the key
-         * @param value The value
-         * @return This builder, for chaining
-         */
-        public <T> Builder add(Supplier<EventContextKey<T>> key, T value) {
-            Objects.requireNonNull(value, "Context object cannot be null");
-            final EventContextKey<T> suppliedKey = key.get();
-            Objects.requireNonNull(suppliedKey, "Supplied key cannot be null!");
-            if (this.entries.containsKey(suppliedKey)) {
-                throw new IllegalArgumentException("Duplicate context keys!");
-            }
-            this.entries.put(suppliedKey, value);
             return this;
         }
 

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
@@ -37,7 +37,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.function.DoubleUnaryOperator;
-import java.util.function.Supplier;
 
 /**
  * Represents a modifier that will apply a function on a damage value to deal
@@ -95,18 +94,6 @@ public interface DamageModifier {
         @Nullable ItemStackSnapshot snapshot;
 
         Builder() {
-        }
-
-
-        /**
-         * Sets the {@link DamageModifierType} for the {@link DamageModifier} to
-         * build.
-         *
-         * @param damageModifierType The damage modifier type
-         * @return This builder, for chaining
-         */
-        public Builder type(final Supplier<? extends DamageModifierType> damageModifierType) {
-            return this.type(damageModifierType.get());
         }
 
         /**

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/DamageSource.java
@@ -32,8 +32,6 @@ import org.spongepowered.api.event.cause.entity.damage.DamageTypes;
 import org.spongepowered.api.util.CopyableBuilder;
 import org.spongepowered.api.world.difficulty.Difficulty;
 
-import java.util.function.Supplier;
-
 /**
  * Represents a {@link Cause} for damage on the {@link Entity} being
  * damaged. Usually the {@link DamageSource} will have different properties
@@ -218,18 +216,6 @@ public interface DamageSource {
          * @return This builder
          */
         B exhaustion(double exhaustion);
-
-        /**
-         * Sets the {@link DamageType} of this source.
-         *
-         * <p>This is required to be set.</p>
-         *
-         * @param damageType The desired damage type
-         * @return This builder
-         */
-        default B type(Supplier<? extends DamageType> damageType) {
-            return this.type(damageType.get());
-        }
 
         /**
          * Sets the {@link DamageType} of this source.

--- a/src/main/java/org/spongepowered/api/fluid/FluidStack.java
+++ b/src/main/java/org/spongepowered/api/fluid/FluidStack.java
@@ -29,8 +29,6 @@ import org.spongepowered.api.data.SerializableDataHolder;
 import org.spongepowered.api.data.SerializableDataHolderBuilder;
 import org.spongepowered.api.item.ItemTypes;
 
-import java.util.function.Supplier;
-
 /**
  * Represents a stack of a particular {@link FluidType} and
  * volume measured in "milliBuckets" where <code>1000</code>mB is equal to
@@ -88,16 +86,6 @@ public interface FluidStack extends SerializableDataHolder.Mutable {
     FluidStack copy();
 
     interface Builder extends SerializableDataHolderBuilder.Mutable<FluidStack, Builder> {
-
-        /**
-         * Sets the {@link FluidType} to use to build the {@link FluidStack}.
-         *
-         * @param fluidType The fluid type
-         * @return This builder, for chaining
-         */
-        default Builder fluid(Supplier<? extends FluidType> fluidType) {
-            return this.fluid(fluidType.get());
-        }
 
         /**
          * Sets the {@link FluidType} to use to build the {@link FluidStack}.

--- a/src/main/java/org/spongepowered/api/fluid/FluidStackSnapshot.java
+++ b/src/main/java/org/spongepowered/api/fluid/FluidStackSnapshot.java
@@ -28,8 +28,6 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.SerializableDataHolder;
 import org.spongepowered.api.data.SerializableDataHolderBuilder;
 
-import java.util.function.Supplier;
-
 public interface FluidStackSnapshot extends SerializableDataHolder.Immutable<FluidStackSnapshot> {
 
     /**
@@ -67,10 +65,6 @@ public interface FluidStackSnapshot extends SerializableDataHolder.Immutable<Flu
     FluidStack createStack();
 
     interface Builder extends SerializableDataHolderBuilder.Immutable<FluidStackSnapshot, Builder> {
-
-        default Builder fluid(Supplier<? extends FluidType> fluidType) {
-            return this.fluid(fluidType.get());
-        }
 
         Builder fluid(FluidType fluidType);
 

--- a/src/main/java/org/spongepowered/api/fluid/FluidState.java
+++ b/src/main/java/org/spongepowered/api/fluid/FluidState.java
@@ -34,7 +34,6 @@ import org.spongepowered.api.world.schematic.Schematic;
 import org.spongepowered.api.world.server.ServerLocation;
 
 import java.util.Objects;
-import java.util.function.Supplier;
 
 /**
  * Represents a particular "state" that can exist at a {@link ServerLocation} with
@@ -91,16 +90,6 @@ public interface FluidState extends State<FluidState> {
      * of {@link DataManipulator}s, otherwise exceptions may be thrown.</p>
      */
     interface Builder extends State.Builder<FluidState, Builder> {
-
-        /**
-         * Sets the {@link FluidType} for the {@link FluidState} to build.
-         *
-         * @param fluidType The fluid type
-         * @return This builder, for chaining
-         */
-        default Builder fluid(Supplier<? extends FluidType> fluidType) {
-            return this.fluid(fluidType.get());
-        }
 
         /**
          * Sets the {@link FluidType} for the {@link FluidState} to build.

--- a/src/main/java/org/spongepowered/api/item/FireworkEffect.java
+++ b/src/main/java/org/spongepowered/api/item/FireworkEffect.java
@@ -30,7 +30,6 @@ import org.spongepowered.api.util.Color;
 import org.spongepowered.api.util.CopyableBuilder;
 
 import java.util.List;
-import java.util.function.Supplier;
 
 /**
  * Represents a firework explosion.
@@ -186,16 +185,6 @@ public interface FireworkEffect extends DataSerializable {
          * @return This builder, for chaining
          */
         Builder shape(FireworkShape shape);
-
-        /**
-         * Sets the shape of the {@link FireworkEffect} explosion.
-         *
-         * @param shape The shape of the explosion
-         * @return This builder, for chaining
-         */
-        default Builder shape(Supplier<? extends FireworkShape> shape) {
-            return this.shape(shape.get());
-        }
 
         /**
          * Builds a {@link FireworkEffect} based on the current state of this

--- a/src/main/java/org/spongepowered/api/item/ItemType.java
+++ b/src/main/java/org/spongepowered/api/item/ItemType.java
@@ -33,7 +33,6 @@ import org.spongepowered.api.tag.Taggable;
 import org.spongepowered.api.util.annotation.CatalogedBy;
 
 import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * A type of item.
@@ -70,16 +69,6 @@ public interface ItemType extends DefaultedRegistryValue, ComponentLike, DataHol
      * @return The default rarity for the item type.
      */
     ItemRarity rarity();
-
-    /**
-     * Returns true if this type is any of the given item types
-     *
-     * @param types the item types to check
-     *
-     * @return true if this type is any of the given item types
-     */
-    @SuppressWarnings("unchecked")
-    boolean isAnyOf(Supplier<? extends ItemType>... types);
 
     /**
      * Returns true if this type is any of the given item types

--- a/src/main/java/org/spongepowered/api/item/enchantment/Enchantment.java
+++ b/src/main/java/org/spongepowered/api/item/enchantment/Enchantment.java
@@ -31,7 +31,6 @@ import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.util.CopyableBuilder;
 
 import java.util.List;
-import java.util.function.Supplier;
 
 /**
  * Represents an {@link EnchantmentType} on an {@link ItemStack} that is paired
@@ -60,20 +59,6 @@ public interface Enchantment extends DataSerializable {
      */
     static RandomListBuilder randomListBuilder() {
         return Sponge.game().builderProvider().provide(RandomListBuilder.class);
-    }
-
-    /**
-     * Creates a new {@link Enchantment} with the provided
-     * {@link EnchantmentType} and level.
-     *
-     * @param enchantmentType The enchantment type
-     * @param level The enchantment level
-     * @return The created enchantment
-     * @throws IllegalArgumentException If the level is smaller than
-     *     {@link Short#MIN_VALUE} or larger than {@link Short#MAX_VALUE}
-     */
-    static Enchantment of(Supplier<? extends EnchantmentType> enchantmentType, int level) throws IllegalArgumentException {
-        return Enchantment.of(enchantmentType.get(), level);
     }
 
     /**
@@ -121,16 +106,6 @@ public interface Enchantment extends DataSerializable {
          * @return The modified builder, for chaining
          */
         Builder type(EnchantmentType enchantmentType);
-
-        /**
-         * Sets the {@link EnchantmentType} for this enchantment.
-         *
-         * @param enchantmentType The desired enchantment type
-         * @return The modified builder, for chaining
-         */
-        default Builder type(Supplier<? extends EnchantmentType> enchantmentType) {
-            return this.type(enchantmentType.get());
-        }
 
         /**
          * Sets the level for this enchantment.

--- a/src/main/java/org/spongepowered/api/item/inventory/ArmorEquipable.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ArmorEquipable.java
@@ -26,8 +26,6 @@ package org.spongepowered.api.item.inventory;
 
 import org.spongepowered.api.data.type.HandType;
 
-import java.util.function.Supplier;
-
 /**
  * <p>Represents something that can be equipped with armor, main hand and off hand items.
  * Each method here is a shorthand for the appropriate {@link #equipped}
@@ -101,27 +99,7 @@ public interface ArmorEquipable extends Equipable {
      * @param handType The hand type to retrieve from
      * @return The item in hand, if available
      */
-    default ItemStack itemInHand(Supplier<? extends HandType> handType) {
-        return this.itemInHand(handType.get());
-    }
-
-    /**
-     * Gets the equipped item in hand.
-     *
-     * @param handType The hand type to retrieve from
-     * @return The item in hand, if available
-     */
     ItemStack itemInHand(HandType handType);
-
-    /**
-     * Sets the equipped item in hand.
-     *
-     * @param handType The hand type to set to
-     * @param itemInHand The item in hand
-     */
-    default void setItemInHand(Supplier<? extends HandType> handType, ItemStack itemInHand) {
-        this.setItemInHand(handType.get(), itemInHand);
-    }
 
     /**
      * Sets the equipped item in hand.

--- a/src/main/java/org/spongepowered/api/item/inventory/Equipable.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Equipable.java
@@ -28,7 +28,6 @@ import org.spongepowered.api.item.inventory.equipment.EquipmentInventory;
 import org.spongepowered.api.item.inventory.equipment.EquipmentType;
 
 import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * Represents the holder of a {@link EquipmentInventory}.
@@ -52,10 +51,6 @@ public interface Equipable {
      */
     boolean canEquip(EquipmentType type);
 
-    default boolean canEquip(final Supplier<? extends EquipmentType> type) {
-        return this.canEquip(type.get());
-    }
-
     /**
      * Gets whether this {@link Equipable} can equip the supplied equipment in its slot of
      * the specified type (eg. whether calling {@link #equip} with the specified
@@ -67,11 +62,6 @@ public interface Equipable {
      */
     boolean canEquip(EquipmentType type, ItemStack equipment);
 
-    default boolean canEquip(final Supplier<? extends EquipmentType> type, final ItemStack equipment) {
-        return this.canEquip(type.get(), equipment);
-    }
-
-
     /**
      * Gets the item currently equipped by this {@link Equipable} in the specified slot.
      *
@@ -79,10 +69,6 @@ public interface Equipable {
      * @return The item in the equipped slot, if available
      */
     Optional<ItemStack> equipped(EquipmentType type);
-
-    default Optional<ItemStack> equipped(final Supplier<? extends EquipmentType> type) {
-        return this.equipped(type.get());
-    }
 
     /**
      * Sets the item currently equipped by the {@link Equipable} in the specified slot, if
@@ -96,8 +82,4 @@ public interface Equipable {
      *     the specified slot.
      */
     boolean equip(EquipmentType type, ItemStack equipment);
-
-    default boolean equip(final Supplier<? extends EquipmentType> type, final ItemStack equipment) {
-        return this.equip(type.get(), equipment);
-    }
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/Inventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Inventory.java
@@ -41,7 +41,6 @@ import org.spongepowered.api.item.inventory.type.ViewableInventory;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Supplier;
 
 /**
  * Base interface for queryable inventories.
@@ -337,21 +336,8 @@ public interface Inventory extends ValueContainer {
      *
      * @return The queried inventory
      */
-    default <P> Inventory query(Supplier<QueryType.OneParam<P>> queryType, P param) {
-        return this.query(queryType.get().of(param));
-    }
-
-    /**
-     * Query this inventory with given {@link QueryType.OneParam} and one parameter.
-     *
-     * @param queryType The queryType
-     * @param param The parameter
-     * @param <P> The parameter type
-     *
-     * @return The queried inventory
-     */
-    default <P> Inventory query(Supplier<QueryType.OneParam<P>> queryType, Supplier<P> param) {
-        return this.query(queryType.get().of(param.get()));
+    default <P> Inventory query(QueryType.OneParam<P> queryType, P param) {
+        return this.query(queryType.of(param));
     }
 
     /**
@@ -365,8 +351,8 @@ public interface Inventory extends ValueContainer {
      *
      * @return The queried inventory
      */
-    default <P1, P2> Inventory query(Supplier<QueryType.TwoParam<P1, P2>> queryType, P1 param1, P2 param2) {
-        return this.query(queryType.get().of(param1, param2));
+    default <P1, P2> Inventory query(QueryType.TwoParam<P1, P2> queryType, P1 param1, P2 param2) {
+        return this.query(queryType.of(param1, param2));
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
@@ -47,7 +47,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 /**
  * Represents a stack of a specific {@link ItemType}. Supports serialization and
@@ -69,15 +68,12 @@ public interface ItemStack extends SerializableDataHolder.Mutable {
     }
 
     /**
-     * Creates a new {@link ItemStack} of the provided {@link ItemType}
-     * and quantity.
+     * Returns an empty {@link ItemStack}.
      *
-     * @param itemType The item type
-     * @param quantity The quantity
-     * @return The new item stack
+     * @return The empty ItemStack
      */
-    static ItemStack of(Supplier<? extends ItemType> itemType, int quantity) {
-        return ItemStack.of(itemType.get(), quantity);
+    static ItemStack empty() {
+        return Sponge.game().factoryProvider().provide(Factory.class).empty();
     }
 
     /**
@@ -98,27 +94,8 @@ public interface ItemStack extends SerializableDataHolder.Mutable {
      * @param itemType The item type
      * @return The new item stack
      */
-    static ItemStack of(Supplier<? extends ItemType> itemType) {
-        return ItemStack.of(itemType.get());
-    }
-
-    /**
-     * Creates a new {@link ItemStack} of the provided {@link ItemType} and quantity of 1
-     *
-     * @param itemType The item type
-     * @return The new item stack
-     */
     static ItemStack of(ItemType itemType) {
         return ItemStack.of(itemType, 1);
-    }
-
-    /**
-     * Returns an empty {@link ItemStack}.
-     *
-     * @return The empty ItemStack
-     */
-    static ItemStack empty() {
-        return ItemStack.builder().itemType(ItemTypes.AIR).build();
     }
 
     /**
@@ -196,34 +173,8 @@ public interface ItemStack extends SerializableDataHolder.Mutable {
      *
      * @return A collection of {@link AttributeModifier}s.
      */
-    default Collection<AttributeModifier> attributeModifiers(Supplier<? extends AttributeType> attributeType, DefaultedRegistryReference<? extends EquipmentType> equipmentType) {
-        return this.attributeModifiers(attributeType.get(), equipmentType.get());
-    }
-
-    /**
-     * Gets all {@link AttributeModifier}s on this item stack.
-     *
-     * @param attributeType The {@link AttributeType} of the modifier.
-     * @param equipmentType The {@link EquipmentType} this modifier is applied
-     * to.
-     *
-     * @return A collection of {@link AttributeModifier}s.
-     */
     default Collection<AttributeModifier> attributeModifiers(AttributeType attributeType, DefaultedRegistryReference<? extends EquipmentType> equipmentType) {
         return this.attributeModifiers(attributeType, equipmentType.get());
-    }
-
-    /**
-     * Gets all {@link AttributeModifier}s on this item stack.
-     *
-     * @param attributeType The {@link AttributeType} of the modifier.
-     * @param equipmentType The {@link EquipmentType} this modifier is applied
-     * to.
-     *
-     * @return A collection of {@link AttributeModifier}s.
-     */
-    default Collection<AttributeModifier> attributeModifiers(Supplier<? extends AttributeType> attributeType, EquipmentType equipmentType) {
-        return this.attributeModifiers(attributeType.get(), equipmentType);
     }
 
     /**
@@ -244,30 +195,8 @@ public interface ItemStack extends SerializableDataHolder.Mutable {
      * @param modifier The attribute modifier.
      * @param equipmentType The equipment type this modifier will apply under.
      */
-    default void addAttributeModifier(Supplier<? extends AttributeType> attributeType, AttributeModifier modifier, EquipmentType equipmentType) {
-        this.addAttributeModifier(attributeType.get(), modifier, equipmentType);
-    }
-
-    /**
-     * Adds an {@link AttributeModifier} to this item stack.
-     *
-     * @param attributeType The attribute type.
-     * @param modifier The attribute modifier.
-     * @param equipmentType The equipment type this modifier will apply under.
-     */
     default void addAttributeModifier(AttributeType attributeType, AttributeModifier modifier, DefaultedRegistryReference<? extends EquipmentType> equipmentType) {
         this.addAttributeModifier(attributeType, modifier, equipmentType.get());
-    }
-
-    /**
-     * Adds an {@link AttributeModifier} to this item stack.
-     *
-     * @param attributeType The attribute type.
-     * @param modifier The attribute modifier.
-     * @param equipmentType The equipment type this modifier will apply under.
-     */
-    default void addAttributeModifier(Supplier<? extends AttributeType> attributeType, AttributeModifier modifier, DefaultedRegistryReference<? extends EquipmentType> equipmentType) {
-        this.addAttributeModifier(attributeType.get(), modifier, equipmentType.get());
     }
 
     /**
@@ -291,16 +220,6 @@ public interface ItemStack extends SerializableDataHolder.Mutable {
          * @return This builder, for chaining
          */
         Builder itemType(ItemType itemType);
-
-        /**
-         * Sets the {@link ItemType} of the item stack.
-         *
-         * @param itemType The type of item
-         * @return This builder, for chaining
-         */
-        default Builder itemType(final Supplier<? extends ItemType> itemType) {
-            return this.itemType(itemType.get());
-        }
 
         ItemType currentItem();
 
@@ -331,19 +250,6 @@ public interface ItemStack extends SerializableDataHolder.Mutable {
          * {@link AttributeModifier} will apply to.
          * @return This builder, for chaining
          */
-        default Builder attributeModifier(Supplier<? extends AttributeType> attributeType, AttributeModifier modifier, DefaultedRegistryReference<? extends EquipmentType> equipmentType) {
-            return this.attributeModifier(attributeType.get(), modifier, equipmentType.get());
-        }
-
-        /**
-         * Adds an {@link AttributeModifier} to this item stack.
-         *
-         * @param attributeType The Attribute type.
-         * @param modifier The Attribute modifier.
-         * @param equipmentType The equipment type this
-         * {@link AttributeModifier} will apply to.
-         * @return This builder, for chaining
-         */
         Builder attributeModifier(AttributeType attributeType, AttributeModifier modifier, EquipmentType equipmentType);
 
         /**
@@ -354,18 +260,6 @@ public interface ItemStack extends SerializableDataHolder.Mutable {
          * @return This builder, for chaining
          */
         Builder fromBlockState(final BlockState blockState);
-
-        /**
-         * Sets the data to recreate a {@link BlockState} in a held {@link ItemStack}
-         * state.
-         *
-         * @param blockState The block state to use
-         * @return This builder, for chaining
-         */
-        default Builder fromBlockState(final Supplier<? extends BlockState> blockState) {
-            Objects.requireNonNull(blockState, "blockState");
-            return this.fromBlockState(blockState.get());
-        }
 
         /**
          * Attempts to reconstruct the builder with all of the data from
@@ -412,5 +306,10 @@ public interface ItemStack extends SerializableDataHolder.Mutable {
          */
         @Override
         ItemStack build() throws IllegalStateException;
+    }
+
+    interface Factory {
+
+        ItemStack empty();
     }
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackBuilderPopulators.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackBuilderPopulators.java
@@ -50,7 +50,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -108,23 +107,6 @@ public final class ItemStackBuilderPopulators {
     }
 
     /**
-     * Creates a new {@link BiConsumer} that defines the provided
-     * {@link ItemType}, provided that the {@link Supplier} does not
-     * return null.
-     *
-     * <p>Note that the {@link Supplier} is not queried for an
-     * {@link ItemType} until the generated {@link BiConsumer} is
-     * called.</p>
-     *
-     * @param supplier The supplier of the item type
-     * @return The new biconsumer to apply to an itemstack builder
-     */
-    public static BiConsumer<ItemStack.Builder, Random> item(Supplier<? extends ItemType> supplier) {
-        Objects.requireNonNull(supplier, "Supplier cannot be null!");
-        return (builder, random) -> builder.itemType(Objects.requireNonNull(supplier.get(), "Supplier returned a null ItemType"));
-    }
-
-    /**
      * Creates a new {@link BiConsumer} that provides a random
      * {@link ItemType} of the provided item types.
      *
@@ -165,23 +147,6 @@ public final class ItemStackBuilderPopulators {
     public static BiConsumer<ItemStack.Builder, Random> quantity(VariableAmount amount) {
         Objects.requireNonNull(amount, "VariableAmount cannot be null!");
         return (builder, random) -> builder.quantity(amount.flooredAmount(random));
-    }
-
-    /**
-     * Creates a new {@link BiConsumer} that sets the desired quantity
-     * for creating an {@link ItemStack}. The supplier is not queried for
-     * a {@link VariableAmount} until the generated bi consumer is
-     * called on.
-     *
-     * <p>Note that the default behavior of an item stack builder is still
-     * expected to take place. Negative values are not allowed.</p>
-     *
-     * @param supplier The supplier of the variable amount
-     * @return The new biconsumer to apply to an itemstack builder
-     */
-    public static BiConsumer<ItemStack.Builder, Random> quantity(Supplier<VariableAmount> supplier) {
-        Objects.requireNonNull(supplier, "Supplier cannot be null!");
-        return (builder, random) -> builder.quantity(supplier.get().flooredAmount(random));
     }
 
     /**
@@ -339,23 +304,6 @@ public final class ItemStackBuilderPopulators {
                     .map(randomEFunction -> randomEFunction.apply(random))
                     .collect(Collectors.toList());
             final DataTransactionResult result = itemStack.offer(key, suppliedElements);
-            if (result.isSuccessful()) {
-                builder.from(itemStack);
-            }
-        };
-    }
-
-    public static <E> BiConsumer<ItemStack.Builder, Random> listValueSuppliers(Supplier<? extends Key<? extends ListValue<E>>> key,
-                                                                               WeightedTable<Function<Random, E>> weightedTable) {
-        Objects.requireNonNull(key, "Key cannot be null!");
-        Objects.requireNonNull(weightedTable, "WeightedTable cannot be null!");
-        return (builder, random) -> {
-            final ItemStack itemStack = builder.build();
-            final List<Function<Random, E>> suppliers = weightedTable.get(random);
-            final List<E> suppliedElements = suppliers.stream()
-                    .map(randomEFunction -> randomEFunction.apply(random))
-                    .collect(Collectors.toList());
-            final DataTransactionResult result = itemStack.offer(key.get(), suppliedElements);
             if (result.isSuccessful()) {
                 builder.from(itemStack);
             }

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackComparators.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackComparators.java
@@ -30,7 +30,6 @@ import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.item.ItemType;
 
 import java.util.Comparator;
-import java.util.function.Supplier;
 
 /**
  * A utility class for getting all available {@link Comparator}s for {@link ItemStack}s.
@@ -43,7 +42,7 @@ public final class ItemStackComparators {
      * ItemStack.equals(ItemStack) for ItemStacks with extra attached data,
      * different damage values, or different sizes.
      */
-    public static final Supplier<Comparator<ItemStack>> TYPE = Sponge.game().factoryProvider().provide(Factory.class).byType().asSupplier();
+    public static final Comparator<ItemStack> TYPE = Sponge.game().factoryProvider().provide(Factory.class).byType().build();
 
     /**
      * Compares ItemStacks based on
@@ -52,7 +51,7 @@ public final class ItemStackComparators {
      * ItemStack.equals(ItemStack) for ItemStacks with extra attached data,
      * different types, or different damage values.
      */
-    public static final Supplier<Comparator<ItemStack>> SIZE = Sponge.game().factoryProvider().provide(Factory.class).bySize().asSupplier();
+    public static final Comparator<ItemStack> SIZE = Sponge.game().factoryProvider().provide(Factory.class).bySize().build();
 
     /**
      * Compares ItemStacks based on {@link ItemType}
@@ -60,31 +59,31 @@ public final class ItemStackComparators {
      * results as ItemStack.equals(ItemStack) for ItemStacks with extra attached
      * data or different damage values.
      */
-    public static final Supplier<Comparator<ItemStack>> TYPE_SIZE = Sponge.game().factoryProvider().provide(Factory.class).byType().bySize().asSupplier();
+    public static final Comparator<ItemStack> TYPE_SIZE = Sponge.game().factoryProvider().provide(Factory.class).byType().bySize().build();
 
     /**
      * The default comparator for {@link ItemStack}s.
      */
-    public static final Supplier<Comparator<ItemStack>> DEFAULT = Sponge.game().factoryProvider().provide(Factory.class).byType().bySize().asSupplier();
+    public static final Comparator<ItemStack> DEFAULT = Sponge.game().factoryProvider().provide(Factory.class).byType().bySize().build();
 
     /**
      * Compares ItemStacks based on their {@link Value}s.
      */
-    public static final Supplier<Comparator<ItemStack>> ITEM_DATA = Sponge.game().factoryProvider().provide(Factory.class).byData().byDurability().asSupplier();
+    public static final Comparator<ItemStack> ITEM_DATA = Sponge.game().factoryProvider().provide(Factory.class).byData().byDurability().build();
 
     /**
      * Compares ItemStacks based on their {@link Value}s ignoring {@link Keys#ITEM_DURABILITY}.
      */
-    public static final Supplier<Comparator<ItemStack>> ITEM_DATA_IGNORE_DURABILITY = Sponge.game().factoryProvider().provide(Factory.class).byData().asSupplier();
+    public static final Comparator<ItemStack> ITEM_DATA_IGNORE_DURABILITY = Sponge.game().factoryProvider().provide(Factory.class).byData().build();
 
     /**
      * Compares ItemStacks only ignoring their stack-size.
      *
      * <p>This means for stackable items that they can stack together</p>
      */
-    public static final Supplier<Comparator<ItemStack>> IGNORE_SIZE = Sponge.game().factoryProvider().provide(Factory.class).byType().byData().byDurability().asSupplier();
+    public static final Comparator<ItemStack> IGNORE_SIZE = Sponge.game().factoryProvider().provide(Factory.class).byType().byData().byDurability().build();
 
-    public static final Supplier<Comparator<ItemStack>> ALL = Sponge.game().factoryProvider().provide(Factory.class).byType().byData().byDurability().bySize().asSupplier();
+    public static final Comparator<ItemStack> ALL = Sponge.game().factoryProvider().provide(Factory.class).byType().byData().byDurability().bySize().build();
 
     public interface Factory {
 
@@ -96,13 +95,9 @@ public final class ItemStackComparators {
 
         Factory bySize();
 
-        Supplier<Comparator<ItemStack>> asSupplier();
-
         Comparator<ItemStack> build();
     }
 
-    // Suppress default constructor to ensure non-instantiability.
     private ItemStackComparators() {
-        throw new AssertionError("You should not be attempting to instantiate this class.");
     }
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackGenerator.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackGenerator.java
@@ -35,7 +35,6 @@ import java.util.Collection;
 import java.util.Random;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * A simple generator that takes a {@link Random} and generates
@@ -82,17 +81,6 @@ public interface ItemStackGenerator extends Function<Random, ItemStack> {
          * @param itemType The base item type
          * @return This builder, for chaining
          */
-        default Builder baseItem(final Supplier<? extends ItemType> itemType) {
-            return this.baseItem(itemType.get());
-        }
-
-        /**
-         * Sets the base {@link ItemType} for the {@link ItemStackGenerator}. A
-         * base type must be set to avoid issues.
-         *
-         * @param itemType The base item type
-         * @return This builder, for chaining
-         */
         Builder baseItem(ItemType itemType);
 
 
@@ -116,18 +104,6 @@ public interface ItemStackGenerator extends Function<Random, ItemStack> {
          * @return This builder, for chaining
          */
         <V> Builder add(Key<? extends Value<V>> key, V value);
-
-        /**
-         * Adds the given {@link Key} with the given value.
-         *
-         * @param key The key to assign the value with
-         * @param value The value to assign with the key
-         * @param <V> The type of the value
-         * @return This builder, for chaining
-         */
-        default <V> Builder add(final Supplier<? extends Key<? extends Value<V>>> key, final V value) {
-            return this.add(key.get(), value);
-        }
 
         /**
          * Creates a new {@link ItemStackGenerator} with all of the added

--- a/src/main/java/org/spongepowered/api/item/inventory/equipment/EquipmentInventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/equipment/EquipmentInventory.java
@@ -31,7 +31,6 @@ import org.spongepowered.api.item.inventory.Slot;
 import org.spongepowered.api.item.inventory.transaction.InventoryTransactionResult;
 
 import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * Equipment inventory for {@link Equipable}s that can carry equipment.
@@ -55,10 +54,6 @@ public interface EquipmentInventory extends Inventory {
      */
     InventoryTransactionResult.Poll poll(EquipmentType equipmentType);
 
-    default InventoryTransactionResult.Poll poll(final Supplier<? extends EquipmentType> equipmentType) {
-        return this.poll(equipmentType.get());
-    }
-
     /**
      * Gets and remove the items from the stack for the specified equipment type
      * in this Inventory.
@@ -70,10 +65,6 @@ public interface EquipmentInventory extends Inventory {
      */
     InventoryTransactionResult.Poll poll(EquipmentType equipmentType, int limit);
 
-    default InventoryTransactionResult.Poll poll(final Supplier<? extends EquipmentType> equipmentType, final int limit) {
-        return this.poll(equipmentType.get(), limit);
-    }
-
     /**
      * Gets without removing the stack for the specified equipment type in this
      * Inventory.
@@ -83,10 +74,6 @@ public interface EquipmentInventory extends Inventory {
      * @return removed ItemStack, per the semantics of {@link Inventory#peek()}
      */
     Optional<ItemStack> peek(EquipmentType equipmentType);
-
-    default Optional<ItemStack> peek(final Supplier<? extends EquipmentType> equipmentType) {
-        return this.peek(equipmentType.get());
-    }
 
     /**
      * Sets the item for the specified equipment type.
@@ -98,10 +85,6 @@ public interface EquipmentInventory extends Inventory {
      */
     InventoryTransactionResult set(EquipmentType equipmentType, ItemStack stack);
 
-    default InventoryTransactionResult set(final Supplier<? extends EquipmentType> equipmentType, final ItemStack stack) {
-        return this.set(equipmentType.get(), stack);
-    }
-
     /**
      * Gets the {@link Slot} for the specified equipment type.
      *
@@ -109,9 +92,4 @@ public interface EquipmentInventory extends Inventory {
      * @return matching slot or {@link Optional#empty()} if no matching slot
      */
     Optional<Slot> slot(EquipmentType equipmentType);
-
-    default Optional<Slot> slot(final Supplier<? extends EquipmentType> equipmentType) {
-        return this.slot(equipmentType.get());
-    }
-
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/type/ViewableInventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/type/ViewableInventory.java
@@ -39,7 +39,6 @@ import org.spongepowered.math.vector.Vector2i;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Supplier;
 
 /**
  * Interface for inventories which may be interacted with by Players.
@@ -98,17 +97,6 @@ public interface ViewableInventory extends Inventory {
          * @return The building step.
          */
         BuildingStep type(ContainerType type);
-
-        /**
-         * Specifies the type of inventory you want to build.
-         * <p>You must define all slots of the given type.</p>
-         *
-         * @param supplier The ContainerType supplier
-         * @return The building step.
-         */
-        default BuildingStep type(Supplier<? extends ContainerType> supplier) {
-            return this.type(supplier.get());
-        }
 
         /**
          * The building step. Define all slots needed for the chosen {@link ContainerType}.

--- a/src/main/java/org/spongepowered/api/item/recipe/RecipeManager.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/RecipeManager.java
@@ -33,7 +33,6 @@ import org.spongepowered.api.world.server.ServerWorld;
 
 import java.util.Collection;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * Manages registered recipes.
@@ -68,16 +67,6 @@ public interface RecipeManager {
     <T extends Recipe> Collection<T> allOfType(RecipeType<T> type);
 
     /**
-     * Returns all registered recipes of given type
-     * @param supplier The recipe type
-     *
-     * @return All recipes of given type
-     */
-    default <T extends Recipe> Collection<T> allOfType(Supplier<? extends RecipeType<T>> supplier) {
-        return this.allOfType(supplier.get());
-    }
-
-    /**
      * Returns all registered recipes of given type and with given item as a result.
      *
      * @param type The recipe type
@@ -86,17 +75,6 @@ public interface RecipeManager {
      * @return The recipes resulting in given item.
      */
     <T extends Recipe> Collection<T> findByResult(RecipeType<T> type, ItemStackSnapshot result);
-
-    /**
-     * Gets all recipes with given item as a result.
-     *
-     * @param result the recipe result to match
-     *
-     * @return All recipes resulting in given item.
-     */
-    default <T extends Recipe> Collection<T> findByResult(Supplier<? extends RecipeType<T>> supplier, ItemStackSnapshot result) {
-        return this.findByResult(supplier.get(), result);
-    }
 
     /**
      * Finds a matching recipe for given inventory and world.
@@ -121,19 +99,6 @@ public interface RecipeManager {
     <T extends Recipe> Optional<T> findMatchingRecipe(RecipeType<T> type, Inventory inventory, ServerWorld world);
 
     /**
-     * Finds a matching recipe for given type, inventory and world
-     *
-     * @param supplier The recipe type
-     * @param inventory The input inventory
-     * @param world The world
-     *
-     * @return The matching recipes.
-     */
-    default <T extends Recipe> Optional<T> findMatchingRecipe(Supplier<? extends RecipeType<T>> supplier, Inventory inventory, ServerWorld world) {
-        return this.findMatchingRecipe(supplier.get(), inventory, world);
-    }
-
-    /**
      * Finds a matching cooking recipe for given type and ingredient
      *
      * @param type The recipe type
@@ -142,18 +107,6 @@ public interface RecipeManager {
      * @return The matching recipe.
      */
     <T extends CookingRecipe> Optional<T> findCookingRecipe(RecipeType<T> type, ItemStackSnapshot ingredient);
-
-    /**
-     * Finds a matching cooking recipe for given type and ingredient
-     *
-     * @param supplier The recipe type
-     * @param ingredient The ingredient
-     *
-     * @return The matching recipe.
-     */
-    default <T extends CookingRecipe> Optional<T> findCookingRecipe(Supplier<? extends RecipeType<T>> supplier, ItemStackSnapshot ingredient) {
-        return this.findCookingRecipe(supplier.get(), ingredient);
-    }
 
     /**
      * Finds the matching recipe and creates the {@link RecipeResult},

--- a/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingRecipe.java
@@ -38,7 +38,6 @@ import org.spongepowered.api.util.ResourceKeyedBuilder;
 
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * A general interface for cooking-type/furnace recipes.
@@ -110,17 +109,6 @@ public interface CookingRecipe extends Recipe {
          */
         IngredientStep type(RecipeType<CookingRecipe> type);
 
-        /**
-         * Sets the type of recipe
-         *
-         * @param type the type of recipe
-         *
-         * @return This builder, for chaining
-         */
-        default IngredientStep type(Supplier<RecipeType<CookingRecipe>> type) {
-            return this.type(type.get());
-        }
-
         interface IngredientStep extends Builder {
 
             /**
@@ -144,18 +132,6 @@ public interface CookingRecipe extends Recipe {
             default ResultStep ingredient(ItemType ingredient) {
                 return this.ingredient(Ingredient.of(ingredient));
             }
-
-            /**
-             * Changes the ingredient and returns this builder.
-             * The {@link Ingredient} required in order for the recipe to be fulfilled.
-             *
-             * @param ingredient The required ingredient
-             *
-             * @return This builder, for chaining
-             */
-            default ResultStep ingredient(Supplier<? extends ItemType> ingredient) {
-                return this.ingredient(ingredient.get());
-            }
         }
 
         interface ResultStep extends Builder {
@@ -168,17 +144,6 @@ public interface CookingRecipe extends Recipe {
              * @return This builder, for chaining
              */
             EndStep result(ItemType result);
-
-            /**
-             * Changes the result and returns this builder. The result is the
-             * {@link ItemType} created when the recipe is fulfilled.
-             *
-             * @param result The output of this recipe
-             * @return This builder, for chaining
-             */
-            default EndStep result(Supplier<? extends ItemType> result) {
-                return this.result(result.get());
-            }
 
             /**
              * Changes the result and returns this builder. The result is the

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/Ingredient.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/Ingredient.java
@@ -32,9 +32,10 @@ import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 /**
  * An Ingredient for a crafting recipe.
@@ -123,7 +124,13 @@ public interface Ingredient extends Predicate<ItemStack> {
         if (itemTypes == null || itemTypes.length == 0) {
             return Ingredient.empty();
         }
-        return Ingredient.builder().with(itemTypes).build();
+
+        final List<ItemType> with = new ArrayList<>();
+        for (final DefaultedRegistryReference<? extends ItemType> itemType : itemTypes) {
+            with.add(itemType.get());
+        }
+
+        return Ingredient.builder().with(with).build();
     }
 
     /**
@@ -169,15 +176,6 @@ public interface Ingredient extends Predicate<ItemStack> {
         Builder with(ItemType... types);
 
         /**
-         * Sets one or more ItemTypes for matching the ingredient.
-         *
-         * @param types The items
-         * @return This Builder, for chaining
-         */
-        @SuppressWarnings("unchecked")
-        Builder with(Supplier<? extends ItemType>... types);
-
-        /**
          * Sets one ore more ItemStack for matching the ingredient.
          *
          * @param types The items
@@ -195,6 +193,14 @@ public interface Ingredient extends Predicate<ItemStack> {
          * @return This Builder, for chaining
          */
         Builder with(ResourceKey resourceKey, Predicate<ItemStack> predicate, ItemStack... exemplaryTypes);
+
+        /**
+         * Sets one ItemStack for matching the ingredient.
+         *
+         * @param types The items
+         * @return This Builder, for chaining
+         */
+        Builder with(Collection<ItemType> types);
 
         /**
          * Sets one ItemStack for matching the ingredient.

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapelessCraftingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapelessCraftingRecipe.java
@@ -36,7 +36,6 @@ import org.spongepowered.api.util.ResourceKeyedBuilder;
 
 import java.util.List;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * A ShapelessCraftingRecipe is a CraftingRecipe that does not have shape and
@@ -66,16 +65,6 @@ public interface ShapelessCraftingRecipe extends CraftingRecipe {
          * @return This builder, for chaining
          */
         ResultStep addIngredients(ItemType... ingredients);
-
-        /**
-         * Adds ingredients for this recipe.
-         *
-         * @param ingredients The ingredients to add
-         *
-         * @return This builder, for chaining
-         */
-        @SuppressWarnings("unchecked")
-        ResultStep addIngredients(Supplier<? extends ItemType>... ingredients);
 
         /**
          * Adds ingredients for this recipe.

--- a/src/main/java/org/spongepowered/api/item/recipe/single/StoneCutterRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/single/StoneCutterRecipe.java
@@ -38,7 +38,6 @@ import org.spongepowered.api.item.recipe.crafting.Ingredient;
 import org.spongepowered.api.util.ResourceKeyedBuilder;
 
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * A StoneCutter Recipe.
@@ -65,17 +64,6 @@ public interface StoneCutterRecipe extends Recipe {
          * @return This builder, for chaining
          */
         ResultStep ingredient(ItemType ingredient);
-
-        /**
-         * Sets the ingredient and returns this builder.
-         *
-         * @param ingredient The ingredient
-         *
-         * @return This builder, for chaining
-         */
-        default ResultStep ingredient(Supplier<? extends ItemType> ingredient) {
-            return this.ingredient(ingredient.get());
-        }
 
         /**
          * Sets the ingredient and returns this builder.

--- a/src/main/java/org/spongepowered/api/item/recipe/smithing/SmithingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/smithing/SmithingRecipe.java
@@ -38,7 +38,6 @@ import org.spongepowered.api.item.recipe.crafting.Ingredient;
 import org.spongepowered.api.util.ResourceKeyedBuilder;
 
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * A Smithing Recipe.
@@ -73,17 +72,6 @@ public interface SmithingRecipe extends Recipe {
          *
          * @return This builder, for chaining
          */
-        default AdditionStep base(Supplier<? extends ItemType> ingredient) {
-            return this.base(ingredient.get());
-        }
-
-        /**
-         * Sets the base ingredient and returns this builder.
-         *
-         * @param ingredient The ingredient
-         *
-         * @return This builder, for chaining
-         */
         AdditionStep base(Ingredient ingredient);
 
         interface AdditionStep extends SmithingRecipe.Builder {
@@ -95,17 +83,6 @@ public interface SmithingRecipe extends Recipe {
              * @return This builder, for chaining
              */
             ResultStep addition(ItemType ingredient);
-
-            /**
-             * Sets the additional ingredient and returns this builder.
-             *
-             * @param ingredient The ingredient
-             *
-             * @return This builder, for chaining
-             */
-            default ResultStep addition(Supplier<? extends ItemType> ingredient) {
-                return this.addition(ingredient.get());
-            }
 
             /**
              * Sets the additional ingredient and returns this builder.

--- a/src/main/java/org/spongepowered/api/map/color/MapColor.java
+++ b/src/main/java/org/spongepowered/api/map/color/MapColor.java
@@ -31,8 +31,6 @@ import org.spongepowered.api.map.MapCanvas;
 import org.spongepowered.api.util.Color;
 import org.spongepowered.api.util.ResettableBuilder;
 
-import java.util.function.Supplier;
-
 /**
  * Represents a {@link MapColorType} in a given {@link MapShade} that may be
  * used when drawing a {@link MapCanvas}.
@@ -60,17 +58,6 @@ public interface MapColor extends DataSerializable {
     }
 
     /**
-     * A method to ease using {@link MapColorTypes} enumeration.
-     * Unwraps the given supplier and calls {@link #of(MapColorType)}.
-     *
-     * @param mapColorTypeSupplier Supplier to unwrap.
-     * @return The {@link MapColor} that represents the provided type
-     */
-    static MapColor of(final Supplier<MapColorType> mapColorTypeSupplier) {
-        return MapColor.of(mapColorTypeSupplier.get());
-    }
-
-    /**
      * Creates a {@link MapColor} that represents the provided
      * {@link MapColorType} with the given {@link MapShade}.
      *
@@ -80,18 +67,6 @@ public interface MapColor extends DataSerializable {
      */
     static MapColor of(final MapColorType mapColorType, final MapShade mapShade) {
         return MapColor.builder().baseColor(mapColorType).shade(mapShade).build();
-    }
-
-    /**
-     * A method to ease using the {@link MapColorTypes} and {@link MapShade}.
-     * Unwraps the given suppliers and calls {@link #of(MapColorType, MapShade)}.
-     *
-     * @param mapColorTypeSupplier Supplier to unwrap
-     * @param mapShadeSupplier Supplier to unwrap
-     * @return The {@link MapColor} that represents the provided type.
-     */
-    static MapColor of(final Supplier<MapColorType> mapColorTypeSupplier, final Supplier<MapShade> mapShadeSupplier) {
-        return MapColor.of(mapColorTypeSupplier.get(), mapShadeSupplier.get());
     }
 
     /**
@@ -166,17 +141,6 @@ public interface MapColor extends DataSerializable {
          * @return This builder, for chaining
          */
         Builder baseColor(MapColorType mapColor);
-
-        /**
-         * Method to ease using {@link MapColorTypes} enumerations. Unwraps
-         * then calls {@link #baseColor(MapColorType)}
-         *
-         * @param mapColorTypeSupplier Supplier to be unwrapped and applied
-         * @return This builder, for chaining
-         */
-        default Builder baseColor(Supplier<MapColorType> mapColorTypeSupplier) {
-            return this.baseColor(mapColorTypeSupplier.get());
-        }
 
         /**
          * Copies all data from the given {@link MapColor} and applies it to this

--- a/src/main/java/org/spongepowered/api/map/color/MapShades.java
+++ b/src/main/java/org/spongepowered/api/map/color/MapShades.java
@@ -26,14 +26,11 @@ package org.spongepowered.api.map.color;
 
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
-import org.spongepowered.api.map.decoration.MapDecorationType;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.registry.RegistryScopes;
 import org.spongepowered.api.registry.RegistryTypes;
-
-import java.util.function.Supplier;
 
 /**
  * A pseudo-enum of supported {@link MapShade}s for a {@link MapColor}.

--- a/src/main/java/org/spongepowered/api/map/decoration/MapDecoration.java
+++ b/src/main/java/org/spongepowered/api/map/decoration/MapDecoration.java
@@ -38,8 +38,6 @@ import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.util.ResettableBuilder;
 import org.spongepowered.math.vector.Vector2i;
 
-import java.util.function.Supplier;
-
 /**
  * A {@code MapDecoration} represents a symbol that may be placed at a specific
  * point on a {@link MapInfo map}, which exists as a separate layer on top of a
@@ -114,10 +112,6 @@ public interface MapDecoration extends DataSerializable {
      */
     void setRotation(MapDecorationOrientation rot);
 
-    default void setRotation(Supplier<MapDecorationOrientation> rotSupplier) {
-        this.setRotation(rotSupplier.get());
-    }
-
     /**
      * Gets the {@link MapDecorationOrientation} the Map Decoration is pointing in
      *
@@ -165,10 +159,6 @@ public interface MapDecoration extends DataSerializable {
          */
         Builder type(MapDecorationType type);
 
-        default Builder type(Supplier<MapDecorationType> type) {
-            return this.type(type.get());
-        }
-
         /**
          * Sets the orientation of the symbol when displayed on a {@link MapInfo}.
          *
@@ -176,10 +166,6 @@ public interface MapDecoration extends DataSerializable {
          * @return This builder, for chaining
          */
         Builder rotation(MapDecorationOrientation rot);
-
-        default Builder rotation(Supplier<MapDecorationOrientation> rotSupplier) {
-            return this.rotation(rotSupplier.get());
-        }
 
         /**
          * Sets the position of the decoration. Valid co-ordinates are between

--- a/src/main/java/org/spongepowered/api/network/channel/raw/handshake/RawHandshakeDataRequestResponse.java
+++ b/src/main/java/org/spongepowered/api/network/channel/raw/handshake/RawHandshakeDataRequestResponse.java
@@ -27,10 +27,8 @@ package org.spongepowered.api.network.channel.raw.handshake;
 import org.spongepowered.api.network.channel.ChannelBuf;
 import org.spongepowered.api.network.channel.ChannelException;
 import org.spongepowered.api.network.channel.NoResponseException;
-import org.spongepowered.api.network.channel.packet.Packet;
 
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 /**
  * Represents a callback for the response of a request payload.

--- a/src/main/java/org/spongepowered/api/projectile/source/ProjectileSource.java
+++ b/src/main/java/org/spongepowered/api/projectile/source/ProjectileSource.java
@@ -30,7 +30,6 @@ import org.spongepowered.api.entity.projectile.Projectile;
 import org.spongepowered.math.vector.Vector3d;
 
 import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * Represents a valid source of a projectile.
@@ -50,34 +49,11 @@ public interface ProjectileSource {
      * Launches a {@link Projectile} from this projectile source.
      *
      * @param projectileType The type of the projectile
-     * @param <T> The Type of Projectile
-     * @return The projectile instance if it was launched, or absent
-     */
-    default <T extends Projectile> Optional<T> launchProjectile(final Supplier<EntityType<T>> projectileType) {
-        return this.launchProjectile(projectileType.get());
-    }
-
-    /**
-     * Launches a {@link Projectile} from this projectile source.
-     *
-     * @param projectileType The type of the projectile
      * @param velocity The velocity to launch the projectile
      * @param <T> The Type of Projectile
      * @return The projectile instance if it was launched, or absent
      */
     <T extends Projectile> Optional<T> launchProjectile(EntityType<T> projectileType, Vector3d velocity);
-
-    /**
-     * Launches a {@link Projectile} from this projectile source.
-     *
-     * @param projectileType The type of the projectile
-     * @param velocity The velocity to launch the projectile
-     * @param <T> The Type of Projectile
-     * @return The projectile instance if it was launched, or absent
-     */
-    default <T extends Projectile> Optional<T> launchProjectile(final Supplier<EntityType<T>> projectileType, final Vector3d velocity) {
-        return this.launchProjectile(projectileType.get(), velocity);
-    }
 
     /**
      * Launches a new {@link Projectile} from this projectile source.
@@ -88,16 +64,4 @@ public interface ProjectileSource {
      * @return the projectile if successfully launched, {@link Optional#empty()} otherwise
      */
     <T extends Projectile> Optional<T> launchProjectileTo(EntityType<T> projectileType, Entity target);
-
-    /**
-     * Launches a new {@link Projectile} from this projectile source.
-     *
-     * @param projectileType The type of the projectile
-     * @param target the target to launch the projectile at
-     * @param <T> The Type of Projectile
-     * @return the projectile if successfully launched, {@link Optional#empty()} otherwise
-     */
-    default <T extends Projectile> Optional<T> launchProjectileTo(final Supplier<EntityType<T>> projectileType, final Entity target) {
-        return this.launchProjectileTo(projectileType.get(), target);
-    }
 }

--- a/src/main/java/org/spongepowered/api/scoreboard/Scoreboard.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Scoreboard.java
@@ -37,7 +37,6 @@ import org.spongepowered.api.util.CopyableBuilder;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Supplier;
 
 /**
  * Represents a scoreboard, which contains {@link Team}s and {@link Objective}s.
@@ -64,17 +63,6 @@ public interface Scoreboard {
      * @return The {@link Objective}, if it exists
      */
     Optional<Objective> objective(String name);
-
-    /**
-     * Gets the {@link Objective} currently displayed in a {@link DisplaySlot} on this
-     * scoreboard, if one is present.
-     *
-     * @param slot The {@link DisplaySlot}
-     * @return the {@link Objective} currently displayed, if present
-     */
-    default Optional<Objective> objective(Supplier<? extends DisplaySlot> slot) {
-        return this.objective(slot.get());
-    }
 
     /**
      * Gets the {@link Objective} currently displayed in a {@link DisplaySlot} on this
@@ -128,27 +116,8 @@ public interface Scoreboard {
      *
      * @param slot The {@link DisplaySlot} to remove any {@link Objective} for
      */
-    default void clearSlot(Supplier<? extends DisplaySlot> slot) {
-        this.clearSlot(slot.get());
-    }
-
-    /**
-     * Clears any {@link Objective} in the specified slot.
-     *
-     * @param slot The {@link DisplaySlot} to remove any {@link Objective} for
-     */
     default void clearSlot(DisplaySlot slot) {
         this.updateDisplaySlot(null, slot);
-    }
-
-    /**
-     * Gets all {@link Objective}s of a Criteria on this scoreboard.
-     *
-     * @param criterion {@link Criterion} to search by
-     * @return A set of {@link Objective}s using the specified criterion
-     */
-    default Set<Objective> objectivesByCriterion(Supplier<? extends Criterion> criterion) {
-        return this.objectivesByCriterion(criterion.get());
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/scoreboard/Team.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Team.java
@@ -32,7 +32,6 @@ import org.spongepowered.api.util.CopyableBuilder;
 
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Supplier;
 
 /**
  * A team on a scoreboard that has a common display theme and other
@@ -185,16 +184,6 @@ public interface Team {
      *
      * @param visibility The {@link Visibility} for this team's nametags
      */
-    default void setNameTagVisibility(Supplier<? extends Visibility> visibility) {
-        this.setNameTagVisibility(visibility.get());
-    }
-
-    /**
-     * Sets the {@link Visibility} which controls to who nametags
-     * of players on this team are visible to.
-     *
-     * @param visibility The {@link Visibility} for this team's nametags
-     */
     void setNameTagVisibility(Visibility visibility);
 
     /**
@@ -211,16 +200,6 @@ public interface Team {
      *
      * @param visibility The {@link Visibility} for this team's death Texts
      */
-    default void setDeathMessageVisibility(Supplier<? extends Visibility> visibility) {
-        this.setDeathMessageVisibility(visibility.get());
-    }
-
-    /**
-     * Sets the {@link Visibility} which controls who death Texts
-     * of players on this team are visible to.
-     *
-     * @param visibility The {@link Visibility} for this team's death Texts
-     */
     void setDeathMessageVisibility(Visibility visibility);
 
     /**
@@ -229,15 +208,6 @@ public interface Team {
      * @return The {@link CollisionRule} for entities on this team
      */
     CollisionRule collisionRule();
-
-    /**
-     * Sets the {@link CollisionRule} for entities on this team.
-     *
-     * @param rule The {@link CollisionRule} for entities on this team
-     */
-    default void setCollisionRule(Supplier<? extends CollisionRule> rule) {
-        this.setCollisionRule(rule.get());
-    }
 
     /**
      * Sets the {@link CollisionRule} for entities on this team.
@@ -390,18 +360,6 @@ public interface Team {
          *     nametags
          * @return This builder
          */
-        default Builder nameTagVisibility(Supplier<? extends Visibility> visibility) {
-            return this.nameTagVisibility(visibility.get());
-        }
-
-        /**
-         * Sets the {@link Visibility} which controls to who nametags
-         * of players on the {@link Team} are visible to.
-         *
-         * @param visibility The {@link Visibility} for the {@link Team}'s
-         *     nametags
-         * @return This builder
-         */
         Builder nameTagVisibility(Visibility visibility);
 
         /**
@@ -412,29 +370,7 @@ public interface Team {
          *     death Texts
          * @return This builder
          */
-        default Builder deathTextVisibility(Supplier<? extends Visibility> visibility) {
-            return this.deathTextVisibility(visibility.get());
-        }
-
-        /**
-         * Sets the {@link Visibility} which controls who death Texts
-         * of players on the {@link Team} are visible to.
-         *
-         * @param visibility The {@link Visibility} for the {@link Team}'s
-         *     death Texts
-         * @return This builder
-         */
         Builder deathTextVisibility(Visibility visibility);
-
-        /**
-         * Sets the {@link CollisionRule} for this team's members.
-         *
-         * @param rule The {@link CollisionRule} for the {@link Team}'s members
-         * @return This builder
-         */
-        default Builder collisionRule(Supplier<? extends CollisionRule> rule) {
-            return this.collisionRule(rule.get());
-        }
 
         /**
          * Sets the {@link CollisionRule} for this team's members.

--- a/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/objective/Objective.java
@@ -35,7 +35,6 @@ import org.spongepowered.api.util.CopyableBuilder;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Supplier;
 
 /**
  * An objective tracks an integer score for each entry it contains.
@@ -196,27 +195,7 @@ public interface Objective {
          * @param criterion The {@link Criterion} to set
          * @return This builder
          */
-        default Builder criterion(final Supplier<? extends Criterion> criterion) {
-            return this.criterion(criterion.get());
-        }
-
-        /**
-         * Sets the {@link Criterion} of the {@link Objective}.
-         *
-         * @param criterion The {@link Criterion} to set
-         * @return This builder
-         */
         Builder criterion(Criterion criterion);
-
-        /**
-         * Sets the {@link ObjectiveDisplayMode} of the {@link Objective}.
-         *
-         * @param objectiveDisplayMode The {@link ObjectiveDisplayMode} to set
-         * @return This builder
-         */
-        default Builder objectiveDisplayMode(final Supplier<? extends ObjectiveDisplayMode> objectiveDisplayMode) {
-            return this.objectiveDisplayMode(objectiveDisplayMode.get());
-        }
 
         /**
          * Sets the {@link ObjectiveDisplayMode} of the {@link Objective}.

--- a/src/main/java/org/spongepowered/api/service/ban/Ban.java
+++ b/src/main/java/org/spongepowered/api/service/ban/Ban.java
@@ -32,9 +32,7 @@ import org.spongepowered.api.util.CopyableBuilder;
 
 import java.net.InetAddress;
 import java.time.Instant;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * Represents a ban made on an object.
@@ -57,7 +55,7 @@ public interface Ban {
      * @return The created ban
      */
     static Ban of(GameProfile profile) {
-        return Ban.builder().type(BanTypes.PROFILE).profile(profile).build();
+        return Ban.builder().type(BanTypes.PROFILE.get()).profile(profile).build();
     }
 
     /**
@@ -68,7 +66,7 @@ public interface Ban {
      * @return The created ban
      */
     static Ban of(GameProfile profile, Component reason) {
-        return Ban.builder().type(BanTypes.PROFILE).profile(profile).reason(reason).build();
+        return Ban.builder().type(BanTypes.PROFILE.get()).profile(profile).reason(reason).build();
     }
 
     /**
@@ -180,16 +178,6 @@ public interface Ban {
          * @return This builder
          */
         Builder type(BanType type);
-
-        /**
-         * Sets the type of the ban.
-         *
-         * @param type The type to be set
-         * @return This builder
-         */
-        default Builder type(Supplier<? extends BanType> type) {
-            return this.type(Objects.requireNonNull(type.get()));
-        }
 
         /**
          * Sets the reason for the ban.

--- a/src/main/java/org/spongepowered/api/state/State.java
+++ b/src/main/java/org/spongepowered/api/state/State.java
@@ -33,7 +33,6 @@ import org.spongepowered.api.util.Cycleable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 public interface State<S extends State<S>> extends SerializableDataHolder.Immutable<S> {
 
@@ -47,19 +46,6 @@ public interface State<S extends State<S>> extends SerializableDataHolder.Immuta
      * @return The comparable value, if available and compatible
      */
     <T extends Comparable<T>> Optional<T> stateProperty(StateProperty<T> stateProperty);
-
-    /**
-     * Gets the {@link Comparable} value for the specific {@link StateProperty}
-     * such that if the {@link State} does not support the
-     * {@link StateProperty}, {@link Optional#empty()} is returned.
-     *
-     * @param stateProperty The state property
-     * @param <T> The generic type of state property
-     * @return The comparable value, if available and compatible
-     */
-    default <T extends Comparable<T>> Optional<T> stateProperty(Supplier<? extends StateProperty<T>> stateProperty) {
-        return this.stateProperty(stateProperty.get());
-    }
 
     /**
      * Attempts to retrieve the {@link StateProperty} instance associated with
@@ -88,24 +74,6 @@ public interface State<S extends State<S>> extends SerializableDataHolder.Immuta
     <T extends Comparable<T>, V extends T> Optional<S> withStateProperty(StateProperty<T> stateProperty, V value);
 
     /**
-     * Gets the {@link State} with the appropriate value for the given
-     * {@link StateProperty}. If the {@link StateProperty} is not supported,
-     * {@link Optional#empty()} is returned. If the object is not either
-     * an instance contained in {@link StateProperty#possibleValues()} or
-     * an instance {@link Object#toString()}, {@link Optional#empty()} may be
-     * returned.
-     *
-     * @param <T> The type of cycleable value
-     * @param stateProperty The state property
-     * @param value The value
-     * @param <V> The type of extended value
-     * @return The state, if the state property and value are supported
-     */
-    default <T extends Comparable<T>, V extends T> Optional<S> withStateProperty(Supplier<? extends StateProperty<T>> stateProperty, V value) {
-        return this.withStateProperty(stateProperty.get(), value);
-    }
-
-    /**
      * Cycles to the next possible value of the {@link StateProperty} and returns
      * the new {@link State}. Returns {@link Optional#empty()} if the state property or
      * the value isn't supported.
@@ -117,19 +85,6 @@ public interface State<S extends State<S>> extends SerializableDataHolder.Immuta
     <T extends Comparable<T>> Optional<S> cycleStateProperty(StateProperty<T> stateProperty);
 
     /**
-     * Cycles to the next possible value of the {@link StateProperty} and returns
-     * the new {@link State}. Returns {@link Optional#empty()} if the state property or
-     * the value isn't supported.
-     *
-     * @param <T> The type of cycleable value
-     * @param stateProperty The state property
-     * @return The cycled state if successful
-     */
-    default <T extends Comparable<T>> Optional<S> cycleStateProperty(Supplier<? extends StateProperty<T>> stateProperty) {
-        return this.cycleStateProperty(stateProperty.get());
-    }
-
-    /**
      * Cycles to the next possible value of the {@link Key} and returns
      * the new {@link State}. Returns {@link Optional#empty()} if the key or
      * the value isn't supported.
@@ -139,19 +94,6 @@ public interface State<S extends State<S>> extends SerializableDataHolder.Immuta
      * @return The cycled state if successful
      */
     <T extends Cycleable<T>> Optional<S> cycleValue(Key<? extends Value<T>> key);
-
-    /**
-     * Cycles to the next possible value of the {@link Key} and returns
-     * the new {@link State}. Returns {@link Optional#empty()} if the key or
-     * the value isn't supported.
-     *
-     * @param <T> The type of cycleable value
-     * @param key The key
-     * @return The cycled state if successful
-     */
-    default <T extends Cycleable<T>> Optional<S> cycleValue(Supplier<? extends Key<? extends Value<T>>> key) {
-        return this.cycleValue(key.get());
-    }
 
     /**
      * Gets an immutable {@link Collection} of all applicable

--- a/src/main/java/org/spongepowered/api/state/StateMatcher.java
+++ b/src/main/java/org/spongepowered/api/state/StateMatcher.java
@@ -35,7 +35,6 @@ import org.spongepowered.api.util.CopyableBuilder;
 
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 /**
  * A {@link StateMatcher} that will match various {@link State}s
@@ -118,25 +117,15 @@ public interface StateMatcher<S extends State<S>> extends Predicate<S> {
          * @param type The {@link StateContainer} to use
          * @return This builder, for chaining
          */
-        default Builder<S, T> type(final Supplier<? extends T> type) {
-            return this.type(type.get());
-        }
-
-        /**
-         * Sets the root {@link StateContainer} for the {@link StateMatcher}.
-         *
-         * @param type The {@link StateContainer} to use
-         * @return This builder, for chaining
-         */
         Builder<S, T> type(T type);
 
         /**
          * Adds a {@link StateProperty} that needs to be present
          * on a {@link State} to match.
          *
-         * <p>{@link #type(StateContainer)} or {@link #type(Supplier)}
-         * <strong>must</strong> be called before this is called as supported
-         * {@link StateProperty state properties} are specific to the type</p>
+         * <p>{@link #type(StateContainer)} <strong>must</strong> be called
+         * before this is called as supported {@link StateProperty state properties}
+         * are specific to the type</p>
          *
          * @param stateProperty The state property
          * @return This builder, for chaining
@@ -144,27 +133,12 @@ public interface StateMatcher<S extends State<S>> extends Predicate<S> {
         Builder<S, T> supportsStateProperty(StateProperty<@NonNull ?> stateProperty);
 
         /**
-         * Adds a {@link StateProperty} that needs to be present
-         * on a {@link State} to match.
-         *
-         * <p>{@link #type(StateContainer)} or {@link #type(Supplier)}
-         * <strong>must</strong> be called before this is called as supported
-         * {@link StateProperty state properties} are specific to the type</p>
-         *
-         * @param stateProperty The state property
-         * @return This builder, for chaining
-         */
-        default Builder<S, T> supportsStateProperty(final Supplier<? extends StateProperty<@NonNull ?>> stateProperty) {
-            return this.supportsStateProperty(stateProperty.get());
-        }
-
-        /**
          * Adds a {@link StateProperty} and value that needs to
          * match on a {@link State} to match.
          *
-         * <p>{@link #type(StateContainer)} or {@link #type(Supplier)}
-         * <strong>must</strong> be called before this is called as supported
-         * {@link StateProperty state properties} are specific to the type</p>
+         * <p>{@link #type(StateContainer)} <strong>must</strong> be called
+         * before this is called as supported {@link StateProperty state properties}
+         * are specific to the type</p>
          *
          * @param stateProperty The state property
          * @param value The value to match
@@ -172,19 +146,6 @@ public interface StateMatcher<S extends State<S>> extends Predicate<S> {
          * @return This builder, for chaining
          */
         <V extends Comparable<V>> Builder<S, T> stateProperty(StateProperty<V> stateProperty, V value);
-
-        /**
-         * Adds a {@link StateProperty} and value that needs to
-         * match on a {@link State} to match.
-         *
-         * @param stateProperty The state property
-         * @param value The value to match
-         * @param <V> The value type
-         * @return This builder, for chaining
-         */
-        default <V extends Comparable<V>> Builder<S, T> stateProperty(final Supplier<? extends StateProperty<V>> stateProperty, final V value) {
-            return this.stateProperty(stateProperty.get(), value);
-        }
 
         /**
          * Adds a {@link KeyValueMatcher} that the {@link State}

--- a/src/main/java/org/spongepowered/api/world/volume/archetype/ArchetypeVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/archetype/ArchetypeVolume.java
@@ -43,7 +43,6 @@ import org.spongepowered.math.vector.Vector3d;
 import org.spongepowered.math.vector.Vector3i;
 
 import java.util.Objects;
-import java.util.function.Supplier;
 
 public interface ArchetypeVolume extends BlockVolume.Modifiable<ArchetypeVolume>,
     BlockEntityArchetypeVolume.Modifiable<ArchetypeVolume>,
@@ -75,7 +74,7 @@ public interface ArchetypeVolume extends BlockVolume.Modifiable<ArchetypeVolume>
      *      compared to this volume's min position as the offset
      * @param spawnContext The context value used for processing spawn entities.
      */
-    default void applyToWorld(final ServerWorld target, final Vector3i placement, final Supplier<SpawnType> spawnContext) {
+    default void applyToWorld(final ServerWorld target, final Vector3i placement, final SpawnType spawnContext) {
         Objects.requireNonNull(target, "Target world cannot be null");
         Objects.requireNonNull(placement, "Target position cannot be null");
         try (final CauseStackManager.StackFrame frame = Sponge.server().causeStackManager().pushCauseFrame()) {

--- a/src/main/java/org/spongepowered/api/world/volume/entity/EntityVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/entity/EntityVolume.java
@@ -38,7 +38,6 @@ import org.spongepowered.api.world.volume.MutableVolume;
 import org.spongepowered.api.world.volume.UnmodifiableVolume;
 import org.spongepowered.api.world.volume.Volume;
 import org.spongepowered.api.world.volume.block.BlockVolume;
-import org.spongepowered.api.world.volume.block.BlockVolumeFactory;
 import org.spongepowered.api.world.volume.stream.StreamOptions;
 import org.spongepowered.api.world.volume.stream.VolumeStream;
 import org.spongepowered.math.vector.Vector3d;
@@ -50,7 +49,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 public interface EntityVolume extends Volume {
 
@@ -189,27 +187,6 @@ public interface EntityVolume extends Volume {
          * customized further prior to traditional "ticking" and processing by core
          * systems.</p>
          *
-         * @param type The type supplier
-         * @param position The position
-         * @return An entity, if one was created
-         * @throws IllegalArgumentException If the position or entity type is not
-         *      valid to create
-         * @throws IllegalStateException If a constructor cannot be found
-         */
-        default <E extends Entity> E createEntity(Supplier<EntityType<E>> type, Vector3d position) throws IllegalArgumentException, IllegalStateException {
-            return this.createEntity(type.get(), position);
-        }
-
-        /**
-         * Create an entity instance at the given position.
-         *
-         * <p>Creating an entity does not spawn the entity into the world. An entity
-         * created means the entity can be spawned at the given location. If
-         * {@link Optional#empty()} was returned, the entity is not able to spawn at
-         * the given location. Furthermore, this allows for the {@link Entity} to be
-         * customized further prior to traditional "ticking" and processing by core
-         * systems.</p>
-         *
          * @param type The type
          * @param position The position
          * @return An entity, if one was created
@@ -220,27 +197,6 @@ public interface EntityVolume extends Volume {
         default <E extends Entity> E createEntity(EntityType<E> type, Vector3i position) throws IllegalArgumentException, IllegalStateException {
             Objects.requireNonNull(position, "position");
             return this.createEntity(type, position.toDouble());
-        }
-
-        /**
-         * Create an entity instance at the given position.
-         *
-         * <p>Creating an entity does not spawn the entity into the world. An entity
-         * created means the entity can be spawned at the given location. If
-         * {@link Optional#empty()} was returned, the entity is not able to spawn at
-         * the given location. Furthermore, this allows for the {@link Entity} to be
-         * customized further prior to traditional "ticking" and processing by core
-         * systems.</p>
-         *
-         * @param type The type supplier
-         * @param position The position
-         * @return An entity, if one was created
-         * @throws IllegalArgumentException If the position or entity type is not
-         *      valid to create
-         * @throws IllegalStateException If a constructor cannot be found
-         */
-        default <E extends Entity> E createEntity(Supplier<EntityType<E>> type, Vector3i position) throws IllegalArgumentException, IllegalStateException {
-            return this.createEntity(type.get(), position);
         }
 
         /**
@@ -274,28 +230,6 @@ public interface EntityVolume extends Volume {
          * customized further prior to traditional "ticking" and processing by core
          * systems.</p>
          *
-         * @param type The type supplier
-         * @param position The position
-         * @return An entity, if one was created
-         * @throws IllegalArgumentException If the position or entity type is not
-         *     valid to create
-         * @throws IllegalStateException If a constructor cannot be found
-         */
-        default <E extends Entity> E createEntityNaturally(Supplier<EntityType<E>> type, Vector3d position) throws IllegalArgumentException, IllegalStateException {
-            return this.createEntityNaturally(type.get(), position);
-        }
-
-        /**
-         * Create an entity instance at the given position with the default
-         * equipment.
-         *
-         * <p>Creating an entity does not spawn the entity into the world. An entity
-         * created means the entity can be spawned at the given location. If
-         * {@link Optional#empty()} was returned, the entity is not able to spawn at
-         * the given location. Furthermore, this allows for the {@link Entity} to be
-         * customized further prior to traditional "ticking" and processing by core
-         * systems.</p>
-         *
          * @param type The type
          * @param position The position
          * @return An entity, if one was created
@@ -306,28 +240,6 @@ public interface EntityVolume extends Volume {
         default <E extends Entity> E createEntityNaturally(EntityType<E> type, Vector3i position) throws IllegalArgumentException, IllegalStateException {
             Objects.requireNonNull(position, "position");
             return this.createEntityNaturally(type, position.toDouble());
-        }
-
-        /**
-         * Create an entity instance at the given position with the default
-         * equipment.
-         *
-         * <p>Creating an entity does not spawn the entity into the world. An entity
-         * created means the entity can be spawned at the given location. If
-         * {@link Optional#empty()} was returned, the entity is not able to spawn at
-         * the given location. Furthermore, this allows for the {@link Entity} to be
-         * customized further prior to traditional "ticking" and processing by core
-         * systems.</p>
-         *
-         * @param type The type supplier
-         * @param position The position
-         * @return An entity, if one was created
-         * @throws IllegalArgumentException If the position or entity type is not
-         *     valid to create
-         * @throws IllegalStateException If a constructor cannot be found
-         */
-        default <E extends Entity> E createEntityNaturally(Supplier<EntityType<E>> type, Vector3i position) throws IllegalArgumentException, IllegalStateException {
-            return this.createEntityNaturally(type.get(), position);
         }
 
         /**

--- a/src/main/java/org/spongepowered/api/world/volume/game/EnvironmentalVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/game/EnvironmentalVolume.java
@@ -30,17 +30,10 @@ import org.spongepowered.api.world.volume.biome.BiomeVolume;
 import org.spongepowered.math.vector.Vector3i;
 
 import java.util.Objects;
-import java.util.function.Supplier;
 
 public interface EnvironmentalVolume extends PrimitiveGameVolume, BiomeVolume {
 
     int light(LightType type, int x, int y, int z);
-
-    default int light(final Supplier<? extends LightType> type, final int x, final int y, final int z) {
-        Objects.requireNonNull(type);
-
-        return this.light(type.get(), x, y, z);
-    }
 
     default int light(final LightType type, final Vector3i position) {
         Objects.requireNonNull(type);
@@ -49,15 +42,8 @@ public interface EnvironmentalVolume extends PrimitiveGameVolume, BiomeVolume {
         return this.light(type, position.x(), position.y(), position.z());
     }
 
-    default int light(final Supplier<? extends LightType> type, final Vector3i position) {
-        Objects.requireNonNull(type);
-        Objects.requireNonNull(position);
-
-        return this.light(type.get(), position.x(), position.y(), position.z());
-    }
-
     default int light(final int x, final int y, final int z) {
-        return this.light(LightTypes.BLOCK, x, y, z);
+        return this.light(LightTypes.BLOCK.get(), x, y, z);
     }
 
     default int light(final Vector3i position) {
@@ -69,7 +55,7 @@ public interface EnvironmentalVolume extends PrimitiveGameVolume, BiomeVolume {
     default boolean isSkylightMax(final Vector3i position) {
         Objects.requireNonNull(position);
 
-        return this.light(LightTypes.SKY, position) >= this.maximumLight();
+        return this.light(LightTypes.SKY.get(), position) >= this.maximumLight();
     }
 
 }

--- a/src/main/java/org/spongepowered/api/world/volume/game/LocationBaseDataHolder.java
+++ b/src/main/java/org/spongepowered/api/world/volume/game/LocationBaseDataHolder.java
@@ -48,7 +48,6 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * A type of {@link ServerLocation} based value store that can handle proxied data api
@@ -73,19 +72,6 @@ public interface LocationBaseDataHolder {
      * Gets the value of data that is keyed to the provided {@link Key} at the
      * give block location.
      *
-     * @param position The position of the block
-     * @param key The key to the data
-     * @param <E> The type of element of data
-     * @return The data, if available
-     */
-    default <E> Optional<E> get(final Vector3i position, final DefaultedRegistryReference<? extends Key<? extends Value<E>>> key) {
-        return this.get(position.x(), position.y(), position.z(), key.get());
-    }
-
-    /**
-     * Gets the value of data that is keyed to the provided {@link Key} at the
-     * give block location.
-     *
      * @param x The X position
      * @param y The Y position
      * @param z The Z position
@@ -94,21 +80,6 @@ public interface LocationBaseDataHolder {
      * @return The data, if available
      */
     <E> Optional<E> get(int x, int y, int z, Key<? extends Value<E>> key);
-
-    /**
-     * Gets the value of data that is keyed to the provided {@link Key} at the
-     * give block location.
-     *
-     * @param x The X position
-     * @param y The Y position
-     * @param z The Z position
-     * @param key The key to the data
-     * @param <E> The type of element of data
-     * @return The data, if available
-     */
-    default <E> Optional<E> get(final int x, final int y, final int z, final DefaultedRegistryReference<? extends Key<? extends Value<E>>> key) {
-        return this.get(x, y, z, key.get());
-    }
 
     /**
      * Gets the int value of data that is keyed to the provided {@link Key} at the
@@ -126,18 +97,6 @@ public interface LocationBaseDataHolder {
      * Gets the int value of data that is keyed to the provided {@link Key} at the
      * give block location.
      *
-     * @param position The position of the block
-     * @param key The key to the data
-     * @return The data, if available
-     */
-    default OptionalInt getInt(final Vector3i position, final DefaultedRegistryReference<? extends Key<? extends Value<Integer>>> key) {
-        return this.getInt(position.x(), position.y(), position.z(), key.get());
-    }
-
-    /**
-     * Gets the int value of data that is keyed to the provided {@link Key} at the
-     * give block location.
-     *
      * @param x The X position
      * @param y The Y position
      * @param z The Z position
@@ -146,20 +105,6 @@ public interface LocationBaseDataHolder {
      */
     default OptionalInt getInt(final int x, final int y, final int z, final Key<? extends Value<Integer>> key) {
         return this.get(x, y, z, key).map(OptionalInt::of).orElseGet(OptionalInt::empty);
-    }
-
-    /**
-     * Gets the int value of data that is keyed to the provided {@link Key} at the
-     * give block location.
-     *
-     * @param x The X position
-     * @param y The Y position
-     * @param z The Z position
-     * @param key The key to the data
-     * @return The data, if available
-     */
-    default OptionalInt getInt(final int x, final int y, final int z, final DefaultedRegistryReference<? extends Key<? extends Value<Integer>>> key) {
-        return this.get(x, y, z, key.get()).map(OptionalInt::of).orElseGet(OptionalInt::empty);
     }
 
     /**
@@ -178,18 +123,6 @@ public interface LocationBaseDataHolder {
      * Gets the double value of data that is keyed to the provided {@link Key} at the
      * give block location.
      *
-     * @param position The position of the block
-     * @param key The key to the data
-     * @return The data, if available
-     */
-    default OptionalDouble getDouble(final Vector3i position, final DefaultedRegistryReference<? extends Key<? extends Value<Double>>> key) {
-        return this.getDouble(position.x(), position.y(), position.z(), key.get());
-    }
-
-    /**
-     * Gets the double value of data that is keyed to the provided {@link Key} at the
-     * give block location.
-     *
      * @param x The X position
      * @param y The Y position
      * @param z The Z position
@@ -197,20 +130,6 @@ public interface LocationBaseDataHolder {
      * @return The data, if available
      */
     default OptionalDouble getDouble(final int x, final int y, final int z, final Key<? extends Value<Double>> key) {
-        return this.get(x, y, z, key).map(OptionalDouble::of).orElseGet(OptionalDouble::empty);
-    }
-
-    /**
-     * Gets the double value of data that is keyed to the provided {@link Key} at the
-     * give block location.
-     *
-     * @param x The X position
-     * @param y The Y position
-     * @param z The Z position
-     * @param key The key to the data
-     * @return The data, if available
-     */
-    default OptionalDouble getDouble(final int x, final int y, final int z, final DefaultedRegistryReference<? extends Key<? extends Value<Double>>> key) {
         return this.get(x, y, z, key).map(OptionalDouble::of).orElseGet(OptionalDouble::empty);
     }
 
@@ -225,18 +144,6 @@ public interface LocationBaseDataHolder {
     default OptionalLong getLong(final Vector3i position, final Key<? extends Value<Long>> key) {
         return this.getLong(position.x(), position.y(), position.z(), key);
     }
-    
-    /**
-     * Gets the long value of data that is keyed to the provided {@link Key} at the
-     * give block location.
-     *
-     * @param position The position of the block
-     * @param key The key to the data
-     * @return The data, if available
-     */
-    default OptionalLong getLong(final Vector3i position, final DefaultedRegistryReference<? extends Key<? extends Value<Long>>> key) {
-        return this.getLong(position.x(), position.y(), position.z(), key.get());
-    }
 
     /**
      * Gets the long value of data that is keyed to the provided {@link Key} at the
@@ -249,20 +156,6 @@ public interface LocationBaseDataHolder {
      * @return The data, if available
      */
     default OptionalLong getLong(final int x, final int y, final int z, final Key<? extends Value<Long>> key) {
-        return this.get(x, y, z, key).map(OptionalLong::of).orElseGet(OptionalLong::empty);
-    }
-
-    /**
-     * Gets the long value of data that is keyed to the provided {@link Key} at the
-     * give block location.
-     *
-     * @param x The X position
-     * @param y The Y position
-     * @param z The Z position
-     * @param key The key to the data
-     * @return The data, if available
-     */
-    default OptionalLong getLong(final int x, final int y, final int z, final DefaultedRegistryReference<? extends Key<? extends Value<Long>>> key) {
         return this.get(x, y, z, key).map(OptionalLong::of).orElseGet(OptionalLong::empty);
     }
 
@@ -290,23 +183,6 @@ public interface LocationBaseDataHolder {
      * <p>If the {@link Key} is not supported or
      * available, {@link NoSuchElementException} will be thrown.</p>
      *
-     * @param position The position of the block
-     * @param key The key
-     * @param <E> The type of value
-     * @return The value
-     * @throws NoSuchElementException If the value is not supported or present
-     */
-    default <E> E require(final Vector3i position, final DefaultedRegistryReference<? extends Key<? extends Value<E>>> key) {
-        return this.require(position.x(), position.y(), position.z(), key.get());
-    }
-
-    /**
-     * Attempts to get the underlying value backed by a {@link Value}
-     * linked to the provided {@link Key}.
-     *
-     * <p>If the {@link Key} is not supported or
-     * available, {@link NoSuchElementException} will be thrown.</p>
-     *
      * @param x The X position
      * @param y The Y position
      * @param z The Z position
@@ -320,30 +196,7 @@ public interface LocationBaseDataHolder {
         if (optional.isPresent()) {
             return optional.get();
         }
-        throw new NoSuchElementException(String.format("Could not retrieve value for key '%s'", key.toString()));
-    }
-
-    /**
-     * Attempts to get the underlying value backed by a {@link Value}
-     * linked to the provided {@link Key}.
-     *
-     * <p>If the {@link Key} is not supported or
-     * available, {@link NoSuchElementException} will be thrown.</p>
-     *
-     * @param x The X position
-     * @param y The Y position
-     * @param z The Z position
-     * @param key The key
-     * @param <E> The type of value
-     * @return The value
-     * @throws NoSuchElementException If the value is not supported or present
-     */
-    default <E> E require(final int x, final int y, final int z, final DefaultedRegistryReference<? extends Key<? extends Value<E>>> key) {
-        final Optional<E> optional = this.get(x, y, z, key.get());
-        if (optional.isPresent()) {
-            return optional.get();
-        }
-        throw new NoSuchElementException(String.format("Could not retrieve value for key '%s'", key.get().toString()));
+        throw new NoSuchElementException(String.format("Could not retrieve value for key '%s'", key));
     }
 
     /**
@@ -365,20 +218,6 @@ public interface LocationBaseDataHolder {
      * give block location. The data may not exist, or may not be compatible in
      * which case <code>null</code> may be returned.
      *
-     * @param position The position of the block
-     * @param key The key to the data
-     * @param <E> The type of element of data
-     * @return The data or null
-     */
-    default <E> @Nullable E orNull(final Vector3i position, final DefaultedRegistryReference<? extends Key<? extends Value<E>>> key) {
-        return this.get(position.x(), position.y(), position.z(), key.get()).orElse(null);
-    }
-
-    /**
-     * Gets the value of data that is keyed to the provided {@link Key} at the
-     * give block location. The data may not exist, or may not be compatible in
-     * which case <code>null</code> may be returned.
-     *
      * @param x The X position
      * @param y The Y position
      * @param z The Z position
@@ -388,22 +227,6 @@ public interface LocationBaseDataHolder {
      */
     default <E> @Nullable E orNull(final int x, final int y, final int z, final Key<? extends Value<E>> key) {
         return this.get(x, y, z, key).orElse(null);
-    }
-
-    /**
-     * Gets the value of data that is keyed to the provided {@link Key} at the
-     * give block location. The data may not exist, or may not be compatible in
-     * which case <code>null</code> may be returned.
-     *
-     * @param x The X position
-     * @param y The Y position
-     * @param z The Z position
-     * @param key The key to the data
-     * @param <E> The type of element of data
-     * @return The data or null
-     */
-    default <E> @Nullable E orNull(final int x, final int y, final int z, final DefaultedRegistryReference<? extends Key<? extends Value<E>>> key) {
-        return this.get(x, y, z, key.get()).orElse(null);
     }
 
     /**
@@ -426,21 +249,6 @@ public interface LocationBaseDataHolder {
      * give block location. The data may not exist, or may not be compatible in
      * which case the default value may be returned.
      *
-     * @param position The position of the block
-     * @param key The key to the data
-     * @param defaultValue The default value to be provided
-     * @param <E> The type of element of data
-     * @return The data or null
-     */
-    default <E> E orElse(final Vector3i position, final DefaultedRegistryReference<? extends Key<? extends Value<E>>> key, final E defaultValue) {
-        return this.get(position.x(), position.y(), position.z(), key.get()).orElse(Objects.requireNonNull(defaultValue));
-    }
-
-    /**
-     * Gets the value of data that is keyed to the provided {@link Key} at the
-     * give block location. The data may not exist, or may not be compatible in
-     * which case the default value may be returned.
-     *
      * @param x The X position
      * @param y The Y position
      * @param z The Z position
@@ -451,88 +259,6 @@ public interface LocationBaseDataHolder {
      */
     default <E> E orElse(final int x, final int y, final int z, final Key<? extends Value<E>> key, final E defaultValue) {
         return this.get(x, y, z, key).orElse(Objects.requireNonNull(defaultValue));
-    }
-
-    /**
-     * Gets the value of data that is keyed to the provided {@link Key} at the
-     * give block location. The data may not exist, or may not be compatible in
-     * which case the default value may be returned.
-     *
-     * @param x The X position
-     * @param y The Y position
-     * @param z The Z position
-     * @param key The key to the data
-     * @param defaultValue The supplier of the default value to return
-     * @param <E> The type of element of data
-     * @return The data or null
-     */
-    default <E> E orElse(final int x, final int y, final int z, final DefaultedRegistryReference<? extends Key<? extends Value<E>>> key, final E defaultValue) {
-        return this.get(x, y, z, key.get()).orElse(Objects.requireNonNull(defaultValue));
-    }
-
-
-    /**
-     * Gets the value of data that is keyed to the provided {@link Key} at the
-     * give block location. The data may not exist, or may not be compatible in
-     * which case the default value may be returned.
-     *
-     * @param position The position of the block
-     * @param key The key to the data
-     * @param defaultValue The supplier of the default value to be provided
-     * @param <E> The type of element of data
-     * @return The data or null
-     */
-    default <E> E orElse(final Vector3i position, final Key<? extends Value<E>> key, final Supplier<? extends E> defaultValue) {
-        return this.get(position.x(), position.y(), position.z(), key).orElseGet(Objects.requireNonNull(defaultValue));
-    }
-
-    /**
-     * Gets the value of data that is keyed to the provided {@link Key} at the
-     * give block location. The data may not exist, or may not be compatible in
-     * which case the default value may be returned.
-     *
-     * @param position The position of the block
-     * @param key The key to the data
-     * @param defaultValue The supplier of the default value to be provided
-     * @param <E> The type of element of data
-     * @return The data or null
-     */
-    default <E> E orElse(final Vector3i position, final DefaultedRegistryReference<? extends Key<? extends Value<E>>> key, final Supplier<? extends E> defaultValue) {
-        return this.get(position.x(), position.y(), position.z(), key.get()).orElseGet(Objects.requireNonNull(defaultValue));
-    }
-
-    /**
-     * Gets the value of data that is keyed to the provided {@link Key} at the
-     * give block location. The data may not exist, or may not be compatible in
-     * which case the default value may be returned.
-     *
-     * @param x The X position
-     * @param y The Y position
-     * @param z The Z position
-     * @param key The key to the data
-     * @param defaultValue The supplier of the default value to return
-     * @param <E> The type of element of data
-     * @return The data or null
-     */
-    default <E> E orElse(final int x, final int y, final int z, final Key<? extends Value<E>> key, final Supplier<E> defaultValue) {
-        return this.get(x, y, z, key).orElseGet(Objects.requireNonNull(defaultValue));
-    }
-
-    /**
-     * Gets the value of data that is keyed to the provided {@link Key} at the
-     * give block location. The data may not exist, or may not be compatible in
-     * which case the default value may be returned.
-     *
-     * @param x The X position
-     * @param y The Y position
-     * @param z The Z position
-     * @param key The key to the data
-     * @param defaultValue The supplier of the default value to return
-     * @param <E> The type of element of data
-     * @return The data or null
-     */
-    default <E> E orElse(final int x, final int y, final int z, final DefaultedRegistryReference<? extends Key<? extends Value<E>>> key, final Supplier<? extends E> defaultValue) {
-        return this.get(x, y, z, key.get()).orElseGet(Objects.requireNonNull(defaultValue));
     }
 
     /**
@@ -552,21 +278,6 @@ public interface LocationBaseDataHolder {
 
     /**
      * Gets the value of data that is keyed to the provided {@link Key} at the
-     * give block location. The data may not exist, or may not be compatible in
-     * which case <code>null</code> may be returned.
-     *
-     * @param position The position of the block
-     * @param key The key to the data
-     * @param <E> The type of element of data
-     * @param <V> The type of value
-     * @return The base value, if available
-     */
-    default <E, V extends Value<E>> Optional<V> getValue(final Vector3i position, final Supplier<? extends Key<V>> key) {
-        return this.getValue(position.x(), position.y(), position.z(), key.get());
-    }
-
-    /**
-     * Gets the value of data that is keyed to the provided {@link Key} at the
      * give block location.
      *
      * @param x The X position
@@ -578,22 +289,6 @@ public interface LocationBaseDataHolder {
      * @return The base value, if available
      */
     <E, V extends Value<E>> Optional<V> getValue(int x, int y, int z, Key<V> key);
-
-    /**
-     * Gets the value of data that is keyed to the provided {@link Key} at the
-     * give block location.
-     *
-     * @param x The X position
-     * @param y The Y position
-     * @param z The Z position
-     * @param key The key to the data
-     * @param <E> The type of element of data
-     * @param <V> The type of value
-     * @return The base value, if available
-     */
-    default <E, V extends Value<E>> Optional<V> getValue(final int x, final int y, final int z, final DefaultedRegistryReference<? extends Key<V>> key) {
-        return this.getValue(x, y, z, key.get());
-    }
 
     /**
      * Checks if the provided {@link Key} to the data is supported by the block
@@ -611,18 +306,6 @@ public interface LocationBaseDataHolder {
      * Checks if the provided {@link Key} to the data is supported by the block
      * at the provided location.
      *
-     * @param position The position of the block
-     * @param key The Key to the value of data
-     * @return True if the block supports the data
-     */
-    default boolean supports(final Vector3i position, final Supplier<? extends Key<?>> key) {
-        return this.supports(position.x(), position.y(), position.z(), key.get());
-    }
-
-    /**
-     * Checks if the provided {@link Key} to the data is supported by the block
-     * at the provided location.
-     *
      * @param x The X coordinate
      * @param y The Y coordinate
      * @param z The Z coordinate
@@ -630,20 +313,6 @@ public interface LocationBaseDataHolder {
      * @return True if the block supports the data
      */
     boolean supports(int x, int y, int z, Key<?> key);
-
-    /**
-     * Checks if the provided {@link Key} to the data is supported by the block
-     * at the provided location.
-     *
-     * @param x The X coordinate
-     * @param y The Y coordinate
-     * @param z The Z coordinate
-     * @param key The Key to the value of data
-     * @return True if the block supports the data
-     */
-    default boolean supports(final int x, final int y, final int z, final Supplier<? extends Key<?>> key) {
-        return this.supports(x, y, z, key.get());
-    }
 
     /**
      * Checks if the provided {@link Value} is supported by the block at the
@@ -737,22 +406,6 @@ public interface LocationBaseDataHolder {
          * the provided {@link Key} and returns a {@link DataTransactionResult} of
          * said transformation.
          *
-         * @param position The position of the block
-         * @param key The key to the data
-         * @param function The function applying the transformation
-         * @param <E> The type of data
-         * @return The transaction result
-         */
-        default <E> DataTransactionResult transform(
-            final Vector3i position, final DefaultedRegistryReference<? extends Key<? extends Value<E>>> key, final Function<E, E> function) {
-            return this.transform(position.x(), position.y(), position.z(), key.get(), function);
-        }
-
-        /**
-         * Applies a transformation on the pre-existing value of the data keyed by
-         * the provided {@link Key} and returns a {@link DataTransactionResult} of
-         * said transformation.
-         *
          * @param x The X position
          * @param y The Y position
          * @param z The Z position
@@ -766,30 +419,6 @@ public interface LocationBaseDataHolder {
                 final Optional<E> optional = this.get(x, y, z, key);
                 if (optional.isPresent()) {
                     return this.offer(x, y, z, key, function.apply(optional.get()));
-                }
-            }
-            return DataTransactionResult.failNoData();
-        }
-
-
-        /**
-         * Applies a transformation on the pre-existing value of the data keyed by
-         * the provided {@link Key} and returns a {@link DataTransactionResult} of
-         * said transformation.
-         *
-         * @param x The X position
-         * @param y The Y position
-         * @param z The Z position
-         * @param key The key to the data
-         * @param function The function applying the transformation
-         * @param <E> The type of data
-         * @return The transaction result
-         */
-        default <E> DataTransactionResult transform(final int x, final int y, final int z, final DefaultedRegistryReference<? extends Key<? extends Value<E>>> key, final Function<E, E> function) {
-            if (this.supports(x, y, z, key)) {
-                final Optional<E> optional = this.get(x, y, z, key.get());
-                if (optional.isPresent()) {
-                    return this.offer(x, y, z, key.get(), function.apply(optional.get()));
                 }
             }
             return DataTransactionResult.failNoData();
@@ -821,24 +450,6 @@ public interface LocationBaseDataHolder {
          * {@link DataTransactionResult} will retain the rejected and replaced
          * data.</p>
          *
-         * @param position The position of the block
-         * @param key The key for the data
-         * @param value The value to offer
-         * @param <E> The type of data being offered
-         * @return The transaction result
-         */
-        default <E> DataTransactionResult offer(final Vector3i position, final DefaultedRegistryReference<? extends Key<? extends Value<E>>> key, final E value) {
-            return this.offer(position.x(), position.y(), position.z(), key.get(), value);
-        }
-
-        /**
-         * Offers the given <code>E</code> value that is keyed by the provided
-         * {@link Key} to the block at the provided location.
-         *
-         * <p>If any data is rejected or existing data is replaced, the
-         * {@link DataTransactionResult} will retain the rejected and replaced
-         * data.</p>
-         *
          * @param x The X position
          * @param y The Y position
          * @param z The Z position
@@ -848,27 +459,6 @@ public interface LocationBaseDataHolder {
          * @return The transaction result
          */
         <E> DataTransactionResult offer(int x, int y, int z, Key<? extends Value<E>> key, E value);
-
-        /**
-         * Offers the given <code>E</code> value that is keyed by the provided
-         * {@link Key} to the block at the provided location.
-         *
-         * <p>If any data is rejected or existing data is replaced, the
-         * {@link DataTransactionResult} will retain the rejected and replaced
-         * data.</p>
-         *
-         * @param x The X position
-         * @param y The Y position
-         * @param z The Z position
-         * @param key The key for the data
-         * @param value The value to offer
-         * @param <E> The type of data being offered
-         * @return The transaction result
-         */
-        default <E> DataTransactionResult offer(final int x, final int y, final int z, final DefaultedRegistryReference<? extends Key<? extends Value<E>>> key,
-                final E value) {
-            return this.offer(x, y, z, key.get(), value);
-        }
 
         /**
          * Offers the given {@link Value} to the block at the given position.
@@ -920,18 +510,6 @@ public interface LocationBaseDataHolder {
          * Attempts to remove the data associated with the provided {@link Key} from
          * the block at the provided location.
          *
-         * @param position The position of the block
-         * @param key The key to the data to remove
-         * @return The transaction result
-         */
-        default DataTransactionResult remove(final Vector3i position, final DefaultedRegistryReference<? extends Key<?>> key) {
-            return this.remove(position.x(), position.y(), position.z(), key.get());
-        }
-
-        /**
-         * Attempts to remove the data associated with the provided {@link Key} from
-         * the block at the provided location.
-         *
          * @param x The X position
          * @param y The Y position
          * @param z The Z position
@@ -939,20 +517,6 @@ public interface LocationBaseDataHolder {
          * @return The transaction result
          */
         DataTransactionResult remove(int x, int y, int z, Key<?> key);
-
-        /**
-         * Attempts to remove the data associated with the provided {@link Key} from
-         * the block at the provided location.
-         *
-         * @param x The X position
-         * @param y The Y position
-         * @param z The Z position
-         * @param key The key of the data to remove
-         * @return The transaction result
-         */
-        default DataTransactionResult remove(final int x, final int y, final int z, final DefaultedRegistryReference<? extends Key<?>> key) {
-            return this.remove(x, y, z, key.get());
-        }
 
         /**
          * Attempts to undo a {@link DataTransactionResult}. Specifically, all

--- a/src/main/java/org/spongepowered/api/world/weather/Weather.java
+++ b/src/main/java/org/spongepowered/api/world/weather/Weather.java
@@ -28,8 +28,6 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.persistence.DataSerializable;
 import org.spongepowered.api.util.Ticks;
 
-import java.util.function.Supplier;
-
 public interface Weather extends DataSerializable {
 
     /**
@@ -52,30 +50,6 @@ public interface Weather extends DataSerializable {
      * @return The running duration
      */
     Ticks runningDuration();
-
-    /**
-     * Creates a new weather with given type, remaining duration and no running duration
-     *
-     * @param type The weather type
-     * @param duration The weather remaining duration
-     *
-     * @return The new weather
-     */
-    static Weather of(Supplier<WeatherType> type, long duration) {
-        return Sponge.game().factoryProvider().provide(Factory.class).of(type.get(), Ticks.of(duration), Ticks.of(0));
-    }
-
-    /**
-     * Creates a new weather with given type, remaining duration and no running duration
-     *
-     * @param type The weather type
-     * @param duration The weather remaining duration
-     *
-     * @return The new weather
-     */
-    static Weather of(Supplier<WeatherType> type, Ticks duration) {
-        return Sponge.game().factoryProvider().provide(Factory.class).of(type.get(), duration, Ticks.of(0));
-    }
 
     /**
      * Creates a new weather with given type, remaining duration and no running duration


### PR DESCRIPTION
Most of the supplier methods existed when types were going to be fed by
explicit suppliers (and not by lookups that references do right now).
Whereas references are suppliers, that was only done for passing to
other java constructs easier. The plugin dev needs to always call get
themselves to terminate the callstack at the call site.

It also doesn't help that the only consistent thing regarding suppliers
were we were inconsistent which makes for a messier API. This cleans
this up.

Signed-off-by: Chris Sanders <zidane@spongepowered.org>

@dualspiral 
@gabizou 