### PR TITLE
Add BlockType#hasBlockEntity

### DIFF
--- a/src/main/java/org/spongepowered/api/block/BlockType.java
+++ b/src/main/java/org/spongepowered/api/block/BlockType.java
@@ -97,4 +97,11 @@ public interface BlockType extends DefaultedRegistryValue, ComponentLike, StateC
      */
     boolean isAnyOf(BlockType... types);
 
+    /**
+     * Returns true if this type will have a block entity when placed in the world
+     *
+     * @return true if this type will have a block entity when placed in the world
+     */
+    boolean hasBlockEntity();
+
 }


### PR DESCRIPTION
[**SpongeAPI**|[Sponge](https://github.com/SpongePowered/Sponge/pull/3884)]

There is currently no quick way in the API to check if a particular block type can contain block entity data. It's possible to iterate over `BlockEntityTypes` and check `BlockEntityType#isValidBlock`, but obviously that would be much slower than just checking `instanceof` behind the scenes. I propose to introduce such a method.