### PR TITLE
Bump Adventure to 4.16

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 format = { version = "1.1" }
 
 [versions]
-adventure = "4.12.0"
+adventure = "4.16.0"
 caffeine = "3.1.8"
 checker = "3.42.0"
 checkstyle = "10.12.7"


### PR DESCRIPTION
Recent additions like ComponentEncoder and ComponentDecoder as super for ComponentSerializer make multi-platform support more cumbersome. Updating Adventure resolves this.

This also aligns the GsonComponentSerializer with vanilla 1.20.4 output by default.