### PR TITLE
Add stream online players method

### DIFF
--- a/src/main/java/org/spongepowered/api/Server.java
+++ b/src/main/java/org/spongepowered/api/Server.java
@@ -38,6 +38,7 @@ import org.spongepowered.api.item.recipe.RecipeManager;
 import org.spongepowered.api.map.MapStorage;
 import org.spongepowered.api.network.ServerSideConnection;
 import org.spongepowered.api.profile.GameProfileManager;
+import org.spongepowered.api.registry.RegistryEntry;
 import org.spongepowered.api.resourcepack.ResourcePack;
 import org.spongepowered.api.scoreboard.Scoreboard;
 import org.spongepowered.api.service.ServiceProvider;
@@ -57,6 +58,7 @@ import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 /**
  * Represents a typical Minecraft Server.
@@ -224,6 +226,13 @@ public interface Server extends ForwardingAudience, Engine, LocaleSource {
      * @return The teleport helper
      */
     TeleportHelper teleportHelper();
+
+    /**
+     * Gets a {@link Stream} of all the {@link ServerPlayer}s currently online.
+     *
+     * @return The stream of online players
+     */
+    Stream<ServerPlayer> streamOnlinePlayers();
 
     /**
      * Gets the {@link ServerPlayer}s currently online.

--- a/src/main/java/org/spongepowered/api/Server.java
+++ b/src/main/java/org/spongepowered/api/Server.java
@@ -38,7 +38,6 @@ import org.spongepowered.api.item.recipe.RecipeManager;
 import org.spongepowered.api.map.MapStorage;
 import org.spongepowered.api.network.ServerSideConnection;
 import org.spongepowered.api.profile.GameProfileManager;
-import org.spongepowered.api.registry.RegistryEntry;
 import org.spongepowered.api.resourcepack.ResourcePack;
 import org.spongepowered.api.scoreboard.Scoreboard;
 import org.spongepowered.api.service.ServiceProvider;

--- a/src/main/java/org/spongepowered/api/network/channel/packet/PacketDispatcher.java
+++ b/src/main/java/org/spongepowered/api/network/channel/packet/PacketDispatcher.java
@@ -58,7 +58,7 @@ public interface PacketDispatcher {
      * @param packet The packet to send
      */
     default void sendToAllPlayers(final Packet packet) {
-        Sponge.server().onlinePlayers().forEach(player -> this.sendTo(player, packet));
+        Sponge.server().streamOnlinePlayers().forEach(player -> this.sendTo(player, packet));
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/network/channel/raw/play/RawPlayDataChannel.java
+++ b/src/main/java/org/spongepowered/api/network/channel/raw/play/RawPlayDataChannel.java
@@ -124,7 +124,7 @@ public interface RawPlayDataChannel {
      * @param payload A consumer to write the data to
      */
     default void sendToAllPlayers(final Consumer<ChannelBuf> payload) {
-        Sponge.server().onlinePlayers().forEach(player -> this.sendTo(player, payload));
+        Sponge.server().streamOnlinePlayers().forEach(player -> this.sendTo(player, payload));
     }
 
     /**


### PR DESCRIPTION
`onlinePlayers` is creating a copy of the collection on each call.

This can get costly on large server, especially because the scheduler is calling that method on each tick.
