### PR TITLE
Replace guava immutable collections with java immutable collections

### DIFF
--- a/src/main/java/org/spongepowered/api/data/DataManipulator.java
+++ b/src/main/java/org/spongepowered/api/data/DataManipulator.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.data;
 
-import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.value.CopyableValueContainer;
 import org.spongepowered.api.data.value.MergeFunction;
@@ -34,11 +33,14 @@ import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.util.annotation.eventgen.TransformWith;
 import org.spongepowered.api.world.World;
 
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Represents a changelist of data that can be applied to a {@link DataHolder.Mutable}.
@@ -367,7 +369,7 @@ public interface DataManipulator extends CopyableValueContainer {
          *           given {@link ValueContainer}
          */
         default Mutable copyFrom(final ValueContainer valueContainer, final MergeFunction overlap, final Key<?> first, final Key<?>... more) {
-            return this.copyFrom(valueContainer, overlap, ImmutableList.<Key<?>>builder().add(first).add(more).build());
+            return this.copyFrom(valueContainer, overlap, Stream.concat(Stream.of(first), Arrays.stream(more)).collect(Collectors.toUnmodifiableList()));
         }
 
         /**

--- a/src/main/java/org/spongepowered/api/data/DataTransactionResult.java
+++ b/src/main/java/org/spongepowered/api/data/DataTransactionResult.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.data;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.data.value.Value;
@@ -79,7 +77,7 @@ public final class DataTransactionResult {
 
         @Override
         public Set<Characteristics> characteristics() {
-            return ImmutableSet.of();
+            return Set.of();
         }
     };
 
@@ -281,26 +279,26 @@ public final class DataTransactionResult {
     }
 
     final Type type;
-    private final ImmutableList<Value.Immutable<?>> rejected;
-    private final ImmutableList<Value.Immutable<?>> replaced;
-    private final ImmutableList<Value.Immutable<?>> success;
+    private final List<Value.Immutable<?>> rejected;
+    private final List<Value.Immutable<?>> replaced;
+    private final List<Value.Immutable<?>> success;
 
     DataTransactionResult(final Builder builder) {
         this.type = builder.resultType;
         if (builder.rejected != null) {
-            this.rejected = ImmutableList.copyOf(builder.rejected);
+            this.rejected = List.copyOf(builder.rejected);
         } else {
-            this.rejected = ImmutableList.of();
+            this.rejected = List.of();
         }
         if (builder.replaced != null) {
-            this.replaced = ImmutableList.copyOf(builder.replaced);
+            this.replaced = List.copyOf(builder.replaced);
         } else {
-            this.replaced = ImmutableList.of();
+            this.replaced = List.of();
         }
         if (builder.successful != null) {
-            this.success = ImmutableList.copyOf(builder.successful);
+            this.success = List.copyOf(builder.successful);
         } else {
-            this.success = ImmutableList.of();
+            this.success = List.of();
         }
     }
 

--- a/src/main/java/org/spongepowered/api/data/value/ValueContainer.java
+++ b/src/main/java/org/spongepowered/api/data/value/ValueContainer.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.data.value;
 
-import com.google.common.collect.ImmutableSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataManipulator;
@@ -210,7 +209,7 @@ public interface ValueContainer {
      * Gets all applicable {@link Key}s for this {@link ValueContainer}.
      * Changes can not be made to the set to alter the {@link ValueContainer},
      * nor can the {@link Value}s be changed with the provided
-     * {@link ImmutableSet}.
+     * {@link Set}.
      *
      * @return An immutable set of known {@link Key}s
      */

--- a/src/main/java/org/spongepowered/api/event/Cause.java
+++ b/src/main/java/org/spongepowered/api/event/Cause.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.event;
 
-import com.google.common.collect.ImmutableList;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.util.CopyableBuilder;
 import org.spongepowered.api.util.annotation.DoNotStore;
@@ -37,6 +36,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 /**
  * A cause represents the reason or initiator of an event.
@@ -116,7 +116,7 @@ public final class Cause implements Iterable<Object> {
     private final EventContext context;
 
     // lazy load
-    @Nullable private ImmutableList<Object> immutableCauses;
+    @Nullable private List<Object> immutableCauses;
 
     /**
      * Constructs a new cause.
@@ -281,7 +281,7 @@ public final class Cause implements Iterable<Object> {
     }
 
     /**
-     * Gets an {@link ImmutableList} of all objects that are instances of the
+     * Gets an immutable {@link List} of all objects that are instances of the
      * given {@link Class} type <code>T</code>.
      *
      * @param <T> The type of objects to query for
@@ -289,13 +289,7 @@ public final class Cause implements Iterable<Object> {
      * @return An immutable list of the objects queried
      */
     public <T> List<T> allOf(final Class<T> target) {
-        final ImmutableList.Builder<T> builder = ImmutableList.builder();
-        for (final Object aCause : this.cause) {
-            if (target.isInstance(aCause)) {
-                builder.add((T) aCause);
-            }
-        }
-        return builder.build();
+        return Arrays.stream(this.cause).filter(target::isInstance).map(entry -> (T) entry).collect(Collectors.toUnmodifiableList());
     }
 
     /**
@@ -306,13 +300,7 @@ public final class Cause implements Iterable<Object> {
      * @return The list of objects not an instance of the provided class
      */
     public List<Object> noneOf(final Class<?> ignoredClass) {
-        final ImmutableList.Builder<Object> builder = ImmutableList.builder();
-        for (final Object cause : this.cause) {
-            if (!ignoredClass.isInstance(cause)) {
-                builder.add(cause);
-            }
-        }
-        return builder.build();
+        return Arrays.stream(this.cause).filter(entry -> !ignoredClass.isInstance(entry)).collect(Collectors.toUnmodifiableList());
     }
 
     /**
@@ -322,7 +310,7 @@ public final class Cause implements Iterable<Object> {
      */
     public List<Object> all() {
         if (this.immutableCauses == null) {
-            this.immutableCauses = ImmutableList.copyOf(this.cause);
+            this.immutableCauses = List.of(this.cause);
         }
         return this.immutableCauses;
     }

--- a/src/main/java/org/spongepowered/api/event/EventContext.java
+++ b/src/main/java/org/spongepowered/api/event/EventContext.java
@@ -24,13 +24,11 @@
  */
 package org.spongepowered.api.event;
 
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.util.CopyableBuilder;
 import org.spongepowered.api.util.annotation.DoNotStore;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -46,7 +44,7 @@ import java.util.function.Supplier;
 @DoNotStore
 public final class EventContext {
 
-    private static final EventContext EMPTY_CONTEXT = new EventContext(ImmutableMap.of());
+    private static final EventContext EMPTY_CONTEXT = new EventContext(Map.of());
 
     /**
      * Gets an empty context.
@@ -83,7 +81,7 @@ public final class EventContext {
     private final Map<EventContextKey<?>, Object> entries;
 
     EventContext(Map<EventContextKey<?>, Object> values) {
-        this.entries = ImmutableMap.copyOf(values);
+        this.entries = Map.copyOf(values);
     }
 
     /**
@@ -226,7 +224,7 @@ public final class EventContext {
     public static final class Builder implements org.spongepowered.api.util.Builder<EventContext, Builder>, CopyableBuilder<EventContext,
         Builder> {
 
-        private final Map<EventContextKey<?>, Object> entries = Maps.newHashMap();
+        private final Map<EventContextKey<?>, Object> entries = new HashMap<>();
 
         Builder() {
 

--- a/src/main/java/org/spongepowered/api/event/entity/AttackEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/AttackEntityEvent.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.event.entity;
 
-import com.google.common.collect.ImmutableMap;
 import org.spongepowered.api.block.entity.carrier.Dispenser;
 import org.spongepowered.api.effect.potion.PotionEffect;
 import org.spongepowered.api.entity.Entity;
@@ -252,7 +251,7 @@ public interface AttackEntityEvent extends Event, Cancellable {
     double originalFinalDamage();
 
     /**
-     * Gets an {@link ImmutableMap} of all original {@link DamageModifier}s
+     * Gets an immutable {@link Map} of all original {@link DamageModifier}s
      * and their associated "modified" damage. Note that ordering is not
      * retained.
      *

--- a/src/main/java/org/spongepowered/api/event/entity/DamageEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/entity/DamageEntityEvent.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.event.entity;
 
-import com.google.common.collect.ImmutableMap;
 import org.spongepowered.api.block.entity.carrier.Dispenser;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.monster.skeleton.Skeleton;
@@ -171,7 +170,7 @@ public interface DamageEntityEvent extends Event, Cancellable {
     double originalFinalDamage();
 
     /**
-     * Gets an {@link ImmutableMap} of all original {@link DamageModifier}s
+     * Gets an immutable {@link Map} of all original {@link DamageModifier}s
      * and their associated "modified" damage. Note that ordering is not
      * retained.
      *

--- a/src/main/java/org/spongepowered/api/event/impl/entity/AbstractAffectEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/entity/AbstractAffectEntityEvent.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.event.impl.entity;
 
-import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntitySnapshot;
 import org.spongepowered.api.event.Order;
@@ -35,6 +34,7 @@ import org.spongepowered.api.util.annotation.eventgen.UseField;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public abstract class AbstractAffectEntityEvent extends AbstractEvent implements AffectEntityEvent {
 
@@ -47,11 +47,7 @@ public abstract class AbstractAffectEntityEvent extends AbstractEvent implements
     public List<EntitySnapshot> entitySnapshots() {
         if (this.entitySnapshots == null) {
             if (this.currentOrder == Order.PRE) {
-                final ImmutableList.Builder<EntitySnapshot> builder = ImmutableList.builder();
-                for (Entity entity : this.entities) {
-                    builder.add(entity.createSnapshot());
-                }
-                this.entitySnapshots = builder.build();
+                this.entitySnapshots = this.entities.stream().map(Entity::createSnapshot).collect(Collectors.toUnmodifiableList());
             } else {
                 throw new IllegalStateException("Can't initialize entity snapshots after PRE!");
             }

--- a/src/main/java/org/spongepowered/api/event/impl/entity/AbstractAttackEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/entity/AbstractAttackEntityEvent.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.event.impl.entity;
 
-import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.event.cause.entity.damage.DamageFunction;
 import org.spongepowered.api.event.cause.entity.damage.DamageModifier;
 import org.spongepowered.api.event.cause.entity.damage.DamageModifierType;
@@ -39,6 +38,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.DoubleUnaryOperator;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public abstract class AbstractAttackEntityEvent extends AbstractModifierEvent<DamageFunction, DamageModifier> implements AttackEntityEvent {
 
@@ -182,14 +183,12 @@ public abstract class AbstractAttackEntityEvent extends AbstractModifierEvent<Da
 
     @Override
     public List<DamageFunction> modifiers() {
-        final ImmutableList.Builder<DamageFunction> builder = ImmutableList.builder();
-        for (final ModifierFunction<DamageModifier> entry : this.modifierFunctions) {
+        return this.modifierFunctions.stream().map((Function<ModifierFunction<DamageModifier>, DamageFunction>) entry -> {
             if (entry instanceof DamageFunction) {
-                builder.add((DamageFunction) entry);
+                return (DamageFunction) entry;
             } else {
-                builder.add(new DamageFunction(entry.modifier(), entry.function()));
+                return new DamageFunction(entry.modifier(), entry.function());
             }
-        }
-        return builder.build();
+        }).collect(Collectors.toUnmodifiableList());
     }
 }

--- a/src/main/java/org/spongepowered/api/event/impl/entity/AbstractDamageEntityEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/entity/AbstractDamageEntityEvent.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.event.impl.entity;
 
-import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.data.Keys;
 import org.spongepowered.api.event.cause.entity.damage.DamageFunction;
 import org.spongepowered.api.event.cause.entity.damage.DamageModifier;
@@ -41,6 +40,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.DoubleUnaryOperator;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public abstract class AbstractDamageEntityEvent extends AbstractModifierEvent<DamageFunction, DamageModifier> implements DamageEntityEvent {
 
@@ -172,15 +173,13 @@ public abstract class AbstractDamageEntityEvent extends AbstractModifierEvent<Da
 
     @Override
     public List<DamageFunction> modifiers() {
-        final ImmutableList.Builder<DamageFunction> builder = ImmutableList.builder();
-        for (ModifierFunction<DamageModifier> entry : this.modifierFunctions) {
+        return this.modifierFunctions.stream().map((Function<ModifierFunction<DamageModifier>, DamageFunction>) entry -> {
             if (entry instanceof DamageFunction) {
-                builder.add((DamageFunction) entry);
+                return (DamageFunction) entry;
             } else {
-                builder.add(new DamageFunction(entry.modifier(), entry.function()));
+                return new DamageFunction(entry.modifier(), entry.function());
             }
-        }
-        return builder.build();
+        }).collect(Collectors.toUnmodifiableList());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/event/impl/entity/AbstractModifierEvent.java
+++ b/src/main/java/org/spongepowered/api/event/impl/entity/AbstractModifierEvent.java
@@ -24,15 +24,13 @@
  */
 package org.spongepowered.api.event.impl.entity;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import org.spongepowered.api.event.cause.entity.damage.ModifierFunction;
 import org.spongepowered.api.event.entity.DamageEntityEvent;
 import org.spongepowered.api.event.impl.AbstractEvent;
 import org.spongepowered.api.util.Tuple;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,13 +46,13 @@ public abstract class AbstractModifierEvent<T extends ModifierFunction<M>, M> ex
     protected double originalFinalAmount;
     protected List<Tuple<M, Double>> originalModifiers;
     protected Map<M, Double> originalModifierMap;
-    protected final LinkedHashMap<M, Double> modifiers = Maps.newLinkedHashMap();
+    protected final LinkedHashMap<M, Double> modifiers = new LinkedHashMap<>();
     protected final List<T> modifierFunctions = new ArrayList<>();
 
-    protected ImmutableList<T> init(double originalValue, List<T> originalFunctions) {
-        final ImmutableList.Builder<Tuple<M, Double>> modifierMapBuilder = ImmutableList.builder();
-        final ImmutableList.Builder<T> functionListBuilder = ImmutableList.builder();
-        final ImmutableMap.Builder<M, Double> mapBuilder = ImmutableMap.builder();
+    protected List<T> init(double originalValue, List<T> originalFunctions) {
+        final List<Tuple<M, Double>> modifierMapBuilder = new ArrayList<>(originalFunctions.size());
+        final List<T> functionListBuilder = new ArrayList<>(originalFunctions.size());
+        final Map<M, Double> mapBuilder = new HashMap<>(originalFunctions.size());
         double finalDamage = originalValue;
         for (T tuple : originalFunctions) {
             this.modifierFunctions.add(this.convertTuple(tuple.modifier(), tuple.function()));
@@ -66,9 +64,9 @@ public abstract class AbstractModifierEvent<T extends ModifierFunction<M>, M> ex
             functionListBuilder.add(this.convertTuple(tuple.modifier(), tuple.function()));
         }
         this.originalFinalAmount = finalDamage;
-        this.originalModifiers = modifierMapBuilder.build();
-        this.originalModifierMap = mapBuilder.build();
-        return functionListBuilder.build();
+        this.originalModifiers = List.copyOf(modifierMapBuilder);
+        this.originalModifierMap = Map.copyOf(mapBuilder);
+        return List.copyOf(functionListBuilder);
     }
 
     protected abstract T convertTuple(M obj, DoubleUnaryOperator function);
@@ -107,10 +105,6 @@ public abstract class AbstractModifierEvent<T extends ModifierFunction<M>, M> ex
      * @return The list of modifiers
      */
     public List<T> modifiers() {
-        final ImmutableList.Builder<T> builder = ImmutableList.builder();
-        for (T entry : this.modifierFunctions) {
-            builder.add(entry);
-        }
-        return builder.build();
+        return List.copyOf(this.modifierFunctions);
     }
 }

--- a/src/main/java/org/spongepowered/api/event/item/inventory/AffectItemStackEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/AffectItemStackEvent.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.event.item.inventory;
 
-import com.google.common.collect.Lists;
 import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
@@ -33,6 +32,7 @@ import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.util.annotation.eventgen.NoFactoryMethod;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -66,7 +66,7 @@ public interface AffectItemStackEvent extends Event, Cancellable {
      *     <code>false</code>
      */
     default List<? extends  Transaction<ItemStackSnapshot>> filter(Predicate<ItemStack> predicate) {
-        final List<Transaction<ItemStackSnapshot>> invalidatedTransactions = Lists.newArrayList();
+        final List<Transaction<ItemStackSnapshot>> invalidatedTransactions = new ArrayList<>();
         this.transactions().stream().filter(transaction -> !predicate.test(transaction.finalReplacement().createStack())).forEach(transaction -> {
             transaction.setValid(false);
             invalidatedTransactions.add(transaction);

--- a/src/main/java/org/spongepowered/api/event/item/inventory/AffectSlotEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/AffectSlotEvent.java
@@ -24,11 +24,11 @@
  */
 package org.spongepowered.api.event.item.inventory;
 
-import com.google.common.collect.Lists;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
 import org.spongepowered.api.util.annotation.eventgen.NoFactoryMethod;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -39,7 +39,7 @@ public interface AffectSlotEvent extends AffectItemStackEvent {
 
     @Override
     default List<SlotTransaction> filter(Predicate<ItemStack> predicate) {
-        final List<SlotTransaction> invalidatedTransactions = Lists.newArrayList();
+        final List<SlotTransaction> invalidatedTransactions = new ArrayList<>();
         this.transactions().stream().filter(transaction -> !predicate.test(transaction.finalReplacement().createStack())).forEach(transaction -> {
             transaction.setValid(false);
             invalidatedTransactions.add(transaction);

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackBuilderPopulators.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackBuilderPopulators.java
@@ -27,8 +27,6 @@ package org.spongepowered.api.item.inventory;
 import static org.spongepowered.api.util.weighted.VariableAmount.baseWithRandomAddition;
 import static org.spongepowered.api.util.weighted.VariableAmount.fixed;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.Key;
 import org.spongepowered.api.data.Keys;
@@ -52,6 +50,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A factory for generating {@link BiConsumer}s to apply to an
@@ -137,7 +136,7 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an item stack builder
      */
     public static BiConsumer<ItemStack.Builder, Random> items(final ItemType itemType, final ItemType... itemTypes) {
-        return ItemStackBuilderPopulators.items(ImmutableList.<ItemType>builder().add(itemType).addAll(Arrays.asList(itemTypes)).build());
+        return ItemStackBuilderPopulators.items(Stream.concat(Stream.of(itemType), Arrays.stream(itemTypes)).collect(Collectors.toUnmodifiableList()));
     }
 
     /**
@@ -148,7 +147,7 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static BiConsumer<ItemStack.Builder, Random> items(final Collection<ItemType> itemTypes) {
-        final ImmutableList<ItemType> copiedItemTypes = ImmutableList.copyOf(itemTypes);
+        final List<ItemType> copiedItemTypes = List.copyOf(itemTypes);
         return (builder, random) -> builder.itemType(copiedItemTypes.get(random.nextInt(copiedItemTypes.size())));
     }
 
@@ -303,7 +302,7 @@ public final class ItemStackBuilderPopulators {
     public static <E> BiConsumer<ItemStack.Builder, Random> listValues(final Key<? extends ListValue.Mutable<E>> key, final WeightedTable<E> weightedTable) {
         Objects.requireNonNull(weightedTable, "Weighted table cannot be null!");
         Objects.requireNonNull(key, "Key cannot be null!");
-        return ItemStackBuilderPopulators.setValue(key, random -> ImmutableList.copyOf(weightedTable.get(random)));
+        return ItemStackBuilderPopulators.setValue(key, random -> List.copyOf(weightedTable.get(random)));
 
     }
 
@@ -426,7 +425,7 @@ public final class ItemStackBuilderPopulators {
         if (weightedTable.isEmpty()) {
             throw new IllegalArgumentException("WeightedTable cannot be empty!");
         }
-        return ItemStackBuilderPopulators.setValue(key, random -> ImmutableSet.copyOf(weightedTable.get(random)));
+        return ItemStackBuilderPopulators.setValue(key, random -> Set.copyOf(weightedTable.get(random)));
     }
 
     /*Note : This is used internally only, no validation is performed.*/
@@ -496,7 +495,7 @@ public final class ItemStackBuilderPopulators {
     public static BiConsumer<ItemStack.Builder, Random> values(final Collection<Value.Immutable<?>> manipulators, final VariableAmount rolls) {
         Objects.requireNonNull(manipulators, "Manipulators cannot be null!");
         Objects.requireNonNull(rolls, "VariableAmount cannot be null!");
-        final ImmutableList<Value.Immutable<?>> copied = ImmutableList.copyOf(manipulators);
+        final List<Value.Immutable<?>> copied = List.copyOf(manipulators);
         final WeightedTable<Value.Immutable<?>> table = new WeightedTable<>();
         table.setRolls(rolls);
         copied.forEach(manipulator1 -> table.add(manipulator1, 1));
@@ -541,7 +540,7 @@ public final class ItemStackBuilderPopulators {
     public static BiConsumer<ItemStack.Builder, Random> enchantment(final VariableAmount level, final EnchantmentType enchantmentType) {
         Objects.requireNonNull(level, "VariableAmount cannot be null!");
         Objects.requireNonNull(enchantmentType, "EnchantmentType cannot be null!");
-        return ItemStackBuilderPopulators.enchantments(fixed(1), ImmutableList.of(new Tuple<>(enchantmentType, level)));
+        return ItemStackBuilderPopulators.enchantments(fixed(1), List.of(new Tuple<>(enchantmentType, level)));
     }
 
     /**
@@ -554,7 +553,7 @@ public final class ItemStackBuilderPopulators {
      * @return The new biconsumer to apply to an itemstack builder
      */
     public static BiConsumer<ItemStack.Builder, Random> enchantmentsWithVanillaLevelVariance(final Collection<EnchantmentType> enchantmentTypes) {
-        return ItemStackBuilderPopulators.enchantmentsWithVanillaLevelVariance(fixed(1), ImmutableList.copyOf(enchantmentTypes));
+        return ItemStackBuilderPopulators.enchantmentsWithVanillaLevelVariance(fixed(1), List.copyOf(enchantmentTypes));
     }
 
     /**
@@ -570,7 +569,7 @@ public final class ItemStackBuilderPopulators {
     public static BiConsumer<ItemStack.Builder, Random> enchantmentsWithVanillaLevelVariance(final VariableAmount amount, final EnchantmentType enchantmentType,
             final EnchantmentType... enchantmentTypes) {
         return ItemStackBuilderPopulators.enchantmentsWithVanillaLevelVariance(amount,
-                ImmutableList.<EnchantmentType>builder().add(enchantmentType).addAll(Arrays.asList(enchantmentTypes)).build());
+                Stream.concat(Stream.of(enchantmentType), Arrays.stream(enchantmentTypes)).collect(Collectors.toUnmodifiableList()));
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeResult.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeResult.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.item.recipe.crafting;
 
-import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.crafting.CraftingGridInventory;
 
@@ -62,7 +61,7 @@ public final class RecipeResult {
         }
 
         this.result = result;
-        this.remainingItems = ImmutableList.copyOf(remainingItems);
+        this.remainingItems = List.copyOf(remainingItems);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/state/StateContainer.java
+++ b/src/main/java/org/spongepowered/api/state/StateContainer.java
@@ -24,14 +24,13 @@
  */
 package org.spongepowered.api.state;
 
-import com.google.common.collect.ImmutableList;
-
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface StateContainer<S extends State<S>> {
 
-    ImmutableList<S> validStates();
+    List<S> validStates();
 
     S defaultState();
 

--- a/src/main/java/org/spongepowered/api/util/weighted/ChanceTable.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/ChanceTable.java
@@ -24,8 +24,7 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import com.google.common.collect.Lists;
-
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.random.RandomGenerator;
@@ -57,7 +56,7 @@ public class ChanceTable<T> extends RandomObjectTable<T> {
 
     @Override
     public List<T> get(RandomGenerator rand) {
-        final List<T> results = Lists.newArrayList();
+        final List<T> results = new ArrayList<>();
         if (this.entries.isEmpty()) {
             return results;
         }

--- a/src/main/java/org/spongepowered/api/util/weighted/LootTable.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/LootTable.java
@@ -24,9 +24,6 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -84,7 +81,7 @@ public class LootTable<T> {
      * @return The tables
      */
     public List<RandomObjectTable<T>> tables() {
-        return ImmutableList.copyOf(this.pool);
+        return List.copyOf(this.pool);
     }
 
     /**
@@ -101,7 +98,7 @@ public class LootTable<T> {
      * @return The retrieved entries
      */
     public List<T> get(final RandomGenerator rand) {
-        final List<T> results = Lists.newArrayList();
+        final List<T> results = new ArrayList<>();
         for (final RandomObjectTable<T> pool : this.pool) {
             results.addAll(pool.get(rand));
         }

--- a/src/main/java/org/spongepowered/api/util/weighted/RandomObjectTable.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/RandomObjectTable.java
@@ -24,9 +24,7 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -41,7 +39,7 @@ import java.util.random.RandomGenerator;
  */
 public abstract class RandomObjectTable<T> implements Collection<TableEntry<T>> {
 
-    protected final List<TableEntry<T>> entries = Lists.newArrayList();
+    protected final List<TableEntry<T>> entries = new ArrayList<>();
     private VariableAmount rolls;
 
     /**
@@ -250,7 +248,7 @@ public abstract class RandomObjectTable<T> implements Collection<TableEntry<T>> 
      * @return The raw entries
      */
     public List<TableEntry<T>> entries() {
-        return ImmutableList.copyOf(this.entries);
+        return List.copyOf(this.entries);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/api/util/weighted/WeightedTable.java
+++ b/src/main/java/org/spongepowered/api/util/weighted/WeightedTable.java
@@ -24,8 +24,7 @@
  */
 package org.spongepowered.api.util.weighted;
 
-import com.google.common.collect.Lists;
-
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -159,7 +158,7 @@ public class WeightedTable<T> extends RandomObjectTable<T> {
 
     @Override
     public List<T> get(RandomGenerator rand) {
-        final List<T> results = Lists.newArrayList();
+        final List<T> results = new ArrayList<>();
         if (this.entries.isEmpty()) {
             return results;
         }

--- a/src/main/java/org/spongepowered/api/world/volume/game/LocationBaseDataHolder.java
+++ b/src/main/java/org/spongepowered/api/world/volume/game/LocationBaseDataHolder.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.api.world.volume.game;
 
-import com.google.common.collect.ImmutableSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataManipulator;
@@ -672,7 +671,7 @@ public interface LocationBaseDataHolder {
     }
 
     /**
-     * Gets an {@link ImmutableSet} of {@link Key}s for the block at the given
+     * Gets an immutable {@link Set} of {@link Key}s for the block at the given
      * location.
      *
      * @param position The position of the block
@@ -683,7 +682,7 @@ public interface LocationBaseDataHolder {
     }
 
     /**
-     * Gets an {@link ImmutableSet} of {@link Key}s for the block at the given
+     * Gets an immutable {@link Set} of {@link Key}s for the block at the given
      * location.
      *
      * @param x The X position
@@ -694,7 +693,7 @@ public interface LocationBaseDataHolder {
     Set<Key<?>> keys(int x, int y, int z);
 
     /**
-     * Gets an {@link ImmutableSet} of {@link org.spongepowered.api.data.value.Value.Immutable}s for the block at
+     * Gets an immutable {@link Set} of {@link org.spongepowered.api.data.value.Value.Immutable}s for the block at
      * the given location.
      *
      * @param position The position of the block
@@ -705,7 +704,7 @@ public interface LocationBaseDataHolder {
     }
 
     /**
-     * Gets an {@link ImmutableSet} of {@link org.spongepowered.api.data.value.Value.Immutable}s for the block at
+     * Gets an immutable {@link Set} of {@link org.spongepowered.api.data.value.Value.Immutable}s for the block at
      * the given location.
      *
      * @param x The X position

--- a/src/test/java/org/spongepowered/api/data/DataQueryTest.java
+++ b/src/test/java/org/spongepowered/api/data/DataQueryTest.java
@@ -28,7 +28,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
-import com.google.common.collect.ImmutableList;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 import org.spongepowered.api.data.persistence.DataQuery;
@@ -110,7 +109,7 @@ class DataQueryTest {
         final DataQuery part2 = DataQuery.of("test");
         final DataQuery part3 = DataQuery.of("query");
         final List<DataQuery> parts = full.queryParts();
-        final List<DataQuery> built = ImmutableList.of(part1, part2, part3);
+        final List<DataQuery> built = List.of(part1, part2, part3);
         MatcherAssert.assertThat(parts, equalTo(built));
         MatcherAssert.assertThat(built, equalTo(parts));
         MatcherAssert.assertThat(built.containsAll(parts), is(true));

--- a/src/test/java/org/spongepowered/api/event/CauseTest.java
+++ b/src/test/java/org/spongepowered/api/event/CauseTest.java
@@ -32,7 +32,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 
-import com.google.common.collect.ImmutableList;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -114,7 +113,7 @@ class CauseTest {
 
     @Test
     void testListedArray() {
-        final List<String> fooList = ImmutableList.of("foo", "bar", "baz", "floof");
+        final List<String> fooList = List.of("foo", "bar", "baz", "floof");
         final Cause cause = Cause.builder().append("foo").append("bar").append("baz").append("floof").build(EventContext.empty());
         final List<String> stringList = cause.allOf(String.class);
         MatcherAssert.assertThat(stringList, is(not(empty())));

--- a/src/test/java/org/spongepowered/api/event/SpongeAbstractDamageEntityEventTest.java
+++ b/src/test/java/org/spongepowered/api/event/SpongeAbstractDamageEntityEventTest.java
@@ -28,7 +28,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.closeTo;
 
-import com.google.common.collect.Lists;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -38,6 +37,8 @@ import org.spongepowered.api.event.cause.entity.damage.DamageFunction;
 import org.spongepowered.api.event.cause.entity.damage.DamageModifier;
 import org.spongepowered.api.event.entity.DamageEntityEvent;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.DoubleUnaryOperator;
@@ -52,7 +53,7 @@ class SpongeAbstractDamageEntityEventTest {
         final int originalDamage = 5;
 
         final DamageEntityEvent event = SpongeEventFactory.createDamageEntityEvent(Cause.of(EventContext.empty(), "none"),
-            targetEntity, Lists.newArrayList(), originalDamage);
+            targetEntity, new ArrayList<>(), originalDamage);
 
         MatcherAssert.assertThat(event.originalDamage(), is(closeTo(originalDamage, SpongeAbstractDamageEntityEventTest.ERROR)));
         MatcherAssert.assertThat(event.originalFinalDamage(), is(closeTo(originalDamage, SpongeAbstractDamageEntityEventTest.ERROR)));
@@ -67,7 +68,7 @@ class SpongeAbstractDamageEntityEventTest {
         final int originalDamage = 5;
 
         final DamageEntityEvent event = SpongeEventFactory.createDamageEntityEvent(Cause.of(EventContext.empty(), "none"),
-            targetEntity, Lists.newArrayList(), originalDamage);
+            targetEntity, new ArrayList<>(), originalDamage);
 
         MatcherAssert.assertThat(event.originalDamage(), is(closeTo(originalDamage, SpongeAbstractDamageEntityEventTest.ERROR)));
         MatcherAssert.assertThat(event.originalFinalDamage(), is(closeTo(originalDamage, SpongeAbstractDamageEntityEventTest.ERROR)));
@@ -94,7 +95,7 @@ class SpongeAbstractDamageEntityEventTest {
         final DamageModifier firstModifer = this.mockParam(DamageModifier.class);
         final DamageModifier secondModifier = this.mockParam(DamageModifier.class);
 
-        final List<DamageFunction> originalFunctions = Lists.newArrayList(DamageFunction.of(firstModifer, p -> p * 2),
+        final List<DamageFunction> originalFunctions = Arrays.asList(DamageFunction.of(firstModifer, p -> p * 2),
             DamageFunction.of(secondModifier, p -> p * 5));
 
         final DamageEntityEvent event = SpongeEventFactory.createDamageEntityEvent(Cause.of(EventContext.empty(), "none"),
@@ -139,7 +140,7 @@ class SpongeAbstractDamageEntityEventTest {
         final DamageModifier firstModifer = this.mockParam(DamageModifier.class);
         final DamageModifier secondModifier = this.mockParam(DamageModifier.class);
 
-        final List<DamageFunction> originalFunctions = Lists.newArrayList(DamageFunction.of(firstModifer, p -> p * 2), DamageFunction.of(secondModifier,
+        final List<DamageFunction> originalFunctions = Arrays.asList(DamageFunction.of(firstModifer, p -> p * 2), DamageFunction.of(secondModifier,
             p -> p * 5));
 
         final DamageEntityEvent event = SpongeEventFactory.createDamageEntityEvent(Cause.of(EventContext.empty(), "none"),
@@ -166,7 +167,7 @@ class SpongeAbstractDamageEntityEventTest {
         MatcherAssert.assertThat(event.originalFunctions(), is(Matchers.equalTo(originalFunctions)));
 
         MatcherAssert.assertThat(event.modifiers(),
-            is(Matchers.equalTo(Lists.newArrayList(DamageFunction.of(firstModifer, newFunction), originalFunctions.get(1)))));
+            is(Matchers.equalTo(Arrays.asList(DamageFunction.of(firstModifer, newFunction), originalFunctions.get(1)))));
     }
 
     @Test
@@ -190,9 +191,9 @@ class SpongeAbstractDamageEntityEventTest {
         final DoubleUnaryOperator thirdFunction = p -> p;
 
         final List<DamageFunction>
-                originalFunctions = Lists.newArrayList(DamageFunction.of(firstModifier, p -> p * 2), DamageFunction.of(secondModifier, p -> p * 5));
+                originalFunctions = Arrays.asList(DamageFunction.of(firstModifier, p -> p * 2), DamageFunction.of(secondModifier, p -> p * 5));
 
-        final List<DamageFunction> newFunctions = Lists.newArrayList(originalFunctions);
+        final List<DamageFunction> newFunctions = new ArrayList<>(originalFunctions);
         newFunctions.add(DamageFunction.of(thirdModifier, thirdFunction));
 
         final DamageEntityEvent event = SpongeEventFactory.createDamageEntityEvent(Cause.of(EventContext.empty(), "none"), targetEntity,
@@ -230,7 +231,7 @@ class SpongeAbstractDamageEntityEventTest {
         final DamageModifier secondModifier = this.mockParam(DamageModifier.class);
 
         final List<DamageFunction>
-                originalFunctions = Lists.newArrayList(DamageFunction.of(firstModifer, p -> p), DamageFunction.of(secondModifier, p -> p));
+                originalFunctions = Arrays.asList(DamageFunction.of(firstModifer, p -> p), DamageFunction.of(secondModifier, p -> p));
 
         final DamageEntityEvent event = SpongeEventFactory.createDamageEntityEvent(Cause.of(EventContext.empty(), "none"), targetEntity,
             originalFunctions, 0);
@@ -243,7 +244,7 @@ class SpongeAbstractDamageEntityEventTest {
     @Test
     void testNotApplicableModifer() {
         final DamageEntityEvent event = SpongeEventFactory.createDamageEntityEvent(Cause.of(EventContext.empty(), "none"), this.mockParam(Entity.class),
-            Lists.newArrayList(), 0);
+            new ArrayList<>(), 0);
 
         final DamageModifier modifier = this.mockParam(DamageModifier.class);
 


### PR DESCRIPTION
Continuation of https://github.com/SpongePowered/SpongeAPI/pull/2246

Replace guava immutable collections with java new immutable collections.

With this the guava usage has been completely removed from the API