### PR TITLE
Rework ChunkEvent

### DIFF
--- a/src/main/java/org/spongepowered/api/event/world/chunk/ChunkEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/chunk/ChunkEvent.java
@@ -82,9 +82,9 @@ public interface ChunkEvent extends Event {
             /**
              * Gets the {@link WorldChunk chunk} block volume.
              *
-             * @return The block volume
+             * @return The block chunk
              */
-            BlockChunk blockVolume();
+            BlockChunk chunk();
         }
 
         /**
@@ -96,14 +96,14 @@ public interface ChunkEvent extends Event {
              * Called before the {@link WorldChunk chunk} block data is saved. Cancelling this
              * will prevent any of the chunk's block data being written to it's storage container.
              */
-            interface Pre extends Save, Cancellable {
+            interface Pre extends Blocks.Save, Cancellable {
 
                 /**
                  * Gets the {@link WorldChunk chunk} block volume.
                  *
-                 * @return The block volume
+                 * @return The block chunk
                  */
-                BlockChunk blockVolume();
+                BlockChunk chunk();
             }
 
             /**
@@ -112,7 +112,7 @@ public interface ChunkEvent extends Event {
              * <p>
              * Depending on the implementation, this event may be called off-thread.
              */
-            interface Post extends Save {}
+            interface Post extends Blocks.Save {}
         }
     }
 
@@ -133,9 +133,9 @@ public interface ChunkEvent extends Event {
             /**
              * Gets the {@link WorldChunk chunk} entity volume.
              *
-             * @return The entity volume
+             * @return The entity chunk
              */
-            EntityChunk entityVolume();
+            EntityChunk chunk();
         }
 
         /**
@@ -147,14 +147,14 @@ public interface ChunkEvent extends Event {
              * Called before the {@link WorldChunk chunk} entity data is saved. Cancelling this
              * will prevent any of the chunk's entity data being written to it's storage container.
              */
-            interface Pre extends Save, Cancellable {
+            interface Pre extends Entities.Save, Cancellable {
 
                 /**
                  * Gets the {@link WorldChunk chunk} entity volume.
                  *
-                 * @return The entity volume
+                 * @return The entity chunk
                  */
-                EntityChunk entityVolume();
+                EntityChunk chunk();
             }
 
             /**
@@ -163,7 +163,7 @@ public interface ChunkEvent extends Event {
              * <p>
              * Depending on the implementation, this event may be called off-thread.
              */
-            interface Post extends Save {}
+            interface Post extends Entities.Save {}
         }
     }
 

--- a/src/main/java/org/spongepowered/api/event/world/chunk/ChunkEvent.java
+++ b/src/main/java/org/spongepowered/api/event/world/chunk/ChunkEvent.java
@@ -29,7 +29,9 @@ import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.util.annotation.eventgen.NoFactoryMethod;
 import org.spongepowered.api.world.World;
+import org.spongepowered.api.world.chunk.BlockChunk;
 import org.spongepowered.api.world.chunk.Chunk;
+import org.spongepowered.api.world.chunk.EntityChunk;
 import org.spongepowered.api.world.chunk.WorldChunk;
 import org.spongepowered.api.world.server.ServerWorld;
 import org.spongepowered.math.vector.Vector3i;
@@ -64,6 +66,108 @@ public interface ChunkEvent extends Event {
     }
 
     /**
+     * Called when a {@link WorldChunk chunk} is performing a block related operation.
+     */
+    interface Blocks extends WorldScoped {
+
+        /**
+         * Called when a block data of {@link WorldChunk chunk} is loaded.
+         * This can be called outside the {@link World#engine() main} {@link Thread}.
+         * It is NOT safe to perform modifications to the {@link World} or via
+         * {@link org.spongepowered.api.world.server.ServerLocation} as this could
+         * result in a deadlock.
+         */
+        interface Load extends Blocks {
+
+            /**
+             * Gets the {@link WorldChunk chunk} block volume.
+             *
+             * @return The block volume
+             */
+            BlockChunk blockVolume();
+        }
+
+        /**
+         * Called when a {@link WorldChunk chunk} is performing a block related save.
+         */
+        interface Save extends Blocks {
+
+            /**
+             * Called before the {@link WorldChunk chunk} block data is saved. Cancelling this
+             * will prevent any of the chunk's block data being written to it's storage container.
+             */
+            interface Pre extends Save, Cancellable {
+
+                /**
+                 * Gets the {@link WorldChunk chunk} block volume.
+                 *
+                 * @return The block volume
+                 */
+                BlockChunk blockVolume();
+            }
+
+            /**
+             * Called after the {@link WorldChunk chunk} block data is saved.
+             * Guaranteed to exist in the chunk's block storage container.
+             * <p>
+             * Depending on the implementation, this event may be called off-thread.
+             */
+            interface Post extends Save {}
+        }
+    }
+
+    /**
+     * Called when a {@link WorldChunk chunk} is performing a entity related operation.
+     */
+    interface Entities extends WorldScoped {
+
+        /**
+         * Called when an entity data of {@link WorldChunk chunk} is loaded.
+         * This can be called outside the {@link World#engine() main} {@link Thread}.
+         * It is NOT safe to perform modifications to the {@link World} or via
+         * {@link org.spongepowered.api.world.server.ServerLocation} as this could
+         * result in a deadlock.
+         */
+        interface Load extends Entities {
+
+            /**
+             * Gets the {@link WorldChunk chunk} entity volume.
+             *
+             * @return The entity volume
+             */
+            EntityChunk entityVolume();
+        }
+
+        /**
+         * Called when a {@link WorldChunk chunk} is performing a entity related save.
+         */
+        interface Save extends Entities {
+
+            /**
+             * Called before the {@link WorldChunk chunk} entity data is saved. Cancelling this
+             * will prevent any of the chunk's entity data being written to it's storage container.
+             */
+            interface Pre extends Save, Cancellable {
+
+                /**
+                 * Gets the {@link WorldChunk chunk} entity volume.
+                 *
+                 * @return The entity volume
+                 */
+                EntityChunk entityVolume();
+            }
+
+            /**
+             * Called after the {@link WorldChunk chunk} entity data is saved.
+             * Guaranteed to exist in the chunk's entity storage container.
+             * <p>
+             * Depending on the implementation, this event may be called off-thread.
+             */
+            interface Post extends Save {}
+        }
+    }
+
+    /**
      * Called when a {@link WorldChunk chunk} was unloaded.
      */
     interface Unload extends WorldScoped {
@@ -90,35 +194,6 @@ public interface ChunkEvent extends Event {
     }
 
     /**
-     * Called when a {@link WorldChunk chunk} is performing a save.
-     */
-    interface Save extends WorldScoped {
-
-        /**
-         * Called before the {@link WorldChunk chunk} is saved. Cancelling this will prevent any of
-         * the chunk's data being written to it's storage container.
-         */
-        interface Pre extends Save, Cancellable {
-
-            /**
-             * Gets the {@link WorldChunk chunk} being changed.
-             *
-             * @return The chunk
-             */
-            WorldChunk chunk();
-
-        }
-
-        /**
-         * Called after the {@link WorldChunk chunk} is saved. Guaranteed to exist in the chunk's
-         * storage container.
-         * <p>
-         * Depending on the implementation, this event may be called off-thread.
-         */
-        interface Post extends Save {}
-    }
-
-    /**
      * Called when a new {@link WorldChunk chunk} was generated.
      */
     interface Generated extends WorldScoped {
@@ -126,11 +201,8 @@ public interface ChunkEvent extends Event {
     }
 
     /**
-     * Called when a {@link WorldChunk chunk} is loaded. This can be called
-     * outside the {@link World#engine() main} {@link Thread}. It is NOT safe
-     * to perform modifications to the {@link World} or via
-     * {@link org.spongepowered.api.world.server.ServerLocation} as this could
-     * result in a deadlock.
+     * Called when a {@link WorldChunk chunk} is loaded. This is called
+     * from the main thread when the chunk is fully loaded and ready to tick.
      */
     interface Load extends WorldScoped {
 

--- a/src/main/java/org/spongepowered/api/world/chunk/BlockChunk.java
+++ b/src/main/java/org/spongepowered/api/world/chunk/BlockChunk.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.world.chunk;
+
+import org.spongepowered.api.world.volume.block.BlockVolume;
+
+public interface BlockChunk extends BlockVolume {
+}

--- a/src/main/java/org/spongepowered/api/world/chunk/EntityChunk.java
+++ b/src/main/java/org/spongepowered/api/world/chunk/EntityChunk.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.world.chunk;
+
+import org.spongepowered.api.world.volume.entity.EntityVolume;
+
+/**
+ * An entity chunk is a portion of a {@link WorldChunk}.
+ */
+public interface EntityChunk extends EntityVolume.Modifiable<EntityChunk> {
+}

--- a/src/main/java/org/spongepowered/api/world/volume/entity/EntityVolume.java
+++ b/src/main/java/org/spongepowered/api/world/volume/entity/EntityVolume.java
@@ -167,7 +167,7 @@ public interface EntityVolume extends Volume {
 
     }
 
-    interface Modifiable<M extends Modifiable<M>> extends Streamable<M>, MutableVolume, BlockVolume.Modifiable<M> {
+    interface Modifiable<M extends Modifiable<M>> extends Streamable<M>, MutableVolume {
 
         /**
          * Create an entity instance at the given position.


### PR DESCRIPTION
[Sponge](https://github.com/SpongePowered/Sponge/pull/3997) | **SpongeAPI**

Reworks the ChunkEvent events to take in account that vanilla has split the block and entity storage. I kept the `BlockChunk` as read-only because it needs more work to implement to be able to mutate it at that state, likely not something we are going to address anytime soon.