### PR TITLE
Add keys related to minecraft:equippable data component

### DIFF
--- a/src/main/java/org/spongepowered/api/data/Keys.java
+++ b/src/main/java/org/spongepowered/api/data/Keys.java
@@ -398,6 +398,11 @@ public final class Keys {
     public static final Key<Value<ParticleConfig>> AMBIENT_PARTICLE = Keys.key(ResourceKey.sponge("ambient_particle"), ParticleConfig.class);
 
     /**
+     * The set of {@link EntityType} allowed to equip an {@link ItemStack}.
+     */
+    public static final Key<SetValue<EntityType<?>>> ALLOWED_ENTITIES = Keys.setKey(ResourceKey.sponge("allowed_entities"), new TypeToken<>() {});
+
+    /**
      * The ambient sound in a {@link Biome}
      * Readonly
      */
@@ -647,6 +652,16 @@ public final class Keys {
      * The {@link DamageType} tag that bypasses a shield-like {@link ItemStack}.
      */
     public static final Key<Value<Tag<DamageType>>> BYPASS_DAMAGE_TAG = Keys.key(ResourceKey.sponge("bypass_damage_tag"), new TypeToken<>() {});
+
+    /**
+     * The {@link ResourceKey} overlay rendered when {@link ItemStack} equipped on head.
+     */
+    public static final Key<Value<ResourceKey>> CAMERA_OVERLAY = Keys.key(ResourceKey.sponge("camera_overlay"), ResourceKey.class);
+
+    /**
+     * Whether an equipped {@link ItemStack} can be removed using shears.
+     */
+    public static final Key<Value<Boolean>> CAN_BE_SHEARED = Keys.key(ResourceKey.sponge("can_be_sheared"), Boolean.class);
 
     /**
      * Whether an {@link ItemStack} can always be eaten.
@@ -961,6 +976,11 @@ public final class Keys {
     public static final Key<Value<Double>> DAMAGE_ABSORPTION = Keys.key(ResourceKey.sponge("damage_absorption"), Double.class);
 
     /**
+     * Whether an equipped {@link ItemStack} is damaged when the wearer is hurt.
+     */
+    public static final Key<Value<Boolean>> DAMAGE_ON_HURT = Keys.key(ResourceKey.sponge("damage_on_hurt"), Boolean.class);
+
+    /**
      * How much damage a {@link FallingBlock} deals to {@link Living} entities
      * it hits per block fallen.
      *
@@ -1129,10 +1149,19 @@ public final class Keys {
     public static final Key<Value<EntityArchetype>> ENTITY_TO_SPAWN = Keys.key(ResourceKey.sponge("entity_to_spawn"), EntityArchetype.class);
 
     /**
+     * Whether an item is equipped when interacting with it.
+     */
+    public static final Key<Value<Boolean>> EQUIP_ON_INTERACT = Keys.key(ResourceKey.sponge("equip_on_interact"), Boolean.class);
+
+    /**
+     * The {@link SoundType} played when equipping an item.
+     */
+    public static final Key<Value<SoundType>> EQUIP_SOUND = Keys.key(ResourceKey.sponge("equip_sound"), SoundType.class);
+
+    /**
      * The {@link EquipmentType} that the target inventory supports. This usually applies to {@link EquipmentSlot}s.
      * or
      * The {@link EquipmentType} of an {@link ItemStack}
-     * Readonly
      */
     public static final Key<Value<EquipmentType>> EQUIPMENT_TYPE = Keys.key(ResourceKey.sponge("equipment_type"), EquipmentType.class);
 
@@ -1815,6 +1844,11 @@ public final class Keys {
     public static final Key<Value<Boolean>> IS_DISARMED = Keys.key(ResourceKey.sponge("is_disarmed"), Boolean.class);
 
     /**
+     * Whether an item can be equipped using a dispenser.
+     */
+    public static final Key<Value<Boolean>> IS_DISPENSABLE = Keys.key(ResourceKey.sponge("is_dispensable"), Boolean.class);
+
+    /**
      * Whether an entity is eating.
      * e.g. {@link Panda}
      */
@@ -2178,6 +2212,11 @@ public final class Keys {
      * Readonly
      */
     public static final Key<Value<Boolean>> IS_SURROGATE_BLOCK = Keys.key(ResourceKey.sponge("is_surrogate_block"), Boolean.class);
+
+    /**
+     * Whether an equipped item can be swapped by interacting with it.
+     */
+    public static final Key<Value<Boolean>> IS_SWAPPABLE = Keys.key(ResourceKey.sponge("is_swappable"), Boolean.class);
 
     /**
      * Whether players are prevented from taking
@@ -3092,6 +3131,11 @@ public final class Keys {
      * The shadow strength duration of a {@link DisplayEntity}
      */
     public static final Key<Value<Double>> SHADOW_STRENGTH = Keys.key(ResourceKey.sponge("shadow_strength"), Double.class);
+
+    /**
+     * The {@link SoundType} played when removing an equipped {@link ItemStack} using shears.
+     */
+    public static final Key<Value<SoundType>> SHEARING_SOUND = Keys.key(ResourceKey.sponge("shearing_sound"), SoundType.class);
 
     /**
      * The sound played when blocking an attack with a shield-like {@link ItemStack}.


### PR DESCRIPTION
**SpongeAPI** | [Sponge](https://github.com/SpongePowered/Sponge/pull/4298)

Exposes keys related to the [`minecraft:equippable`](https://minecraft.wiki/w/Data_component_format#equippable) data component.