### PR TITLE
docs: add missing p tags and rework existing tag for consistency

### DIFF
--- a/src/main/java/org/spongepowered/api/Client.java
+++ b/src/main/java/org/spongepowered/api/Client.java
@@ -42,11 +42,8 @@ public interface Client extends Engine, LocaleSource {
      * Gets the {@link ClientPlayer player} responsible
      * for controlling this client.
      *
-     * <p>
-     *     A client may not always have a local player if browsing menus prior to joining a
-     *     world or server.
-     * </p>
-     *
+     * @implNote A client may not always have a local player if browsing menus prior to joining a
+     * world or server.
      * @return The local player or {@link Optional#empty()} if it is not found
      */
     Optional<LocalPlayer> player();
@@ -55,10 +52,7 @@ public interface Client extends Engine, LocaleSource {
      * Gets the {@link LocalServer server} that powers a local SinglePlayer game instance
      * of a typical Minecraft client.
      *
-     * <p>
-     *     A client will not have a local server if it is outside of SinglePlayer
-     * </p>
-     *
+     * @implNote A client will not have a local server if it is outside of SinglePlayer
      * @return The local server or {@link Optional#empty()} if it is not found
      */
     Optional<LocalServer> server();
@@ -67,10 +61,7 @@ public interface Client extends Engine, LocaleSource {
      * Gets the {@link ClientWorld world} that a typical Minecraft client will be viewing
      * while in some game instance (local or remote).
      *
-     * <p>
-     *     A client will not have a client world if it is browsing the main menus
-     * </p>
-     *
+     * @implNote A client will not have a client world if it is browsing the main menus
      * @return The client world or {@link Optional#empty()}} if it is not found
      */
     Optional<ClientWorld> world();

--- a/src/main/java/org/spongepowered/api/Engine.java
+++ b/src/main/java/org/spongepowered/api/Engine.java
@@ -82,8 +82,7 @@ public interface Engine extends RegistryHolder {
     /**
      * Rediscovers all {@link Resource resources} within all {@link Pack pack's} {@link PackContents contents}.
      *
-     * <p>On the server, the future will always be completed.</p>
-     *
+     * @implNote On the server, the future will always be completed.
      * @return A future that completes when reloading is complete
      */
     CompletableFuture<Void> reloadResources();

--- a/src/main/java/org/spongepowered/api/Game.java
+++ b/src/main/java/org/spongepowered/api/Game.java
@@ -195,10 +195,9 @@ public interface Game extends RegistryHolder {
      * services that plugins may provide. Services provided here are
      * scoped to the lifetime of the Game.
      *
-     * <p>The provider will not be available during plugin construction and will
+     * @implNote The provider will not be available during plugin construction and will
      * throw an {@link IllegalStateException} if there is an attempt to access
-     * this before the provider is ready.</p>
-     *
+     * this before the provider is ready.
      * @return The service manager
      */
     ServiceProvider.GameScoped serviceProvider();

--- a/src/main/java/org/spongepowered/api/MinecraftVersion.java
+++ b/src/main/java/org/spongepowered/api/MinecraftVersion.java
@@ -37,12 +37,9 @@ public interface MinecraftVersion extends Comparable<MinecraftVersion> {
     /**
      * Gets the name of this Minecraft version.
      *
-     * <p>
-     * <strong>Note:</strong> The returned name does not necessarily represent
+     * @implNote The returned name does not necessarily represent
      * the name of a Minecraft version. Depending on the client and
      * implementation, this may also just return a numeric value.
-     * </p>
-     *
      * @return The version name
      */
     String name();
@@ -52,10 +49,8 @@ public interface MinecraftVersion extends Comparable<MinecraftVersion> {
      * all of the features in {@link StatusResponse}. These versions are only
      * supported for the {@link ClientPingServerEvent}, normally they should not be
      * able to join the server.
-     * <p>
-     * For Vanilla, this returns {@code true} for all clients older than 1.7.
-     * </p>
      *
+     * @implNote For Vanilla, this returns {@code true} for all clients older than 1.7.
      * @return {@code True} if this version is a legacy version
      */
     boolean isLegacy();
@@ -63,10 +58,7 @@ public interface MinecraftVersion extends Comparable<MinecraftVersion> {
     /**
      * Gets the data version of this Minecraft version.
      *
-     * <p>
- *     <strong>Note:</strong> The data version will not be available in a status response.
-     * </p>
-     *
+     * @implNote The data version will not be available in a status response.
      * @return The data version
      */
     OptionalInt dataVersion();

--- a/src/main/java/org/spongepowered/api/Platform.java
+++ b/src/main/java/org/spongepowered/api/Platform.java
@@ -46,10 +46,9 @@ public interface Platform {
     /**
      * Retrieves the current {@link Type} the platform is executing on.
      *
-     * <p>A Minecraft instance will have a client and server thread. If the
+     * @implNote A Minecraft instance will have a client and server thread. If the
      * server is executing, this will return {@linkplain Type#SERVER} but
-     * {@link Platform#type()} would return {@linkplain Type#CLIENT}.</p>
-     *
+     * {@link Platform#type()} would return {@linkplain Type#CLIENT}.
      * @return The execution type
      */
     Type executionType();
@@ -72,25 +71,23 @@ public interface Platform {
 
     /**
      * Returns this platform instance, as a key-value map.
+     * <p>
+     * This mechanism allows for platform-specific information like Forge
+     * version.
      *
-     * <p>The returned map instance is connected directly to this platform
+     * @implNote The returned map instance is connected directly to this platform
      * instance. Existing keys like name and version are not modifiable, but
      * new keys are stored in this instance and are shared between any
-     * references to a map obtained through the retrieved map.</p>
-     *
-     * <p>This mechanism allows for platform-specific information like Forge
-     * version.</p>
-     *
+     * references to a map obtained through the retrieved map.
      * @return This platform as a map
      */
     Map<String, Object> asMap();
 
     /**
      * The type of the platform, or where the game is currently running.
-     *
-     * <p>A side is what part of Minecraft this is being run on. The client, or
+     * <p>
+     * A side is what part of Minecraft this is being run on. The client, or
      * the server. The internal server is also treated like a dedicated server.
-     * </p>
      */
     enum Type {
 

--- a/src/main/java/org/spongepowered/api/ResourceKey.java
+++ b/src/main/java/org/spongepowered/api/ResourceKey.java
@@ -37,7 +37,7 @@ import java.util.Objects;
 /**
  * An object representation of a location or pointer to resources.
  * The key can be represented as a {@link String} by {@link Object#toString()}.
- *
+ * <p>
  * The key is built with two parts:
  * <ol>
  *     <li>The Namespace</li>
@@ -134,9 +134,8 @@ public interface ResourceKey extends Key {
     /**
      * Resolves a resource key from a string.
      *
-     * <p>If no namespace is found in {@code formatted} then
-     * {@link #MINECRAFT_NAMESPACE} will be the namespace.</p>
-     *
+     * @implNote If no namespace is found in {@code formatted} then
+     * {@link #MINECRAFT_NAMESPACE} will be the namespace.
      * @param formatted The formatted string to parse
      * @return A new resource key
      */
@@ -146,10 +145,10 @@ public interface ResourceKey extends Key {
 
     /**
      * Gets this key as a formatted value.
-     *
-     * <p>It is up to the implementation to determine the formatting. In
+     * <p>
+     * It is up to the implementation to determine the formatting. In
      * vanilla Minecraft, keys are formatted as "namespace:value". For example,
-     * "minecraft:carrot".</p>
+     * "minecraft:carrot".
      *
      * @return The key, formatted
      */
@@ -174,11 +173,11 @@ public interface ResourceKey extends Key {
 
         /**
          * Sets the key's namespace.
-         *
-         * <p>If using a {@link #MINECRAFT_NAMESPACE} or
+         * <p>
+         * If using a {@link #MINECRAFT_NAMESPACE} or
          * {@link #SPONGE_NAMESPACE}, it is preferable to use
          * {@link ResourceKey#minecraft(String)} or
-         * {@link ResourceKey#sponge(String)} instead.</p>
+         * {@link ResourceKey#sponge(String)} instead.
          *
          * @param namespace The namespace to use
          * @return This builder, for chaining

--- a/src/main/java/org/spongepowered/api/Server.java
+++ b/src/main/java/org/spongepowered/api/Server.java
@@ -87,9 +87,8 @@ public interface Server extends ForwardingAudience, Engine, LocaleSource {
     /**
      * Gets if multiple {@link ServerWorld worlds} will be loaded by the server.
      *
-     * <p>If false, no calls to loading worlds via the {@link WorldManager world manager} or otherwise will
-     * load a world</p>
-     *
+     * @implNote If false, no calls to loading worlds via the {@link WorldManager world manager} or otherwise will
+     * load a world
      * @return True if enabled, false if not
      */
     boolean isMultiWorldEnabled();
@@ -140,8 +139,7 @@ public interface Server extends ForwardingAudience, Engine, LocaleSource {
     /**
      * Gets the player idle timeout, in minutes.
      *
-     * <p>A value of {@code 0} means the timeout is disabled</p>
-     *
+     * @implNote A value of {@code 0} means the timeout is disabled
      * @return The player idle timeout
      */
     int playerIdleTimeout();
@@ -169,7 +167,7 @@ public interface Server extends ForwardingAudience, Engine, LocaleSource {
 
     /**
      * Gets if {@link ServerPlayer players} will have their {@link GameMode game mode} set to the default.
-     *
+     * <p>
      * {@link Server#gameMode()}
      *
      * @return True if enforced, false if not
@@ -244,12 +242,11 @@ public interface Server extends ForwardingAudience, Engine, LocaleSource {
 
     /**
      * Gets a {@link ServerPlayer} by their name.
+     * <p>
+     * This only works for online players.
      *
-     * <p>This only works for online players.</p>
-     *
-     * <p><b>Note: Do not use names for persistent storage, the
-     * Notch of today may not be the Notch of yesterday.</b></p>
-     *
+     * @implNote Do not use names for persistent storage, the
+     * Notch of today may not be the Notch of yesterday.
      * @param name The name to get the player from
      * @return The {@link ServerPlayer} or empty if not found
      */
@@ -258,14 +255,13 @@ public interface Server extends ForwardingAudience, Engine, LocaleSource {
     /**
      * Gets the 'server' scoreboard. In Vanilla, this is the scoreboard of
      * dimension 0 (the overworld).
+     * <p>
+     * The server scoreboard is used with the Vanilla /scoreboard command,
+     * automatic score updating through criteria, and other things.
      *
-     * <p>The server scoreboard is used with the Vanilla /scoreboard command,
-     * automatic score updating through criteria, and other things.</p>
-     *
-     * <p>The server scoreboard may not be available if dimension 0
+     * @implNote The server scoreboard may not be available if dimension 0
      * is not yet loaded. In Vanilla, this will only occur when the
-     * server is first starting, as dimension 0 is normally always loaded.</p>
-     *
+     * server is first starting, as dimension 0 is normally always loaded.
      * @return the server scoreboard, if available.
      */
     Optional<? extends Scoreboard> serverScoreboard();
@@ -282,9 +278,8 @@ public interface Server extends ForwardingAudience, Engine, LocaleSource {
      * Gets the time, in ticks, since this server began running for the current
      * session.
      *
-     * <p>This value is not persisted across server restarts, it is set to zero
-     * each time the server starts.</p>
-     *
+     * @implNote This value is not persisted across server restarts, it is set to zero
+     * each time the server starts.
      * @return The number of ticks since this server started running
      */
     Ticks runningTimeTicks();
@@ -322,8 +317,8 @@ public interface Server extends ForwardingAudience, Engine, LocaleSource {
      * Shuts down the server, and kicks all players with the default kick
      * message.
      *
-     * <p>For the Sponge implementation on the client, this will trigger the
-     * Integrated Server to shutdown a tick later.</p>
+     * @implNote For the Sponge implementation on the client, this will trigger the
+     * Integrated Server to shutdown a tick later.
      */
     void shutdown();
 
@@ -358,8 +353,8 @@ public interface Server extends ForwardingAudience, Engine, LocaleSource {
 
     /**
      * Gets the target ticks per second for this server.
-     *
-     * <p>This is dependent on the implementation.</p>
+     * <p>
+     * This is dependent on the implementation.
      *
      * @return The target tick per second rate.
      */
@@ -368,8 +363,7 @@ public interface Server extends ForwardingAudience, Engine, LocaleSource {
     /**
      * Sets the player idle timeout, in minutes.
      *
-     * <p>A value of {@code 0} disables the player idle timeout.</p>
-     *
+     * @implNote A value of {@code 0} disables the player idle timeout.
      * @param timeout The player idle timeout
      */
     void setPlayerIdleTimeout(int timeout);
@@ -379,19 +373,18 @@ public interface Server extends ForwardingAudience, Engine, LocaleSource {
      * services that plugins may provide. Services provided here are
      * scoped to the lifetime of this Server.
      *
-     * <p>The provider will not be available during plugin construction and will
+     * @implNote The provider will not be available during plugin construction and will
      * throw an {@link IllegalStateException} if there is an attempt to access
-     * this before the provider is ready.</p>
-     *
+     * this before the provider is ready.
      * @return The service manager
      */
     ServiceProvider.ServerScoped serviceProvider();
 
     /**
      * Gets the {@link CommandManager} for executing and inspecting commands.
-     *
-     * <p>Commands must be registered by listening to the
-     * {@link RegisterCommandEvent} instead.</p>
+     * <p>
+     * Commands must be registered by listening to the
+     * {@link RegisterCommandEvent} instead.
      *
      * @return The {@link CommandManager} instance.
      */
@@ -399,9 +392,9 @@ public interface Server extends ForwardingAudience, Engine, LocaleSource {
 
     /**
      * Gets the map storage for this server
-     *
-     * <p>This allows for control over the server's maps,
-     * including obtaining and creating them</p>
+     * <p>
+     * This allows for control over the server's maps,
+     * including obtaining and creating them
      *
      * @return MapStorage
      */

--- a/src/main/java/org/spongepowered/api/Sponge.java
+++ b/src/main/java/org/spongepowered/api/Sponge.java
@@ -128,10 +128,9 @@ public final class Sponge {
     /**
      * Gets the {@link Server} instance from the {@link Game} instance.
      *
-     * <p>Note: During various {@link LifecycleEvent events}, a {@link Server} instance
+     * @implNote During various {@link LifecycleEvent events}, a {@link Server} instance
      * may <strong>NOT</strong> be available. Calling {@link Game#server()} during one
-     * will throw an exception. To double check, call {@link #isServerAvailable()}</p>
-     *
+     * will throw an exception. To double check, call {@link #isServerAvailable()}
      * @see Game#server()
      * @see Game#isServerAvailable()
      * @return The server instance
@@ -154,9 +153,8 @@ public final class Sponge {
     /**
      * Gets the {@link Client} instance from the {@link Game} instance.
      *
-     * <p>Note: Not all implementations support a client, consult your
-     * vendor for further information.</p>
-     *
+     * @implNote Not all implementations support a client, consult your
+     * vendor for further information.
      * @see Game#client()
      * @see Game#isClientAvailable()
      * @return The client instance
@@ -207,9 +205,9 @@ public final class Sponge {
     /**
      * Gets the {@link Game} scoped {@link ServiceProvider} for providing
      * services.
-     *
-     * <p>{@link Engine} scoped services, if they exist, can be found on the
-     * respective engine.</p>
+     * <p>
+     * {@link Engine} scoped services, if they exist, can be found on the
+     * respective engine.
      *
      * @return The service provider.
      */

--- a/src/main/java/org/spongepowered/api/SystemSubject.java
+++ b/src/main/java/org/spongepowered/api/SystemSubject.java
@@ -30,14 +30,14 @@ import org.spongepowered.api.util.locale.LocaleSource;
 
 /**
  * Represents the "super user" of the game.
- *
- * <p>The {@link SystemSubject} is intended to be the {@link Subject} that
+ * <p>
+ * The {@link SystemSubject} is intended to be the {@link Subject} that
  * represents server actions. This subject may represent an interaction
- * through a console.</p>
- *
- * <p>This object is also a {@link LocaleSource}. Any message sent here
+ * through a console.
+ * <p>
+ * This object is also a {@link LocaleSource}. Any message sent here
  * should be directed to a system visible location, such as a log or a
- * console.</p>
+ * console.
  */
 public interface SystemSubject extends Subject, Audience, LocaleSource {
 

--- a/src/main/java/org/spongepowered/api/command/parameter/managed/ValueParameter.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/ValueParameter.java
@@ -84,7 +84,7 @@ public interface ValueParameter<T> extends DefaultedRegistryValue, ValueComplete
         /**
          * This should not be overridden by implementations of this class. If
          * you wish to do so, implement {@link ValueParameter} instead.
-         *
+         * <p>
          * {@inheritDoc}
          */
         @Override
@@ -109,7 +109,7 @@ public interface ValueParameter<T> extends DefaultedRegistryValue, ValueComplete
         /**
          * This should not be overridden by implementations of this class. If
          * you wish to do so, implement {@link ValueParameter} instead.
-         *
+         * <p>
          * {@inheritDoc}
          */
         @Override

--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -2099,7 +2099,7 @@ public final class Keys {
     /**
      * Represents the {@link Key} for the {@link MapInfo}
      * of an {@link ItemStack} of type {@link ItemTypes#FILLED_MAP}.
-     *
+     * <p>
      * <b>Can be null if the ItemStack was made by a plugin and hasn't been offered a MapInfo yet.</b>
      */
     public static final Key<Value<MapInfo>> MAP_INFO = Keys.key(ResourceKey.sponge("map_info"), MapInfo.class);

--- a/src/main/java/org/spongepowered/api/entity/living/monster/Patroller.java
+++ b/src/main/java/org/spongepowered/api/entity/living/monster/Patroller.java
@@ -62,7 +62,7 @@ public interface Patroller extends Monster {
 
     /**
      * Instructs the patroller to find a new patrol target.
-     *
+     * <p>
      * {@link Keys#TARGET_POSITION}
      */
     void findPatrolTarget();

--- a/src/main/java/org/spongepowered/api/event/Event.java
+++ b/src/main/java/org/spongepowered/api/event/Event.java
@@ -45,7 +45,7 @@ public interface Event {
      * So, when investigating the Cause of the event a common
      * idiom is to use operations (functions) on the result
      * of cause as follows:
-     *
+     * <p>
      * Use-case: Getting the Player (if any) responsible:
      * {@code Optional<Player> optPlayer = event.cause().first(Player.class);}
      *

--- a/src/main/java/org/spongepowered/api/event/EventContextKeys.java
+++ b/src/main/java/org/spongepowered/api/event/EventContextKeys.java
@@ -75,9 +75,9 @@ public final class EventContextKeys {
 
     /**
      * Used when a {@link World} block event is being processed.
-     * 
+     * <p>
      * For example, a piston head retracting and extending.
-     * 
+     * <p>
      * Note: This represents vanilla's block event.
      * Note: This occurs at the end of a world tick after
      *  {@link #BLOCK_EVENT_QUEUE}.
@@ -86,10 +86,10 @@ public final class EventContextKeys {
 
     /**
      * Used to queue a block event to be processed in a {@link World}.
-     * 
+     * <p>
      * For example, a piston will queue retract/extend movements using this
      * event.
-     * 
+     * <p>
      * Note: This represents vanilla's block event.
      */
     public static final EventContextKey<LocatableBlock> BLOCK_EVENT_QUEUE = EventContextKeys.key(ResourceKey.sponge("block_event_queue"), LocatableBlock.class);
@@ -127,7 +127,7 @@ public final class EventContextKeys {
 
     /**
      * Represents the target {@link Entity}.
-     * 
+     * <p>
      * Used when an entity, such as a Player, targets an entity via an
      * interaction.
      */
@@ -135,7 +135,7 @@ public final class EventContextKeys {
 
     /**
      * Represents a fake player responsible for an action.
-     * 
+     * <p>
      * Note: This is normally only used with mods.
      */
     public static final EventContextKey<Player> FAKE_PLAYER = EventContextKeys.key(ResourceKey.sponge("fake_player"), Player.class);

--- a/src/main/java/org/spongepowered/api/event/network/ServerSideConnectionEvent.java
+++ b/src/main/java/org/spongepowered/api/event/network/ServerSideConnectionEvent.java
@@ -124,7 +124,7 @@ public interface ServerSideConnectionEvent extends Event {
      * {@link MessageEvent#setMessage(Component)}. No action on the part
      * of the registered {@link BanService} or {@link WhitelistService} is
      * required for this to occur.
-     *
+     * <p>
      * Plugins may uncancel the event to allow a client to join, regardless of
      * its ban/whitelist status.</p>
      */

--- a/src/main/java/org/spongepowered/api/event/server/query/QueryServerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/server/query/QueryServerEvent.java
@@ -60,7 +60,7 @@ public interface QueryServerEvent extends Event {
          * Gets the GameType to respond with.
          *
          * <p>By default, this is <code>SMP</code>.
-         *
+         * <p>
          * If setting the string causes the message to go over the
          * maximum size, the message will be automatically truncated.</p>
          *
@@ -101,7 +101,7 @@ public interface QueryServerEvent extends Event {
          * Gets the player count to respond with.
          *
          * <p>By default, this is the number of players present on the server.
-         *
+         * <p>
          * If setting the string causes the message to go over the
          * maximum size, the message will be automatically truncated.</p>
          *

--- a/src/main/java/org/spongepowered/api/event/world/chunk/ChunkEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/chunk/ChunkEvent.java
@@ -112,7 +112,7 @@ public interface ChunkEvent extends Event {
         /**
          * Called after the {@link WorldChunk chunk} is saved. Guaranteed to exist in the chunk's
          * storage container.
-         *
+         * <p>
          * Depending on the implementation, this event may be called off-thread.
          */
         interface Post extends Save {}

--- a/src/main/java/org/spongepowered/api/map/decoration/MapDecorationBannerType.java
+++ b/src/main/java/org/spongepowered/api/map/decoration/MapDecorationBannerType.java
@@ -30,7 +30,7 @@ import org.spongepowered.api.data.type.DyeColor;
  * An extension of {@link MapDecorationType} that represents a banner, and provides
  * the {@link org.spongepowered.api.data.type.DyeColor} of the banner it
  * represents.
- *
+ * <p>
  * Not all {@link MapDecorationType MapDecorationTypes} are {@link MapDecorationBannerType}.
  */
 public interface MapDecorationBannerType extends MapDecorationType {

--- a/src/main/java/org/spongepowered/api/scoreboard/Team.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Team.java
@@ -48,12 +48,12 @@ import java.util.function.Supplier;
  * <p>With the exception of {@link #nameTagVisibility()} (which is handled client-side),
  * all of the team options require players to have the same team object (and by
  * extension, the same scoreboard).
- *
+ * <p>
  * For example, consider two players who each have different scoreboards set.
  * Each scoreboard has a team registered with identical names, each containing
  * the same players. Both players would always be able to attack each other,
  * regardless of the value of {@link #allowFriendlyFire()}.
- *
+ * <p>
  * For it to work, both players must have the same scoreboard, and be on a team
  * registered to said scoreboard.</p>
  */

--- a/src/main/java/org/spongepowered/api/service/economy/account/Account.java
+++ b/src/main/java/org/spongepowered/api/service/economy/account/Account.java
@@ -47,10 +47,10 @@ import java.util.UUID;
  *
  * <p>Accounts come in two varieties: {@link UniqueAccount user accounts}
  * and {@link VirtualAccount} virtual accounts.
- *
+ * <p>
  * Unique accounts are bound to a {@link UUID}, usually of a particular
  * {@link User}'s {@link GameProfile}.
- *
+ * <p>
  * Virtual accounts are identified by a String identifier, which may have any
  * value. They are not tied to any {@link Entity}, player or otherwise. Virtual
  * accounts may be used for purposes such as bank accounts, non-player

--- a/src/main/java/org/spongepowered/api/world/ChunkRegenerateFlag.java
+++ b/src/main/java/org/spongepowered/api/world/ChunkRegenerateFlag.java
@@ -45,7 +45,7 @@ public interface ChunkRegenerateFlag extends DefaultedRegistryValue {
     /**
      * Gets whether this flag will preserve entities in chunks that are
      * regenerated.
-     *
+     * <p>
      * Note: It is up to the implementation to decide whether this will
      * include moving entities to safe locations.
      *

--- a/src/main/java/org/spongepowered/api/world/ChunkRegenerateFlags.java
+++ b/src/main/java/org/spongepowered/api/world/ChunkRegenerateFlags.java
@@ -61,7 +61,7 @@ public final class ChunkRegenerateFlags {
 
     /**
      * A flag that defines whether a chunk should preserve entities.
-     * 
+     * <p>
      * Note: It is up to the implementation to decide whether this will
      * include moving entities to safe locations.
      */

--- a/src/main/java/org/spongepowered/api/world/WorldType.java
+++ b/src/main/java/org/spongepowered/api/world/WorldType.java
@@ -90,7 +90,7 @@ public interface WorldType extends DefaultedRegistryValue, ContextSource, DataHo
     /**
      * Gets the coordinate scale applied to the coordinates of a {@link ServerPlayer player}
      * traveling in a {@link ServerWorld world} of this type.
-     *
+     * <p>
      * Best seen when transferring that player from one world to another (as the player's
      * coordinates will adjust to the scale of the destination world's).
      *

--- a/src/main/java/org/spongepowered/api/world/generation/ChunkGenerator.java
+++ b/src/main/java/org/spongepowered/api/world/generation/ChunkGenerator.java
@@ -39,11 +39,11 @@ import java.util.Objects;
 
 /**
  * A chunk generator.
- *
+ * <p>
  * Vanilla builtin generators include
  * - configurable flat generator see {@link FlatGeneratorConfig}
  * - configurable noise generator see {@link NoiseGeneratorConfig}.
- *
+ * <p>
  * Other chunk generators may be provided by third parties and may be obtained from
  * - {@link ServerWorld#generator()}
  * - {@link WorldTemplate#generator()}

--- a/src/main/java/org/spongepowered/api/world/schematic/Schematic.java
+++ b/src/main/java/org/spongepowered/api/world/schematic/Schematic.java
@@ -95,7 +95,6 @@ public interface Schematic extends ArchetypeVolume, LocationBaseDataHolder.Mutab
          * also affecting {@link #blockEntities(BlockEntityVolume) the block
          * entity volume}.
          *
-         *
          * @param volume The archetype volume
          * @return This builder, for chaining
          */


### PR DESCRIPTION
add implNote when the comment is an implementation detail
remove ignored newlines

____

Opening a PR to gather more feedback on this before pushing more changes.

We're currently using a mix of 
```javadoc
* foo
*
* <p>bar
```
and
```javadoc
* foo
* <p>
* bar
```

This is confusing and already created some issues (missing paragraphs). Since empty lines are ignored by the javadoc, this PR is using 2) consistently.