### PR TITLE
Make Enchantment a ComponentLike

### DIFF
--- a/src/main/java/org/spongepowered/api/item/enchantment/Enchantment.java
+++ b/src/main/java/org/spongepowered/api/item/enchantment/Enchantment.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.api.item.enchantment;
 
+import net.kyori.adventure.text.ComponentLike;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.data.persistence.DataSerializable;
@@ -42,7 +43,7 @@ import java.util.function.Supplier;
  * they will work properly outside of {@link EnchantmentType#minimumLevel()}
  * and {@link EnchantmentType#maximumLevel()}.</p>
  */
-public interface Enchantment extends DataSerializable {
+public interface Enchantment extends DataSerializable, ComponentLike {
 
     /**
      * Creates a new {@link Builder} to create an {@link Enchantment}.


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/4229)

Makes Enchantment implement ComponentLike which #asComponent returns a full localized name with level (the one that is displayed in the item lore)