### PR TITLE
Make the plugin optional for CommandMapping

### DIFF
--- a/src/main/java/org/spongepowered/api/command/manager/CommandMapping.java
+++ b/src/main/java/org/spongepowered/api/command/manager/CommandMapping.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.command.manager;
 import org.spongepowered.api.command.registrar.CommandRegistrar;
 import org.spongepowered.plugin.PluginContainer;
 
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -59,11 +60,11 @@ public interface CommandMapping {
     Set<String> allAliases();
 
     /**
-     * Gets the plugin that owns the command.
+     * Gets the plugin that owns the command, if known.
      *
      * @return The plugin.
      */
-    PluginContainer plugin();
+    Optional<PluginContainer> plugin();
 
     /**
      * Gets the {@link CommandRegistrar} that registered this command.


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/3546) | [Original Issue](https://github.com/SpongePowered/Sponge/issues/3540)

This is because we don't necessarily know the plugin or mod that registers a command via Brigadier

See the original issue.