### PR TITLE
TeleportDuration Key for Display Entities

### DIFF
--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -3089,6 +3089,11 @@ public final class Keys {
     public static final Key<Value<Vector3i>> TARGET_POSITION = Keys.key(ResourceKey.sponge("target_position"), Vector3i.class);
 
     /**
+     * The teleport duration of a {@link DisplayEntity}
+     */
+    public static final Key<Value<Ticks>> TELEPORT_DURATION = Keys.key(ResourceKey.sponge("teleport_duration"), Ticks.class);
+
+    /**
      * The {@link TemperatureModifier} of a {@link Biome}.
      * Readonly
      */

--- a/src/main/java/org/spongepowered/api/entity/display/DisplayEntity.java
+++ b/src/main/java/org/spongepowered/api/entity/display/DisplayEntity.java
@@ -46,14 +46,9 @@ public interface DisplayEntity extends Entity {
         return this.require(Keys.TRANSFORM);
     }
 
-    /**
-     * Returns the duration of the teleport
-     *
-     * @return the duration of the teleport
-     */
-    default Ticks teleportDuration() {
-        return this.require(Keys.TELEPORT_DURATION);
-    }
+    Ticks bridge$getTeleportDuration();
+
+    boolean bridge$setTeleportDuration(Ticks duration);
 
     /**
      * Returns the duration of the interpolation

--- a/src/main/java/org/spongepowered/api/entity/display/DisplayEntity.java
+++ b/src/main/java/org/spongepowered/api/entity/display/DisplayEntity.java
@@ -55,14 +55,9 @@ public interface DisplayEntity extends Entity {
         return this.require(Keys.TELEPORT_DURATION);
     }
 
-    /**
-     * Returns the duration of the interpolation
-     *
-     * @return the duration of the interpolation
-     */
-    default Ticks interpolationDuration() {
-        return this.require(Keys.INTERPOLATION_DURATION);
-    }
+    Ticks bridge$getTeleportDuration();
+
+    boolean bridge$setTeleportDuration(Ticks duration);
 
     /**
      * Returns the delay to the start of the interpolation

--- a/src/main/java/org/spongepowered/api/entity/display/DisplayEntity.java
+++ b/src/main/java/org/spongepowered/api/entity/display/DisplayEntity.java
@@ -55,9 +55,14 @@ public interface DisplayEntity extends Entity {
         return this.require(Keys.TELEPORT_DURATION);
     }
 
-    Ticks bridge$getTeleportDuration();
-
-    boolean bridge$setTeleportDuration(Ticks duration);
+    /**
+     * Returns the duration of the interpolation
+     *
+     * @return the duration of the interpolation
+     */
+    default Ticks interpolationDuration() {
+        return this.require(Keys.INTERPOLATION_DURATION);
+    }
 
     /**
      * Returns the delay to the start of the interpolation

--- a/src/main/java/org/spongepowered/api/entity/display/DisplayEntity.java
+++ b/src/main/java/org/spongepowered/api/entity/display/DisplayEntity.java
@@ -47,6 +47,15 @@ public interface DisplayEntity extends Entity {
     }
 
     /**
+     * Returns the duration of the teleport
+     *
+     * @return the duration of the teleport
+     */
+    default Ticks teleportDuration() {
+        return this.require(Keys.TELEPORT_DURATION);
+    }
+
+    /**
      * Returns the duration of the interpolation
      *
      * @return the duration of the interpolation


### PR DESCRIPTION
`teleport_duration` was added in MC 1.20.2

SpongeAPI | https://github.com/SpongePowered/Sponge/pull/4020

