### PR TITLE
Add Keys.FROZEN_TIME & Keys.MAX_FROZEN_TIME

### DIFF
--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -1093,6 +1093,11 @@ public final class Keys {
     public static final Key<Value<FoxType>> FOX_TYPE = Keys.key(ResourceKey.sponge("fox_type"), FoxType.class);
 
     /**
+     * The time (in ticks) an {@link Entity} is frozen.
+     */
+    public static final Key<Value<Ticks>> FROZEN_TIME = Keys.key(ResourceKey.sponge("frozen_time"), Ticks.class);
+
+    /**
      * Represents the {@link Key} for the amount of fuel left in a {@link BrewingStand} or {@link FurnaceBlockEntity} or {@link FurnaceMinecart}
      *
      * <p>One {@link ItemTypes#BLAZE_POWDER} adds 20 fuel to the brewing stand.</p>
@@ -2241,6 +2246,13 @@ public final class Keys {
      * @see Keys#FOOD_LEVEL
      */
     public static final Key<Value<Integer>> MAX_FOOD_LEVEL = Keys.key(ResourceKey.sponge("max_food_level"), Integer.class);
+
+    /**
+     * The frozen time after which an {@link Entity} is completely frozen. Readonly.
+     *
+     * @see Keys#FROZEN_TIME
+     */
+    public static final Key<Value<Ticks>> MAX_FROZEN_TIME = Keys.key(ResourceKey.sponge("max_frozen_time"), Ticks.class);
 
     /**
      * The maximum health of a {@link Living}.

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -356,6 +356,15 @@ public interface Entity extends Identifiable, HoverEventSource<HoverEvent.ShowEn
     }
 
     /**
+     * {@link Keys#FROZEN_TIME}
+     *
+     * @return The frozen time
+     */
+    default Value.Mutable<Ticks> frozenTime() {
+        return this.requireValue(Keys.FROZEN_TIME).asMutable();
+    }
+
+    /**
      * {@link Keys#PASSENGERS}
      *
      * @return The list of passengers that may be riding this entity
@@ -587,6 +596,15 @@ public interface Entity extends Identifiable, HoverEventSource<HoverEvent.ShowEn
      */
     default Value.Mutable<Integer> maxAir() {
         return this.requireValue(Keys.MAX_AIR).asMutable();
+    }
+
+    /**
+     * {@link Keys#MAX_FROZEN_TIME}
+     *
+     * @return The max frozen time
+     */
+    default Value.Mutable<Ticks> maxFrozenTime() {
+        return this.requireValue(Keys.MAX_FROZEN_TIME).asMutable();
     }
 
     /**


### PR DESCRIPTION
[Sponge](https://github.com/SpongePowered/Sponge/pull/3876) | SpongeAPI

Add keys to access & modify the frozen ticks of entities. This is the value that causes the freeze effect to appear on the screen & freeze damage when an entity is inside powdered snow. 