### PR TITLE
Fix EnderDragon#bossBar() & Add ServerWorld#dragonFightBossBar()

### DIFF
--- a/src/main/java/org/spongepowered/api/entity/living/monster/boss/Boss.java
+++ b/src/main/java/org/spongepowered/api/entity/living/monster/boss/Boss.java
@@ -29,6 +29,8 @@ import org.spongepowered.api.data.Keys;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.entity.Entity;
 
+import java.util.Optional;
+
 /**
  * Represents a boss monster that may cause a boss health bar to show
  * on client interfaces.
@@ -40,7 +42,7 @@ public interface Boss extends Entity {
      *
      * @return The boss bar
      */
-    default Value<BossBar> bossBar() {
-        return this.requireValue(Keys.BOSS_BAR);
+    default Optional<Value<BossBar>> bossBar() {
+        return this.getValue(Keys.BOSS_BAR);
     }
 }

--- a/src/main/java/org/spongepowered/api/world/server/ServerWorld.java
+++ b/src/main/java/org/spongepowered/api/world/server/ServerWorld.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.world.server;
 
+import net.kyori.adventure.bossbar.BossBar;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Server;
 import org.spongepowered.api.block.BlockSnapshot;
@@ -242,6 +243,13 @@ public interface ServerWorld extends World<ServerWorld, ServerLocation>, Identif
      * @return The raid at that location, if present
      */
     Optional<Raid> raidAt(Vector3i blockPosition);
+
+    /**
+     * Gets the {@link BossBar} of the ender dragon fight occurring in this {@link ServerWorld}.
+     *
+     * @return The dragon fight boss bar, if present
+     */
+    Optional<BossBar> dragonFightBossBar();
 
     /**
      * Gets the {@link ChunkManager} for this world.


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/4077)

In vanilla only one dragon has assosiatiated `BossBar` via `EndDragonFight` while other dragons has no `BossBar` so `Boss#bossBar()` should be Optional.

`ServerLevel` also may have its own tracked `EndDragonFight` with `BossBar` so I think it's nice to have in API