### PR TITLE
Add Current Page Request to Pagination Service

### DIFF
--- a/src/main/java/org/spongepowered/api/service/pagination/PaginationService.java
+++ b/src/main/java/org/spongepowered/api/service/pagination/PaginationService.java
@@ -24,6 +24,9 @@
  */
 package org.spongepowered.api.service.pagination;
 
+import java.util.Optional;
+import net.kyori.adventure.audience.Audience;
+
 /**
  * This service allows pagination of output to users.
  */
@@ -35,4 +38,17 @@ public interface PaginationService {
      * @return The pagination builder
      */
     PaginationList.Builder builder();
+
+    /**
+     * Gets the last known page index of a certain {@link PaginationList} viewed by an {@link Audience}.
+     * If the {@link Audience} is reading another {@link PaginationList}, the last known page number of this
+     * given list may still be saved and returned.
+     *
+     * <p>After some time, the list is forgotten about, at which point the page index will return empty.
+     *
+     * @param audience the audience member who may or may not have viewed any paginated output
+     * @param list     the paginated output that the audience member may be viewing
+     * @return the last known page index, if it exists
+     */
+    Optional<Integer> currentPage(Audience audience, PaginationList list);
 }


### PR DESCRIPTION
I am interested in knowing the page that a player is viewing of a paginated list I sent them.

I want the option to send a new paginated list as a clickable menu, but it will only work well if I send them back an updated paginated list at the same page they left off at. So, I want to be able to ask what page they were viewing when they clicked on something.

To use this, the developer would do something like the following:

```java
Map<UUID, PaginationList> playerLists = new HashMap<>();
String textData = "Click to update me!";

void sendPagination(ServerPlayer player) {
  PaginationList list = paginationService.builder().title("title")
    .contents(Collections.singletonList(Component.text(textData)
      .clickEvent(ClickEvent.runCommand("/update"))
    .build();
  int index;
  if (playerLists.contains(player.uniqueId())) {
    index = paginationService.currentPage(playerLists.get(player.uniqueId())).orElse(1);
  } else {
    index = 1;
  }
  list.sendTo(player, index);
  playerLists.put(player.uniqueId(), list);
}

...
// in send command
sendPagination(player);
...

...
// in update command
textData = "Updated!"
sendPagination(player)
...
```

Another option would be to put this current page data in the PaginationList interface itself. Or is there another, simpler way to request a specific page that a player left off at?