### PR TITLE
Implement missing method isFire in AbstractDamageSource

### DIFF
--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSource.java
@@ -46,6 +46,7 @@ public abstract class AbstractDamageSource implements DamageSource {
     private final boolean explosive;
     private final boolean magic;
     private final boolean creative;
+    private final boolean fire;
     private final double exhaustion;
 
     protected AbstractDamageSource(AbstractDamageSourceBuilder<?, ?> builder) {
@@ -56,6 +57,7 @@ public abstract class AbstractDamageSource implements DamageSource {
         this.explosive = builder.explosion;
         this.magic = builder.magical;
         this.creative = builder.creative;
+        this.fire = builder.fire;
         if (builder.exhaustion != null) {
             this.exhaustion = builder.exhaustion;
         } else if (this.absolute || this.bypassesArmor) {
@@ -98,6 +100,11 @@ public abstract class AbstractDamageSource implements DamageSource {
     @Override
     public boolean doesAffectCreative() {
         return this.creative;
+    }
+
+    @Override
+    public boolean isFire() {
+        return this.fire;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSourceBuilder.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractDamageSourceBuilder.java
@@ -107,6 +107,7 @@ public abstract class AbstractDamageSourceBuilder<T extends DamageSource, B exte
         this.explosion = value.isExplosive();
         this.creative = value.doesAffectCreative();
         this.magical = value.isMagic();
+        this.fire = value.isFire();
         this.exhaustion = value.exhaustion();
         this.damageType = value.type();
         return (B) this;
@@ -120,6 +121,7 @@ public abstract class AbstractDamageSourceBuilder<T extends DamageSource, B exte
         this.absolute = false;
         this.magical = false;
         this.creative = false;
+        this.fire = false;
         this.exhaustion = null;
         this.damageType = null;
         return (B) this;

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractEntityDamageSource.java
@@ -39,6 +39,7 @@ public abstract class AbstractEntityDamageSource implements EntityDamageSource {
     private final boolean explosive;
     private final boolean magic;
     private final boolean creative;
+    private final boolean fire;
     private final double exhaustion;
     private final Entity source;
 
@@ -50,6 +51,7 @@ public abstract class AbstractEntityDamageSource implements EntityDamageSource {
         this.explosive = builder.explosion;
         this.magic = builder.magical;
         this.creative = builder.creative;
+        this.fire = builder.fire;
         if (builder.exhaustion != null) {
             this.exhaustion = builder.exhaustion;
         } else if (this.absolute || this.bypassesArmor) {
@@ -98,6 +100,11 @@ public abstract class AbstractEntityDamageSource implements EntityDamageSource {
     @Override
     public boolean doesAffectCreative() {
         return this.creative;
+    }
+
+    @Override
+    public boolean isFire() {
+        return this.fire;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSource.java
@@ -39,6 +39,7 @@ public abstract class AbstractIndirectEntityDamageSource implements IndirectEnti
     private final boolean explosive;
     private final boolean magic;
     private final boolean creative;
+    private final boolean fire;
     private final double exhaustion;
     private final Entity source;
     private final Entity indirect;
@@ -51,6 +52,7 @@ public abstract class AbstractIndirectEntityDamageSource implements IndirectEnti
         this.explosive = builder.explosion;
         this.magic = builder.magical;
         this.creative = builder.creative;
+        this.fire = builder.fire;
         if (builder.exhaustion != null) {
             this.exhaustion = builder.exhaustion;
         } else if (this.absolute || this.bypassesArmor) {
@@ -100,6 +102,11 @@ public abstract class AbstractIndirectEntityDamageSource implements IndirectEnti
     @Override
     public boolean doesAffectCreative() {
         return this.creative;
+    }
+
+    @Override
+    public boolean isFire() {
+        return this.fire;
     }
 
     @Override


### PR DESCRIPTION
[Sponge](https://github.com/SpongePowered/Sponge/pull/3821) | **SpongeAPI**

`AbstractDamageSource` is supposed to implement all methods in `DamageSource`. `isFire` was missing.