### PR TITLE
Expose minecraft:blocks_attacks and minecraft:weapon

### DIFF
--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -3073,7 +3073,7 @@ public final class Keys {
     /**
      * The amount of attack damage a shield-like {@link ItemStack} reduces for certain {@link DamageType}s
      */
-    public static final Key<ListValue<ShieldDamageReduction>> SHIELD_DAMAGE_REDUCTIONS = Keys.listKey(ResourceKey.sponge("shield_damage_reductions"), ShieldDamageReduction.class);
+    public static final Key<ListValue<ShieldDamageReduction<?>>> SHIELD_DAMAGE_REDUCTIONS = Keys.listKey(ResourceKey.sponge("shield_damage_reductions"), ShieldDamageReduction.class);
 
     /**
      * The amount of {@link Ticks} player must use this shield-like {@link ItemStack} for to block attacks successfully.
@@ -3088,7 +3088,7 @@ public final class Keys {
     /**
      * Function for the amount of {@link Keys#ITEM_DURABILITY} damage a shield-like {@link ItemStack} takes when blocking an attack.
      */
-    public static final Key<Value<ShieldItemDamageFunction>> SHIELD_ITEM_DAMAGE_FUNCTION = Keys.key(ResourceKey.sponge("shield_item_damage_function"), ShieldItemDamageFunction.class);
+    public static final Key<Value<ShieldItemDamageFunction<?>>> SHIELD_ITEM_DAMAGE_FUNCTION = Keys.key(ResourceKey.sponge("shield_item_damage_function"), ShieldItemDamageFunction.class);
 
     /**
      * The shooter of a {@link Projectile}.

--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -3665,6 +3665,16 @@ public final class Keys {
      */
     public static final Key<Value<WorldTypeEffect>> WORLD_TYPE_EFFECT = Keys.key(ResourceKey.sponge("world_type_effect"), WorldTypeEffect.class);
 
+    /**
+     * The {@link #ITEM_DURABILITY} damage an {@link ItemStack} takes per attack.
+     */
+    public static final Key<Value<Integer>> WEAPON_DAMAGE_PER_ATTACK = Keys.key(ResourceKey.sponge("weapon_damage_per_attack"), Integer.class);
+
+    /**
+     * The amount of {@link Ticks} this {@link ItemStack} disables blocking for on successful attack.
+     */
+    public static final Key<Value<Ticks>> DISABLE_BLOCKING_TICKS = Keys.key(ResourceKey.sponge("disable_blocking_ticks"), Ticks.class);
+
     // SORTFIELDS:OFF
 
     // @formatter:on

--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -3073,7 +3073,7 @@ public final class Keys {
     /**
      * The amount of attack damage a shield-like {@link ItemStack} reduces for certain {@link DamageType}s
      */
-    public static final Key<ListValue<ShieldDamageReduction<?>>> SHIELD_DAMAGE_REDUCTIONS = Keys.listKey(ResourceKey.sponge("shield_damage_reductions"), ShieldDamageReduction.class);
+    public static final Key<ListValue<ShieldDamageReduction<?>>> SHIELD_DAMAGE_REDUCTIONS = Keys.listKey(ResourceKey.sponge("shield_damage_reductions"), new TypeToken<>() {});
 
     /**
      * The amount of {@link Ticks} player must use this shield-like {@link ItemStack} for to block attacks successfully.
@@ -3088,7 +3088,7 @@ public final class Keys {
     /**
      * Function for the amount of {@link Keys#ITEM_DURABILITY} damage a shield-like {@link ItemStack} takes when blocking an attack.
      */
-    public static final Key<Value<ShieldItemDamageFunction<?>>> SHIELD_ITEM_DAMAGE_FUNCTION = Keys.key(ResourceKey.sponge("shield_item_damage_function"), ShieldItemDamageFunction.class);
+    public static final Key<Value<ShieldItemDamageFunction<?>>> SHIELD_ITEM_DAMAGE_FUNCTION = Keys.key(ResourceKey.sponge("shield_item_damage_function"), new TypeToken<>() {});
 
     /**
      * The shooter of a {@link Projectile}.

--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -643,6 +643,11 @@ public final class Keys {
     public static final Key<Value<Integer>> BURN_TIME = Keys.key(ResourceKey.sponge("burn_time"), Integer.class);
 
     /**
+     * The {@link DamageType} tag that bypasses a shield-like {@link ItemStack}.
+     */
+    public static final Key<Value<Tag<DamageType>>> BYPASS_DAMAGE_TAG = Keys.key(ResourceKey.sponge("bypass_damage_tag"), new TypeToken<>() {});
+
+    /**
      * Whether an {@link ItemStack} can always be eaten.
      */
     public static final Key<Value<Boolean>> CAN_ALWAYS_EAT = Keys.key(ResourceKey.sponge("can_always_eat"), Boolean.class);
@@ -978,6 +983,17 @@ public final class Keys {
      * heading of a {@link ShulkerBullet}.
      */
     public static final Key<Value<Direction>> DIRECTION = Keys.key(ResourceKey.sponge("direction"), Direction.class);
+
+    /**
+     * The amount of {@link Ticks} this {@link ItemStack} disables blocking with a shield-like {@link ItemStack} on a successful attack.
+     */
+    public static final Key<Value<Ticks>> DISABLE_SHIELD_TICKS = Keys.key(ResourceKey.sponge("disable_shield_ticks"), Ticks.class);
+
+    /**
+     * The multiplier applied to the cooldown time during which blocking using this shield-like {@link ItemStack} is disabled.
+     * If set to 0, this item can never be disabled by attacks.
+     */
+    public static final Key<Value<Double>> DISABLE_SHIELD_TICKS_SCALE = Keys.key(ResourceKey.sponge("disable_shield_ticks_scale"), Double.class);
 
     /**
      * The display name of an {@link Entity}, {@link ItemStack} or {@link BlockEntity}.
@@ -3050,6 +3066,31 @@ public final class Keys {
     public static final Key<Value<Double>> SHADOW_STRENGTH = Keys.key(ResourceKey.sponge("shadow_strength"), Double.class);
 
     /**
+     * The sound played when blocking an attack with a shield-like {@link ItemStack}.
+     */
+    public static final Key<Value<SoundType>> SHIELD_BLOCK_SOUND = Keys.key(ResourceKey.sponge("shield_block_sound"), SoundType.class);
+
+    /**
+     * The amount of attack damage a shield-like {@link ItemStack} reduces for certain {@link DamageType}s
+     */
+    public static final Key<ListValue<ShieldDamageReduction>> SHIELD_DAMAGE_REDUCTIONS = Keys.listKey(ResourceKey.sponge("shield_damage_reductions"), ShieldDamageReduction.class);
+
+    /**
+     * The amount of {@link Ticks} player must use this shield-like {@link ItemStack} for to block attacks successfully.
+     */
+    public static final Key<Value<Ticks>> SHIELD_DEPLOY_TICKS = Keys.key(ResourceKey.sponge("shield_deploy_ticks"), Ticks.class);
+
+    /**
+     * The sound played when a shield-like {@link ItemStack} is disabled.
+     */
+    public static final Key<Value<SoundType>> SHIELD_DISABLE_SOUND = Keys.key(ResourceKey.sponge("shield_disable_sound"), SoundType.class);
+
+    /**
+     * Function for the amount of {@link Keys#ITEM_DURABILITY} damage a shield-like {@link ItemStack} takes when blocking an attack.
+     */
+    public static final Key<Value<ShieldItemDamageFunction>> SHIELD_ITEM_DAMAGE_FUNCTION = Keys.key(ResourceKey.sponge("shield_item_damage_function"), ShieldItemDamageFunction.class);
+
+    /**
      * The shooter of a {@link Projectile}.
      */
     public static final Key<Value<ProjectileSource>> SHOOTER = Keys.key(ResourceKey.sponge("shooter"), ProjectileSource.class);
@@ -3538,6 +3579,11 @@ public final class Keys {
     public static final Key<Value<Color>> WATER_FOG_COLOR = Keys.key(ResourceKey.sponge("water_fog_color"), Color.class);
 
     /**
+     * The {@link #ITEM_DURABILITY} damage an {@link ItemStack} takes per attack.
+     */
+    public static final Key<Value<Integer>> WEAPON_DAMAGE_PER_ATTACK = Keys.key(ResourceKey.sponge("weapon_damage_per_attack"), Integer.class);
+
+    /**
      * The weather of a {@link ServerWorldProperties}.
      */
     public static final Key<Value<Weather>> WEATHER = Keys.key(ResourceKey.sponge("weather"), Weather.class);
@@ -3668,51 +3714,6 @@ public final class Keys {
      */
     public static final Key<Value<WorldTypeEffect>> WORLD_TYPE_EFFECT = Keys.key(ResourceKey.sponge("world_type_effect"), WorldTypeEffect.class);
 
-    /**
-     * The {@link #ITEM_DURABILITY} damage an {@link ItemStack} takes per attack.
-     */
-    public static final Key<Value<Integer>> WEAPON_DAMAGE_PER_ATTACK = Keys.key(ResourceKey.sponge("weapon_damage_per_attack"), Integer.class);
-
-    /**
-     * The amount of {@link Ticks} this {@link ItemStack} disables blocking with a shield-like {@link ItemStack} on a successful attack.
-     */
-    public static final Key<Value<Ticks>> DISABLE_SHIELD_TICKS = Keys.key(ResourceKey.sponge("disable_shield_ticks"), Ticks.class);
-
-    /**
-     * The amount of {@link Ticks} player must use this shield-like {@link ItemStack} for to block attacks successfully.
-     */
-    public static final Key<Value<Ticks>> SHIELD_DEPLOY_TICKS = Keys.key(ResourceKey.sponge("shield_deploy_ticks"), Ticks.class);
-
-    /**
-     * The multiplier applied to the cooldown time during which blocking using this shield-like {@link ItemStack} is disabled.
-     * If set to 0, this item can never be disabled by attacks.
-     */
-    public static final Key<Value<Double>> DISABLE_SHIELD_TICKS_SCALE = Keys.key(ResourceKey.sponge("disable_shield_ticks_scale"), Double.class);
-
-    /**
-     * The amount of attack damage a shield-like {@link ItemStack} reduces for certain {@link DamageType}s
-     */
-    public static final Key<ListValue<ShieldDamageReduction>> SHIELD_DAMAGE_REDUCTIONS = Keys.listKey(ResourceKey.sponge("shield_damage_reductions"), ShieldDamageReduction.class);
-
-    /**
-     * Function for the amount of {@link Keys#ITEM_DURABILITY} damage a shield-like {@link ItemStack} takes when blocking an attack.
-     */
-    public static final Key<Value<ShieldItemDamageFunction>> SHIELD_ITEM_DAMAGE_FUNCTION = Keys.key(ResourceKey.sponge("shield_item_damage_function"), ShieldItemDamageFunction.class);
-
-    /**
-     * The {@link DamageType} tag that bypasses a shield-like {@link ItemStack}.
-     */
-    public static final Key<Value<Tag<DamageType>>> BYPASS_DAMAGE_TAG = Keys.key(ResourceKey.sponge("bypass_damage_tag"), new TypeToken<>() {});
-
-    /**
-     * The sound played when blocking an attack with a shield-like {@link ItemStack}.
-     */
-    public static final Key<Value<SoundType>> SHIELD_BLOCK_SOUND = Keys.key(ResourceKey.sponge("shield_block_sound"), SoundType.class);
-
-    /**
-     * The sound played when a shield-like {@link ItemStack} is disabled.
-     */
-    public static final Key<Value<SoundType>> SHIELD_DISABLE_SOUND = Keys.key(ResourceKey.sponge("shield_disable_sound"), SoundType.class);
 
     // SORTFIELDS:OFF
 

--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -3681,14 +3681,14 @@ public final class Keys {
     /**
      * The amount of {@link Ticks} player must use this {@link ItemStack} for to block attacks successfully.
      */
-    public static final Key<Value<Ticks>> BLOCK_DELAY_TICKS = Keys.key(ResourceKey.sponge("block_delay_ticks"), Ticks.class);
+    public static final Key<Value<Ticks>> BLOCK_DEPLOY_TICKS = Keys.key(ResourceKey.sponge("block_deploy_ticks"), Ticks.class);
 
     /**
      * Multiplier applied to the cooldown during which blocking using this item is disabled.
      *
      * @see <a href="https://minecraft.wiki/w/Data_component_format#blocks_attacks">blocks_attacks</a>
      */
-    public static final Key<Value<Float>> DISABLED_BLOCKING_COOLDOWN_SCALE = Keys.key(ResourceKey.sponge("disabled_blocking_cooldown_scale"), Float.class);
+    public static final Key<Value<Double>> DISABLED_BLOCKING_COOLDOWN_SCALE = Keys.key(ResourceKey.sponge("disabled_blocking_cooldown_scale"), Double.class);
 
     /**
      * The amount of attack damage a shield-like {@link ItemStack} reduces for certain {@link DamageType}s

--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -90,6 +90,8 @@ import org.spongepowered.api.data.type.RabbitType;
 import org.spongepowered.api.data.type.RailDirection;
 import org.spongepowered.api.data.type.SalmonSize;
 import org.spongepowered.api.data.type.SculkSensorState;
+import org.spongepowered.api.data.type.ShieldDamageReduction;
+import org.spongepowered.api.data.type.ShieldItemDamageFunction;
 import org.spongepowered.api.data.type.SkinPart;
 import org.spongepowered.api.data.type.SlabPortion;
 import org.spongepowered.api.data.type.SpellType;
@@ -224,6 +226,7 @@ import org.spongepowered.api.entity.vehicle.minecart.FurnaceMinecart;
 import org.spongepowered.api.entity.vehicle.minecart.Minecart;
 import org.spongepowered.api.entity.vehicle.minecart.MinecartLike;
 import org.spongepowered.api.entity.weather.LightningBolt;
+import org.spongepowered.api.event.cause.entity.damage.DamageType;
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSources;
 import org.spongepowered.api.fluid.FluidStackSnapshot;
@@ -3674,6 +3677,43 @@ public final class Keys {
      * The amount of {@link Ticks} this {@link ItemStack} disables blocking for on successful attack.
      */
     public static final Key<Value<Ticks>> DISABLE_BLOCKING_TICKS = Keys.key(ResourceKey.sponge("disable_blocking_ticks"), Ticks.class);
+
+    /**
+     * The amount of {@link Ticks} player must use this {@link ItemStack} for to block attacks successfully.
+     */
+    public static final Key<Value<Ticks>> BLOCK_DELAY_TICKS = Keys.key(ResourceKey.sponge("block_delay_ticks"), Ticks.class);
+
+    /**
+     * Multiplier applied to the cooldown during which blocking using this item is disabled.
+     *
+     * @see <a href="https://minecraft.wiki/w/Data_component_format#blocks_attacks">blocks_attacks</a>
+     */
+    public static final Key<Value<Float>> DISABLED_BLOCKING_COOLDOWN_SCALE = Keys.key(ResourceKey.sponge("disabled_blocking_cooldown_scale"), Float.class);
+
+    /**
+     * The amount of attack damage a shield-like {@link ItemStack} reduces for certain {@link DamageType}s
+     */
+    public static final Key<ListValue<ShieldDamageReduction>> SHIELD_DAMAGE_REDUCTIONS = Keys.listKey(ResourceKey.sponge("shield_damage_reductions"), ShieldDamageReduction.class);
+
+    /**
+     * Function for the amount of {@link Keys#ITEM_DURABILITY} damage a shield-like {@link ItemStack} takes when blocking an attack.
+     */
+    public static final Key<Value<ShieldItemDamageFunction>> SHIELD_ITEM_DAMAGE_FUNCTION = Keys.key(ResourceKey.sponge("shield_item_damage_function"), ShieldItemDamageFunction.class);
+
+    /**
+     * The {@link DamageType} tag that bypasses a shield-like {@link ItemStack}.
+     */
+    public static final Key<Value<Tag<DamageType>>> BYPASS_DAMAGE_TAG = Keys.key(ResourceKey.sponge("bypass_damage_tag"), new TypeToken<>() {});
+
+    /**
+     * The sound played when blocking an attack with a shield-like {@link ItemStack}.
+     */
+    public static final Key<Value<SoundType>> SHIELD_BLOCK_SOUND = Keys.key(ResourceKey.sponge("shield_block_sound"), SoundType.class);
+
+    /**
+     * The sound played when a shield-like {@link ItemStack} is disabled.
+     */
+    public static final Key<Value<SoundType>> SHIELD_DISABLE_SOUND = Keys.key(ResourceKey.sponge("shield_disable_sound"), SoundType.class);
 
     // SORTFIELDS:OFF
 

--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -3674,21 +3674,21 @@ public final class Keys {
     public static final Key<Value<Integer>> WEAPON_DAMAGE_PER_ATTACK = Keys.key(ResourceKey.sponge("weapon_damage_per_attack"), Integer.class);
 
     /**
-     * The amount of {@link Ticks} this {@link ItemStack} disables blocking for on successful attack.
+     * The amount of {@link Ticks} this {@link ItemStack} disables blocking with a shield-like {@link ItemStack} on a successful attack.
      */
-    public static final Key<Value<Ticks>> DISABLE_BLOCKING_TICKS = Keys.key(ResourceKey.sponge("disable_blocking_ticks"), Ticks.class);
+    public static final Key<Value<Ticks>> DISABLE_SHIELD_TICKS = Keys.key(ResourceKey.sponge("disable_shield_ticks"), Ticks.class);
 
     /**
-     * The amount of {@link Ticks} player must use this {@link ItemStack} for to block attacks successfully.
+     * The amount of {@link Ticks} player must use this shield-like {@link ItemStack} for to block attacks successfully.
      */
-    public static final Key<Value<Ticks>> BLOCK_DEPLOY_TICKS = Keys.key(ResourceKey.sponge("block_deploy_ticks"), Ticks.class);
+    public static final Key<Value<Ticks>> SHIELD_DEPLOY_TICKS = Keys.key(ResourceKey.sponge("shield_deploy_ticks"), Ticks.class);
 
     /**
-     * Multiplier applied to the cooldown during which blocking using this item is disabled.
+     * Multiplier applied to the cooldown during which blocking using this shield-like {@link ItemStack} is disabled.
      *
      * @see <a href="https://minecraft.wiki/w/Data_component_format#blocks_attacks">blocks_attacks</a>
      */
-    public static final Key<Value<Double>> DISABLED_BLOCKING_COOLDOWN_SCALE = Keys.key(ResourceKey.sponge("disabled_blocking_cooldown_scale"), Double.class);
+    public static final Key<Value<Double>> DISABLE_SHIELD_TICKS_SCALE = Keys.key(ResourceKey.sponge("disable_shield_ticks_scale"), Double.class);
 
     /**
      * The amount of attack damage a shield-like {@link ItemStack} reduces for certain {@link DamageType}s

--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -3684,7 +3684,8 @@ public final class Keys {
     public static final Key<Value<Ticks>> SHIELD_DEPLOY_TICKS = Keys.key(ResourceKey.sponge("shield_deploy_ticks"), Ticks.class);
 
     /**
-     * Multiplier applied to the cooldown during which blocking using this shield-like {@link ItemStack} is disabled.
+     * The multiplier applied to the cooldown time during which blocking using this shield-like {@link ItemStack} is disabled.
+     * If set to 0, this item can never be disabled by attacks.
      *
      * @see <a href="https://minecraft.wiki/w/Data_component_format#blocks_attacks">blocks_attacks</a>
      */

--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -3686,8 +3686,6 @@ public final class Keys {
     /**
      * The multiplier applied to the cooldown time during which blocking using this shield-like {@link ItemStack} is disabled.
      * If set to 0, this item can never be disabled by attacks.
-     *
-     * @see <a href="https://minecraft.wiki/w/Data_component_format#blocks_attacks">blocks_attacks</a>
      */
     public static final Key<Value<Double>> DISABLE_SHIELD_TICKS_SCALE = Keys.key(ResourceKey.sponge("disable_shield_ticks_scale"), Double.class);
 

--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -3714,7 +3714,6 @@ public final class Keys {
      */
     public static final Key<Value<WorldTypeEffect>> WORLD_TYPE_EFFECT = Keys.key(ResourceKey.sponge("world_type_effect"), WorldTypeEffect.class);
 
-
     // SORTFIELDS:OFF
 
     // @formatter:on

--- a/src/main/java/org/spongepowered/api/data/type/ShieldDamageReduction.java
+++ b/src/main/java/org/spongepowered/api/data/type/ShieldDamageReduction.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
 import org.spongepowered.api.tag.Tag;
 import org.spongepowered.api.util.ResettableBuilder;
 
+import java.util.Optional;
 import java.util.Set;
 
 
@@ -38,11 +39,13 @@ import java.util.Set;
  */
 public interface ShieldDamageReduction<T> {
 
-    double resolve(DamageSource source, double damage, double angle);
-
     static ShieldDamageReduction<MultiplyAdd> of(MultiplyAdd config) {
         return Sponge.game().factoryProvider().provide(Factory.class).create(config);
     }
+
+    T configuration();
+
+    double resolve(DamageSource source, double damage, double angle);
 
     interface Factory {
 
@@ -55,11 +58,39 @@ public interface ShieldDamageReduction<T> {
      */
     interface MultiplyAdd {
 
-        double resolve(DamageSource source, double damage, double angle);
-
         static Builder builder() {
             return Sponge.game().builderProvider().provide(Builder.class);
         }
+
+        /**
+         * Returns the {@link DamageType damage types} this reduction applies to.
+         * {@link Optional#empty()} means this reduction is not restricted to any given damage type.
+         *
+         * @return the affected damage types
+         */
+        Optional<Set<DamageType>> damageTypes();
+
+        /**
+         * Returns the maximum angle between the users facing direction and the direction of the incoming attack.
+         *
+         * @return the maximum angle
+         */
+        double horizontalBlockingAngle();
+
+        /**
+         * Returns the constant amount of damage to be blocked.
+         *
+         * @return a constant amount of damage to block
+         */
+        double constantReduction();
+
+        /**
+         * Returns fractional amount of damage to block, where a factor of 1 means that all damage is blocked,
+         * and a factor of 0 that no damage is blocked.
+         *
+         * @return fractional amount of damage to block
+         */
+        double fractionalReduction();
 
         interface Builder extends ResettableBuilder<MultiplyAdd, Builder> {
 

--- a/src/main/java/org/spongepowered/api/data/type/ShieldDamageReduction.java
+++ b/src/main/java/org/spongepowered/api/data/type/ShieldDamageReduction.java
@@ -32,62 +32,81 @@ import org.spongepowered.api.util.ResettableBuilder;
 
 import java.util.Set;
 
+
 /**
  * Defines the amount of damage reduced when blocking with a shield-like {@link org.spongepowered.api.item.inventory.ItemStack}.
- * The final amount of blocked damage will be {@code constantReduction + fractionalReduction * damage}
  */
-public interface ShieldDamageReduction {
+public interface ShieldDamageReduction<T> {
 
     double resolve(DamageSource source, double damage, double angle);
 
-    static Builder builder() {
-        return Sponge.game().builderProvider().provide(Builder.class);
+    static ShieldDamageReduction<MultiplyAdd> of(MultiplyAdd config) {
+        return Sponge.game().factoryProvider().provide(Factory.class).create(config);
     }
 
-    interface Builder extends ResettableBuilder<ShieldDamageReduction, Builder> {
+    interface Factory {
 
-        /**
-         * Limits the {@link DamageType damage types} this reduction applies to.
-         *
-         * @param damageTypes the affected damage types
-         * @return This builder, for chaining
-         */
-        Builder damageTypes(Set<DamageType> damageTypes);
+        ShieldDamageReduction<MultiplyAdd> create(MultiplyAdd config);
 
-        /**
-         * Limits the {@link DamageType damage types} this reduction applies to.
-         *
-         * @param tag the tag defining affected damage types
-         * @return This builder, for chaining
-         */
-        Builder damageTypes(Tag<DamageType> tag);
+    }
 
-        /**
-         * Sets the maximum angle between the users facing direction and the direction of the incoming attack.
-         *
-         * @param angle the maximum angle
-         * @return This builder, for chaining
-         */
-        Builder horizontalBlockingAngle(double angle);
+    /**
+     * The final amount of blocked damage will be {@code constantReduction + fractionalReduction * damage}
+     */
+    interface MultiplyAdd {
 
-        /**
-         * Sets the constant amount of damage to be blocked.
-         *
-         * @param constant a constant amount of damage to block
-         * @return This builder, for chaining
-         */
-        Builder constantReduction(double constant);
+        double resolve(DamageSource source, double damage, double angle);
 
-        /**
-         * Sets fractional amount of damage to block, where a factor of 1 means that all damage is blocked,
-         * and a factor of 0 that no damage is blocked.
-         *
-         * @param fraction fractional amount of damage to block
-         * @return This builder, for chaining
-         */
-        Builder fractionalReduction(double fraction);
+        static Builder builder() {
+            return Sponge.game().builderProvider().provide(Builder.class);
+        }
 
-        ShieldDamageReduction build();
+        interface Builder extends ResettableBuilder<MultiplyAdd, Builder> {
+
+            /**
+             * Limits the {@link DamageType damage types} this reduction applies to.
+             *
+             * @param damageTypes the affected damage types
+             * @return This builder, for chaining
+             */
+            Builder damageTypes(Set<DamageType> damageTypes);
+
+            /**
+             * Limits the {@link DamageType damage types} this reduction applies to.
+             *
+             * @param tag the tag defining affected damage types
+             * @return This builder, for chaining
+             */
+            Builder damageTypes(Tag<DamageType> tag);
+
+            /**
+             * Sets the maximum angle between the users facing direction and the direction of the incoming attack.
+             *
+             * @param angle the maximum angle
+             * @return This builder, for chaining
+             */
+            Builder horizontalBlockingAngle(double angle);
+
+            /**
+             * Sets the constant amount of damage to be blocked.
+             *
+             * @param constant a constant amount of damage to block
+             * @return This builder, for chaining
+             */
+            Builder constantReduction(double constant);
+
+            /**
+             * Sets fractional amount of damage to block, where a factor of 1 means that all damage is blocked,
+             * and a factor of 0 that no damage is blocked.
+             *
+             * @param fraction fractional amount of damage to block
+             * @return This builder, for chaining
+             */
+            Builder fractionalReduction(double fraction);
+
+            MultiplyAdd build();
+
+        }
 
     }
 

--- a/src/main/java/org/spongepowered/api/data/type/ShieldDamageReduction.java
+++ b/src/main/java/org/spongepowered/api/data/type/ShieldDamageReduction.java
@@ -26,10 +26,10 @@ package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.event.cause.entity.damage.DamageType;
+import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
 import org.spongepowered.api.tag.Tag;
 import org.spongepowered.api.util.ResettableBuilder;
 
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -38,35 +38,7 @@ import java.util.Set;
  */
 public interface ShieldDamageReduction {
 
-    /**
-     * Returns the {@link DamageType damage types} this reduction applies to.
-     * {@link Optional#empty()} means this reduction is not restricted to any given damage type.
-     *
-     * @return the affected damage types
-     */
-    Optional<Set<DamageType>> damageTypes();
-
-    /**
-     * Returns the maximum angle between the users facing direction and the direction of the incoming attack.
-     *
-     * @return the maximum angle
-     */
-    double horizontalBlockingAngle();
-
-    /**
-     * Returns the constant amount of damage to be blocked.
-     *
-     * @return a constant amount of damage to block
-     */
-    double constantReduction();
-
-    /**
-     * Returns fractional amount of damage to block, where a factor of 1 means that all damage is blocked,
-     * and a factor of 0 that no damage is blocked.
-     *
-     * @return fractional amount of damage to block
-     */
-    double fractionalReduction();
+    double resolve(DamageSource source, double damage, double angle);
 
     static Builder builder() {
         return Sponge.game().builderProvider().provide(Builder.class);
@@ -74,14 +46,45 @@ public interface ShieldDamageReduction {
 
     interface Builder extends ResettableBuilder<ShieldDamageReduction, Builder> {
 
+        /**
+         * Limits the {@link DamageType damage types} this reduction applies to.
+         *
+         * @param damageTypes the affected damage types
+         * @return This builder, for chaining
+         */
         Builder damageTypes(Set<DamageType> damageTypes);
 
+        /**
+         * Limits the {@link DamageType damage types} this reduction applies to.
+         *
+         * @param tag the tag defining affected damage types
+         * @return This builder, for chaining
+         */
         Builder damageTypes(Tag<DamageType> tag);
 
+        /**
+         * Sets the maximum angle between the users facing direction and the direction of the incoming attack.
+         *
+         * @param angle the maximum angle
+         * @return This builder, for chaining
+         */
         Builder horizontalBlockingAngle(double angle);
 
+        /**
+         * Sets the constant amount of damage to be blocked.
+         *
+         * @param constant a constant amount of damage to block
+         * @return This builder, for chaining
+         */
         Builder constantReduction(double constant);
 
+        /**
+         * Sets fractional amount of damage to block, where a factor of 1 means that all damage is blocked,
+         * and a factor of 0 that no damage is blocked.
+         *
+         * @param fraction fractional amount of damage to block
+         * @return This builder, for chaining
+         */
         Builder fractionalReduction(double fraction);
 
         ShieldDamageReduction build();

--- a/src/main/java/org/spongepowered/api/data/type/ShieldDamageReduction.java
+++ b/src/main/java/org/spongepowered/api/data/type/ShieldDamageReduction.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.Sponge;

--- a/src/main/java/org/spongepowered/api/data/type/ShieldDamageReduction.java
+++ b/src/main/java/org/spongepowered/api/data/type/ShieldDamageReduction.java
@@ -1,0 +1,67 @@
+package org.spongepowered.api.data.type;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.event.cause.entity.damage.DamageType;
+import org.spongepowered.api.tag.Tag;
+import org.spongepowered.api.util.ResettableBuilder;
+
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Defines the amount of damage reduced when blocking with a shield-like {@link org.spongepowered.api.item.inventory.ItemStack}.
+ * The final amount of blocked damage will be {@code constantReduction + fractionalReduction * damage}
+ */
+public interface ShieldDamageReduction {
+
+    /**
+     * Returns the {@link DamageType damage types} this reduction applies to.
+     * {@link Optional#empty()} means this reduction is not restricted to any given damage type.
+     *
+     * @return the affected damage types
+     */
+    Optional<Set<DamageType>> damageTypes();
+
+    /**
+     * Returns the maximum angle between the users facing direction and the direction of the incoming attack.
+     *
+     * @return the maximum angle
+     */
+    double horizontalBlockingAngle();
+
+    /**
+     * Returns the constant amount of damage to be blocked.
+     *
+     * @return a constant amount of damage to block
+     */
+    double constantReduction();
+
+    /**
+     * Returns fractional amount of damage to block, where a factor of 1 means that all damage is blocked,
+     * and a factor of 0 that no damage is blocked.
+     *
+     * @return fractional amount of damage to block
+     */
+    double fractionalReduction();
+
+    static Builder builder() {
+        return Sponge.game().builderProvider().provide(Builder.class);
+    }
+
+    interface Builder extends ResettableBuilder<ShieldDamageReduction, Builder> {
+
+        Builder damageTypes(Set<DamageType> damageTypes);
+
+        Builder damageTypes(Tag<DamageType> tag);
+
+        Builder horizontalBlockingAngle(double angle);
+
+        Builder constantReduction(double constant);
+
+        Builder fractionalReduction(double fraction);
+
+        ShieldDamageReduction build();
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/data/type/ShieldItemDamageFunction.java
+++ b/src/main/java/org/spongepowered/api/data/type/ShieldItemDamageFunction.java
@@ -1,0 +1,51 @@
+package org.spongepowered.api.data.type;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.util.ResettableBuilder;
+
+/**
+ * Defines the amount of {@link org.spongepowered.api.data.Keys#ITEM_DURABILITY} damage a shield-like
+ * {@link org.spongepowered.api.item.inventory.ItemStack} takes, when blocking an attack.
+ * The final amount of damage will be {@code constantDamage + fractionalDamage * attackDamage}
+ */
+public interface ShieldItemDamageFunction {
+
+    /**
+     * Returns the minimum amount of damage blocked attack must have had, for the item to take damage at all.
+     *
+     * @return minimum attack damage required for any durability loss
+     */
+    double minAttackDamage();
+
+    /**
+     * Returns the constant amount of damage taken.
+     *
+     * @return a constant amount of damage to take
+     */
+    double constantDamage();
+
+    /**
+     * Returns fractional amount of damage to take, where a factor of 1 means that the amount of durability lost is equal to attack damage,
+     * and a factor of 0 that no durability is lost.
+     *
+     * @return fractional amount of damage to take
+     */
+    double fractionalDamage();
+
+    static Builder builder() {
+        return Sponge.game().builderProvider().provide(Builder.class);
+    }
+
+    interface Builder extends ResettableBuilder<ShieldItemDamageFunction, Builder> {
+
+        Builder minAttackDamage(double minDamage);
+
+        Builder constantDamage(double constantDamage);
+
+        Builder fractionalDamage(double fractionalDamage);
+
+        ShieldItemDamageFunction build();
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/api/data/type/ShieldItemDamageFunction.java
+++ b/src/main/java/org/spongepowered/api/data/type/ShieldItemDamageFunction.java
@@ -33,11 +33,13 @@ import org.spongepowered.api.util.ResettableBuilder;
  */
 public interface ShieldItemDamageFunction<T> {
 
-    double resolve(double damage);
-
     static ShieldItemDamageFunction<MultiplyAdd> of(MultiplyAdd config) {
         return Sponge.game().factoryProvider().provide(Factory.class).create(config);
     }
+
+    T configuration();
+
+    double resolve(double damage);
 
     interface Factory {
 
@@ -50,11 +52,31 @@ public interface ShieldItemDamageFunction<T> {
      */
     interface MultiplyAdd {
 
-        double resolve(double damage);
-
         static Builder builder() {
             return Sponge.game().builderProvider().provide(Builder.class);
         }
+
+        /**
+         * Returns the minimum amount of damage blocked attack must have had, for the item to take damage at all.
+         *
+         * @return minimum attack damage required for any durability loss
+         */
+        double minAttackDamage();
+
+        /**
+         * Returns the constant amount of damage taken.
+         *
+         * @return a constant amount of damage to take
+         */
+        double constantDamage();
+
+        /**
+         * Returns fractional amount of damage to take, where a factor of 1 means that the amount of durability lost is equal to attack damage,
+         * and a factor of 0 that no durability is lost.
+         *
+         * @return fractional amount of damage to take
+         */
+        double fractionalDamage();
 
         interface Builder extends ResettableBuilder<MultiplyAdd, Builder> {
 

--- a/src/main/java/org/spongepowered/api/data/type/ShieldItemDamageFunction.java
+++ b/src/main/java/org/spongepowered/api/data/type/ShieldItemDamageFunction.java
@@ -30,44 +30,62 @@ import org.spongepowered.api.util.ResettableBuilder;
 /**
  * Defines the amount of {@link org.spongepowered.api.data.Keys#ITEM_DURABILITY} damage a shield-like
  * {@link org.spongepowered.api.item.inventory.ItemStack} takes, when blocking an attack.
- * The final amount of damage will be {@code constantDamage + fractionalDamage * attackDamage}
  */
-public interface ShieldItemDamageFunction {
+public interface ShieldItemDamageFunction<T> {
 
     double resolve(double damage);
 
-    static Builder builder() {
-        return Sponge.game().builderProvider().provide(Builder.class);
+    static ShieldItemDamageFunction<MultiplyAdd> of(MultiplyAdd config) {
+        return Sponge.game().factoryProvider().provide(Factory.class).create(config);
     }
 
-    interface Builder extends ResettableBuilder<ShieldItemDamageFunction, Builder> {
+    interface Factory {
 
-        /**
-         * Sets the minimum amount of damage blocked attack must have had, for the item to take damage at all.
-         *
-         * @param minDamage minimum attack damage required for any durability loss
-         * @return This builder, for chaining
-         */
-        Builder minAttackDamage(double minDamage);
+        ShieldItemDamageFunction<MultiplyAdd> create(MultiplyAdd config);
 
-        /**
-         * Sets the constant amount of damage taken.
-         *
-         * @param constantDamage a constant amount of damage to take
-         * @return This builder, for chaining
-         */
-        Builder constantDamage(double constantDamage);
+    }
 
-        /**
-         * Sets fractional amount of damage to take, where a factor of 1 means that the amount of durability lost is equal to attack damage,
-         * and a factor of 0 that no durability is lost.
-         *
-         * @param fractionalDamage fractional amount of damage to take
-         * @return This builder, for chaining
-         */
-        Builder fractionalDamage(double fractionalDamage);
+    /**
+     * The final amount of damage will be {@code constantDamage + fractionalDamage * attackDamage}
+     */
+    interface MultiplyAdd {
 
-        ShieldItemDamageFunction build();
+        double resolve(double damage);
+
+        static Builder builder() {
+            return Sponge.game().builderProvider().provide(Builder.class);
+        }
+
+        interface Builder extends ResettableBuilder<MultiplyAdd, Builder> {
+
+            /**
+             * Sets the minimum amount of damage blocked attack must have had, for the item to take damage at all.
+             *
+             * @param minDamage minimum attack damage required for any durability loss
+             * @return This builder, for chaining
+             */
+            Builder minAttackDamage(double minDamage);
+
+            /**
+             * Sets the constant amount of damage taken.
+             *
+             * @param constantDamage a constant amount of damage to take
+             * @return This builder, for chaining
+             */
+            Builder constantDamage(double constantDamage);
+
+            /**
+             * Sets fractional amount of damage to take, where a factor of 1 means that the amount of durability lost is equal to attack damage,
+             * and a factor of 0 that no durability is lost.
+             *
+             * @param fractionalDamage fractional amount of damage to take
+             * @return This builder, for chaining
+             */
+            Builder fractionalDamage(double fractionalDamage);
+
+            MultiplyAdd build();
+
+        }
 
     }
 

--- a/src/main/java/org/spongepowered/api/data/type/ShieldItemDamageFunction.java
+++ b/src/main/java/org/spongepowered/api/data/type/ShieldItemDamageFunction.java
@@ -34,27 +34,7 @@ import org.spongepowered.api.util.ResettableBuilder;
  */
 public interface ShieldItemDamageFunction {
 
-    /**
-     * Returns the minimum amount of damage blocked attack must have had, for the item to take damage at all.
-     *
-     * @return minimum attack damage required for any durability loss
-     */
-    double minAttackDamage();
-
-    /**
-     * Returns the constant amount of damage taken.
-     *
-     * @return a constant amount of damage to take
-     */
-    double constantDamage();
-
-    /**
-     * Returns fractional amount of damage to take, where a factor of 1 means that the amount of durability lost is equal to attack damage,
-     * and a factor of 0 that no durability is lost.
-     *
-     * @return fractional amount of damage to take
-     */
-    double fractionalDamage();
+    double resolve(double damage);
 
     static Builder builder() {
         return Sponge.game().builderProvider().provide(Builder.class);
@@ -62,10 +42,29 @@ public interface ShieldItemDamageFunction {
 
     interface Builder extends ResettableBuilder<ShieldItemDamageFunction, Builder> {
 
+        /**
+         * Sets the minimum amount of damage blocked attack must have had, for the item to take damage at all.
+         *
+         * @param minDamage minimum attack damage required for any durability loss
+         * @return This builder, for chaining
+         */
         Builder minAttackDamage(double minDamage);
 
+        /**
+         * Sets the constant amount of damage taken.
+         *
+         * @param constantDamage a constant amount of damage to take
+         * @return This builder, for chaining
+         */
         Builder constantDamage(double constantDamage);
 
+        /**
+         * Sets fractional amount of damage to take, where a factor of 1 means that the amount of durability lost is equal to attack damage,
+         * and a factor of 0 that no durability is lost.
+         *
+         * @param fractionalDamage fractional amount of damage to take
+         * @return This builder, for chaining
+         */
         Builder fractionalDamage(double fractionalDamage);
 
         ShieldItemDamageFunction build();

--- a/src/main/java/org/spongepowered/api/data/type/ShieldItemDamageFunction.java
+++ b/src/main/java/org/spongepowered/api/data/type/ShieldItemDamageFunction.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.api.data.type;
 
 import org.spongepowered.api.Sponge;


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/4233)

Exposes [`minecraft:blocks_attacks`](https://minecraft.wiki/w/Data_component_format#blocks_attacks) and [`minecraft:weapon`](https://minecraft.wiki/w/Data_component_format#weapon) data components.