### PR TITLE
Move deprecated ItemStackLike related methods to Common

### DIFF
--- a/src/main/java/org/spongepowered/api/advancement/DisplayInfo.java
+++ b/src/main/java/org/spongepowered/api/advancement/DisplayInfo.java
@@ -165,22 +165,6 @@ public interface DisplayInfo {
         }
 
         /**
-         * @deprecated Use {@link #icon(ItemStackLike)} instead.
-         */
-        @Deprecated(forRemoval = true)
-        default Builder icon(ItemStack itemStack) {
-            return this.icon((ItemStackLike) itemStack);
-        }
-
-        /**
-         * @deprecated Use {@link #icon(ItemStackLike)} instead.
-         */
-        @Deprecated(forRemoval = true)
-        default Builder icon(ItemStackSnapshot itemStackSnapshot) {
-            return this.icon((ItemStackLike) itemStackSnapshot);
-        }
-
-        /**
          * Sets the icon of the advancement with the
          * specified {@link ItemStackLike}.
          *

--- a/src/main/java/org/spongepowered/api/block/entity/Jukebox.java
+++ b/src/main/java/org/spongepowered/api/block/entity/Jukebox.java
@@ -26,7 +26,6 @@ package org.spongepowered.api.block.entity;
 
 import org.spongepowered.api.data.Keys;
 import org.spongepowered.api.data.value.Value;
-import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 
@@ -59,14 +58,6 @@ public interface Jukebox extends BlockEntity {
      * Ejects the music disc item in this Jukebox into the world.
      */
     void eject();
-
-    /**
-     * @deprecated Use {@link #insert(ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default void insert(ItemStack disc) {
-        this.insert((ItemStackLike) disc);
-    }
 
     /**
      * Ejects the current music disc item in this Jukebox and inserts the given one.

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageModifier.java
@@ -163,22 +163,6 @@ public interface DamageModifier {
             return this;
         }
 
-        /**
-         * @deprecated Use {@link #item(ItemStackLike)} instead.
-         */
-        @Deprecated(forRemoval = true)
-        public Builder item(final ItemStack itemStack) {
-            return this.item((ItemStackLike) itemStack);
-        }
-
-        /**
-         * @deprecated Use {@link #item(ItemStackLike)} instead.
-         */
-        @Deprecated(forRemoval = true)
-        public Builder item(final ItemStackSnapshot snapshot) {
-            return this.item((ItemStackLike) snapshot);
-        }
-
         public Builder item(final ItemStackLike item) {
             this.snapshot = java.util.Objects.requireNonNull(item, "item").asImmutable();
             return this;

--- a/src/main/java/org/spongepowered/api/item/enchantment/EnchantmentType.java
+++ b/src/main/java/org/spongepowered/api/item/enchantment/EnchantmentType.java
@@ -26,7 +26,6 @@ package org.spongepowered.api.item.enchantment;
 
 import net.kyori.adventure.text.ComponentLike;
 import org.spongepowered.api.block.entity.EnchantmentTable;
-import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.registry.DefaultedRegistryValue;
 import org.spongepowered.api.tag.EnchantmenTypeTags;
@@ -83,28 +82,12 @@ public interface EnchantmentType extends DefaultedRegistryValue, ComponentLike, 
     int maximumEnchantabilityForLevel(int level);
 
     /**
-     * @deprecated Use {@link #canBeAppliedToStack(ItemStackLike)} instead,
-     */
-    @Deprecated(forRemoval = true)
-    default boolean canBeAppliedToStack(ItemStack stack) {
-        return this.canBeAppliedToStack((ItemStackLike) stack);
-    }
-
-    /**
      * Test if this enchantment type can be applied to an {@link ItemStackLike}.
      *
      * @param stack The item stack to check
      * @return Whether this enchantment type can be applied
      */
     boolean canBeAppliedToStack(ItemStackLike stack);
-
-    /**
-     * @deprecated Use {@link #canBeAppliedToStack(ItemStackLike)} instead,
-     */
-    @Deprecated(forRemoval = true)
-    default boolean canBeAppliedByTable(ItemStack stack) {
-        return this.canBeAppliedByTable((ItemStackLike) stack);
-    }
 
     /**
      * Test if this enchantment type can be applied to an {@link ItemStackLike} by

--- a/src/main/java/org/spongepowered/api/item/inventory/ArmorEquipable.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/ArmorEquipable.java
@@ -47,14 +47,6 @@ public interface ArmorEquipable extends Equipable {
     ItemStack head();
 
     /**
-     * @deprecated Use {@link #setHead(ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default void setHead(ItemStack head) {
-        this.setHead((ItemStackLike) head);
-    }
-
-    /**
      * Sets the head.
      *
      * @param head The head
@@ -67,14 +59,6 @@ public interface ArmorEquipable extends Equipable {
      * @return The chest, if available
      */
     ItemStack chest();
-
-    /**
-     * @deprecated Use {@link #setChest(ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default void setChest(ItemStack chest) {
-        this.setChest((ItemStackLike) chest);
-    }
 
     /**
      * Sets the chest.
@@ -91,14 +75,6 @@ public interface ArmorEquipable extends Equipable {
     ItemStack legs();
 
     /**
-     * @deprecated Use {@link #setLegs(ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default void setLegs(ItemStack legs) {
-        this.setLegs((ItemStackLike) legs);
-    }
-
-    /**
      * Sets the legs.
      *
      * @param legs The legs
@@ -111,14 +87,6 @@ public interface ArmorEquipable extends Equipable {
      * @return The feet, if available
      */
     ItemStack feet();
-
-    /**
-     * @deprecated Use {@link #setFeet(ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default void setFeet(ItemStack feet) {
-        this.setFeet((ItemStackLike) feet);
-    }
 
     /**
      * Sets the feet.
@@ -146,14 +114,6 @@ public interface ArmorEquipable extends Equipable {
     ItemStack itemInHand(HandType handType);
 
     /**
-     * @deprecated Use {@link #setItemInHand(Supplier, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default void setItemInHand(Supplier<? extends HandType> handType, ItemStack itemInHand) {
-        this.setItemInHand(handType, (ItemStackLike) itemInHand);
-    }
-
-    /**
      * Sets the equipped item in hand.
      *
      * @param handType The hand type to set to
@@ -161,14 +121,6 @@ public interface ArmorEquipable extends Equipable {
      */
     default void setItemInHand(Supplier<? extends HandType> handType, ItemStackLike itemInHand) {
         this.setItemInHand(handType.get(), itemInHand);
-    }
-
-    /**
-     * @deprecated Use {@link #setItemInHand(HandType, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default void setItemInHand(HandType handType, ItemStack itemInHand) {
-        this.setItemInHand(handType, (ItemStackLike) itemInHand);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/item/inventory/Container.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Container.java
@@ -60,14 +60,6 @@ public interface Container extends Inventory {
     List<Inventory> viewed();
 
     /**
-     * @deprecated Use {@link #setCursor(ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default boolean setCursor(ItemStack item) {
-        return this.setCursor((ItemStackLike) item);
-    }
-
-    /**
      * Sets the viewing players cursor item.
      * <p>Returns false when the container is no longer open.</p>
      *

--- a/src/main/java/org/spongepowered/api/item/inventory/Equipable.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Equipable.java
@@ -57,14 +57,6 @@ public interface Equipable {
     }
 
     /**
-     * @deprecated Use {@link #canEquip(EquipmentType, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default boolean canEquip(EquipmentType type, ItemStack equipment) {
-        return this.canEquip(type, (ItemStackLike) equipment);
-    }
-
-    /**
      * Gets whether this {@link Equipable} can equip the supplied equipment in its slot of
      * the specified type (eg. whether calling {@link #equip} with the specified
      * slot type and item will succeed)
@@ -74,14 +66,6 @@ public interface Equipable {
      * @return true if can equip the supplied equipment
      */
     boolean canEquip(EquipmentType type, ItemStackLike equipment);
-
-    /**
-     * @deprecated Use {@link #canEquip(Supplier, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default boolean canEquip(final Supplier<? extends EquipmentType> type, final ItemStack equipment) {
-        return this.canEquip(type, (ItemStackLike) equipment);
-    }
 
     default boolean canEquip(final Supplier<? extends EquipmentType> type, final ItemStackLike equipment) {
         return this.canEquip(type.get(), equipment);
@@ -101,14 +85,6 @@ public interface Equipable {
     }
 
     /**
-     * @deprecated Use {@link #equip(EquipmentType, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default boolean equip(EquipmentType type, ItemStack equipment) {
-        return this.equip(type, (ItemStackLike) equipment);
-    }
-
-    /**
      * Sets the item currently equipped by the {@link Equipable} in the specified slot, if
      * the equipable has such a slot.
      *
@@ -120,14 +96,6 @@ public interface Equipable {
      *     the specified slot.
      */
     boolean equip(EquipmentType type, ItemStackLike equipment);
-
-    /**
-     * @deprecated Use {@link #equip(Supplier, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default boolean equip(final Supplier<? extends EquipmentType> type, final ItemStack equipment) {
-        return this.equip(type, (ItemStackLike) equipment);
-    }
 
     default boolean equip(final Supplier<? extends EquipmentType> type, final ItemStackLike equipment) {
         return this.equip(type.get(), equipment);

--- a/src/main/java/org/spongepowered/api/item/inventory/Inventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Inventory.java
@@ -143,14 +143,6 @@ public interface Inventory extends ValueContainer {
     ItemStack peek();
 
     /**
-     * @deprecated Use {@link #offer(ItemStackLike...)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default InventoryTransactionResult offer(ItemStack... stacks) {
-        return this.offer((ItemStackLike[]) stacks);
-    }
-
-    /**
      * Adds one or more ItemStacks to this inventory.
      *
      * @param stacks The stacks to add to this inventory.
@@ -159,14 +151,6 @@ public interface Inventory extends ValueContainer {
      *           FAILURE when at least one stack was not or only partially added to the inventory.
      */
     InventoryTransactionResult offer(ItemStackLike... stacks);
-
-    /**
-     * @deprecated Use {@link #canFit(ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default boolean canFit(ItemStack stack) {
-        return this.canFit((ItemStackLike) stack);
-    }
 
     /**
      * Returns true if the entire stack can fit in this inventory.
@@ -215,14 +199,6 @@ public interface Inventory extends ValueContainer {
     Optional<ItemStack> peekAt(int index);
 
     /**
-     * @deprecated Use {@link #offer(int, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default InventoryTransactionResult offer(int index, ItemStack stack) {
-        return this.offer(index, (ItemStackLike) stack);
-    }
-
-    /**
      * Adds an ItemStack to the slot at given index.
      * Returns a {@link InventoryTransactionResult.Type#SUCCESS} only if the entire {@link ItemStackLike} fits the slot.
      *
@@ -233,14 +209,6 @@ public interface Inventory extends ValueContainer {
      *           FAILURE when the stack was not or only partially added to the inventory.
      */
     InventoryTransactionResult offer(int index, ItemStackLike stack);
-
-    /**
-     * @deprecated Use {@link #set(int, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default InventoryTransactionResult set(int index, ItemStack stack) {
-        return this.set(index, (ItemStackLike) stack);
-    }
 
     /**
      * Adds the ItemStack to the slot at given index overwriting the existing item.
@@ -293,14 +261,6 @@ public interface Inventory extends ValueContainer {
     int capacity();
 
     /**
-     * @deprecated Use {@link #contains(ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default boolean contains(ItemStack stack) {
-        return this.contains((ItemStackLike) stack);
-    }
-
-    /**
      * Checks whether the stacks quantity or more of given stack is contained in this Inventory.
      * To check if an inventory contains any amount use {@link #containsAny(ItemStackLike)}.
      *
@@ -318,14 +278,6 @@ public interface Inventory extends ValueContainer {
      * @return True if at least one stack in this list has the given type
      */
     boolean contains(ItemType type);
-
-    /**
-     * @deprecated Use {@link #containsAny(ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default boolean containsAny(ItemStack stack) {
-        return this.containsAny((ItemStackLike) stack);
-    }
 
     /**
      * Checks whether the given stack is contained in this Inventory.

--- a/src/main/java/org/spongepowered/api/item/inventory/Slot.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/Slot.java
@@ -39,14 +39,6 @@ public interface Slot extends Inventory {
     Slot viewedSlot();
 
     /**
-     * @deprecated Use {@link #set(ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default InventoryTransactionResult set(ItemStack stack) {
-        return this.set((ItemStackLike) stack);
-    }
-
-    /**
      * Adds the ItemStack to this slot overwriting the existing item.
      *
      * <p>Stacks bigger than the max stack size will be partially rejected.</p>

--- a/src/main/java/org/spongepowered/api/item/inventory/equipment/EquipmentInventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/equipment/EquipmentInventory.java
@@ -90,14 +90,6 @@ public interface EquipmentInventory extends Inventory {
     }
 
     /**
-     * @deprecated Use {@link #set(EquipmentType, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default InventoryTransactionResult set(EquipmentType equipmentType, ItemStack stack) {
-        return this.set(equipmentType, (ItemStackLike) stack);
-    }
-
-    /**
      * Sets the item for the specified equipment type.
      *
      * @see Slot#set(ItemStackLike)
@@ -106,14 +98,6 @@ public interface EquipmentInventory extends Inventory {
      * @return operation result, for details see {@link Inventory#set}
      */
     InventoryTransactionResult set(EquipmentType equipmentType, ItemStackLike stack);
-
-    /**
-     * @deprecated Use {@link #set(Supplier, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default InventoryTransactionResult set(final Supplier<? extends EquipmentType> equipmentType, final ItemStack stack) {
-        return this.set(equipmentType, (ItemStackLike) stack);
-    }
 
     default InventoryTransactionResult set(final Supplier<? extends EquipmentType> equipmentType, final ItemStackLike stack) {
         return this.set(equipmentType.get(), stack);

--- a/src/main/java/org/spongepowered/api/item/inventory/slot/FilteringSlot.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/slot/FilteringSlot.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.item.inventory.slot;
 
 import org.spongepowered.api.item.ItemType;
-import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.Slot;
 
@@ -33,14 +32,6 @@ import org.spongepowered.api.item.inventory.Slot;
  * An inventory slot which can only accept certain types of item.
  */
 public interface FilteringSlot extends Slot {
-
-    /**
-     * @deprecated Use {@link #isValidItem(ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default boolean isValidItem(ItemStack stack) {
-        return this.isValidItem((ItemStackLike) stack);
-    }
 
     /**
      * Check whether the supplied item can be inserted into this slot. Returning

--- a/src/main/java/org/spongepowered/api/item/inventory/slot/SidedSlot.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/slot/SidedSlot.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.item.inventory.slot;
 
 import org.spongepowered.api.item.inventory.Inventory;
-import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.Slot;
 import org.spongepowered.api.util.Direction;
@@ -34,14 +33,6 @@ import org.spongepowered.api.util.Direction;
  * A slot which belongs to a particular side of a "sided" inventory.
  */
 public interface SidedSlot extends Slot {
-
-    /**
-     * @deprecated Use {@link #canAccept(ItemStackLike, Direction)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default boolean canAccept(ItemStack stack, Direction from) {
-        return this.canAccept((ItemStackLike) stack, from);
-    }
 
     /**
      * Gets whether this slot can accept the specified item from the specified
@@ -55,14 +46,6 @@ public interface SidedSlot extends Slot {
     boolean canAccept(ItemStackLike stack, Direction from);
 
     /**
-     * @deprecated Use {@link #offer(ItemStackLike, Direction)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default boolean offer(ItemStack stack, Direction from) {
-        return this.offer((ItemStackLike) stack, from);
-    }
-
-    /**
      * Attempts to insert the supplied stack into this inventory from the
      * specified direction.
      *
@@ -73,14 +56,6 @@ public interface SidedSlot extends Slot {
      *      specified direction
      */
     boolean offer(ItemStackLike stack, Direction from);
-
-    /**
-     * @deprecated Use {@link #canGet(ItemStackLike, Direction)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default boolean canGet(ItemStack stack, Direction from) {
-        return this.canGet((ItemStackLike) stack, from);
-    }
 
     /**
      * Gets whether automation can extract the specified item from the specified

--- a/src/main/java/org/spongepowered/api/item/inventory/transaction/InventoryTransactionResult.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/transaction/InventoryTransactionResult.java
@@ -180,14 +180,6 @@ public interface InventoryTransactionResult {
         Builder type(final Type type);
 
         /**
-         * @deprecated Use {@link #reject(ItemStackLike...)} instead.
-         */
-        @Deprecated(forRemoval = true)
-        default Builder reject(ItemStack... itemStacks) {
-            return this.reject((ItemStackLike[]) itemStacks);
-        }
-
-        /**
          * Adds the provided {@link ItemStackLike itemstacks} as stacks that have been
          * "rejected".
          *
@@ -204,14 +196,6 @@ public interface InventoryTransactionResult {
          * @return This builder, for chaining
          */
         Builder reject(Iterable<? extends ItemStackLike> itemStacks);
-
-        /**
-         * @deprecated Use {@link #poll(ItemStackLike)} instead.
-         */
-        @Deprecated(forRemoval = true)
-        default Builder.PollBuilder poll(ItemStackSnapshot itemStack) {
-            return this.poll((ItemStackLike) itemStack);
-        }
 
         /**
          * Sets the provided {@link ItemStackLike} as the stack that has been polled from the inventory.

--- a/src/main/java/org/spongepowered/api/item/inventory/transaction/SlotTransaction.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/transaction/SlotTransaction.java
@@ -25,7 +25,6 @@
 package org.spongepowered.api.item.inventory.transaction;
 
 import org.spongepowered.api.data.Transaction;
-import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.Slot;
@@ -49,14 +48,6 @@ public class SlotTransaction extends Transaction<ItemStackSnapshot> {
     public SlotTransaction(Slot slot, ItemStackSnapshot original, ItemStackSnapshot defaultReplacement) {
         super(original, defaultReplacement);
         this.slot = Objects.requireNonNull(slot, "Slot cannot be null!");
-    }
-
-    /**
-     * @deprecated Use {@link #setCustom(ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    public void setCustom(ItemStack stack) {
-        this.setCustom((ItemStackLike) stack);
     }
 
     /**

--- a/src/main/java/org/spongepowered/api/item/inventory/type/GridInventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/type/GridInventory.java
@@ -97,14 +97,6 @@ public interface GridInventory extends Inventory2D {
     Optional<ItemStack> peek(int x, int y);
 
     /**
-     * @deprecated Use {@link #set(int, int, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default InventoryTransactionResult set(int x, int y, ItemStack stack) {
-        return this.set(x, y, (ItemStackLike) stack);
-    }
-
-    /**
      * Sets the item in the specified slot.
      *
      * @see Slot#set(ItemStackLike)

--- a/src/main/java/org/spongepowered/api/item/inventory/type/Inventory2D.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/type/Inventory2D.java
@@ -75,14 +75,6 @@ public interface Inventory2D extends Inventory {
     }
 
     /**
-     * @deprecated Use {@link #set(Vector2i, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default InventoryTransactionResult set(Vector2i pos, ItemStack stack) {
-        return this.set(pos, (ItemStackLike) stack);
-    }
-
-    /**
      * Sets the item in the specified slot.
      *
      * @see Slot#set(ItemStackLike)

--- a/src/main/java/org/spongepowered/api/item/inventory/type/ViewableInventory.java
+++ b/src/main/java/org/spongepowered/api/item/inventory/type/ViewableInventory.java
@@ -33,7 +33,6 @@ import org.spongepowered.api.item.inventory.Carrier;
 import org.spongepowered.api.item.inventory.ContainerType;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStackLike;
-import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.Slot;
 import org.spongepowered.api.item.inventory.menu.InventoryMenu;
 import org.spongepowered.math.vector.Vector2i;
@@ -247,14 +246,6 @@ public interface ViewableInventory extends Inventory {
         }
 
         interface DummyStep extends BuildingStep {
-
-            /**
-             * @deprecated Use {@link #item(ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default BuildingStep item(ItemStackSnapshot item) {
-                return this.item((ItemStackLike) item);
-            }
 
             /**
              * Sets the default item for the dummy-slots.

--- a/src/main/java/org/spongepowered/api/item/merchant/TradeOffer.java
+++ b/src/main/java/org/spongepowered/api/item/merchant/TradeOffer.java
@@ -28,7 +28,6 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.data.persistence.DataSerializable;
 import org.spongepowered.api.entity.living.Humanoid;
-import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.util.CopyableBuilder;
@@ -166,14 +165,6 @@ public interface TradeOffer extends DataSerializable {
     interface Builder extends org.spongepowered.api.util.Builder<TradeOffer, Builder>, CopyableBuilder<TradeOffer, Builder>, DataBuilder<TradeOffer> {
 
         /**
-         * @deprecated Use {@link #firstBuyingItem(ItemStackLike)} instead.
-         */
-        @Deprecated(forRemoval = true)
-        default Builder firstBuyingItem(ItemStack item) {
-            return this.firstBuyingItem((ItemStackLike) item);
-        }
-
-        /**
          * <p>Sets the first selling item of the trade offer to be
          * generated.</p>
          *
@@ -185,28 +176,12 @@ public interface TradeOffer extends DataSerializable {
         Builder firstBuyingItem(ItemStackLike item);
 
         /**
-         * @deprecated Use {@link #secondBuyingItem(ItemStackLike)} instead.
-         */
-        @Deprecated(forRemoval = true)
-        default Builder secondBuyingItem(ItemStack item) {
-            return this.secondBuyingItem((ItemStackLike) item);
-        }
-
-        /**
          * Sets the second selling item of the trade offer to be generated.
          *
          * @param item The second item to buy
          * @return This builder
          */
         Builder secondBuyingItem(ItemStackLike item);
-
-        /**
-         * @deprecated Use {@link #sellingItem(ItemStackLike)} instead.
-         */
-        @Deprecated(forRemoval = true)
-        default Builder sellingItem(ItemStack item) {
-            return this.sellingItem((ItemStackLike) item);
-        }
 
         /**
          * Sets the selling item of the trade offer to be generated.

--- a/src/main/java/org/spongepowered/api/item/recipe/RecipeManager.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/RecipeManager.java
@@ -26,7 +26,6 @@ package org.spongepowered.api.item.recipe;
 
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.item.inventory.ItemStackLike;
-import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.cooking.CookingRecipe;
 import org.spongepowered.api.item.recipe.crafting.RecipeInput;
 import org.spongepowered.api.world.server.ServerWorld;
@@ -78,14 +77,6 @@ public interface RecipeManager {
     }
 
     /**
-     * @deprecated Use {@link #findByResult(RecipeType, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default <T extends Recipe<?>> Collection<T> findByResult(RecipeType<T> type, ItemStackSnapshot result) {
-        return this.findByResult(type, (ItemStackLike) result);
-    }
-
-    /**
      * Returns all registered recipes of given type and with given item as a result.
      *
      * @param type The recipe type
@@ -94,14 +85,6 @@ public interface RecipeManager {
      * @return The recipes resulting in given item.
      */
     <T extends Recipe<?>> Collection<T> findByResult(RecipeType<T> type, ItemStackLike result);
-
-    /**
-     * @deprecated Use {@link #findByResult(Supplier, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default <T extends Recipe<?>> Collection<T> findByResult(Supplier<? extends RecipeType<T>> supplier, ItemStackSnapshot result) {
-        return this.findByResult(supplier, (ItemStackLike) result);
-    }
 
     /**
      * Gets all recipes with given item as a result.
@@ -139,14 +122,6 @@ public interface RecipeManager {
     }
 
     /**
-     * @deprecated Use {@link #findCookingRecipe(RecipeType, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default <T extends CookingRecipe> Optional<T> findCookingRecipe(RecipeType<T> type, ItemStackSnapshot ingredient) {
-        return this.findCookingRecipe(type, (ItemStackLike) ingredient);
-    }
-
-    /**
      * Finds a matching cooking recipe for given type and ingredient
      *
      * @param type The recipe type
@@ -155,14 +130,6 @@ public interface RecipeManager {
      * @return The matching recipe.
      */
     <T extends CookingRecipe> Optional<T> findCookingRecipe(RecipeType<T> type, ItemStackLike ingredient);
-
-    /**
-     * @deprecated Use {@link #findCookingRecipe(Supplier, ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default <T extends CookingRecipe> Optional<T> findCookingRecipe(Supplier<? extends RecipeType<T>> supplier, ItemStackSnapshot ingredient) {
-        return this.findCookingRecipe(supplier, (ItemStackLike) ingredient);
-    }
 
     /**
      * Finds a matching cooking recipe for given type and ingredient

--- a/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/cooking/CookingRecipe.java
@@ -28,9 +28,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.datapack.DataPack;
 import org.spongepowered.api.item.ItemType;
-import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackLike;
-import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.Recipe;
 import org.spongepowered.api.item.recipe.RecipeRegistration;
 import org.spongepowered.api.item.recipe.RecipeType;
@@ -65,14 +63,6 @@ public interface CookingRecipe extends Recipe<RecipeInput.Single> {
     Ingredient ingredient();
 
     /**
-     * @deprecated Use {@link #isValid(ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default boolean isValid(ItemStackSnapshot ingredient) {
-        return this.isValid((ItemStackLike) ingredient);
-    }
-
-    /**
      * Checks if the given {@link ItemStackLike} fits the required
      * constraints to craft this {@link CookingRecipe}.
      *
@@ -81,14 +71,6 @@ public interface CookingRecipe extends Recipe<RecipeInput.Single> {
      * @return Whether this ingredient can be used to craft the result
      */
     boolean isValid(ItemStackLike ingredient);
-
-    /**
-     * @deprecated Use {@link #result(ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default Optional<CookingResult> result(ItemStackSnapshot ingredient) {
-        return this.result((ItemStackLike) ingredient);
-    }
 
     /**
      * <p>Returns the {@link CookingResult} containing the resulting
@@ -200,22 +182,6 @@ public interface CookingRecipe extends Recipe<RecipeInput.Single> {
             }
 
             /**
-             * @deprecated Use {@link #result(ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(ItemStack result) {
-                return this.result((ItemStackLike) result);
-            }
-
-            /**
-             * @deprecated Use {@link #result(ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(ItemStackSnapshot result) {
-                return this.result((ItemStackLike) result);
-            }
-
-            /**
              * Changes the result and returns this builder. The result is the
              * {@link ItemStackLike} created when the recipe is fulfilled.
              *
@@ -224,14 +190,6 @@ public interface CookingRecipe extends Recipe<RecipeInput.Single> {
              * @return This builder, for chaining
              */
             EndStep result(ItemStackLike result);
-
-            /**
-             * @deprecated Use {@link #result(Function, ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(final Function<RecipeInput.Single, ItemStack> resultFunction, final ItemStack exemplaryResult) {
-                return this.result(resultFunction, (ItemStackLike) exemplaryResult);
-            }
 
             /**
              * Sets the result function and an exemplary result.

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/Ingredient.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/Ingredient.java
@@ -54,15 +54,6 @@ public interface Ingredient extends Predicate<ItemStack> {
         return Sponge.game().factoryProvider().provide(Factory.class).empty();
     }
 
-    /**
-     * @deprecated Use {@link #test(ItemStackLike)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    @Override
-    default boolean test(ItemStack itemStack) {
-        return this.test((ItemStackLike) itemStack);
-    }
-
     boolean test(ItemStackLike item);
 
     /**
@@ -198,28 +189,12 @@ public interface Ingredient extends Predicate<ItemStack> {
         Builder with(Supplier<? extends ItemType>... types);
 
         /**
-         * @deprecated Use {@link #with(ItemStackLike...)} instead
-         */
-        @Deprecated(forRemoval = true)
-        default Builder with(ItemStack... types) {
-            return this.with((ItemStackLike[]) types);
-        }
-
-        /**
          * Sets one or more ItemStackLike for matching the ingredient.
          *
          * @param types The items
          * @return This Builder, for chaining
          */
         Builder with(ItemStackLike... types);
-
-        /**
-         * @deprecated Use {@link #with(ResourceKey, Predicate, ItemStackLike...)} instead.
-         */
-        @Deprecated(forRemoval = true)
-        default Builder with(ResourceKey resourceKey, Predicate<ItemStack> predicate, ItemStack... exemplaryTypes) {
-            return this.with(resourceKey, itemStack -> predicate.test(itemStack.asMutable()), (ItemStackLike[]) exemplaryTypes);
-        }
 
         /**
          * Sets a Predicate for matching the ingredient.
@@ -231,14 +206,6 @@ public interface Ingredient extends Predicate<ItemStack> {
          * @return This Builder, for chaining
          */
         Builder with(ResourceKey resourceKey, Predicate<? super ItemStackLike> predicate, ItemStackLike... exemplaryTypes);
-
-        /**
-         * @deprecated Use {@link #with(ItemStackLike...)} instead
-         */
-        @Deprecated(forRemoval = true)
-        default Builder with(ItemStackSnapshot... types) {
-            return this.with((ItemStackLike[]) types);
-        }
 
         /**
          * Sets the item tag for matching the ingredient.

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeInput.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/RecipeInput.java
@@ -67,14 +67,6 @@ public interface RecipeInput extends Inventory {
     interface Factory {
 
         /**
-         * @deprecated Use {@link #single(ItemStackLike)} instead.
-         */
-        @Deprecated(forRemoval = true)
-        default RecipeInput.Single single(ItemStack stack) {
-            return this.single((ItemStackLike) stack);
-        }
-
-        /**
          * Creates a recipe input for
          * {@link CookingRecipe} and
          * {@link StoneCutterRecipe}
@@ -84,14 +76,6 @@ public interface RecipeInput extends Inventory {
          * @return the recipe input
          */
         RecipeInput.Single single(ItemStackLike stack);
-
-        /**
-         * @deprecated Use {@link #smithing(ItemStackLike, ItemStackLike, ItemStackLike)} instead.
-         */
-        @Deprecated(forRemoval = true)
-        default RecipeInput.Smithing smithing(ItemStack templateStack, ItemStack baseStack, ItemStack additionStack) {
-            return this.smithing((ItemStackLike) templateStack, (ItemStackLike) baseStack, (ItemStackLike) additionStack);
-        }
 
         /**
          * Creates a recipe input for {@link SmithingRecipe}

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapedCraftingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapedCraftingRecipe.java
@@ -30,7 +30,6 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.datapack.DataPack;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackLike;
-import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.RecipeRegistration;
 import org.spongepowered.api.util.ResourceKeyedBuilder;
 
@@ -215,26 +214,8 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
              * @param remainingItemsFunction the remaining items function
              *
              * @return This builder, for chaining
-             * @deprecated Will be replaced with ItemStackLike variant
              */
-            @Deprecated
             ResultStep remainingItems(Function<RecipeInput.Crafting, ? extends List<? extends ItemStackLike>> remainingItemsFunction);
-
-            /**
-             * @deprecated Use {@link #result(ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(ItemStackSnapshot result) {
-                return this.result((ItemStackLike) result);
-            }
-
-            /**
-             * @deprecated Use {@link #result(ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(ItemStack result) {
-                return this.result((ItemStackLike) result);
-            }
 
             /**
              * Sets the resultant {@link ItemStackLike} for when this shaped
@@ -245,14 +226,6 @@ public interface ShapedCraftingRecipe extends CraftingRecipe {
              * @return The builder
              */
             EndStep result(ItemStackLike result);
-
-            /**
-             * @deprecated Use {@link #result(Function, ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(Function<RecipeInput.Crafting, ItemStack> resultFunction, ItemStack exemplaryResult) {
-                return this.result(resultFunction, (ItemStackLike) exemplaryResult);
-            }
 
             /**
              * Sets the result function and an exemplary result.

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapelessCraftingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/ShapelessCraftingRecipe.java
@@ -29,9 +29,7 @@ import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.datapack.DataPack;
 import org.spongepowered.api.item.ItemType;
-import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackLike;
-import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.RecipeRegistration;
 import org.spongepowered.api.util.ResourceKeyedBuilder;
 
@@ -102,22 +100,6 @@ public interface ShapelessCraftingRecipe extends CraftingRecipe {
             ResultStep remainingItems(Function<RecipeInput.Crafting, ? extends List<? extends ItemStackLike>> remainingItemsFunction);
 
             /**
-             * @deprecated Use {@link #result(ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(ItemStackSnapshot result) {
-                return this.result((ItemStackLike) result);
-            }
-
-            /**
-             * @deprecated Use {@link #result(ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(ItemStack result) {
-                return this.result((ItemStackLike) result);
-            }
-
-            /**
              * Sets the result and returns this builder. The result is the
              * {@link ItemStackLike} created when the recipe is fulfilled.
              *
@@ -126,14 +108,6 @@ public interface ShapelessCraftingRecipe extends CraftingRecipe {
              * @return This builder, for chaining
              */
             EndStep result(ItemStackLike result);
-
-            /**
-             * @deprecated Use {@link #result(Function, ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(Function<RecipeInput.Crafting, ItemStack> resultFunction, ItemStack exemplaryResult) {
-                return this.result(resultFunction, (ItemStackLike) exemplaryResult);
-            }
 
             /**
              * Sets the result function and an exemplary result.

--- a/src/main/java/org/spongepowered/api/item/recipe/crafting/SpecialCraftingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/crafting/SpecialCraftingRecipe.java
@@ -26,7 +26,6 @@ package org.spongepowered.api.item.recipe.crafting;
 
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.datapack.DataPack;
-import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackLike;
 import org.spongepowered.api.item.recipe.RecipeRegistration;
 import org.spongepowered.api.util.ResourceKeyedBuilder;
@@ -85,14 +84,6 @@ public interface SpecialCraftingRecipe extends CraftingRecipe {
              * @return This builder, for chaining
              */
             EndStep result(Function<RecipeInput.Crafting, ? extends ItemStackLike> resultFunction);
-
-            /**
-             * @deprecated Use {@link #result(ItemStackLike)} instead;
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(ItemStack result) {
-                return this.result((ItemStackLike) result);
-            }
 
             /**
              * Sets the result

--- a/src/main/java/org/spongepowered/api/item/recipe/single/StoneCutterRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/single/StoneCutterRecipe.java
@@ -29,9 +29,7 @@ import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.datapack.DataPack;
 import org.spongepowered.api.item.ItemType;
-import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackLike;
-import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.Recipe;
 import org.spongepowered.api.item.recipe.RecipeRegistration;
 import org.spongepowered.api.item.recipe.RecipeType;
@@ -91,22 +89,6 @@ public interface StoneCutterRecipe extends Recipe<RecipeInput.Single> {
         interface ResultStep extends StoneCutterRecipe.Builder {
 
             /**
-             * @deprecated Use {@link #result(ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(ItemStackSnapshot result) {
-                return this.result((ItemStackLike) result);
-            }
-
-            /**
-             * @deprecated Use {@link #result(ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(ItemStack result) {
-                return this.result((ItemStackLike) result);
-            }
-
-            /**
              * Changes the result and returns this builder. The result is the
              * {@link ItemStackLike} created when the recipe is fulfilled.
              *
@@ -115,14 +97,6 @@ public interface StoneCutterRecipe extends Recipe<RecipeInput.Single> {
              * @return This builder, for chaining
              */
             EndStep result(ItemStackLike result);
-
-            /**
-             * @deprecated Use {@link #result(Function, ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(Function<RecipeInput.Single, ItemStack> resultFunction, ItemStack exemplaryResult) {
-                return this.result(resultFunction, (ItemStackLike) exemplaryResult);
-            }
 
             /**
              * Changes the result and returns this builder. The result is the

--- a/src/main/java/org/spongepowered/api/item/recipe/smithing/SmithingRecipe.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/smithing/SmithingRecipe.java
@@ -29,9 +29,7 @@ import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.datapack.DataPack;
 import org.spongepowered.api.item.ItemType;
-import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackLike;
-import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.recipe.Recipe;
 import org.spongepowered.api.item.recipe.RecipeRegistration;
 import org.spongepowered.api.item.recipe.RecipeType;
@@ -156,22 +154,6 @@ public interface SmithingRecipe extends Recipe<RecipeInput.Smithing> {
         interface ResultStep extends SmithingRecipe.Builder {
 
             /**
-             * @deprecated Use {@link #result(ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(ItemStackSnapshot result) {
-                return this.result((ItemStackLike) result);
-            }
-
-            /**
-             * @deprecated Use {@link #result(ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(ItemStack result) {
-                return this.result((ItemStackLike) result);
-            }
-
-            /**
              * Changes the result and returns this builder. The result is the
              * {@link ItemStackLike} created when the recipe is fulfilled.
              *
@@ -180,14 +162,6 @@ public interface SmithingRecipe extends Recipe<RecipeInput.Smithing> {
              * @return This builder, for chaining
              */
             EndStep result(ItemStackLike result);
-
-            /**
-             * @deprecated Use {@link #result(Function, ItemStackLike)} instead.
-             */
-            @Deprecated(forRemoval = true)
-            default EndStep result(Function<RecipeInput.Smithing, ItemStack> resultFunction, ItemStack exemplaryResult) {
-                return this.result(resultFunction, (ItemStackLike) exemplaryResult);
-            }
 
             /**
              * Changes the result and returns this builder. The result is the


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/4136)

Removed most deprecated `ItemStackLike` related methods from api and added them back in mixins.
Remaining things that need to be done in API 13 (writing this to not forget):
- Remove `ItemStack#createSnapshot()` and `ItemStackSnapshot#createStack()`
- Remove deprecated static methods in `Ingredient`
- Remove deprecated constructors in `CookingResult` and `RecipeResult`
- Change `Ingredient` from `Predicate<ItemStack>` to `Predicate<ItemStackLike>`