### PR TITLE
Add client completion type for remaining joined strings

### DIFF
--- a/src/main/java/org/spongepowered/api/command/parameter/managed/clientcompletion/ClientCompletionTypes.java
+++ b/src/main/java/org/spongepowered/api/command/parameter/managed/clientcompletion/ClientCompletionTypes.java
@@ -67,6 +67,12 @@ public final class ClientCompletionTypes {
     public static final DefaultedRegistryReference<ClientCompletionType> NONE = ClientCompletionTypes.key(ResourceKey.sponge("none"));
 
     /**
+     * Indicates to the client that the {@link ValueParser} is a greedy
+     * string.
+     */
+    public static final DefaultedRegistryReference<ClientCompletionType> REMAINING_JOINED_STRINGS = ClientCompletionTypes.key(ResourceKey.sponge("remaining_joined_strings"));
+
+    /**
      * Indicates to the client that the {@link ValueParser} is a
      * {@link ResourceKey}.
      */


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/issues/4212)

This adds `ClientCompletionTypes.REMAINING_JOINED_STRINGS` for value parsers.

So now custom value parsers, returning custom types, can take a joined string of inputs.

In value parsers:
```java
@Override
public List<ClientCompletionType> clientCompletionType() {
    return List.of(ClientCompletionTypes.REMAINING_JOINED_STRINGS.get());
}
```