### PR TITLE
Improve PotionEffect(.Builder) javadocs

### DIFF
--- a/src/main/java/org/spongepowered/api/effect/potion/PotionEffect.java
+++ b/src/main/java/org/spongepowered/api/effect/potion/PotionEffect.java
@@ -105,8 +105,8 @@ public interface PotionEffect extends DataSerializable {
     int amplifier();
 
     /**
-     * Gets if the potion effect is an ambient effect. The particles emitted
-     * by ambient effects are less opaque than otherwise.
+     * Gets whether or not this potion effect is an ambient effect.
+     * Ambient potions emit more translucent particles.
      *
      * @return If the effect should be ambient.
      */
@@ -175,8 +175,8 @@ public interface PotionEffect extends DataSerializable {
         Builder amplifier(int amplifier) throws IllegalArgumentException;
 
         /**
-         * Sets the potion effect to be ambient or not. The particles emitted
-         * by ambient effects are less opaque than otherwise.
+         * Sets whether the potion effect is ambient.
+         * Ambient potions emit more translucent particles.
          *
          * @param ambient Whether the potion effect is ambient
          * @return This builder, for chaining
@@ -184,7 +184,7 @@ public interface PotionEffect extends DataSerializable {
         Builder ambient(boolean ambient);
 
         /**
-         * Sets the potion effect to show particles when applied or not.
+         * Sets whether the potion effect should show particles when applied.
          *
          * @param showParticles Whether the potion effect will show particles
          * @return This builder, for chaining
@@ -192,7 +192,7 @@ public interface PotionEffect extends DataSerializable {
         Builder showParticles(boolean showParticles);
 
         /**
-         * Sets the potion effect to show its icon when applied or not.
+         * Sets whether the potion effect should show its icon when applied.
          *
          * @param showIcon Whether the potion effect will show its icon
          * @return This builder, for chaining

--- a/src/main/java/org/spongepowered/api/effect/potion/PotionEffect.java
+++ b/src/main/java/org/spongepowered/api/effect/potion/PotionEffect.java
@@ -90,7 +90,7 @@ public interface PotionEffect extends DataSerializable {
      * Gets the duration in ticks for which this potion effect
      * will apply for.
      *
-     * @return The duration.
+     * @return The duration in ticks.
      */
     int duration();
 
@@ -98,14 +98,15 @@ public interface PotionEffect extends DataSerializable {
      * Gets the amplifier at which this potion effect
      * will apply effects.
      *
-     * @return The amplifier.
+     * @return The amplifier as a zero-indexed integer.
      */
     int amplifier();
 
     /**
-     * Gets if the potion effect is an ambient effect.
+     * Gets if the potion effect is an ambient effect. The particles emitted
+     * by ambient effects are less opaque than otherwise.
      *
-     * @return Gets if ambient.
+     * @return If the effect should be ambient.
      */
     boolean isAmbient();
 
@@ -152,15 +153,18 @@ public interface PotionEffect extends DataSerializable {
         /**
          * Sets the duration in ticks of the potion effect.
          *
+         * <p>The duration must be greater than zero ticks.</p>
+         *
          * @param duration The duration in ticks of this effect
          * @return This builder, for chaining
+         * @throws IllegalArgumentException If the duration is less than or equal to zero
          */
         Builder duration(int duration);
 
         /**
          * Sets the amplifier power of the potion effect.
          *
-         * <p>Amplifiers must be above zero.</p>
+         * <p>Amplifiers must be greater than or equal to zero.</p>
          *
          * @param amplifier The amplifier power
          * @return This builder, for chaining
@@ -169,7 +173,8 @@ public interface PotionEffect extends DataSerializable {
         Builder amplifier(int amplifier) throws IllegalArgumentException;
 
         /**
-         * Sets the potion effect to be ambient or not.
+         * Sets the potion effect to be ambient or not. The particles emitted
+         * by ambient effects are less opaque than otherwise.
          *
          * @param ambient Whether the potion effect is ambient
          * @return This builder, for chaining

--- a/src/main/java/org/spongepowered/api/effect/potion/PotionEffect.java
+++ b/src/main/java/org/spongepowered/api/effect/potion/PotionEffect.java
@@ -57,11 +57,12 @@ public interface PotionEffect extends DataSerializable {
      * duration in ticks.
      *
      * @param type The potion type
-     * @param amplifier The amplifier
+     * @param amplifier The zero-indexed amplifier
      * @param duration The duration in ticks
      * @return The potion effect
+     * @throws IllegalArgumentException If the amplifier is negative or the duration is not positive
      */
-    static PotionEffect of(PotionEffectType type, int amplifier, int duration) {
+    static PotionEffect of(PotionEffectType type, int amplifier, int duration) throws IllegalArgumentException {
         return PotionEffect.builder().potionType(type).amplifier(amplifier).duration(duration).build();
     }
 
@@ -74,8 +75,9 @@ public interface PotionEffect extends DataSerializable {
      * @param amplifier The amplifier
      * @param duration The duration in ticks
      * @return The potion effect
+     * @throws IllegalArgumentException If the amplifier is negative or the duration is not positive
      */
-    static PotionEffect of(Supplier<? extends PotionEffectType> type, int amplifier, int duration) {
+    static PotionEffect of(Supplier<? extends PotionEffectType> type, int amplifier, int duration) throws IllegalArgumentException {
         return PotionEffect.builder().potionType(type).amplifier(amplifier).duration(duration).build();
     }
 
@@ -159,7 +161,7 @@ public interface PotionEffect extends DataSerializable {
          * @return This builder, for chaining
          * @throws IllegalArgumentException If the duration is less than or equal to zero
          */
-        Builder duration(int duration);
+        Builder duration(int duration) throws IllegalArgumentException;
 
         /**
          * Sets the amplifier power of the potion effect.


### PR DESCRIPTION
Fixes outright issues in some of the builder javadocs and elaborates on some non-obvious methods/parameters/etc

Some of these could also be backported to API 7 but I believe that's officially finished? Would be happy to PR to it anyway if desired