### PR TITLE
[NO MERGE] Contextual Data API

### DIFF
--- a/src/main/java/org/spongepowered/api/data/DataPerspective.java
+++ b/src/main/java/org/spongepowered/api/data/DataPerspective.java
@@ -1,0 +1,13 @@
+package org.spongepowered.api.data;
+
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.plugin.PluginContainer;
+
+public interface DataPerspective {
+
+    Iterable<DataPerspective> perceives();
+
+    ValueContainer getDataPerception(DataPerspective perspective);
+
+    DataHolder.Mutable createDataPerception(PluginContainer plugin, DataPerspective perspective);
+}

--- a/src/main/java/org/spongepowered/api/data/DataPerspective.java
+++ b/src/main/java/org/spongepowered/api/data/DataPerspective.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.api.data;
 
 import org.spongepowered.api.data.value.ValueContainer;

--- a/src/main/java/org/spongepowered/api/data/DataPerspectiveResolver.java
+++ b/src/main/java/org/spongepowered/api/data/DataPerspectiveResolver.java
@@ -1,0 +1,31 @@
+package org.spongepowered.api.data;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.data.value.Value;
+
+public interface DataPerspectiveResolver<V extends Value<E>, E> {
+
+    /**
+     * Gets the {@link Key} this resolver supports.
+     *
+     * @return The key
+     */
+    Key<V> key();
+
+    /**
+     * When multiple plugins provide the same key this is used to
+     * merge and pick the best.
+     *
+     * @return The merged value
+     */
+    E merge(Iterable<E> values);
+
+    /**
+     * When data holders value changes when looking at perspective of.
+     *
+     * @param dataHolder The data holder which value was overridden.
+     * @param perspective The perspective it is perceived from.
+     * @param value The value.
+     */
+    void apply(DataHolder dataHolder, DataPerspective perspective, @Nullable E value);
+}

--- a/src/main/java/org/spongepowered/api/data/DataPerspectiveResolver.java
+++ b/src/main/java/org/spongepowered/api/data/DataPerspectiveResolver.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.api.data;
 
 import org.checkerframework.checker.nullness.qual.Nullable;

--- a/src/main/java/org/spongepowered/api/data/DataRegistration.java
+++ b/src/main/java/org/spongepowered/api/data/DataRegistration.java
@@ -111,6 +111,8 @@ public interface DataRegistration {
      */
     Optional<DataStore> dataStore(Class<? extends DataHolder> token);
 
+    <V extends Value<E>, E> Optional<DataPerspectiveResolver<V, E>> dataPerspectiveResolverFor(Key<V> key);
+
     /**
      * Gets the registered {@link Key Keys} this controls. Note that each
      * {@link Key} can only be registered/owned by a single
@@ -180,6 +182,8 @@ public interface DataRegistration {
          *     for the key
          */
         Builder provider(DataProvider<?, ?> provider) throws DuplicateProviderException;
+
+        Builder perspectiveResolver(DataPerspectiveResolver<?, ?> resolver);
 
         /**
          * Gives the {@link Key} to this builder signifying the key is to be

--- a/src/main/java/org/spongepowered/api/entity/Entity.java
+++ b/src/main/java/org/spongepowered/api/entity/Entity.java
@@ -28,6 +28,7 @@ import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
+import org.spongepowered.api.data.DataPerspective;
 import org.spongepowered.api.data.Keys;
 import org.spongepowered.api.data.SerializableDataHolder;
 import org.spongepowered.api.data.value.ListValue;
@@ -79,7 +80,7 @@ import java.util.function.UnaryOperator;
  */
 @DoNotStore
 public interface Entity extends Identifiable, HoverEventSource<HoverEvent.ShowEntity>, Locatable, EntityProjectileSource, Sound.Emitter,
-        SerializableDataHolder.Mutable, RandomProvider, TeamMember {
+        SerializableDataHolder.Mutable, RandomProvider, TeamMember, DataPerspective {
 
     /**
      * Gets the {@link EntityType}.

--- a/src/main/java/org/spongepowered/api/scoreboard/Team.java
+++ b/src/main/java/org/spongepowered/api/scoreboard/Team.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.scoreboard;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataPerspective;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.util.CopyableBuilder;
 
@@ -57,7 +58,7 @@ import java.util.function.Supplier;
  * For it to work, both players must have the same scoreboard, and be on a team
  * registered to said scoreboard.</p>
  */
-public interface Team {
+public interface Team extends DataPerspective {
 
     /**
      * Creates a new {@link Builder} to build a {@link Team}.

--- a/src/main/java/org/spongepowered/api/world/World.java
+++ b/src/main/java/org/spongepowered/api/world/World.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.world;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
 import org.spongepowered.api.Server;
+import org.spongepowered.api.data.DataPerspective;
 import org.spongepowered.api.effect.Viewer;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.player.Player;
@@ -59,7 +60,8 @@ public interface World<W extends World<W, L>, L extends Location<W, L>> extends
     Viewer,
     ArchetypeVolumeCreator,
     WeatherUniverse,
-    RegistryHolder {
+    RegistryHolder,
+    DataPerspective {
 
     /**
      * Gets the {@link WorldProperties properties}.


### PR DESCRIPTION
[Sponge](https://github.com/SpongePowered/Sponge/pull/3995) | **SpongeAPI**

Open questions?
- [ ] Server as DataPerspective? One could implement way to hide specific entity data like health from clients globally.
- [ ] This could also be used to change the world properties send to the client like weather by taking advantage of the World -> Entity data direction. Do we want that?
- [ ] How do we implement collection operations? What happen happen when you do `offerSingle` to the data perspective and the base entity already has elements. Append? Create new list with just that single item?
- [ ] Do we want to allow plugins to provide more info how to solve merge conflicts?
  - [ ] Provide types to provide the operation type? Like `Value<Integer>` could have addition, multiplication, etc.
  - [ ] Allow that same concept for values with collections?