### PR TITLE
Expose protocol version for status pings

### DIFF
--- a/src/main/java/org/spongepowered/api/MinecraftVersion.java
+++ b/src/main/java/org/spongepowered/api/MinecraftVersion.java
@@ -45,6 +45,16 @@ public interface MinecraftVersion extends Comparable<MinecraftVersion> {
     String name();
 
     /**
+     * Gets the protocol version of this Minecraft version.
+     *
+     * @implNote This should be interpreted together with {@link #isLegacy()},
+     * since legacy clients use a different protocol version numbering scheme.
+     * @return The protocol version
+     * @see <a href="https://minecraft.fandom.com/wiki/Protocol_version">Protocol version (Minecraft Wiki)</a>
+     */
+    int protocolVersion();
+
+    /**
      * Returns whether this version is an older version that doesn't support
      * all of the features in {@link StatusResponse}. These versions are only
      * supported for the {@link ClientPingServerEvent}, normally they should not be
@@ -62,4 +72,13 @@ public interface MinecraftVersion extends Comparable<MinecraftVersion> {
      * @return The data version
      */
     OptionalInt dataVersion();
+
+    @Override
+    default int compareTo(MinecraftVersion o) {
+        final int result = Boolean.compare(this.isLegacy(), o.isLegacy());
+        if (result != 0) {
+            return result;
+        }
+        return this.protocolVersion() - o.protocolVersion();
+    }
 }

--- a/src/main/java/org/spongepowered/api/event/server/ClientPingServerEvent.java
+++ b/src/main/java/org/spongepowered/api/event/server/ClientPingServerEvent.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.event.server;
 
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.MinecraftVersion;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.network.status.Favicon;
@@ -92,6 +93,9 @@ public interface ClientPingServerEvent extends Event, Cancellable {
          */
         void setHidePlayers(boolean hide);
 
+        @Override
+        Version version();
+
         /**
          * Sets the {@link Favicon} to display on the client.
          *
@@ -129,6 +133,33 @@ public interface ClientPingServerEvent extends Event, Cancellable {
              */
             @Override
             List<GameProfile> profiles();
+        }
+
+        /**
+         * Represents the information about the version of the server, sent
+         * after the {@link ClientPingServerEvent}.
+         */
+        @NoFactoryMethod
+        interface Version extends MinecraftVersion {
+
+            /**
+             * Sets the name of the version of the server. This is usually
+             * displayed on the client if the server is using an incompatible
+             * protocol version.
+             *
+             * @param name The new display name of the server version
+             */
+            void setName(String name);
+
+            /**
+             * Sets the server protocol version reported to the client.
+             * Modifying this will change if the client sees the server as
+             * incompatible or not, forcing it to display the {@link #name()}.
+             *
+             * @param protocolVersion The new server protocol version
+             * @see <a href="https://minecraft.fandom.com/wiki/Protocol_version">Protocol version (Minecraft Wiki)</a>
+             */
+            void setProtocolVersion(int protocolVersion);
         }
     }
 


### PR DESCRIPTION
Historically we considered the Minecraft protocol versions as "implementation detail" that should not be exposed in SpongeAPI.

However, since the addition of the status ping API 8 years ago (#367) the protocol version still exists exactly the same way, and there are use cases for checking it (identifying the exact client version) and modifying it (making the server appear as incompatible to clients).

Right now plugins have to resort to using implementation-specific code for this, which is complicated and now hopelessly broken for api-10 (due to internal changes in the Minecraft code).

Make it possible to check and modify the server version to fix this once and for all.

Closes #2251