### PR TITLE
introduce scoped registry holder using PhaseTracker

### DIFF
--- a/src/main/java/org/spongepowered/api/adventure/ChatTypes.java
+++ b/src/main/java/org/spongepowered/api/adventure/ChatTypes.java
@@ -98,6 +98,6 @@ public final class ChatTypes {
     }
 
     public static DefaultedRegistryReference<ChatType> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.CHAT_TYPE, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.CHAT_TYPE, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/command/registrar/tree/CommandTreeNodeTypes.java
+++ b/src/main/java/org/spongepowered/api/command/registrar/tree/CommandTreeNodeTypes.java
@@ -138,6 +138,6 @@ public final class CommandTreeNodeTypes {
     }
 
     private static <T extends CommandTreeNode<T>> DefaultedRegistryReference<CommandTreeNodeType<T>> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.COMMAND_TREE_NODE_TYPE, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.COMMAND_TREE_NODE_TYPE, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/data/type/ArtTypes.java
+++ b/src/main/java/org/spongepowered/api/data/type/ArtTypes.java
@@ -148,6 +148,6 @@ public final class ArtTypes {
     }
 
     private static DefaultedRegistryReference<ArtType> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.ART_TYPE, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.ART_TYPE, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/data/type/BannerPatternShapes.java
+++ b/src/main/java/org/spongepowered/api/data/type/BannerPatternShapes.java
@@ -134,6 +134,6 @@ public final class BannerPatternShapes {
     }
 
     private static DefaultedRegistryReference<BannerPatternShape> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.BANNER_PATTERN_SHAPE, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.BANNER_PATTERN_SHAPE, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/effect/sound/music/MusicDiscs.java
+++ b/src/main/java/org/spongepowered/api/effect/sound/music/MusicDiscs.java
@@ -86,6 +86,6 @@ public final class MusicDiscs {
     }
 
     private static DefaultedRegistryReference<MusicDisc> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.MUSIC_DISC, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.MUSIC_DISC, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageTypes.java
+++ b/src/main/java/org/spongepowered/api/event/cause/entity/damage/DamageTypes.java
@@ -146,6 +146,6 @@ public final class DamageTypes {
     }
 
     private static DefaultedRegistryReference<DamageType> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.DAMAGE_TYPE, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.DAMAGE_TYPE, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/item/enchantment/EnchantmentTypes.java
+++ b/src/main/java/org/spongepowered/api/item/enchantment/EnchantmentTypes.java
@@ -284,6 +284,6 @@ public final class EnchantmentTypes {
     }
 
     private static DefaultedRegistryReference<EnchantmentType> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.ENCHANTMENT_TYPE, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.ENCHANTMENT_TYPE, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/item/recipe/smithing/TrimMaterials.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/smithing/TrimMaterials.java
@@ -67,6 +67,6 @@ public final class TrimMaterials {
     }
 
     private static DefaultedRegistryReference<TrimMaterial> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.TRIM_MATERIAL, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.TRIM_MATERIAL, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/item/recipe/smithing/TrimPatterns.java
+++ b/src/main/java/org/spongepowered/api/item/recipe/smithing/TrimPatterns.java
@@ -81,6 +81,6 @@ public final class TrimPatterns {
     }
 
     private static DefaultedRegistryReference<TrimPattern> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.TRIM_PATTERN, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.TRIM_PATTERN, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/registry/RegistryKey.java
+++ b/src/main/java/org/spongepowered/api/registry/RegistryKey.java
@@ -73,6 +73,14 @@ public interface RegistryKey<T> {
      */
     <V extends T> DefaultedRegistryReference<V> asDefaultedReference(final Supplier<RegistryHolder> defaultHolder);
 
+    /**
+     * Generates a utility {@link DefaultedRegistryReference reference} used to assist in querying a value from this key.
+     * This uses the current Cause to determine the {@link RegistryHolder}
+     *
+     * @return The reference
+     */
+    <V extends T> DefaultedRegistryReference<V> asScopedReference();
+
     interface Factory {
 
         <T> RegistryKey<T> of(RegistryType<T> registry, ResourceKey location);

--- a/src/main/java/org/spongepowered/api/registry/RegistryType.java
+++ b/src/main/java/org/spongepowered/api/registry/RegistryType.java
@@ -58,6 +58,8 @@ public interface RegistryType<T> {
      */
     <V extends T> DefaultedRegistryType<V> asDefaultedType(Supplier<RegistryHolder> defaultHolder);
 
+    <V> DefaultedRegistryType<V> asScopedType();
+
     interface Factory {
 
         <T> RegistryType<T> create(final ResourceKey root, ResourceKey location);

--- a/src/main/java/org/spongepowered/api/registry/RegistryTypes.java
+++ b/src/main/java/org/spongepowered/api/registry/RegistryTypes.java
@@ -538,7 +538,7 @@ public final class RegistryTypes {
     }
 
     private static <V> DefaultedRegistryType<V> minecraftKeyInServer(final String key) {
-        return RegistryType.of(RegistryRoots.MINECRAFT, ResourceKey.minecraft(Objects.requireNonNull(key, "key"))).asDefaultedType(Sponge::server);
+        return RegistryType.of(RegistryRoots.MINECRAFT, ResourceKey.minecraft(Objects.requireNonNull(key, "key"))).asScopedType();
     }
 
     private static <V> DefaultedRegistryType<V> spongeKeyInGame(final String key) {
@@ -546,6 +546,6 @@ public final class RegistryTypes {
     }
 
     private static <V> DefaultedRegistryType<V> spongeKeyInServer(final String key) {
-        return RegistryType.of(RegistryRoots.SPONGE, ResourceKey.sponge(Objects.requireNonNull(key, "key"))).asDefaultedType(Sponge::server);
+        return RegistryType.of(RegistryRoots.SPONGE, ResourceKey.sponge(Objects.requireNonNull(key, "key"))).asScopedType();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/WorldTypes.java
+++ b/src/main/java/org/spongepowered/api/world/WorldTypes.java
@@ -56,6 +56,6 @@ public final class WorldTypes {
     }
 
     private static DefaultedRegistryReference<WorldType> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.WORLD_TYPE, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.WORLD_TYPE, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/biome/Biomes.java
+++ b/src/main/java/org/spongepowered/api/world/biome/Biomes.java
@@ -178,6 +178,6 @@ public final class Biomes {
     }
 
     private static DefaultedRegistryReference<Biome> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.BIOME, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.BIOME, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/generation/carver/Carvers.java
+++ b/src/main/java/org/spongepowered/api/world/generation/carver/Carvers.java
@@ -56,6 +56,6 @@ public final class Carvers {
     }
 
     private static DefaultedRegistryReference<Carver> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.CARVER, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.CARVER, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/generation/config/flat/FlatGeneratorConfigs.java
+++ b/src/main/java/org/spongepowered/api/world/generation/config/flat/FlatGeneratorConfigs.java
@@ -66,6 +66,6 @@ public final class FlatGeneratorConfigs {
     }
 
     private static DefaultedRegistryReference<FlatGeneratorConfig> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.FLAT_GENERATOR_CONFIG, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.FLAT_GENERATOR_CONFIG, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/generation/config/noise/DensityFunctions.java
+++ b/src/main/java/org/spongepowered/api/world/generation/config/noise/DensityFunctions.java
@@ -118,6 +118,6 @@ public final class DensityFunctions {
     }
 
     private static DefaultedRegistryReference<DensityFunction> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.DENSITY_FUNCTION, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.DENSITY_FUNCTION, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/generation/config/noise/NoiseGeneratorConfigs.java
+++ b/src/main/java/org/spongepowered/api/world/generation/config/noise/NoiseGeneratorConfigs.java
@@ -62,6 +62,6 @@ public final class NoiseGeneratorConfigs {
     }
 
     private static DefaultedRegistryReference<NoiseGeneratorConfig> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.NOISE_GENERATOR_CONFIG, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.NOISE_GENERATOR_CONFIG, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/generation/config/noise/Noises.java
+++ b/src/main/java/org/spongepowered/api/world/generation/config/noise/Noises.java
@@ -168,6 +168,6 @@ public final class Noises {
     }
 
     private static DefaultedRegistryReference<Noise> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.NOISE, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.NOISE, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/generation/feature/FeatureTypes.java
+++ b/src/main/java/org/spongepowered/api/world/generation/feature/FeatureTypes.java
@@ -172,6 +172,6 @@ public final class FeatureTypes {
     }
 
     private static DefaultedRegistryReference<FeatureType> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.FEATURE_TYPE, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.FEATURE_TYPE, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/generation/feature/Features.java
+++ b/src/main/java/org/spongepowered/api/world/generation/feature/Features.java
@@ -456,6 +456,6 @@ public final class Features {
     }
 
     private static DefaultedRegistryReference<Feature> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.FEATURE, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.FEATURE, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/generation/feature/PlacedFeatures.java
+++ b/src/main/java/org/spongepowered/api/world/generation/feature/PlacedFeatures.java
@@ -524,6 +524,6 @@ public final class PlacedFeatures {
     }
 
     private static DefaultedRegistryReference<PlacedFeature> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.PLACED_FEATURE, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.PLACED_FEATURE, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/generation/feature/PlacementModifierTypes.java
+++ b/src/main/java/org/spongepowered/api/world/generation/feature/PlacementModifierTypes.java
@@ -78,6 +78,6 @@ public final class PlacementModifierTypes {
     }
 
     private static DefaultedRegistryReference<PlacementModifierType> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.PLACEMENT_MODIFIER, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.PLACEMENT_MODIFIER, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/generation/structure/StructureSets.java
+++ b/src/main/java/org/spongepowered/api/world/generation/structure/StructureSets.java
@@ -88,6 +88,6 @@ public final class StructureSets {
     }
 
     private static DefaultedRegistryReference<StructureSet> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.STRUCTURE_SET, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.STRUCTURE_SET, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/generation/structure/Structures.java
+++ b/src/main/java/org/spongepowered/api/world/generation/structure/Structures.java
@@ -116,6 +116,6 @@ public final class Structures {
     }
 
     private static DefaultedRegistryReference<Structure> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.STRUCTURE, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.STRUCTURE, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/generation/structure/jigsaw/JigsawPools.java
+++ b/src/main/java/org/spongepowered/api/world/generation/structure/jigsaw/JigsawPools.java
@@ -424,6 +424,6 @@ public final class JigsawPools {
     }
 
     private static DefaultedRegistryReference<JigsawPool> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.JIGSAW_POOL, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.JIGSAW_POOL, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/generation/structure/jigsaw/ProcessorLists.java
+++ b/src/main/java/org/spongepowered/api/world/generation/structure/jigsaw/ProcessorLists.java
@@ -128,6 +128,6 @@ public final class ProcessorLists {
     }
 
     private static DefaultedRegistryReference<ProcessorList> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.PROCESSOR_LIST, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.PROCESSOR_LIST, location).asScopedReference();
     }
 }

--- a/src/main/java/org/spongepowered/api/world/server/WorldArchetypeTypes.java
+++ b/src/main/java/org/spongepowered/api/world/server/WorldArchetypeTypes.java
@@ -48,6 +48,6 @@ public final class WorldArchetypeTypes {
     }
 
     private static DefaultedRegistryReference<WorldArchetypeType> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.WORLD_ARCHETYPE_TYPE, location).asDefaultedReference(Sponge::server);
+        return RegistryKey.of(RegistryTypes.WORLD_ARCHETYPE_TYPE, location).asScopedReference();
     }
 }


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/4194)

Adds `RegistryKey#asScopedReference` 
and `RegistryType#asScopedType`
which uses the current Cause to determine an appropiate `RegistryHolder`
if none is found it falls back to `Server` if available else to `Game`

This allows early access to registries available after Game but before Server.
E.g. EnchantmentTypes during registration for recipes.