### PR TITLE
Fix contribution guidelines link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 We will always have a need for developers to help us improve SpongeAPI. There is no such thing as a perfect project and things can always be improved. If you are a developer and are interested in helping then please do not hesitate. Just make sure you follow our guidelines.
 
-Please check our [Contribution Guidelines in the Sponge Documentation](https://docs.spongepowered.org/en/contributing/guidelines.html) for more information.
+Please check our [Contribution Guidelines in the Sponge Documentation](https://docs.spongepowered.org/stable/en/contributing/guidelines.html) for more information.


### PR DESCRIPTION
The previous link was liking to a dead page. This is now changed to always point to the newest version of the contribution guidelines.

Even though this is currently merging into `api-8` this problem exists in the other branches as well.