### PR TITLE
Add key for item model

### DIFF
--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -2439,6 +2439,8 @@ public final class Keys {
 
     /**
      * Location for the model of an {@link ItemStack}
+     *
+     * @see <a href="https://minecraft.wiki/w/Data_component_format#item_model">The item_model data component</a>
      */
     public static final Key<Value<ResourceKey>> MODEL = Keys.key(ResourceKey.sponge("model"), ResourceKey.class);
 

--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -2438,9 +2438,9 @@ public final class Keys {
     public static final Key<Value<Ticks>> MIN_SPAWN_DELAY = Keys.key(ResourceKey.sponge("min_spawn_delay"), Ticks.class);
 
     /**
-     * Location for the model of an {@link ItemStack}
+     * Location of the resource pack model for an {@link ItemStack}.
      *
-     * @see <a href="https://minecraft.wiki/w/Data_component_format#item_model">The item_model data component</a>
+     * @see <a href="https://minecraft.wiki/w/Model">Model</a>
      */
     public static final Key<Value<ResourceKey>> MODEL = Keys.key(ResourceKey.sponge("model"), ResourceKey.class);
 

--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -2438,6 +2438,11 @@ public final class Keys {
     public static final Key<Value<Ticks>> MIN_SPAWN_DELAY = Keys.key(ResourceKey.sponge("min_spawn_delay"), Ticks.class);
 
     /**
+     * Location for the model of an {@link ItemStack}
+     */
+    public static final Key<Value<ResourceKey>> MODEL = Keys.key(ResourceKey.sponge("model"), ResourceKey.class);
+
+    /**
      * The moisture value of a {@link BlockTypes#FARMLAND} {@link BlockState}.
      */
     public static final Key<Value<Integer>> MOISTURE = Keys.key(ResourceKey.sponge("moisture"), Integer.class);


### PR DESCRIPTION
[SpongeAPI | [Sponge](https://github.com/SpongePowered/Sponge/pull/4147)]

In 1.21.2 Mojang added an item component for the model of an ItemStack. This provides a more straightforward way of setting the model of an item compared to custom model data.