### PR TITLE
Abstract ItemStack & ItemStackSnapshot to ItemStackLike

### DIFF
--- a/src/main/java/org/spongepowered/api/advancement/DisplayInfo.java
+++ b/src/main/java/org/spongepowered/api/advancement/DisplayInfo.java
@@ -171,7 +171,7 @@ public interface DisplayInfo {
          * @return This builder, for chaining
          */
         default Builder icon(ItemStack itemStack) {
-            return this.icon(itemStack.createSnapshot());
+            return this.icon(itemStack.asImmutable());
         }
 
         /**

--- a/src/main/java/org/spongepowered/api/advancement/DisplayInfo.java
+++ b/src/main/java/org/spongepowered/api/advancement/DisplayInfo.java
@@ -28,6 +28,7 @@ import net.kyori.adventure.text.Component;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.util.CopyableBuilder;
 
@@ -164,24 +165,29 @@ public interface DisplayInfo {
         }
 
         /**
-         * Sets the icon of the advancement with the
-         * specified {@link ItemStack}.
-         *
-         * @param itemStack The item stack
-         * @return This builder, for chaining
+         * @deprecated Use {@link #icon(ItemStackLike)} instead.
          */
+        @Deprecated(forRemoval = true)
         default Builder icon(ItemStack itemStack) {
-            return this.icon(itemStack.asImmutable());
+            return this.icon((ItemStackLike) itemStack);
+        }
+
+        /**
+         * @deprecated Use {@link #icon(ItemStackLike)} instead.
+         */
+        @Deprecated(forRemoval = true)
+        default Builder icon(ItemStackSnapshot itemStackSnapshot) {
+            return this.icon((ItemStackLike) itemStackSnapshot);
         }
 
         /**
          * Sets the icon of the advancement with the
-         * specified {@link ItemStackSnapshot}.
+         * specified {@link ItemStackLike}.
          *
-         * @param itemStackSnapshot The item stack snapshot
+         * @param itemStack The item stack snapshot
          * @return This builder, for chaining
          */
-        Builder icon(ItemStackSnapshot itemStackSnapshot);
+        Builder icon(ItemStackLike itemStack);
 
         /**
          * Sets whether a toast should be shown. This is the notification

--- a/src/main/java/org/spongepowered/api/block/entity/Jukebox.java
+++ b/src/main/java/org/spongepowered/api/block/entity/Jukebox.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.block.entity;
 import org.spongepowered.api.data.Keys;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 
 /**
@@ -60,9 +61,17 @@ public interface Jukebox extends BlockEntity {
     void eject();
 
     /**
+     * @deprecated Use {@link #insert(ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default void insert(ItemStack disc) {
+        this.insert((ItemStackLike) disc);
+    }
+
+    /**
      * Ejects the current music disc item in this Jukebox and inserts the given one.
      *
      * @param disc The music disc item to insert
      */
-    void insert(ItemStack disc);
+    void insert(ItemStackLike disc);
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
@@ -163,7 +163,7 @@ public interface DamageModifier {
         }
 
         public Builder item(final ItemStack itemStack) {
-            this.item(java.util.Objects.requireNonNull(itemStack, "ItemStack").createSnapshot());
+            this.item(java.util.Objects.requireNonNull(itemStack, "ItemStack").asImmutable());
             return this;
         }
 

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.event.Cause;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.enchantment.Enchantment;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.util.CopyableBuilder;
 
@@ -162,13 +163,24 @@ public interface DamageModifier {
             return this;
         }
 
+        /**
+         * @deprecated Use {@link #item(ItemStackLike)} instead.
+         */
+        @Deprecated(forRemoval = true)
         public Builder item(final ItemStack itemStack) {
-            this.item(java.util.Objects.requireNonNull(itemStack, "ItemStack").asImmutable());
-            return this;
+            return this.item((ItemStackLike) itemStack);
         }
 
+        /**
+         * @deprecated Use {@link #item(ItemStackLike)} instead.
+         */
+        @Deprecated(forRemoval = true)
         public Builder item(final ItemStackSnapshot snapshot) {
-            this.snapshot = java.util.Objects.requireNonNull(snapshot, "ItemStackSnapshot");
+            return this.item((ItemStackLike) snapshot);
+        }
+
+        public Builder item(final ItemStackLike item) {
+            this.snapshot = java.util.Objects.requireNonNull(item, "item").asImmutable();
             return this;
         }
 

--- a/src/main/java/org/spongepowered/api/event/item/inventory/AffectItemStackEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/AffectItemStackEvent.java
@@ -67,7 +67,7 @@ public interface AffectItemStackEvent extends Event, Cancellable {
      */
     default List<? extends  Transaction<ItemStackSnapshot>> filter(Predicate<ItemStack> predicate) {
         final List<Transaction<ItemStackSnapshot>> invalidatedTransactions = new ArrayList<>();
-        this.transactions().stream().filter(transaction -> !predicate.test(transaction.finalReplacement().createStack())).forEach(transaction -> {
+        this.transactions().stream().filter(transaction -> !predicate.test(transaction.finalReplacement().asMutable())).forEach(transaction -> {
             transaction.setValid(false);
             invalidatedTransactions.add(transaction);
         });

--- a/src/main/java/org/spongepowered/api/event/item/inventory/AffectSlotEvent.java
+++ b/src/main/java/org/spongepowered/api/event/item/inventory/AffectSlotEvent.java
@@ -40,7 +40,7 @@ public interface AffectSlotEvent extends AffectItemStackEvent {
     @Override
     default List<SlotTransaction> filter(Predicate<ItemStack> predicate) {
         final List<SlotTransaction> invalidatedTransactions = new ArrayList<>();
-        this.transactions().stream().filter(transaction -> !predicate.test(transaction.finalReplacement().createStack())).forEach(transaction -> {
+        this.transactions().stream().filter(transaction -> !predicate.test(transaction.finalReplacement().asMutable())).forEach(transaction -> {
             transaction.setValid(false);
             invalidatedTransactions.add(transaction);
         });

--- a/src/main/java/org/spongepowered/api/item/enchantment/EnchantmentType.java
+++ b/src/main/java/org/spongepowered/api/item/enchantment/EnchantmentType.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.item.enchantment;
 import net.kyori.adventure.text.ComponentLike;
 import org.spongepowered.api.block.entity.EnchantmentTable;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.registry.DefaultedRegistryValue;
 import org.spongepowered.api.tag.EnchantmenTypeTags;
 import org.spongepowered.api.tag.Taggable;
@@ -82,22 +83,38 @@ public interface EnchantmentType extends DefaultedRegistryValue, ComponentLike, 
     int maximumEnchantabilityForLevel(int level);
 
     /**
-     * Test if this enchantment type can be applied to an {@link ItemStack}.
+     * @deprecated Use {@link #canBeAppliedToStack(ItemStackLike)} instead,
+     */
+    @Deprecated(forRemoval = true)
+    default boolean canBeAppliedToStack(ItemStack stack) {
+        return this.canBeAppliedToStack((ItemStackLike) stack);
+    }
+
+    /**
+     * Test if this enchantment type can be applied to an {@link ItemStackLike}.
      *
      * @param stack The item stack to check
      * @return Whether this enchantment type can be applied
      */
-    boolean canBeAppliedToStack(ItemStack stack);
+    boolean canBeAppliedToStack(ItemStackLike stack);
 
     /**
-     * Test if this enchantment type can be applied to an {@link ItemStack} by
+     * @deprecated Use {@link #canBeAppliedToStack(ItemStackLike)} instead,
+     */
+    @Deprecated(forRemoval = true)
+    default boolean canBeAppliedByTable(ItemStack stack) {
+        return this.canBeAppliedByTable((ItemStackLike) stack);
+    }
+
+    /**
+     * Test if this enchantment type can be applied to an {@link ItemStackLike} by
      * the {@link EnchantmentTable}.
      *
      * @param stack Te item stack to check
      * @return Whether this enchantment type can be applied by the
      *     enchantment table
      */
-    boolean canBeAppliedByTable(ItemStack stack);
+    boolean canBeAppliedByTable(ItemStackLike stack);
 
     /**
      * Test if this enchantment type can be applied along with

--- a/src/main/java/org/spongepowered/api/item/inventory/ArmorEquipable.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ArmorEquipable.java
@@ -47,11 +47,19 @@ public interface ArmorEquipable extends Equipable {
     ItemStack head();
 
     /**
+     * @deprecated Use {@link #setHead(ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default void setHead(ItemStack head) {
+        this.setHead((ItemStackLike) head);
+    }
+
+    /**
      * Sets the head.
      *
      * @param head The head
      */
-    void setHead(ItemStack head);
+    void setHead(ItemStackLike head);
 
     /**
      * Gets the chest.
@@ -61,11 +69,19 @@ public interface ArmorEquipable extends Equipable {
     ItemStack chest();
 
     /**
+     * @deprecated Use {@link #setChest(ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default void setChest(ItemStack chest) {
+        this.setChest((ItemStackLike) chest);
+    }
+
+    /**
      * Sets the chest.
      *
      * @param chest The chest
      */
-    void setChest(ItemStack chest);
+    void setChest(ItemStackLike chest);
 
     /**
      * Gets the legs.
@@ -75,11 +91,19 @@ public interface ArmorEquipable extends Equipable {
     ItemStack legs();
 
     /**
+     * @deprecated Use {@link #setLegs(ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default void setLegs(ItemStack legs) {
+        this.setLegs((ItemStackLike) legs);
+    }
+
+    /**
      * Sets the legs.
      *
      * @param legs The legs
      */
-    void setLegs(ItemStack legs);
+    void setLegs(ItemStackLike legs);
 
     /**
      * Gets the feet.
@@ -89,11 +113,19 @@ public interface ArmorEquipable extends Equipable {
     ItemStack feet();
 
     /**
+     * @deprecated Use {@link #setFeet(ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default void setFeet(ItemStack feet) {
+        this.setFeet((ItemStackLike) feet);
+    }
+
+    /**
      * Sets the feet.
      *
      * @param feet The feet
      */
-    void setFeet(ItemStack feet);
+    void setFeet(ItemStackLike feet);
 
     /**
      * Gets the equipped item in hand.
@@ -114,13 +146,11 @@ public interface ArmorEquipable extends Equipable {
     ItemStack itemInHand(HandType handType);
 
     /**
-     * Sets the equipped item in hand.
-     *
-     * @param handType The hand type to set to
-     * @param itemInHand The item in hand
+     * @deprecated Use {@link #setItemInHand(Supplier, ItemStackLike)} instead.
      */
+    @Deprecated(forRemoval = true)
     default void setItemInHand(Supplier<? extends HandType> handType, ItemStack itemInHand) {
-        this.setItemInHand(handType.get(), itemInHand);
+        this.setItemInHand(handType, (ItemStackLike) itemInHand);
     }
 
     /**
@@ -129,5 +159,23 @@ public interface ArmorEquipable extends Equipable {
      * @param handType The hand type to set to
      * @param itemInHand The item in hand
      */
-    void setItemInHand(HandType handType, ItemStack itemInHand);
+    default void setItemInHand(Supplier<? extends HandType> handType, ItemStackLike itemInHand) {
+        this.setItemInHand(handType.get(), itemInHand);
+    }
+
+    /**
+     * @deprecated Use {@link #setItemInHand(HandType, ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default void setItemInHand(HandType handType, ItemStack itemInHand) {
+        this.setItemInHand(handType, (ItemStackLike) itemInHand);
+    }
+
+    /**
+     * Sets the equipped item in hand.
+     *
+     * @param handType The hand type to set to
+     * @param itemInHand The item in hand
+     */
+    void setItemInHand(HandType handType, ItemStackLike itemInHand);
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/Container.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Container.java
@@ -60,6 +60,14 @@ public interface Container extends Inventory {
     List<Inventory> viewed();
 
     /**
+     * @deprecated Use {@link #setCursor(ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default boolean setCursor(ItemStack item) {
+        return this.setCursor((ItemStackLike) item);
+    }
+
+    /**
      * Sets the viewing players cursor item.
      * <p>Returns false when the container is no longer open.</p>
      *
@@ -67,7 +75,7 @@ public interface Container extends Inventory {
      *
      * @return true if the cursor was set.
      */
-    boolean setCursor(ItemStack item);
+    boolean setCursor(ItemStackLike item);
 
     /**
      * Gets the viewing players cursor item.

--- a/src/main/java/org/spongepowered/api/item/inventory/Equipable.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Equipable.java
@@ -57,6 +57,14 @@ public interface Equipable {
     }
 
     /**
+     * @deprecated Use {@link #canEquip(EquipmentType, ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default boolean canEquip(EquipmentType type, ItemStack equipment) {
+        return this.canEquip(type, (ItemStackLike) equipment);
+    }
+
+    /**
      * Gets whether this {@link Equipable} can equip the supplied equipment in its slot of
      * the specified type (eg. whether calling {@link #equip} with the specified
      * slot type and item will succeed)
@@ -65,9 +73,17 @@ public interface Equipable {
      * @param equipment The equipment to check for
      * @return true if can equip the supplied equipment
      */
-    boolean canEquip(EquipmentType type, ItemStack equipment);
+    boolean canEquip(EquipmentType type, ItemStackLike equipment);
 
+    /**
+     * @deprecated Use {@link #canEquip(Supplier, ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
     default boolean canEquip(final Supplier<? extends EquipmentType> type, final ItemStack equipment) {
+        return this.canEquip(type, (ItemStackLike) equipment);
+    }
+
+    default boolean canEquip(final Supplier<? extends EquipmentType> type, final ItemStackLike equipment) {
         return this.canEquip(type.get(), equipment);
     }
 
@@ -85,6 +101,14 @@ public interface Equipable {
     }
 
     /**
+     * @deprecated Use {@link #equip(EquipmentType, ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default boolean equip(EquipmentType type, ItemStack equipment) {
+        return this.equip(type, (ItemStackLike) equipment);
+    }
+
+    /**
      * Sets the item currently equipped by the {@link Equipable} in the specified slot, if
      * the equipable has such a slot.
      *
@@ -95,9 +119,17 @@ public interface Equipable {
      *     specified equipment type or because the item was incompatible with
      *     the specified slot.
      */
-    boolean equip(EquipmentType type, ItemStack equipment);
+    boolean equip(EquipmentType type, ItemStackLike equipment);
 
+    /**
+     * @deprecated Use {@link #equip(Supplier, ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
     default boolean equip(final Supplier<? extends EquipmentType> type, final ItemStack equipment) {
+        return this.equip(type, (ItemStackLike) equipment);
+    }
+
+    default boolean equip(final Supplier<? extends EquipmentType> type, final ItemStackLike equipment) {
         return this.equip(type.get(), equipment);
     }
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/Inventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Inventory.java
@@ -143,6 +143,14 @@ public interface Inventory extends ValueContainer {
     ItemStack peek();
 
     /**
+     * @deprecated Use {@link #offer(ItemStackLike...)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default InventoryTransactionResult offer(ItemStack... stacks) {
+        return this.offer((ItemStackLike[]) stacks);
+    }
+
+    /**
      * Adds one or more ItemStacks to this inventory.
      *
      * @param stacks The stacks to add to this inventory.
@@ -150,18 +158,26 @@ public interface Inventory extends ValueContainer {
      * @return A SUCCESS transaction-result if all stacks were added and
      *           FAILURE when at least one stack was not or only partially added to the inventory.
      */
-    InventoryTransactionResult offer(ItemStack... stacks);
+    InventoryTransactionResult offer(ItemStackLike... stacks);
+
+    /**
+     * @deprecated Use {@link #canFit(ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default boolean canFit(ItemStack stack) {
+        return this.canFit((ItemStackLike) stack);
+    }
 
     /**
      * Returns true if the entire stack can fit in this inventory.
      *
-     * <p>If this returns {@code true} {@link #offer(ItemStack...)} should always succeed.</p>
+     * <p>If this returns {@code true} {@link #offer(ItemStackLike...)} should always succeed.</p>
      *
      * @param stack The stack of items to check if it can fit in this inventory.
      *
      * @return true if the entire stack can fit in this inventory.
      */
-    boolean canFit(ItemStack stack);
+    boolean canFit(ItemStackLike stack);
 
     /**
      * Gets and removes the stack at the supplied index in this Inventory.
@@ -199,8 +215,16 @@ public interface Inventory extends ValueContainer {
     Optional<ItemStack> peekAt(int index);
 
     /**
+     * @deprecated Use {@link #offer(int, ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default InventoryTransactionResult offer(int index, ItemStack stack) {
+        return this.offer(index, (ItemStackLike) stack);
+    }
+
+    /**
      * Adds an ItemStack to the slot at given index.
-     * Returns a {@link InventoryTransactionResult.Type#SUCCESS} only if the entire {@link ItemStack} fits the slot.
+     * Returns a {@link InventoryTransactionResult.Type#SUCCESS} only if the entire {@link ItemStackLike} fits the slot.
      *
      * @param index The slot index
      * @param stack The stack to add to this inventory.
@@ -208,7 +232,15 @@ public interface Inventory extends ValueContainer {
      * @return A SUCCESS transaction-result if the entire stack was added and
      *           FAILURE when the stack was not or only partially added to the inventory.
      */
-    InventoryTransactionResult offer(int index, ItemStack stack);
+    InventoryTransactionResult offer(int index, ItemStackLike stack);
+
+    /**
+     * @deprecated Use {@link #set(int, ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default InventoryTransactionResult set(int index, ItemStack stack) {
+        return this.set(index, (ItemStackLike) stack);
+    }
 
     /**
      * Adds the ItemStack to the slot at given index overwriting the existing item.
@@ -223,7 +255,7 @@ public interface Inventory extends ValueContainer {
      * @return A SUCCESS transaction-result if the entire stack was added and
      *           FAILURE when the stack was not or only partially added to the inventory.
      */
-    InventoryTransactionResult set(int index, ItemStack stack);
+    InventoryTransactionResult set(int index, ItemStackLike stack);
 
     /**
      * Gets the {@link Slot} at the given index.
@@ -261,14 +293,22 @@ public interface Inventory extends ValueContainer {
     int capacity();
 
     /**
+     * @deprecated Use {@link #contains(ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default boolean contains(ItemStack stack) {
+        return this.contains((ItemStackLike) stack);
+    }
+
+    /**
      * Checks whether the stacks quantity or more of given stack is contained in this Inventory.
-     * To check if an inventory contains any amount use {@link #containsAny(ItemStack)}.
+     * To check if an inventory contains any amount use {@link #containsAny(ItemStackLike)}.
      *
      * @param stack The stack to check for
      *
      * @return True if there are at least the given stack's amount of items present in this inventory.
      */
-    boolean contains(ItemStack stack);
+    boolean contains(ItemStackLike stack);
 
     /**
      * Checks whether the given ItemType is contained in this Inventory
@@ -280,17 +320,25 @@ public interface Inventory extends ValueContainer {
     boolean contains(ItemType type);
 
     /**
+     * @deprecated Use {@link #containsAny(ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default boolean containsAny(ItemStack stack) {
+        return this.containsAny((ItemStackLike) stack);
+    }
+
+    /**
      * Checks whether the given stack is contained in this Inventory.
      * The stack size is ignored.
      *
      * <p>Note this will return true if any amount of the supplied stack is found.
-     * To check if an inventory contains at least a given quantity use {@link #contains(ItemStack)}.</p>
+     * To check if an inventory contains at least a given quantity use {@link #contains(ItemStackLike)}.</p>
      *
      * @param stack The stack to check for
      *
      * @return True if the stack is present in this inventory
      */
-    boolean containsAny(ItemStack stack);
+    boolean containsAny(ItemStackLike stack);
 
     // TODO remove from API? do we need to get a property relative to another parent in API?
     /**

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
@@ -24,26 +24,19 @@
  */
 package org.spongepowered.api.item.inventory;
 
-import net.kyori.adventure.text.ComponentLike;
-import net.kyori.adventure.text.event.HoverEvent;
-import net.kyori.adventure.text.event.HoverEventSource;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.entity.BlockEntity;
 import org.spongepowered.api.data.DataHolderBuilder;
-import org.spongepowered.api.data.Key;
 import org.spongepowered.api.data.SerializableDataHolder;
 import org.spongepowered.api.data.persistence.DataView;
-import org.spongepowered.api.data.value.Value;
-import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.entity.attribute.AttributeModifier;
 import org.spongepowered.api.entity.attribute.type.AttributeType;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.equipment.EquipmentType;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -52,14 +45,10 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
- * Represents a stack of a specific {@link ItemType}. Supports serialization and
- * can be compared using the comparators listed in {@link ItemStackComparators}.
- *
- * <p>{@link ItemStack}s have a variety of properties and data. It is advised to
- * use {@link ValueContainer#get(Key)} in order to retrieve information regarding
- * this item stack.</p>
+ * Represents mutable {@link ItemStackLike}. Can be compared
+ * using the comparators listed in {@link ItemStackComparators}.
  */
-public interface ItemStack extends SerializableDataHolder.Mutable, ComponentLike, HoverEventSource<HoverEvent.ShowItem> {
+public interface ItemStack extends ItemStackLike, SerializableDataHolder.Mutable {
 
     /**
      * Returns an empty {@link ItemStack}.
@@ -124,22 +113,6 @@ public interface ItemStack extends SerializableDataHolder.Mutable, ComponentLike
     }
 
     /**
-     * Gets the {@link ItemType} of this {@link ItemStack}.
-     *
-     * @return The item type
-     */
-    ItemType type();
-
-    /**
-     * Gets the quantity of items in this stack. This may exceed the max stack
-     * size of the item, and if added to an inventory will then be divided by
-     * the max stack.
-     *
-     * @return Quantity of items
-     */
-    int quantity();
-
-    /**
      * Sets the quantity in this stack.
      *
      * @param quantity Quantity
@@ -147,24 +120,6 @@ public interface ItemStack extends SerializableDataHolder.Mutable, ComponentLike
      * {@link ItemStack#maxStackQuantity()}
      */
     void setQuantity(int quantity) throws IllegalArgumentException;
-
-    /**
-     * Gets the maximum quantity per stack. By default, returns
-     * {@link ItemType#maxStackQuantity()}, unless a
-     * different value has been set for this specific stack.
-     *
-     * @return Max stack quantity
-     */
-    int maxStackQuantity();
-
-    /**
-     * Gets the {@link ItemStackSnapshot} of this {@link ItemStack}. All
-     * known {@link Value}s existing on this {@link ItemStack} are added
-     * as copies to the {@link ItemStackSnapshot}.
-     *
-     * @return The newly created item stack snapshot
-     */
-    ItemStackSnapshot createSnapshot();
 
     /**
      * Returns true if the specified {@link ItemStack} has the same stack
@@ -178,66 +133,6 @@ public interface ItemStack extends SerializableDataHolder.Mutable, ComponentLike
      * @return True if this equals the ItemStack
      */
     boolean equalTo(ItemStack that);
-
-    /**
-     * Returns true if {@link #quantity()} is zero and therefore this
-     * ItemStack is empty.
-     *
-     * <p>In Vanilla empty ItemStacks are not rendered by the client.</p>
-     *
-     * @return True if this ItemStack is empty
-     */
-    boolean isEmpty();
-
-    /**
-     * Gets all {@link AttributeModifier}s on this item stack.
-     *
-     * @param attributeType The {@link AttributeType} of the modifier.
-     * @param equipmentType The {@link EquipmentType} this modifier is applied
-     * to.
-     *
-     * @return A collection of {@link AttributeModifier}s.
-     */
-    default Collection<AttributeModifier> attributeModifiers(Supplier<? extends AttributeType> attributeType, DefaultedRegistryReference<? extends EquipmentType> equipmentType) {
-        return this.attributeModifiers(attributeType.get(), equipmentType.get());
-    }
-
-    /**
-     * Gets all {@link AttributeModifier}s on this item stack.
-     *
-     * @param attributeType The {@link AttributeType} of the modifier.
-     * @param equipmentType The {@link EquipmentType} this modifier is applied
-     * to.
-     *
-     * @return A collection of {@link AttributeModifier}s.
-     */
-    default Collection<AttributeModifier> attributeModifiers(AttributeType attributeType, DefaultedRegistryReference<? extends EquipmentType> equipmentType) {
-        return this.attributeModifiers(attributeType, equipmentType.get());
-    }
-
-    /**
-     * Gets all {@link AttributeModifier}s on this item stack.
-     *
-     * @param attributeType The {@link AttributeType} of the modifier.
-     * @param equipmentType The {@link EquipmentType} this modifier is applied
-     * to.
-     *
-     * @return A collection of {@link AttributeModifier}s.
-     */
-    default Collection<AttributeModifier> attributeModifiers(Supplier<? extends AttributeType> attributeType, EquipmentType equipmentType) {
-        return this.attributeModifiers(attributeType.get(), equipmentType);
-    }
-
-    /**
-     * Gets all {@link AttributeModifier}s on this item stack.
-     *
-     * @param attributeType The {@link AttributeType} of the modifier.
-     * @param equipmentType The {@link EquipmentType} this modifier is applied
-     * to.
-     *
-     * @return A collection of {@link AttributeModifier}s.
-     */
-    Collection<AttributeModifier> attributeModifiers(AttributeType attributeType, EquipmentType equipmentType);
 
     /**
      * Adds an {@link AttributeModifier} to this item stack.
@@ -386,7 +281,7 @@ public interface ItemStack extends SerializableDataHolder.Mutable, ComponentLike
          * @return This builder, for chaining
          */
         default Builder fromSnapshot(final ItemStackSnapshot snapshot) {
-            return this.fromItemStack(snapshot.createStack());
+            return this.fromItemStack(snapshot.asMutable());
         }
 
         /**

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStack.java
@@ -122,6 +122,14 @@ public interface ItemStack extends ItemStackLike, SerializableDataHolder.Mutable
     void setQuantity(int quantity) throws IllegalArgumentException;
 
     /**
+     * @deprecated Use {@link #asImmutable()} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default ItemStackSnapshot createSnapshot() {
+        return this.asImmutable();
+    }
+
+    /**
      * Returns true if the specified {@link ItemStack} has the same stack
      * size, {@link ItemType}, and data. Note that this method is not an
      * overrider of {@link Object#equals(Object)} in order to maintain

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackLike.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackLike.java
@@ -1,0 +1,172 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.api.item.inventory;
+
+import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.event.HoverEventSource;
+import org.spongepowered.api.data.Key;
+import org.spongepowered.api.data.Keys;
+import org.spongepowered.api.data.SerializableDataHolder;
+import org.spongepowered.api.data.value.Value;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.entity.attribute.AttributeModifier;
+import org.spongepowered.api.entity.attribute.type.AttributeType;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.inventory.equipment.EquipmentType;
+import org.spongepowered.api.registry.DefaultedRegistryReference;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+
+/**
+ * Represents a stack of a specific {@link ItemType}. Supports serialization.
+ *
+ * <p>{@link ItemStackLike} have a variety of properties and data. It is advised to
+ * use {@link ValueContainer#get(Key)} in order to retrieve information regarding
+ * this item stack.</p>
+ */
+public interface ItemStackLike extends SerializableDataHolder, ComponentLike, HoverEventSource<HoverEvent.ShowItem> {
+
+    /**
+     * Gets the {@link ItemType} of this {@link ItemStackLike}.
+     *
+     * @return The item type
+     */
+    ItemType type();
+
+    /**
+     * Gets the quantity of items in this stack. This may exceed the max stack
+     * size of the item, and if added to an inventory will then be divided by
+     * the max stack.
+     *
+     * @return Quantity of items
+     */
+    int quantity();
+
+    /**
+     * Gets the maximum quantity per stack. By default, returns
+     * {@link ItemType#maxStackQuantity()}, unless a
+     * different value has been set for this specific stack.
+     *
+     * @return Max stack quantity
+     */
+    default int maxStackQuantity() {
+        return this.require(Keys.MAX_STACK_SIZE);
+    }
+
+    /**
+     * Returns true if {@link #quantity()} is zero and therefore this
+     * {@link ItemStackLike} is empty.
+     *
+     * <p>In Vanilla empty ItemStacks are not rendered by the client.</p>
+     *
+     * @return True if this ItemStackLike is empty
+     */
+    boolean isEmpty();
+
+    /**
+     * Gets all {@link AttributeModifier}s on this {@link ItemStackLike}.
+     *
+     * @param attributeType The {@link AttributeType} of the modifier.
+     * @param equipmentType The {@link EquipmentType} this modifier is applied.
+     * to.
+     *
+     * @return A collection of {@link AttributeModifier}s.
+     */
+    default Collection<AttributeModifier> attributeModifiers(Supplier<? extends AttributeType> attributeType, DefaultedRegistryReference<? extends EquipmentType> equipmentType) {
+        return this.attributeModifiers(attributeType.get(), equipmentType.get());
+    }
+
+    /**
+     * Gets all {@link AttributeModifier}s on this {@link ItemStackLike}.
+     *
+     * @param attributeType The {@link AttributeType} of the modifier.
+     * @param equipmentType The {@link EquipmentType} this modifier is applied.
+     * to.
+     *
+     * @return A collection of {@link AttributeModifier}s.
+     */
+    default Collection<AttributeModifier> attributeModifiers(AttributeType attributeType, DefaultedRegistryReference<? extends EquipmentType> equipmentType) {
+        return this.attributeModifiers(attributeType, equipmentType.get());
+    }
+
+    /**
+     * Gets all {@link AttributeModifier}s on this {@link ItemStackLike}.
+     *
+     * @param attributeType The {@link AttributeType} of the modifier.
+     * @param equipmentType The {@link EquipmentType} this modifier is applied.
+     * to.
+     *
+     * @return A collection of {@link AttributeModifier}s.
+     */
+    default Collection<AttributeModifier> attributeModifiers(Supplier<? extends AttributeType> attributeType, EquipmentType equipmentType) {
+        return this.attributeModifiers(attributeType.get(), equipmentType);
+    }
+
+    /**
+     * Gets all {@link AttributeModifier}s on this {@link ItemStackLike}.
+     *
+     * @param attributeType The {@link AttributeType} of the modifier.
+     * @param equipmentType The {@link EquipmentType} this modifier is applied.
+     * to.
+     *
+     * @return A collection of {@link AttributeModifier}s.
+     */
+    Collection<AttributeModifier> attributeModifiers(AttributeType attributeType, EquipmentType equipmentType);
+
+    /**
+     * Retrieves a mutable form of this {@link ItemStackLike}. If this
+     * ItemStackLike is already mutable, this would simply return itself.
+     * In other cases, a new {@link ItemStack} is created with all the
+     * data currently available on this {@link ItemStackLike}.
+     *
+     * @return An ItemStack
+     */
+    ItemStack asMutable();
+
+    /**
+     * Retrieves a copy in the mutable form of this {@link ItemStackLike}.
+     * The new {@link ItemStack} is created with all the data currently
+     * available on this {@link ItemStackLike}.
+     *
+     * @return A new ItemStack
+     */
+    ItemStack asMutableCopy();
+
+    /**
+     * Retrieves an immutable form of this {@link ItemStackLike}. If this
+     * ItemStackLike is already immutable, this would simply return itself.
+     * In other cases, a new {@link ItemStackSnapshot} is created with all
+     * known {@link Value}s existing on this {@link ItemStackLike} added
+     * as copies to the {@link ItemStackSnapshot}.
+     *
+     * @return An ItemStackSnapshot
+     */
+    ItemStackSnapshot asImmutable();
+
+    @Override
+    ItemStackLike copy();
+}

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackSnapshot.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackSnapshot.java
@@ -24,11 +24,8 @@
  */
 package org.spongepowered.api.item.inventory;
 
-import net.kyori.adventure.text.event.HoverEvent;
-import net.kyori.adventure.text.event.HoverEventSource;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.SerializableDataHolder;
-import org.spongepowered.api.item.ItemType;
 
 /**
  * Represents a snapshot of an {@link ItemStack} as an
@@ -37,7 +34,7 @@ import org.spongepowered.api.item.ItemType;
  * it is a snapshot, a snapshot cannot be modified, but modifications will
  * result in a new instance of the {@link ItemStackSnapshot}.
  */
-public interface ItemStackSnapshot extends HoverEventSource<HoverEvent.ShowItem>, SerializableDataHolder.Immutable<ItemStackSnapshot> {
+public interface ItemStackSnapshot extends ItemStackLike, SerializableDataHolder.Immutable<ItemStackSnapshot> {
 
     /**
      * Gets a empty {@link ItemStackSnapshot}.
@@ -47,38 +44,6 @@ public interface ItemStackSnapshot extends HoverEventSource<HoverEvent.ShowItem>
     static ItemStackSnapshot empty() {
         return Sponge.game().factoryProvider().provide(Factory.class).empty();
     }
-
-    /**
-     * Gets the {@link ItemType} of this {@link ItemStackSnapshot}. The
-     * {@link ItemType} is always available.
-     *
-     * @return The item type
-     */
-    ItemType type();
-
-    /**
-     * Gets the quantity of items in this the {@link ItemStack} this
-     * {@link ItemStackSnapshot} is representing.
-     *
-     * @return The current stack size
-     */
-    int quantity();
-
-    /**
-     * Returns true if {@link #quantity()} is zero and therefore this
-     * ItemStackSnapshot is empty.
-     *
-     * @return True if this ItemStackSnapshot is empty
-     */
-    boolean isEmpty();
-
-    /**
-     * Creates a new {@link ItemStack} with all the data currently available
-     * on this {@link ItemStackSnapshot}.
-     *
-     * @return The newly generated item stack
-     */
-    ItemStack createStack();
 
     interface Factory {
 

--- a/src/main/java/org/spongepowered/api/item/inventory/ItemStackSnapshot.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ItemStackSnapshot.java
@@ -45,6 +45,14 @@ public interface ItemStackSnapshot extends ItemStackLike, SerializableDataHolder
         return Sponge.game().factoryProvider().provide(Factory.class).empty();
     }
 
+    /**
+     * @deprecated Use {@link #asMutable()} or {@link #asMutableCopy()} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default ItemStack createStack() {
+        return this.asMutable();
+    }
+
     interface Factory {
 
         ItemStackSnapshot empty();

--- a/src/main/java/org/spongepowered/api/item/inventory/Slot.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Slot.java
@@ -39,6 +39,14 @@ public interface Slot extends Inventory {
     Slot viewedSlot();
 
     /**
+     * @deprecated Use {@link #set(ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default InventoryTransactionResult set(ItemStack stack) {
+        return this.set((ItemStackLike) stack);
+    }
+
+    /**
      * Adds the ItemStack to this slot overwriting the existing item.
      *
      * <p>Stacks bigger than the max stack size will be partially rejected.</p>
@@ -48,5 +56,5 @@ public interface Slot extends Inventory {
      * @return A SUCCESS transaction-result if the entire stack was added and
      *           FAILURE when the stack was not or only partially added to the inventory.
      */
-    InventoryTransactionResult set(ItemStack stack);
+    InventoryTransactionResult set(ItemStackLike stack);
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/equipment/EquipmentInventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/equipment/EquipmentInventory.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.item.inventory.equipment;
 import org.spongepowered.api.item.inventory.Equipable;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.Slot;
 import org.spongepowered.api.item.inventory.transaction.InventoryTransactionResult;
 
@@ -89,16 +90,32 @@ public interface EquipmentInventory extends Inventory {
     }
 
     /**
+     * @deprecated Use {@link #set(EquipmentType, ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default InventoryTransactionResult set(EquipmentType equipmentType, ItemStack stack) {
+        return this.set(equipmentType, (ItemStackLike) stack);
+    }
+
+    /**
      * Sets the item for the specified equipment type.
      *
-     * @see Slot#set(ItemStack)
+     * @see Slot#set(ItemStackLike)
      * @param equipmentType Type of equipment slot to set
      * @param stack stack to insert
      * @return operation result, for details see {@link Inventory#set}
      */
-    InventoryTransactionResult set(EquipmentType equipmentType, ItemStack stack);
+    InventoryTransactionResult set(EquipmentType equipmentType, ItemStackLike stack);
 
+    /**
+     * @deprecated Use {@link #set(Supplier, ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
     default InventoryTransactionResult set(final Supplier<? extends EquipmentType> equipmentType, final ItemStack stack) {
+        return this.set(equipmentType, (ItemStackLike) stack);
+    }
+
+    default InventoryTransactionResult set(final Supplier<? extends EquipmentType> equipmentType, final ItemStackLike stack) {
         return this.set(equipmentType.get(), stack);
     }
 

--- a/src/main/java/org/spongepowered/api/item/inventory/slot/FilteringSlot.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/slot/FilteringSlot.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.item.inventory.slot;
 
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.Slot;
 
 /**
@@ -34,14 +35,22 @@ import org.spongepowered.api.item.inventory.Slot;
 public interface FilteringSlot extends Slot {
 
     /**
+     * @deprecated Use {@link #isValidItem(ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default boolean isValidItem(ItemStack stack) {
+        return this.isValidItem((ItemStackLike) stack);
+    }
+
+    /**
      * Check whether the supplied item can be inserted into this slot. Returning
      * false from this method implies that {@link #offer} <b>would always return
      * false</b> for this item.
      *
-     * @param stack ItemStack to check
+     * @param stack ItemStackLike to check
      * @return true if the stack is valid for this slot
      */
-    boolean isValidItem(ItemStack stack);
+    boolean isValidItem(ItemStackLike stack);
 
     /**
      * Check whether the supplied item can be inserted into this slot. Returning

--- a/src/main/java/org/spongepowered/api/item/inventory/slot/SidedSlot.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/slot/SidedSlot.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.item.inventory.slot;
 
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.Slot;
 import org.spongepowered.api.util.Direction;
 
@@ -33,6 +34,14 @@ import org.spongepowered.api.util.Direction;
  * A slot which belongs to a particular side of a "sided" inventory.
  */
 public interface SidedSlot extends Slot {
+
+    /**
+     * @deprecated Use {@link #canAccept(ItemStackLike, Direction)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default boolean canAccept(ItemStack stack, Direction from) {
+        return this.canAccept((ItemStackLike) stack, from);
+    }
 
     /**
      * Gets whether this slot can accept the specified item from the specified
@@ -43,19 +52,35 @@ public interface SidedSlot extends Slot {
      * @return true if this inventory can accept the supplied stack from the
      *      specified direction
      */
-    boolean canAccept(ItemStack stack, Direction from);
+    boolean canAccept(ItemStackLike stack, Direction from);
+
+    /**
+     * @deprecated Use {@link #offer(ItemStackLike, Direction)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default boolean offer(ItemStack stack, Direction from) {
+        return this.offer((ItemStackLike) stack, from);
+    }
 
     /**
      * Attempts to insert the supplied stack into this inventory from the
      * specified direction.
      *
-     * @see Inventory#offer(ItemStack...)
+     * @see Inventory#offer(ItemStackLike...)
      * @param stack Stack to insert
      * @param from Direction to check for insertion from
      * @return true if this inventory can accept the supplied stack from the
      *      specified direction
      */
-    boolean offer(ItemStack stack, Direction from);
+    boolean offer(ItemStackLike stack, Direction from);
+
+    /**
+     * @deprecated Use {@link #canGet(ItemStackLike, Direction)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default boolean canGet(ItemStack stack, Direction from) {
+        return this.canGet((ItemStackLike) stack, from);
+    }
 
     /**
      * Gets whether automation can extract the specified item from the specified
@@ -66,6 +91,6 @@ public interface SidedSlot extends Slot {
      * @return true if automation can retrieve the supplied stack from the
      *      specified direction
      */
-    boolean canGet(ItemStack stack, Direction from);
+    boolean canGet(ItemStackLike stack, Direction from);
 
 }

--- a/src/main/java/org/spongepowered/api/item/inventory/transaction/InventoryTransactionResult.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/transaction/InventoryTransactionResult.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.item.inventory.transaction;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.util.CopyableBuilder;
 
@@ -179,31 +180,47 @@ public interface InventoryTransactionResult {
         Builder type(final Type type);
 
         /**
-         * Adds the provided {@link ItemStack itemstacks} as stacks that have been
+         * @deprecated Use {@link #reject(ItemStackLike...)} instead.
+         */
+        @Deprecated(forRemoval = true)
+        default Builder reject(ItemStack... itemStacks) {
+            return this.reject((ItemStackLike[]) itemStacks);
+        }
+
+        /**
+         * Adds the provided {@link ItemStackLike itemstacks} as stacks that have been
          * "rejected".
          *
          * @param itemStacks The itemstacks being rejected
          * @return This builder, for chaining
          */
-        Builder reject(ItemStack... itemStacks);
+        Builder reject(ItemStackLike... itemStacks);
 
         /**
-         * Adds the provided {@link ItemStack itemstacks} as stacks that have been
+         * Adds the provided {@link ItemStackLike itemstacks} as stacks that have been
          * "rejected".
          *
          * @param itemStacks The itemstacks being rejected
          * @return This builder, for chaining
          */
-        Builder reject(Iterable<ItemStackSnapshot> itemStacks);
+        Builder reject(Iterable<? extends ItemStackLike> itemStacks);
 
         /**
-         * Sets the provided {@link ItemStackSnapshot} as the stack that has been polled from the inventory.
+         * @deprecated Use {@link #poll(ItemStackLike)} instead.
+         */
+        @Deprecated(forRemoval = true)
+        default Builder.PollBuilder poll(ItemStackSnapshot itemStack) {
+            return this.poll((ItemStackLike) itemStack);
+        }
+
+        /**
+         * Sets the provided {@link ItemStackLike} as the stack that has been polled from the inventory.
          *
          * @param itemStack The polled itemstack
          *
          * @return This builder, for chaining
          */
-        Builder.PollBuilder poll(ItemStackSnapshot itemStack);
+        Builder.PollBuilder poll(ItemStackLike itemStack);
 
         /**
          * Adds the provided {@link ItemStack itemstacks} as stacks that are

--- a/src/main/java/org/spongepowered/api/item/inventory/transaction/SlotTransaction.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/transaction/SlotTransaction.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.item.inventory.transaction;
 
 import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.Slot;
 
@@ -51,12 +52,20 @@ public class SlotTransaction extends Transaction<ItemStackSnapshot> {
     }
 
     /**
-     * Sets the custom {@link ItemStack} output of this
+     * @deprecated Use {@link #setCustom(ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public void setCustom(ItemStack stack) {
+        this.setCustom((ItemStackLike) stack);
+    }
+
+    /**
+     * Sets the custom {@link ItemStackLike} output of this
      * {@link SlotTransaction}.
      *
      * @param stack The stack
      */
-    public void setCustom(ItemStack stack) {
+    public void setCustom(ItemStackLike stack) {
         this.setCustom(Objects.requireNonNull(stack, "ItemStack was null").asImmutable());
     }
 

--- a/src/main/java/org/spongepowered/api/item/inventory/transaction/SlotTransaction.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/transaction/SlotTransaction.java
@@ -57,7 +57,7 @@ public class SlotTransaction extends Transaction<ItemStackSnapshot> {
      * @param stack The stack
      */
     public void setCustom(ItemStack stack) {
-        this.setCustom(Objects.requireNonNull(stack, "ItemStack was null").createSnapshot());
+        this.setCustom(Objects.requireNonNull(stack, "ItemStack was null").asImmutable());
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/item/inventory/type/GridInventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/type/GridInventory.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.item.inventory.type;
 
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.Slot;
 import org.spongepowered.api.item.inventory.transaction.InventoryTransactionResult;
 import org.spongepowered.math.vector.Vector2i;
@@ -96,15 +97,23 @@ public interface GridInventory extends Inventory2D {
     Optional<ItemStack> peek(int x, int y);
 
     /**
+     * @deprecated Use {@link #set(int, int, ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default InventoryTransactionResult set(int x, int y, ItemStack stack) {
+        return this.set(x, y, (ItemStackLike) stack);
+    }
+
+    /**
      * Sets the item in the specified slot.
      *
-     * @see Slot#set(ItemStack)
+     * @see Slot#set(ItemStackLike)
      * @param x x coordinate
      * @param y y coordinate
      * @param stack Item stack to insert
      * @return operation result
      */
-    InventoryTransactionResult set(int x, int y, ItemStack stack);
+    InventoryTransactionResult set(int x, int y, ItemStackLike stack);
 
     /**
      * Gets the {@link Slot} at the specified position.

--- a/src/main/java/org/spongepowered/api/item/inventory/type/Inventory2D.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/type/Inventory2D.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.item.inventory.type;
 
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.Slot;
 import org.spongepowered.api.item.inventory.transaction.InventoryTransactionResult;
@@ -74,14 +75,22 @@ public interface Inventory2D extends Inventory {
     }
 
     /**
+     * @deprecated Use {@link #set(Vector2i, ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default InventoryTransactionResult set(Vector2i pos, ItemStack stack) {
+        return this.set(pos, (ItemStackLike) stack);
+    }
+
+    /**
      * Sets the item in the specified slot.
      *
-     * @see Slot#set(ItemStack)
+     * @see Slot#set(ItemStackLike)
      * @param pos Slot position to set
      * @param stack Stack to insert
      * @return matching stacks, as per the semantics of {@link Inventory#set}
      */
-    default InventoryTransactionResult set(Vector2i pos, ItemStack stack) {
+    default InventoryTransactionResult set(Vector2i pos, ItemStackLike stack) {
         return this.slot(pos).map(slot -> slot.set(stack)).orElse(InventoryTransactionResult.failNoTransactions());
     }
 

--- a/src/main/java/org/spongepowered/api/item/inventory/type/ViewableInventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/type/ViewableInventory.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 import org.spongepowered.api.item.inventory.Carrier;
 import org.spongepowered.api.item.inventory.ContainerType;
 import org.spongepowered.api.item.inventory.Inventory;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.Slot;
 import org.spongepowered.api.item.inventory.menu.InventoryMenu;
@@ -248,13 +249,21 @@ public interface ViewableInventory extends Inventory {
         interface DummyStep extends BuildingStep {
 
             /**
+             * @deprecated Use {@link #item(ItemStackLike)} instead.
+             */
+            @Deprecated(forRemoval = true)
+            default BuildingStep item(ItemStackSnapshot item) {
+                return this.item((ItemStackLike) item);
+            }
+
+            /**
              * Sets the default item for the dummy-slots.
              *
              * @param item the default item
              *
              * @return the building step
              */
-            BuildingStep item(ItemStackSnapshot item);
+            BuildingStep item(ItemStackLike item);
         }
 
         interface EndStep extends Builder {

--- a/src/main/java/org/spongepowered/api/item/merchant/TradeOffer.java
+++ b/src/main/java/org/spongepowered/api/item/merchant/TradeOffer.java
@@ -29,6 +29,7 @@ import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.data.persistence.DataSerializable;
 import org.spongepowered.api.entity.living.Humanoid;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.util.CopyableBuilder;
 
@@ -165,6 +166,14 @@ public interface TradeOffer extends DataSerializable {
     interface Builder extends org.spongepowered.api.util.Builder<TradeOffer, Builder>, CopyableBuilder<TradeOffer, Builder>, DataBuilder<TradeOffer> {
 
         /**
+         * @deprecated Use {@link #firstBuyingItem(ItemStackLike)} instead.
+         */
+        @Deprecated(forRemoval = true)
+        default Builder firstBuyingItem(ItemStack item) {
+            return this.firstBuyingItem((ItemStackLike) item);
+        }
+
+        /**
          * <p>Sets the first selling item of the trade offer to be
          * generated.</p>
          *
@@ -173,7 +182,15 @@ public interface TradeOffer extends DataSerializable {
          * @param item The first item to buy
          * @return This builder
          */
-        Builder firstBuyingItem(ItemStack item);
+        Builder firstBuyingItem(ItemStackLike item);
+
+        /**
+         * @deprecated Use {@link #secondBuyingItem(ItemStackLike)} instead.
+         */
+        @Deprecated(forRemoval = true)
+        default Builder secondBuyingItem(ItemStack item) {
+            return this.secondBuyingItem((ItemStackLike) item);
+        }
 
         /**
          * Sets the second selling item of the trade offer to be generated.
@@ -181,7 +198,15 @@ public interface TradeOffer extends DataSerializable {
          * @param item The second item to buy
          * @return This builder
          */
-        Builder secondBuyingItem(ItemStack item);
+        Builder secondBuyingItem(ItemStackLike item);
+
+        /**
+         * @deprecated Use {@link #sellingItem(ItemStackLike)} instead.
+         */
+        @Deprecated(forRemoval = true)
+        default Builder sellingItem(ItemStack item) {
+            return this.sellingItem((ItemStackLike) item);
+        }
 
         /**
          * Sets the selling item of the trade offer to be generated.
@@ -189,7 +214,7 @@ public interface TradeOffer extends DataSerializable {
          * @param item The item to sell
          * @return This builder
          */
-        Builder sellingItem(ItemStack item);
+        Builder sellingItem(ItemStackLike item);
 
         /**
          * Sets the existing uses of the trade offer to be generated. A trade

--- a/src/main/java/org/spongepowered/api/item/recipe/RecipeManager.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/RecipeManager.java
@@ -25,6 +25,7 @@
 package org.spongepowered.api.item.recipe;
 
 import org.spongepowered.api.ResourceKey;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.cooking.CookingRecipe;
 import org.spongepowered.api.item.recipe.crafting.RecipeInput;
@@ -77,6 +78,14 @@ public interface RecipeManager {
     }
 
     /**
+     * @deprecated Use {@link #findByResult(RecipeType, ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default <T extends Recipe<?>> Collection<T> findByResult(RecipeType<T> type, ItemStackSnapshot result) {
+        return this.findByResult(type, (ItemStackLike) result);
+    }
+
+    /**
      * Returns all registered recipes of given type and with given item as a result.
      *
      * @param type The recipe type
@@ -84,7 +93,15 @@ public interface RecipeManager {
      *
      * @return The recipes resulting in given item.
      */
-    <T extends Recipe<?>> Collection<T> findByResult(RecipeType<T> type, ItemStackSnapshot result);
+    <T extends Recipe<?>> Collection<T> findByResult(RecipeType<T> type, ItemStackLike result);
+
+    /**
+     * @deprecated Use {@link #findByResult(Supplier, ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default <T extends Recipe<?>> Collection<T> findByResult(Supplier<? extends RecipeType<T>> supplier, ItemStackSnapshot result) {
+        return this.findByResult(supplier, (ItemStackLike) result);
+    }
 
     /**
      * Gets all recipes with given item as a result.
@@ -93,7 +110,7 @@ public interface RecipeManager {
      *
      * @return All recipes resulting in given item.
      */
-    default <T extends Recipe<?>> Collection<T> findByResult(Supplier<? extends RecipeType<T>> supplier, ItemStackSnapshot result) {
+    default <T extends Recipe<?>> Collection<T> findByResult(Supplier<? extends RecipeType<T>> supplier, ItemStackLike result) {
         return this.findByResult(supplier.get(), result);
     }
 
@@ -122,6 +139,14 @@ public interface RecipeManager {
     }
 
     /**
+     * @deprecated Use {@link #findCookingRecipe(RecipeType, ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default <T extends CookingRecipe> Optional<T> findCookingRecipe(RecipeType<T> type, ItemStackSnapshot ingredient) {
+        return this.findCookingRecipe(type, (ItemStackLike) ingredient);
+    }
+
+    /**
      * Finds a matching cooking recipe for given type and ingredient
      *
      * @param type The recipe type
@@ -129,7 +154,15 @@ public interface RecipeManager {
      *
      * @return The matching recipe.
      */
-    <T extends CookingRecipe> Optional<T> findCookingRecipe(RecipeType<T> type, ItemStackSnapshot ingredient);
+    <T extends CookingRecipe> Optional<T> findCookingRecipe(RecipeType<T> type, ItemStackLike ingredient);
+
+    /**
+     * @deprecated Use {@link #findCookingRecipe(Supplier, ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default <T extends CookingRecipe> Optional<T> findCookingRecipe(Supplier<? extends RecipeType<T>> supplier, ItemStackSnapshot ingredient) {
+        return this.findCookingRecipe(supplier, (ItemStackLike) ingredient);
+    }
 
     /**
      * Finds a matching cooking recipe for given type and ingredient
@@ -139,7 +172,7 @@ public interface RecipeManager {
      *
      * @return The matching recipe.
      */
-    default <T extends CookingRecipe> Optional<T> findCookingRecipe(Supplier<? extends RecipeType<T>> supplier, ItemStackSnapshot ingredient) {
+    default <T extends CookingRecipe> Optional<T> findCookingRecipe(Supplier<? extends RecipeType<T>> supplier, ItemStackLike ingredient) {
         return this.findCookingRecipe(supplier.get(), ingredient);
     }
 

--- a/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingRecipe.java
@@ -29,6 +29,7 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.datapack.DataPack;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.Recipe;
 import org.spongepowered.api.item.recipe.RecipeRegistration;
@@ -64,25 +65,41 @@ public interface CookingRecipe extends Recipe<RecipeInput.Single> {
     Ingredient ingredient();
 
     /**
-     * Checks if the given {@link ItemStackSnapshot} fits the required
+     * @deprecated Use {@link #isValid(ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default boolean isValid(ItemStackSnapshot ingredient) {
+        return this.isValid((ItemStackLike) ingredient);
+    }
+
+    /**
+     * Checks if the given {@link ItemStackLike} fits the required
      * constraints to craft this {@link CookingRecipe}.
      *
      * @param ingredient The ingredient to check against
      *
      * @return Whether this ingredient can be used to craft the result
      */
-    boolean isValid(ItemStackSnapshot ingredient);
+    boolean isValid(ItemStackLike ingredient);
+
+    /**
+     * @deprecated Use {@link #result(ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    default Optional<CookingResult> result(ItemStackSnapshot ingredient) {
+        return this.result((ItemStackLike) ingredient);
+    }
 
     /**
      * <p>Returns the {@link CookingResult} containing the resulting
-     * {@link ItemStackSnapshot} and the amount of experience released.</p>
+     * {@link ItemStackLike} and the amount of experience released.</p>
      *
-     * @param ingredient The {@link ItemStackSnapshot} currently being cooked
+     * @param ingredient The {@link ItemStackLike} currently being cooked
      * @return The {@link CookingResult}, or {@link Optional#empty()}
      *         if the recipe is not valid according to
-     *         {@link #isValid(ItemStackSnapshot)}.
+     *         {@link #isValid(ItemStackLike)}.
      */
-    Optional<CookingResult> result(ItemStackSnapshot ingredient);
+    Optional<CookingResult> result(ItemStackLike ingredient);
 
     /**
      * Returns the cooking time in ticks.
@@ -183,24 +200,38 @@ public interface CookingRecipe extends Recipe<RecipeInput.Single> {
             }
 
             /**
-             * Changes the result and returns this builder. The result is the
-             * {@link ItemStack} created when the recipe is fulfilled.
-             *
-             * @param result The output of this recipe
-             *
-             * @return This builder, for chaining
+             * @deprecated Use {@link #result(ItemStackLike)} instead.
              */
-            EndStep result(ItemStack result);
+            @Deprecated(forRemoval = true)
+            default EndStep result(ItemStack result) {
+                return this.result((ItemStackLike) result);
+            }
+
+            /**
+             * @deprecated Use {@link #result(ItemStackLike)} instead.
+             */
+            @Deprecated(forRemoval = true)
+            default EndStep result(ItemStackSnapshot result) {
+                return this.result((ItemStackLike) result);
+            }
 
             /**
              * Changes the result and returns this builder. The result is the
-             * {@link ItemStack} created when the recipe is fulfilled.
+             * {@link ItemStackLike} created when the recipe is fulfilled.
              *
              * @param result The output of this recipe
              *
              * @return This builder, for chaining
              */
-            EndStep result(ItemStackSnapshot result);
+            EndStep result(ItemStackLike result);
+
+            /**
+             * @deprecated Use {@link #result(Function, ItemStackLike)} instead.
+             */
+            @Deprecated(forRemoval = true)
+            default EndStep result(final Function<RecipeInput.Single, ItemStack> resultFunction, final ItemStack exemplaryResult) {
+                return this.result(resultFunction, (ItemStackLike) exemplaryResult);
+            }
 
             /**
              * Sets the result function and an exemplary result.
@@ -210,7 +241,7 @@ public interface CookingRecipe extends Recipe<RecipeInput.Single> {
              *
              * @return The builder
              */
-            EndStep result(final Function<RecipeInput.Single, ItemStack> resultFunction, final ItemStack exemplaryResult);
+            EndStep result(final Function<RecipeInput.Single, ? extends ItemStackLike> resultFunction, final ItemStackLike exemplaryResult);
         }
 
         interface EndStep extends Builder,

--- a/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingResult.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingResult.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.item.recipe.cooking;
 
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 
 import java.util.Objects;
@@ -38,6 +39,14 @@ public final class CookingResult {
     private final double experience;
 
     /**
+     * @deprecated Use {@link #CookingResult(ItemStackLike, double)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public CookingResult(final ItemStackSnapshot result, final double experience) {
+        this((ItemStackLike) result, experience);
+    }
+
+    /**
      * Creates a new {@link CookingResult}.
      *
      * <p>Note that this may be replaced with a static of method in the future.</p>
@@ -45,16 +54,16 @@ public final class CookingResult {
      * @param result The result of the cooking recipe
      * @param experience The experience that should be created from this result
      */
-    public CookingResult(final ItemStackSnapshot result, final double experience) {
+    public CookingResult(final ItemStackLike result, final double experience) {
         Objects.requireNonNull(result, "result");
         if (result.isEmpty()) {
-            throw new IllegalArgumentException("The resulting snapshot must not be empty");
+            throw new IllegalArgumentException("The result must not be empty");
         }
         if (experience < 0) {
             throw new IllegalArgumentException("The experience must be non-negative.");
         }
 
-        this.result = result;
+        this.result = result.asImmutable();
         this.experience = experience;
     }
 

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/Ingredient.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/Ingredient.java
@@ -29,6 +29,7 @@ import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
 
@@ -53,11 +54,19 @@ public interface Ingredient extends Predicate<ItemStack> {
         return Sponge.game().factoryProvider().provide(Factory.class).empty();
     }
 
+    /**
+     * @deprecated Use {@link #test(ItemStackLike)} instead.
+     */
+    @Deprecated(forRemoval = true)
     @Override
-    boolean test(ItemStack itemStack);
+    default boolean test(ItemStack itemStack) {
+        return this.test((ItemStackLike) itemStack);
+    }
+
+    boolean test(ItemStackLike item);
 
     /**
-     * Returns the list of {@link ItemStack}s used to display the ingredient in a recipe.
+     * Returns the list of {@link ItemStackSnapshot}s used to display the ingredient in a recipe.
      * These are not necessarily all the items that this Ingredient can match.
      *
      * @return The list of items to display the Ingredient in a recipe.
@@ -87,25 +96,28 @@ public interface Ingredient extends Predicate<ItemStack> {
     }
 
     /**
-     * Creates a new {@link Ingredient} for the provided {@link ItemStack}s.
-     *
-     * @param items The items
-     * @return The new ingredient
+     * @deprecated Use {@link #of(ItemStackLike...)} instead.
      */
+    @Deprecated(forRemoval = true)
     static Ingredient of(ItemStack @Nullable ... items) {
-        if (items == null || items.length == 0) {
-            return Ingredient.empty();
-        }
-        return Ingredient.builder().with(items).build();
+        return Ingredient.of((ItemStackLike[]) items);
     }
 
     /**
-     * Creates a new {@link Ingredient} for the provided {@link ItemStackSnapshot}s.
+     * @deprecated Use {@link #of(ItemStackLike...)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    static Ingredient of(ItemStackSnapshot @Nullable ... items) {
+        return Ingredient.of((ItemStackLike[]) items);
+    }
+
+    /**
+     * Creates a new {@link Ingredient} for the provided {@link ItemStackLike}s.
      *
      * @param items The item
      * @return The new ingredient
      */
-    static Ingredient of(ItemStackSnapshot @Nullable ... items) {
+    static Ingredient of(ItemStackLike @Nullable ... items) {
         if (items == null) {
             return Ingredient.empty();
         }
@@ -127,7 +139,15 @@ public interface Ingredient extends Predicate<ItemStack> {
     }
 
     /**
-     * Creates a new {@link Ingredient} for the provided {@link Predicate} and exemplary {@link ItemStack}s.
+     * @deprecated Use {@link #of(ResourceKey, Predicate, ItemStackLike...)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    static Ingredient of(ResourceKey key, Predicate<ItemStack> predicate, ItemStack... exemplaryStacks) {
+        return Ingredient.of(key, itemStack -> predicate.test(itemStack.asMutable()), (ItemStackLike[]) exemplaryStacks);
+    }
+
+    /**
+     * Creates a new {@link Ingredient} for the provided {@link Predicate} and exemplary {@link ItemStackLike}s.
      * <p>Note: Predicate ingredients may not be fully supported for all recipe types</p>
      *
      * @param key A unique resource key
@@ -136,7 +156,7 @@ public interface Ingredient extends Predicate<ItemStack> {
      *
      * @return The new ingredient
      */
-    static Ingredient of(ResourceKey key, Predicate<ItemStack> predicate, ItemStack... exemplaryStacks) {
+    static Ingredient of(ResourceKey key, Predicate<? super ItemStackLike> predicate, ItemStackLike... exemplaryStacks) {
         if (exemplaryStacks.length == 0) {
             throw new IllegalArgumentException("At least exemplary stack is required");
         }
@@ -178,12 +198,28 @@ public interface Ingredient extends Predicate<ItemStack> {
         Builder with(Supplier<? extends ItemType>... types);
 
         /**
-         * Sets one ore more ItemStack for matching the ingredient.
+         * @deprecated Use {@link #with(ItemStackLike...)} instead
+         */
+        @Deprecated(forRemoval = true)
+        default Builder with(ItemStack... types) {
+            return this.with((ItemStackLike[]) types);
+        }
+
+        /**
+         * Sets one or more ItemStackLike for matching the ingredient.
          *
          * @param types The items
          * @return This Builder, for chaining
          */
-        Builder with(ItemStack... types);
+        Builder with(ItemStackLike... types);
+
+        /**
+         * @deprecated Use {@link #with(ResourceKey, Predicate, ItemStackLike...)} instead.
+         */
+        @Deprecated(forRemoval = true)
+        default Builder with(ResourceKey resourceKey, Predicate<ItemStack> predicate, ItemStack... exemplaryTypes) {
+            return this.with(resourceKey, itemStack -> predicate.test(itemStack.asMutable()), (ItemStackLike[]) exemplaryTypes);
+        }
 
         /**
          * Sets a Predicate for matching the ingredient.
@@ -194,15 +230,15 @@ public interface Ingredient extends Predicate<ItemStack> {
          * @param exemplaryTypes The items
          * @return This Builder, for chaining
          */
-        Builder with(ResourceKey resourceKey, Predicate<ItemStack> predicate, ItemStack... exemplaryTypes);
+        Builder with(ResourceKey resourceKey, Predicate<? super ItemStackLike> predicate, ItemStackLike... exemplaryTypes);
 
         /**
-         * Sets one ItemStack for matching the ingredient.
-         *
-         * @param types The items
-         * @return This Builder, for chaining
+         * @deprecated Use {@link #with(ItemStackLike...)} instead
          */
-        Builder with(ItemStackSnapshot... types);
+        @Deprecated(forRemoval = true)
+        default Builder with(ItemStackSnapshot... types) {
+            return this.with((ItemStackLike[]) types);
+        }
 
         /**
          * Sets the item tag for matching the ingredient.

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeInput.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeInput.java
@@ -26,6 +26,7 @@ package org.spongepowered.api.item.recipe.crafting;
 
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.type.GridInventory;
 import org.spongepowered.api.item.recipe.cooking.CookingRecipe;
 import org.spongepowered.api.item.recipe.single.StoneCutterRecipe;
@@ -66,6 +67,14 @@ public interface RecipeInput extends Inventory {
     interface Factory {
 
         /**
+         * @deprecated Use {@link #single(ItemStackLike)} instead.
+         */
+        @Deprecated(forRemoval = true)
+        default RecipeInput.Single single(ItemStack stack) {
+            return this.single((ItemStackLike) stack);
+        }
+
+        /**
          * Creates a recipe input for
          * {@link CookingRecipe} and
          * {@link StoneCutterRecipe}
@@ -74,7 +83,15 @@ public interface RecipeInput extends Inventory {
          *
          * @return the recipe input
          */
-        RecipeInput.Single single(ItemStack stack);
+        RecipeInput.Single single(ItemStackLike stack);
+
+        /**
+         * @deprecated Use {@link #smithing(ItemStackLike, ItemStackLike, ItemStackLike)} instead.
+         */
+        @Deprecated(forRemoval = true)
+        default RecipeInput.Smithing smithing(ItemStack templateStack, ItemStack baseStack, ItemStack additionStack) {
+            return this.smithing((ItemStackLike) templateStack, (ItemStackLike) baseStack, (ItemStackLike) additionStack);
+        }
 
         /**
          * Creates a recipe input for {@link SmithingRecipe}
@@ -85,7 +102,7 @@ public interface RecipeInput extends Inventory {
          *
          * @return the recipe input
          */
-        RecipeInput.Smithing smithing(ItemStack templateStack, ItemStack baseStack, ItemStack additionStack);
+        RecipeInput.Smithing smithing(ItemStackLike templateStack, ItemStackLike baseStack, ItemStackLike additionStack);
 
         /**
          * Creates a recipe input for {@link CraftingRecipe}

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeResult.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeResult.java
@@ -24,12 +24,14 @@
  */
 package org.spongepowered.api.item.recipe.crafting;
 
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.crafting.CraftingGridInventory;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 /**
  * The result of fulfilling a {@link CraftingRecipe}.
@@ -38,6 +40,14 @@ public final class RecipeResult {
 
     private final ItemStackSnapshot result;
     private final List<ItemStackSnapshot> remainingItems;
+
+    /**
+     * @deprecated Use {@link #RecipeResult(ItemStackLike, List)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public RecipeResult(ItemStackSnapshot result, List<ItemStackSnapshot> remainingItems) {
+        this((ItemStackLike) result, (List<? extends ItemStackLike>) remainingItems);
+    }
 
     /**
      * Creates a new {@link RecipeResult}.
@@ -49,7 +59,7 @@ public final class RecipeResult {
      * @param remainingItems The remaining items to leave in the
      *     crafting window
      */
-    public RecipeResult(ItemStackSnapshot result, List<ItemStackSnapshot> remainingItems) {
+    public RecipeResult(ItemStackLike result, List<? extends ItemStackLike> remainingItems) {
         Objects.requireNonNull(result, "result");
         if (result.isEmpty()) {
             throw new IllegalArgumentException("The result must not be empty!");
@@ -60,8 +70,8 @@ public final class RecipeResult {
                 + " It should contain empty ItemStackSnapshot values for slots which should be cleared.");
         }
 
-        this.result = result;
-        this.remainingItems = List.copyOf(remainingItems);
+        this.result = result.asImmutable();
+        this.remainingItems = remainingItems.stream().map(ItemStackLike::asImmutable).toList();
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeResult.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeResult.java
@@ -31,7 +31,6 @@ import org.spongepowered.api.item.inventory.crafting.CraftingGridInventory;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 
 /**
  * The result of fulfilling a {@link CraftingRecipe}.

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapedCraftingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapedCraftingRecipe.java
@@ -29,6 +29,7 @@ import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.datapack.DataPack;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.RecipeRegistration;
 import org.spongepowered.api.util.ResourceKeyedBuilder;
@@ -214,28 +215,44 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
              * @param remainingItemsFunction the remaining items function
              *
              * @return This builder, for chaining
+             * @deprecated Will be replaced with ItemStackLike variant
              */
-            ResultStep remainingItems(Function<RecipeInput.Crafting, List<ItemStack>> remainingItemsFunction);
+            @Deprecated
+            ResultStep remainingItems(Function<RecipeInput.Crafting, ? extends List<? extends ItemStackLike>> remainingItemsFunction);
 
             /**
-             * Sets the resultant {@link ItemStackSnapshot} for when this shaped
+             * @deprecated Use {@link #result(ItemStackLike)} instead.
+             */
+            @Deprecated(forRemoval = true)
+            default EndStep result(ItemStackSnapshot result) {
+                return this.result((ItemStackLike) result);
+            }
+
+            /**
+             * @deprecated Use {@link #result(ItemStackLike)} instead.
+             */
+            @Deprecated(forRemoval = true)
+            default EndStep result(ItemStack result) {
+                return this.result((ItemStackLike) result);
+            }
+
+            /**
+             * Sets the resultant {@link ItemStackLike} for when this shaped
              * recipe is correctly crafted.
              *
              * @param result The resultant snapshot
              *
              * @return The builder
              */
-            EndStep result(ItemStackSnapshot result);
+            EndStep result(ItemStackLike result);
 
             /**
-             * Sets the resultant {@link ItemStack} for when this shaped recipe
-             * is correctly crafted.
-             *
-             * @param result The resultant stack
-             *
-             * @return The builder
+             * @deprecated Use {@link #result(Function, ItemStackLike)} instead.
              */
-            EndStep result(ItemStack result);
+            @Deprecated(forRemoval = true)
+            default EndStep result(Function<RecipeInput.Crafting, ItemStack> resultFunction, ItemStack exemplaryResult) {
+                return this.result(resultFunction, (ItemStackLike) exemplaryResult);
+            }
 
             /**
              * Sets the result function and an exemplary result.
@@ -246,7 +263,7 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
              *
              * @return The builder
              */
-            EndStep result(Function<RecipeInput.Crafting, ItemStack> resultFunction, ItemStack exemplaryResult);
+            EndStep result(Function<RecipeInput.Crafting, ? extends ItemStackLike> resultFunction, ItemStackLike exemplaryResult);
         }
 
         /**

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapelessCraftingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapelessCraftingRecipe.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.datapack.DataPack;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.RecipeRegistration;
 import org.spongepowered.api.util.ResourceKeyedBuilder;
@@ -98,27 +99,41 @@ public interface ShapelessCraftingRecipe extends CraftingRecipe {
              *
              * @return This builder, for chaining
              */
-            ResultStep remainingItems(Function<RecipeInput.Crafting, List<ItemStack>> remainingItemsFunction);
+            ResultStep remainingItems(Function<RecipeInput.Crafting, ? extends List<? extends ItemStackLike>> remainingItemsFunction);
+
+            /**
+             * @deprecated Use {@link #result(ItemStackLike)} instead.
+             */
+            @Deprecated(forRemoval = true)
+            default EndStep result(ItemStackSnapshot result) {
+                return this.result((ItemStackLike) result);
+            }
+
+            /**
+             * @deprecated Use {@link #result(ItemStackLike)} instead.
+             */
+            @Deprecated(forRemoval = true)
+            default EndStep result(ItemStack result) {
+                return this.result((ItemStackLike) result);
+            }
 
             /**
              * Sets the result and returns this builder. The result is the
-             * {@link ItemStack} created when the recipe is fulfilled.
+             * {@link ItemStackLike} created when the recipe is fulfilled.
              *
              * @param result The result
              *
              * @return This builder, for chaining
              */
-            EndStep result(ItemStackSnapshot result);
+            EndStep result(ItemStackLike result);
 
             /**
-             * Sets the result and returns this builder. The result is the
-             * {@link ItemStack} created when the recipe is fulfilled.
-             *
-             * @param result The result
-             *
-             * @return This builder, for chaining
+             * @deprecated Use {@link #result(Function, ItemStackLike)} instead.
              */
-            EndStep result(ItemStack result);
+            @Deprecated(forRemoval = true)
+            default EndStep result(Function<RecipeInput.Crafting, ItemStack> resultFunction, ItemStack exemplaryResult) {
+                return this.result(resultFunction, (ItemStackLike) exemplaryResult);
+            }
 
             /**
              * Sets the result function and an exemplary result.
@@ -129,7 +144,7 @@ public interface ShapelessCraftingRecipe extends CraftingRecipe {
              *
              * @return This builder, for chaining
              */
-            EndStep result(Function<RecipeInput.Crafting, ItemStack> resultFunction, ItemStack exemplaryResult);
+            EndStep result(Function<RecipeInput.Crafting, ? extends ItemStackLike> resultFunction, ItemStackLike exemplaryResult);
 
         }
 

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/SpecialCraftingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/SpecialCraftingRecipe.java
@@ -27,6 +27,7 @@ package org.spongepowered.api.item.recipe.crafting;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.datapack.DataPack;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.recipe.RecipeRegistration;
 import org.spongepowered.api.util.ResourceKeyedBuilder;
 import org.spongepowered.api.world.server.ServerWorld;
@@ -74,7 +75,7 @@ public interface SpecialCraftingRecipe extends CraftingRecipe {
              *
              * @return This builder, for chaining
              */
-            ResultStep remainingItems(Function<RecipeInput.Crafting, List<ItemStack>> remainingItemsFunction);
+            ResultStep remainingItems(Function<RecipeInput.Crafting, ? extends List<? extends ItemStackLike>> remainingItemsFunction);
 
             /**
              * Sets the result function.
@@ -83,7 +84,15 @@ public interface SpecialCraftingRecipe extends CraftingRecipe {
              *
              * @return This builder, for chaining
              */
-            EndStep result(Function<RecipeInput.Crafting, ItemStack> resultFunction);
+            EndStep result(Function<RecipeInput.Crafting, ? extends ItemStackLike> resultFunction);
+
+            /**
+             * @deprecated Use {@link #result(ItemStackLike)} instead;
+             */
+            @Deprecated(forRemoval = true)
+            default EndStep result(ItemStack result) {
+                return this.result((ItemStackLike) result);
+            }
 
             /**
              * Sets the result
@@ -92,7 +101,7 @@ public interface SpecialCraftingRecipe extends CraftingRecipe {
              *
              * @return This builder, for chaining
              */
-            EndStep result(ItemStack result);
+            EndStep result(ItemStackLike result);
         }
 
         interface EndStep extends Builder, org.spongepowered.api.util.Builder<RecipeRegistration, Builder> {

--- a/src/main/java/org/spongepowered/api/item/recipe/single/StoneCutterRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/single/StoneCutterRecipe.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.datapack.DataPack;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.Recipe;
 import org.spongepowered.api.item.recipe.RecipeRegistration;
@@ -90,35 +91,49 @@ public interface StoneCutterRecipe extends Recipe<RecipeInput.Single> {
         interface ResultStep extends StoneCutterRecipe.Builder {
 
             /**
+             * @deprecated Use {@link #result(ItemStackLike)} instead.
+             */
+            @Deprecated(forRemoval = true)
+            default EndStep result(ItemStackSnapshot result) {
+                return this.result((ItemStackLike) result);
+            }
+
+            /**
+             * @deprecated Use {@link #result(ItemStackLike)} instead.
+             */
+            @Deprecated(forRemoval = true)
+            default EndStep result(ItemStack result) {
+                return this.result((ItemStackLike) result);
+            }
+
+            /**
              * Changes the result and returns this builder. The result is the
-             * {@link ItemStack} created when the recipe is fulfilled.
+             * {@link ItemStackLike} created when the recipe is fulfilled.
              *
              * @param result The output of this recipe
              *
              * @return This builder, for chaining
              */
-            EndStep result(ItemStackSnapshot result);
+            EndStep result(ItemStackLike result);
 
             /**
-             * Changes the result and returns this builder. The result is the
-             * {@link ItemStack} created when the recipe is fulfilled.
-             *
-             * @param result The output of this recipe
-             *
-             * @return This builder, for chaining
+             * @deprecated Use {@link #result(Function, ItemStackLike)} instead.
              */
-            EndStep result(ItemStack result);
+            @Deprecated(forRemoval = true)
+            default EndStep result(Function<RecipeInput.Single, ItemStack> resultFunction, ItemStack exemplaryResult) {
+                return this.result(resultFunction, (ItemStackLike) exemplaryResult);
+            }
 
             /**
              * Changes the result and returns this builder. The result is the
-             * {@link ItemStack} created when the recipe is fulfilled.
+             * {@link ItemStackLike} created when the recipe is fulfilled.
              *
              * @param resultFunction The result function
              * @param exemplaryResult The exemplary output of this recipe
              *
              * @return This builder, for chaining
              */
-            EndStep result(Function<RecipeInput.Single, ItemStack> resultFunction, ItemStack exemplaryResult);
+            EndStep result(Function<RecipeInput.Single, ? extends ItemStackLike> resultFunction, ItemStackLike exemplaryResult);
 
         }
 

--- a/src/main/java/org/spongepowered/api/item/recipe/smithing/SmithingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/smithing/SmithingRecipe.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.datapack.DataPack;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.Recipe;
 import org.spongepowered.api.item.recipe.RecipeRegistration;
@@ -155,35 +156,49 @@ public interface SmithingRecipe extends Recipe<RecipeInput.Smithing> {
         interface ResultStep extends SmithingRecipe.Builder {
 
             /**
+             * @deprecated Use {@link #result(ItemStackLike)} instead.
+             */
+            @Deprecated(forRemoval = true)
+            default EndStep result(ItemStackSnapshot result) {
+                return this.result((ItemStackLike) result);
+            }
+
+            /**
+             * @deprecated Use {@link #result(ItemStackLike)} instead.
+             */
+            @Deprecated(forRemoval = true)
+            default EndStep result(ItemStack result) {
+                return this.result((ItemStackLike) result);
+            }
+
+            /**
              * Changes the result and returns this builder. The result is the
-             * {@link ItemStack} created when the recipe is fulfilled.
+             * {@link ItemStackLike} created when the recipe is fulfilled.
              *
              * @param result The output of this recipe
              *
              * @return This builder, for chaining
              */
-            EndStep result(ItemStackSnapshot result);
+            EndStep result(ItemStackLike result);
 
             /**
-             * Changes the result and returns this builder. The result is the
-             * {@link ItemStack} created when the recipe is fulfilled.
-             *
-             * @param result The output of this recipe
-             *
-             * @return This builder, for chaining
+             * @deprecated Use {@link #result(Function, ItemStackLike)} instead.
              */
-            EndStep result(ItemStack result);
+            @Deprecated(forRemoval = true)
+            default EndStep result(Function<RecipeInput.Smithing, ItemStack> resultFunction, ItemStack exemplaryResult) {
+                return this.result(resultFunction, (ItemStackLike) exemplaryResult);
+            }
 
             /**
              * Changes the result and returns this builder. The result is the
-             * {@link ItemStack} created when the recipe is fulfilled.
+             * {@link ItemStackLike} created when the recipe is fulfilled.
              *
              * @param resultFunction The result function
              * @param exemplaryResult The exemplary output of this recipe
              *
              * @return This builder, for chaining
              */
-            EndStep result(Function<RecipeInput.Smithing, ItemStack> resultFunction, ItemStack exemplaryResult);
+            EndStep result(Function<RecipeInput.Smithing, ? extends ItemStackLike> resultFunction, ItemStackLike exemplaryResult);
 
         }
 


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/4130)

Completely QOL PR.
I was doing some item stuff and realized I need a lot of copy-pasted methods for `ItemStack` and `ItemStackSnapshot`.
Then I realized they are in fact the same object with the only difference is mutability, so why not abstract it?

Also made `ItemStack#maxStackQuantity()` defaulted in `ItemStackLike` ([this PR](https://github.com/SpongePowered/Sponge/pull/4121) allowed it).

Breaking changes:
- Removed `ItemStack#createSnapshot()` and `ItemStackSnapshot#createStack()`
- Added `ItemStackLike#asMutable()`, `#asMutableCopy()` and `#asImmutable()`

These breaking changes are not vital for this PR so if they are not okay, I can revert them. But they feel natural to work with `ItemStackLike` (and imo new methods just look better).

Possible usage in API (I guess this makes sense only if breaking changes are accepted):
There are a lot of places where methods accept only `ItemStack` or only `ItemStackSnapshot` while there is no real difference for dev in what to pass (because `ItemStack`s are copied anyway). So they can be easily changed to accept `ItemStackLike` 