### PR TITLE
Add ServerWorld#saveAndFlush() method

### DIFF
--- a/src/main/java/org/spongepowered/api/world/server/ServerWorld.java
+++ b/src/main/java/org/spongepowered/api/world/server/ServerWorld.java
@@ -197,6 +197,15 @@ public interface ServerWorld extends World<ServerWorld, ServerLocation>, Identif
     boolean save() throws IOException;
 
     /**
+     * Instructs the world to save and flush all data.
+     *
+     * @return True if save was successful, or false if
+     *     {@link SerializationBehavior} is {@link SerializationBehavior#NONE}
+     * @throws IOException If the save failed
+     */
+    boolean saveAndFlush() throws IOException;
+
+    /**
      * Unloads the given chunk from the world. Returns a {@code boolean} flag
      * for whether the operation was successful.
      *


### PR DESCRIPTION
**SpongeAPI** |  [Sponge](https://github.com/SpongePowered/Sponge/pull/3686)

Add separate method for saving world with forced flushing.
Required to avoid memory leaks during intensive modification of a huge number of chunks.
By analogy with the `/save-all [flush]` command, you can perform both simple save and save with flush here and now.