### PR TITLE
Improved human skin API

### DIFF
--- a/src/main/java/org/spongepowered/api/data/key/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/key/Keys.java
@@ -1903,6 +1903,26 @@ public final class Keys {
     public static final Key<Value<UUID>> SKIN_UNIQUE_ID = DummyObjectProvider.createExtendedFor(Key.class,"SKIN_UNIQUE_ID");
 
     /**
+     * Represents the {@link Key} for the skin texture of a {@link Humanoid}.
+     *
+     * <p>Skins can be manipulated by supplying the texture string
+     * such as those stored in player heads</p>
+     *
+     * @see SkinTextureData#skinTexture()
+     */
+    public static final Key<Value<String>> SKIN_TEXTURE = DummyObjectProvider.createExtendedFor(Key.class,"SKIN_TEXTURE");
+
+    /**
+     * Represents the {@link Key} for the skin signature of a {@link Humanoid}.
+     *
+     * <p>Skins can be manipulated by supplying the signature string
+     * such as those stored in player heads</p>
+     *
+     * @see SkinSignatureData#skinSignature()
+     */
+    public static final Key<Value<String>> SKIN_SIGNATURE = DummyObjectProvider.createExtendedFor(Key.class,"SKIN_SIGNATURE");
+
+    /**
      * Represents the {@link Key} for the type of skull a block or item stack
      * has.
      *

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableSkinSignatureData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableSkinSignatureData.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.entity.SkinSignatureData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.entity.living.Humanoid;
+
+/**
+ * An {@link ImmutableDataManipulator} handling the Signature for  the
+ * {@link Humanoid} skin used.
+ */
+public interface ImmutableSkinSignatureData extends ImmutableDataManipulator<ImmutableSkinSignatureData, SkinSignatureData> {
+
+    /**
+     * Gets the {@link ImmutableValue} for the Signature of the skin to
+     * display on a {@link Humanoid} entity for customization.
+     *
+     * @return The immutable value for the skin Signature
+     */
+    ImmutableValue<String> skinSignature();
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableSkinTextureData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/immutable/entity/ImmutableSkinTextureData.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.entity.SkinTextureData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.entity.living.Humanoid;
+
+/**
+ * An {@link ImmutableDataManipulator} handling the texture for  the
+ * {@link Humanoid} skin used.
+ */
+public interface ImmutableSkinTextureData extends ImmutableDataManipulator<ImmutableSkinTextureData, SkinTextureData> {
+
+    /**
+     * Gets the {@link ImmutableValue} for the texture of the skin to
+     * display on a {@link Humanoid} entity for customization.
+     *
+     * @return The immutable value for the skin texture
+     */
+    ImmutableValue<String> skinTexture();
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/SkinSignatureData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/SkinSignatureData.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSkinSignatureData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.entity.living.Humanoid;
+
+/**
+ * Represents the Signature of the skin for a {@link Humanoid}.
+ */
+public interface SkinSignatureData extends DataManipulator<SkinSignatureData, ImmutableSkinSignatureData> {
+
+    /**
+     * Gets the {@link Value} for the Signature of the skin to display on a
+     * {@link Humanoid} entity for customization.
+     *
+     * @return The value for the skin Signature
+     * @see Keys#SKIN_Signature
+     */
+    Value<String> skinSignature();
+
+}

--- a/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/SkinTextureData.java
+++ b/src/main/java/org/spongepowered/api/data/manipulator/mutable/entity/SkinTextureData.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSkinTextureData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.entity.living.Humanoid;
+
+/**
+ * Represents the texture of the skin for a {@link Humanoid}.
+ */
+public interface SkinTextureData extends DataManipulator<SkinTextureData, ImmutableSkinTextureData> {
+
+    /**
+     * Gets the {@link Value} for the texture of the skin to display on a
+     * {@link Humanoid} entity for customization.
+     *
+     * @return The value for the skin texture
+     * @see Keys#SKIN_TEXTURE
+     */
+    Value<String> skinTexture();
+
+}


### PR DESCRIPTION
So that it doesn't rely on the current skin for one specific player UUID.
But instead can use any skin from Mojang (with signature).

See https://github.com/SpongePowered/Sponge/pull/3909 for implementation pull request.