### PR TITLE
Expose adventure's new ComponentLogger to plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     val junitVersion: String by project
     val mockitoVersion: String by project
     val pluginSpiVersion: String by project
+    val slf4jVersion: String by project
 
     // Directly tied to what's available from Minecraft
     api("org.apache.logging.log4j:log4j-api:$log4jVersion")
@@ -43,6 +44,7 @@ dependencies {
         exclude(group = "org.codehaus.mojo", module = "animal-sniffer-annotations")
     }
     api("com.google.code.gson:gson:2.8.0")
+    api("org.slf4j:slf4j-api:$slf4jVersion") // technically only included starting in 1.17, but we'll backport the same version for consistency
 
     // Adventure
     api(platform("net.kyori:adventure-bom:$adventureVersion"))
@@ -59,6 +61,10 @@ dependencies {
     }
     api("net.kyori:adventure-text-minimessage") {
         exclude(group = "net.kyori", module = "adventure-api")
+    }
+    api("net.kyori:adventure-text-logger-slf4j") {
+        exclude(group = "net.kyori", module = "adventure-api")
+        exclude(group = "org.slf4j", module = "slf4j-api")
     }
 
     // Dependency injection

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,4 @@ log4jVersion=2.8.1
 mathVersion=2.0.1
 mockitoVersion=4.8.0
 pluginSpiVersion=0.3.0
+slf4jVersion=1.8.0-beta4


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/3779)

As a consequence, SLF4J is an API dependency again (it's always existed at some level in the implementations). We don't really want that, but how long can we avoid it if MC's switch to slf4j leads to developers expecting SLF4J to be present?

Now, we currently expose component logging functionality on SpongeVanilla by injecting into log4j -- that allows passing components to a logger the exact same way from the plugin developer side. This takes a fair bit of mucking about with Log4J internals, though so it is vulnerable to being disrupted by changes on Mojang's side. This functionality also hasn't been implemented on SpongeForge, and I am unsure exactly how much work it would be to do so.

Use of Adventure's ComponentLogger wrapper results in less work on our side, but adds more places for plugin developers to be confused about which logging interfaces should be used.

Thoughts?
